### PR TITLE
chore: stop tracking .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f5574358-7c30-4259-abb7-a23e8e6d99e4","pid":305230,"procStart":"87577653","acquiredAt":1778601367388}

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,10 @@ test/e2e/playwright/playwright-report/
 # drift in post-merge-golden-drift.mjs's own untracked-file scan.
 /patches/
 /patches-out/
+
+# Session-local runtime state written by the Claude Code scheduled-task
+# machinery: a session id, a pid and a proc-start stamp. It is rewritten on
+# every session start, so tracking it dirties every checkout and every
+# worktree against a value that is meaningless anywhere but the machine that
+# wrote it.
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
`.claude/scheduled_tasks.lock` is session-local runtime state — a session id, a
pid and a proc-start stamp — rewritten every time a Claude Code session starts.
It has been tracked since #69/#89, where it was swept in by accident.

## Why it matters

Every checkout and every linked worktree therefore reports a dirty tree against
a value that is meaningless anywhere but the machine that wrote it:

```
$ git pull --ff-only
error: Please commit or stash them.
$ git status --porcelain
 M .claude/scheduled_tasks.lock
```

Two concrete costs:

- `git pull --ff-only` on the primary checkout fails until the churn is dealt
  with, which is exactly the moment one is tempted to `git checkout --` a file
  that another live session is holding;
- an agent that stages broadly sweeps the churn into an unrelated commit, where
  it reads as a deliberate change to session state.

## The change

`git rm --cached` plus a `.gitignore` entry. The working file is untouched — the
machinery keeps writing it, git simply stops watching.

After this merges, a checkout that still has the tracked copy will see git
remove it on the next pull. That is correct and harmless: the running session
recreates it on demand.
