### PR TITLE
refactor(chsql): delete metricsReducerFrag's unreachable row-counting arms

### DIFF
--- a/internal/chsql/exemplars.go
+++ b/internal/chsql/exemplars.go
@@ -177,7 +177,14 @@ func (e *emitter) emitMetricsExemplars(
 	}
 	tsCol := rw.TimestampColumn
 	innerSb.SelectAs(func(b *Builder) { b.Ident(tsCol) }, "ts")
-	if m.Op != chplan.MetricsOpRate && m.Op != chplan.MetricsOpCountOverTime && m.Attr != nil {
+	// One decision, read twice: whether this exemplar stream reduces over
+	// the operand column or over a constant 1. The inner SELECT projects
+	// `metric_arg` iff readsOperand, and the outer SELECT reads
+	// `metric_arg` iff readsOperand — so the projection and the read
+	// cannot disagree and emit SQL naming an unprojected column (the
+	// failure TestExemplarsRateAndCountIgnoreAttr guards).
+	readsOperand := !metricsOpCountsRowsRatherThanOperand(m.Op) && m.Attr != nil
+	if readsOperand {
 		attr := m.Attr
 		innerSb.SelectAs(func(b *Builder) { _ = b.Expr(attr) }, "metric_arg")
 	}
@@ -271,13 +278,12 @@ func (e *emitter) emitMetricsExemplars(
 	))
 	outerSb.SelectAs(Col("anchor_ts"), "TimeUnix")
 
-	var valueFrag Frag
-	if m.Op == chplan.MetricsOpRate || m.Op == chplan.MetricsOpCountOverTime {
-		valueFrag = Call("toFloat64", Call("argMax", InlineLit(int64(1)), Col("ts")))
-	} else if m.Attr != nil {
+	// The row-counting ops carry no operand, and an operand-reading op
+	// whose Attr the lowering left unset has nothing to read — both fall
+	// back to a constant 1, which is the exemplar's own presence.
+	valueFrag := Call("toFloat64", Call("argMax", InlineLit(int64(1)), Col("ts")))
+	if readsOperand {
 		valueFrag = Call("toFloat64", Call("argMax", Col("metric_arg"), Col("ts")))
-	} else {
-		valueFrag = Call("toFloat64", Call("argMax", InlineLit(int64(1)), Col("ts")))
 	}
 	outerSb.Select(As(valueFrag, "Value"))
 

--- a/internal/chsql/exemplars_misc_mutation_test.go
+++ b/internal/chsql/exemplars_misc_mutation_test.go
@@ -18,7 +18,7 @@ import (
 // that cap.
 //
 // It does NOT kill the CONDITIONALS_BOUNDARY mutant on the guard it
-// exercises (exemplars.go:292, `if maxPerSeries > 0` -> `>= 0`); see the
+// exercises (exemplars.go:298, `if maxPerSeries > 0` -> `>= 0`); see the
 // NOT KILLABLE note at the foot of this file for why that mutant is
 // equivalent. The contract is worth pinning regardless — it is the
 // difference between "uncapped" and "every bucket capped to zero rows".
@@ -246,7 +246,7 @@ func TestExemplarsRateAndCountIgnoreAttr(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// exemplars.go:292:18 (CONDITIONALS_BOUNDARY, `if maxPerSeries > 0` ->
+// exemplars.go:298:18 (CONDITIONALS_BOUNDARY, `if maxPerSeries > 0` ->
 // `>= 0`). The two forms differ only at maxPerSeries == 0, where the mutant
 // enters the block and calls `outerSb.Limit(0)` followed by
 // `outerSb.LimitBy(...)`. QueryBuilder.Limit records `hasLimit = n > 0`, so
@@ -256,7 +256,7 @@ func TestExemplarsRateAndCountIgnoreAttr(t *testing.T) {
 // byte-identical statement and an identical args slice; only two dead
 // allocations differ. (A negative maxPerSeries fails both forms alike.)
 //
-// exemplars.go:228:51 (ARITHMETIC_BASE, `make([]Frag, 0,
+// exemplars.go:235:51 (ARITHMETIC_BASE, `make([]Frag, 0,
 // len(groupAliases)*2+6)` -> `len(groupAliases)/2+6`). The mutated operand
 // is the Attributes-map slice's capacity HINT, which append grows on
 // demand; `len/2 + 6` is non-negative for every input, so it cannot even

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -1277,7 +1277,11 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 	if zeroFill {
 		outerSb.Select(As(metricsSumWeightReducerFrag(m.Op, rangeSeconds), m.ValueAlias))
 	} else {
-		outerSb.Select(As(metricsReducerFrag(m.Op, fn, params, args, rangeSeconds), m.ValueAlias))
+		reducer, err := metricsReducerFrag(m.Op, fn, params, args)
+		if err != nil {
+			return err
+		}
+		outerSb.Select(As(reducer, m.ValueAlias))
 	}
 
 	// GROUP BY group aliases + anchor_ts.
@@ -1419,6 +1423,31 @@ func metricsOpZeroFillsEmptyBuckets(op chplan.MetricsOp) bool {
 	case chplan.MetricsOpCountOverTime,
 		chplan.MetricsOpRate,
 		chplan.MetricsOpQuantileOverTime:
+		return true
+	}
+	return false
+}
+
+// metricsOpCountsRowsRatherThanOperand reports whether the given
+// MetricsAggregate.Op derives its value from the NUMBER of matching rows
+// rather than from a per-row operand column. rate and count_over_time do
+// (metricsAggregateCH maps both to `count(1)`); every other op reduces
+// over MetricsAggregate.Attr and therefore needs that operand projected
+// under the `metric_arg` alias first.
+//
+// This is deliberately NOT metricsOpZeroFillsEmptyBuckets: that predicate
+// also carries quantile_over_time, which reads an operand and merely
+// shares the zero-filling wire contract. The two sets answer different
+// questions and only overlap.
+//
+// The exemplars emitter branches on this twice — once to decide whether
+// to PROJECT `metric_arg` and once to decide whether to READ it — and
+// those two decisions must agree or the emitted SQL references an
+// unprojected column (see TestExemplarsRateAndCountIgnoreAttr). Naming
+// the predicate once is what makes the agreement structural.
+func metricsOpCountsRowsRatherThanOperand(op chplan.MetricsOp) bool {
+	switch op {
+	case chplan.MetricsOpRate, chplan.MetricsOpCountOverTime:
 		return true
 	}
 	return false
@@ -2621,39 +2650,43 @@ func windowValsFrag() Frag {
 	)
 }
 
-// metricsReducerFrag returns the per-bucket reducer Frag for the matrix
-// emission path. rate normalises `count(1)` by dividing through the
-// range duration in seconds (rendered as a literal — duration constants
-// are query-shape, not user-data).
+// metricsReducerFrag returns the per-bucket reducer Frag for the
+// OBSERVED-ONLY branch of the matrix emission path: the CH aggregate
+// metricsAggregateCH selected, applied to the operand column the sample
+// SELECT projects under the `metric_arg` alias.
 //
-// The reducer is always wrapped in `toFloat64(...)` so the projected
-// `Value` column has a uniform Float64 wire type — `chclient.Sample.Value`
-// is `float64`, and the CH Go driver refuses to coerce UInt64 (the
-// natural type of `count()`) or Int64 (the natural type of
-// `sum/min/max(Duration)`) into `*float64` at Scan time. Without the
-// cast, `| count_over_time() by (...)` against a real ClickHouse
-// surfaces as `engine: execute: chclient: scan: (Value) converting
-// UInt64 to *float64 is unsupported`. The rate case keeps the cast as
-// well even though `count() / N` already promotes to Float64 in CH —
-// the uniform wrap is cheaper to reason about than a per-op exception.
-func metricsReducerFrag(op chplan.MetricsOp, fn chplan.Fn, params, args []chplan.Expr, rangeSeconds float64) Frag {
+// Only the operand-reading ops reach here — sum / avg / min /
+// max_over_time. The row-counting ops (rate, count_over_time) and
+// quantile_over_time zero-fill their empty buckets, so
+// emitRangeWindowMetrics answers them with metricsSumWeightReducerFrag
+// or with the bucket-shape emitter before the reducer choice reaches
+// this function (see metricsOpZeroFillsEmptyBuckets). Their sample arm
+// projects no `metric_arg` at all — it projects the `in_window` weight
+// instead — so reducing over `metric_arg` here would emit SQL naming a
+// column the FROM does not expose. The guard below refuses rather than
+// renders that.
+//
+// The reducer is wrapped in `toFloat64(...)` so the projected `Value`
+// column has a uniform Float64 wire type — `chclient.Sample.Value` is
+// `float64`, and the CH Go driver refuses to coerce Int64 (the natural
+// type of `sum/min/max(Duration)`) into `*float64` at Scan time.
+// TestRangeWindowMetricsReducerIsFloat64 pins the wrap across the whole
+// op matrix.
+func metricsReducerFrag(op chplan.MetricsOp, fn chplan.Fn, params, args []chplan.Expr) (Frag, error) {
+	if metricsOpCountsRowsRatherThanOperand(op) {
+		return nil, fmt.Errorf(
+			"%w: MetricsAggregate op %s counts rows rather than reading an operand, so it is "+
+				"answered by the zero-fill reducer and never by the observed-only operand reducer",
+			ErrUnsupported, op,
+		)
+	}
 	// Translate Attr operand to a metric_arg reference (the alias the
 	// inner SELECT projects under) for *_over_time cases.
 	aggArgs := make([]chplan.Expr, len(args))
 	for i := range args {
 		aggArgs[i] = &chplan.ColumnRef{Name: "metric_arg"}
 	}
-	if op == chplan.MetricsOpRate || op == chplan.MetricsOpCountOverTime {
-		// args is [LitInt{1}] — pass through verbatim so we emit count(?).
-		aggArgs = args
-	}
-
-	agg := Call("toFloat64", aggFuncFrag(chplan.AggFunc{Fn: fn, Params: params, Args: aggArgs}))
-	switch op {
-	case chplan.MetricsOpRate:
-		return Div(agg, InlineLit(rangeSeconds))
-	}
-	return agg
+	return Call("toFloat64", aggFuncFrag(chplan.AggFunc{Fn: fn, Params: params, Args: aggArgs})), nil
 }
 
 // outerGroupAliases returns the SELECT-list aliases used to refer to

--- a/internal/chsql/range_window_metrics_reducer_mutation_test.go
+++ b/internal/chsql/range_window_metrics_reducer_mutation_test.go
@@ -2,6 +2,7 @@ package chsql
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -73,9 +74,9 @@ func metricsReducerRoutePlan(op chplan.MetricsOp) *chplan.RangeWindow {
 	}
 }
 
-// TestMetricsMatrixCountingOpsTakeTheZeroFillReducer pins the routing fact the
-// NOT KILLABLE note at the foot of this file depends on: in the matrix path,
-// rate and count_over_time are answered by the zero-fill reducer
+// TestMetricsMatrixCountingOpsTakeTheZeroFillReducer pins the routing fact
+// metricsReducerFrag's guard depends on: in the matrix path, rate and
+// count_over_time are answered by the zero-fill reducer
 // (metricsSumWeightReducerFrag) and never reach metricsReducerFrag at all.
 //
 // The two are not interchangeable. metricsSumWeightReducerFrag sums the
@@ -139,8 +140,8 @@ func TestMetricsMatrixCountingOpsTakeTheZeroFillReducer(t *testing.T) {
 	// metricsReducerFrag, asserted directly and over the WHOLE enum rather
 	// than a hand-picked sample: an op added to chplan.MetricsOp later must
 	// have its zero-fill answer recorded here, or this fails. That is what
-	// keeps the equivalence note at the foot of this file from quietly going
-	// stale behind a new op.
+	// keeps a new op from quietly joining the observed-only branch without
+	// anyone deciding whether its empty buckets need filling.
 	t.Run("zero-fill op set", func(t *testing.T) {
 		t.Parallel()
 		for op := chplan.MetricsOpInvalid; op <= chplan.MetricsOpHistogramOverTime; op++ {
@@ -157,35 +158,102 @@ func TestMetricsMatrixCountingOpsTakeTheZeroFillReducer(t *testing.T) {
 	})
 }
 
-// NOT KILLABLE — documented, not defended by a test.
+// metricsReducerRowCountingOps are the MetricsAggregate ops whose value is the
+// NUMBER of matching rows rather than a reduction over an operand column.
+// metricsReducerFrag refuses them; emitRangeWindowMetrics never offers them.
+var metricsReducerRowCountingOps = []chplan.MetricsOp{
+	chplan.MetricsOpRate,
+	chplan.MetricsOpCountOverTime,
+}
+
+// metricsReducerOperandOps are the ops that DO reach metricsReducerFrag from
+// emitRangeWindowMetrics: the observed-only ops, which reduce over the operand
+// the sample SELECT projects as `metric_arg`. quantile_over_time is absent
+// because it leaves emitRangeWindowMetrics for the bucket-shape emitter before
+// any reducer is chosen; MetricsOpInvalid and histogram_over_time are absent
+// because metricsAggregateCH refuses them first.
+var metricsReducerOperandOps = []chplan.MetricsOp{
+	chplan.MetricsOpSumOverTime,
+	chplan.MetricsOpAvgOverTime,
+	chplan.MetricsOpMinOverTime,
+	chplan.MetricsOpMaxOverTime,
+}
+
+// TestMetricsReducerFragRefusesRowCountingOps reaches metricsReducerFrag's
+// guard by calling it directly with each row-counting op — the call
+// emitRangeWindowMetrics cannot make, since its `if zeroFill` branch sends both
+// ops to metricsSumWeightReducerFrag instead.
 //
-// range_window.go:2646:32 (INVERT_LOGICAL, `if op == chplan.MetricsOpRate ||
-// op == chplan.MetricsOpCountOverTime` -> `&&`, inside metricsReducerFrag).
-// The mutated conjunction is unsatisfiable, so the block never runs — but
-// neither does the original disjunction, because metricsReducerFrag is never
-// called with either of those two ops.
+// The guard replaced two arms that handled exactly these ops and that no input
+// could reach (cerberus issue #2945). It exists so the impossibility is
+// ENFORCED rather than merely commented: a later edit that widened the
+// observed-only branch to a row-counting op would otherwise emit
+// `count(metric_arg)` over a sample arm that projects `in_window` and no
+// `metric_arg` at all — SQL naming a column its own FROM does not expose.
 //
-// metricsReducerFrag has exactly ONE caller in the tree
-// (emitRangeWindowMetrics, range_window.go:1280), and that call sits in the
-// `else` of `if zeroFill`, where `zeroFill :=
-// metricsOpZeroFillsEmptyBuckets(m.Op)` was computed from the SAME m.Op a few
-// lines above. metricsOpZeroFillsEmptyBuckets returns true for exactly
-// count_over_time, rate and quantile_over_time, so the reachable op set at
-// line 1280 excludes rate and count_over_time outright. (quantile_over_time is
-// excluded twice over: emitRangeWindowMetrics routes it to
-// emitRangeWindowMetricsQuantileBuckets before the reducer choice is made.)
-// TestMetricsMatrixCountingOpsTakeTheZeroFillReducer above pins both halves of
-// that routing, so this equivalence claim fails loudly if it ever stops
-// holding — and the mutant becomes killable again at the same moment.
+// Calling the unexported function directly is the only way to reach that
+// guard, and reaching it is the point: an error branch nothing ever executes
+// would be the same unkillable dead code this change removed.
 //
-// Verified empirically as well as by construction: emitting every one of the
-// nine chplan.MetricsOp values through the matrix path, crossed with
-// Attr-set/Attr-nil and grouped/ungrouped (36 statements), produces
-// byte-identical SQL and identical argument slices with the mutation applied
-// and reverted.
-//
-// The same reachability makes the `case chplan.MetricsOpRate` arm of
-// metricsReducerFrag's own switch, and the rate half of its doc comment,
-// stale — tracked as a separate cleanup in cerberus issue #2945, because
-// deleting reachable-looking production code belongs in a change that is about
-// that code rather than in a mutation-coverage one.
+// The operand-op half keeps the assertion discriminating — a guard widened to
+// refuse everything fails there rather than passing vacuously.
+func TestMetricsReducerFragRefusesRowCountingOps(t *testing.T) {
+	t.Parallel()
+
+	// The aggregate call metricsAggregateCH hands the reducer, per op — so
+	// the guard is exercised against the real (fn, params, args) triple
+	// rather than a hand-made one that might not be what the emitter passes.
+	chFor := func(t *testing.T, op chplan.MetricsOp) (chplan.Fn, []chplan.Expr, []chplan.Expr) {
+		t.Helper()
+		fn, params, args, err := metricsAggregateCH(&chplan.MetricsAggregate{
+			Op:   op,
+			Attr: &chplan.ColumnRef{Name: "Duration"},
+		})
+		if err != nil {
+			t.Fatalf("metricsAggregateCH(%v): %v", op, err)
+		}
+		return fn, params, args
+	}
+
+	for _, op := range metricsReducerRowCountingOps {
+		t.Run("refuses "+op.String(), func(t *testing.T) {
+			t.Parallel()
+			fn, params, args := chFor(t, op)
+			frag, err := metricsReducerFrag(op, fn, params, args)
+			if err == nil {
+				t.Fatalf("metricsReducerFrag(%v) returned a reducer; %v counts rows and must be "+
+					"refused so it can never reduce over the unprojected metric_arg column", op, op)
+			}
+			if !errors.Is(err, ErrUnsupported) {
+				t.Errorf("metricsReducerFrag(%v) error = %v, want it to wrap ErrUnsupported", op, err)
+			}
+			if frag != nil {
+				t.Errorf("metricsReducerFrag(%v) returned a non-nil Frag alongside its refusal", op)
+			}
+		})
+	}
+
+	for _, op := range metricsReducerOperandOps {
+		t.Run("renders "+op.String(), func(t *testing.T) {
+			t.Parallel()
+			fn, params, args := chFor(t, op)
+			frag, err := metricsReducerFrag(op, fn, params, args)
+			if err != nil {
+				t.Fatalf("metricsReducerFrag(%v): %v — this op reaches the reducer from "+
+					"emitRangeWindowMetrics and must render", op, err)
+			}
+			if frag == nil {
+				t.Fatalf("metricsReducerFrag(%v) returned a nil Frag and no error", op)
+			}
+			b := NewBuilder()
+			frag(b)
+			sql, _, err := b.Build()
+			if err != nil {
+				t.Fatalf("Build(%v): %v", op, err)
+			}
+			if !strings.Contains(sql, "metric_arg") {
+				t.Errorf("metricsReducerFrag(%v) = %s, want it to reduce over the projected metric_arg", op, sql)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`metricsReducerFrag` (`internal/chsql/range_window.go`) carried two arms for `rate` and
`count_over_time` that no input could reach. They are removed, and the impossibility is now
enforced by a guard rather than left as a comment.

## Proving the arms unreachable

The premise was verified independently of the issue's argument, statically and empirically.

**Statically.** `metricsReducerFrag` has exactly one caller in the tree — `emitRangeWindowMetrics`
— and that call sits in the `else` of `if zeroFill`, where `zeroFill :=
metricsOpZeroFillsEmptyBuckets(m.Op)` is computed from the same `m.Op` a few lines above and `m.Op`
is not written to in between. That predicate is true for exactly `count_over_time`, `rate` and
`quantile_over_time`, so those three cannot reach the `else`. `quantile_over_time` is excluded twice
over: `emitRangeWindowMetrics` routes it to `emitRangeWindowMetricsQuantileBuckets` before the
reducer choice is made. `MetricsOpInvalid` and `histogram_over_time` are rejected by
`metricsAggregateCH`, which runs before the branch and whose error is returned. The reachable op set
is therefore exactly `sum` / `avg` / `min` / `max_over_time`.

`MetricsAggregate` is produced only by the TraceQL lowering (`internal/traceql/`); the PromQL and
LogQL heads never construct one, so there is no second producer to widen the reachable set.

**Empirically.** Both arms were temporarily replaced with `panic(...)` and the following were run
with the instrumentation in place, none of which panicked:

- `go test -race ./internal/chsql/`
- `go test -tags chdb ./internal/chsql/... ./internal/api/tempo/...`
- `go test -tags chdb ./test/spec/traceql/` (the golden lane that owns the metrics fixtures)
- `go test ./internal/api/tempo/... ./internal/traceql/... ./internal/optimizer/... ./internal/engine/...`
- an exhaustive probe emitting every one of the nine `chplan.MetricsOp` values crossed with
  Attr-set/Attr-nil, grouped/ungrouped and three `Quantiles` shapes

## Byte-identical SQL

Two independent lines of evidence:

1. **Exhaustive matrix.** A temporary probe dumped the emitted SQL, the bound-argument slice and the
   returned error for 216 statements — 9 ops x {Attr set, nil} x {grouped, ungrouped} x {no
   quantiles, one phi, two phis} x {matrix path, exemplars path} — before and after the change.
   The two dumps `diff` clean, error strings included.
2. **Spec goldens.** The traceql, promql and logql golden lanes pass unchanged with no fixture
   regenerated; `git status` over `test/spec/` is clean. No golden churns, which is the assertion
   the deletion rests on.

## Making the impossibility structural

`metricsReducerFrag` now returns `(Frag, error)` and refuses a row-counting op instead of rendering
`count(metric_arg)` over a sample arm that projects `in_window` and no `metric_arg` at all — SQL
naming a column its own FROM does not expose.

A guard nothing reaches would relocate the very problem this PR removes, so
`TestMetricsReducerFragRefusesRowCountingOps` calls the unexported function directly with each
row-counting op. Both halves were verified discriminating: neutering the guard fails the two
`refuses` subtests, and widening it to refuse everything fails the four `renders` subtests.

## The predicate, named once

The `rate || count_over_time` set was spelled out inline at three sites. It is now
`metricsOpCountsRowsRatherThanOperand`, and the two `exemplars.go` sites share a single
`readsOperand` boolean — so the "project `metric_arg`" and "read `metric_arg`" decisions are one
decision and cannot drift apart. `TestExemplarsRateAndCountIgnoreAttr` exists because a mutation
that broke their agreement emitted SQL referencing an unprojected column; that agreement is now
structural rather than a thing a reviewer has to notice.

`metricsOpZeroFillsEmptyBuckets` is deliberately left as a separate predicate: it also carries
`quantile_over_time`, which reads an operand and merely shares the zero-filling wire contract.

## Siblings

The family was checked for the same shape. `metricsSumWeightReducerFrag` is reached only with `rate`
and `count_over_time` (its caller's `if zeroFill` arm, minus the `quantile_over_time` the emitter
routed away earlier), and both of its arms are live: `rate` takes the `/ <window seconds>` case and
`count_over_time` takes the default. `emitRangeWindowHistogram` operates on a different plan node
and has no op switch. No other unreachable arm was found.

## Bookkeeping

The `NOT KILLABLE` footer in `range_window_metrics_reducer_mutation_test.go` is deleted: the mutant
it adjudicated no longer exists, because the code it mutated is gone.
`TestMetricsMatrixCountingOpsTakeTheZeroFillReducer` stays and still pins the routing the new guard
depends on. Two `file:line` citations in `exemplars_misc_mutation_test.go` that this change shifted
were refreshed.

Closes #2945

🤖 Generated with [Claude Code](https://claude.com/claude-code)
