### PR TITLE
fix(chclient): classify CH errors by scope so statement rejections cannot trip the breaker

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -285,6 +285,47 @@ MeterProvider is installed before any instrument is minted: OTel's
 package-global provider is a delegating shim, and a synchronous `Add`
 recorded before delegation is dropped with no buffering and no error.
 
+#### ClickHouse circuit breaker
+
+The same `internal/chclient` meter scope carries the circuit breaker's own
+instruments. One breaker fronts each logical head, so every series is keyed on
+`head` (`prom` / `loki` / `tempo` / `probe`).
+
+| Metric                                           | Type    | Attributes      | Meaning                                                                          |
+| ------------------------------------------------ | ------- | --------------- | -------------------------------------------------------------------------------- |
+| `cerberus_ch_breaker_state`                      | gauge   | `head`          | Lifecycle phase: `0` closed, `1` open, `2` half-open.                            |
+| `cerberus_ch_breaker_trips_total`                | counter | `head`, `cause` | Cumulative CLOSED→OPEN trips, split by why the breaker tripped.                  |
+| `cerberus_ch_breaker_statement_rejections_total` | counter | `head`          | ClickHouse rejections classified as statement-scoped and deliberately uncounted. |
+
+The phase rides the gauge's numeric LEVEL, never a `state` label: an OTel
+observable gauge only overwrites the series it re-observes, so a phase-keyed
+label would orphan the previous phase's series and leave a recovered breaker
+still exporting `state="open"=1` forever.
+
+A trip is the highest-blast-radius event cerberus has — it fast-fails every
+query behind that head with a 503 and flips `/readyz` — so `cause` names which
+kind of backend trouble caused it:
+
+- `no-server-answer` — ClickHouse never answered: a refused dial, a dropped
+  connection, a socket timeout, an unrecognised driver failure.
+- `server-condition` — ClickHouse answered, but with a code naming a condition
+  of the server or its cluster (saturation, coordination loss, allocator
+  failure). The trip's WARN log additionally names the code and its symbolic
+  name.
+
+Statement-scoped rejections — a syntax error, an unknown column, an
+unsatisfiable setting combination — can never trip the breaker. ClickHouse
+answering a statement with a typed exception is positive proof it is serving,
+and counting those turns a handful of bad queries into a shed-everything
+outage: exactly what happened when ~21 code-704 rejections became 1015 compat
+divergences and read like a total engine regression for 32 hours. They are
+counted separately instead, and the pair is what makes triage decidable:
+
+- rising `statement_rejections_total` with a flat `trips_total` — cerberus is
+  emitting SQL ClickHouse declines. The backend is fine; look at the query
+  pipeline.
+- rising `trips_total` — the backend is in trouble; `cause` says which kind.
+
 #### Failure classification
 
 `result` alone answers "did the query fail", never "whose fault was

--- a/internal/chclient/breaker.go
+++ b/internal/chclient/breaker.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"sync"
 	"time"
-
-	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 // ErrCircuitOpen is the sentinel returned by Client methods when the
@@ -111,6 +109,15 @@ type breaker struct {
 	// request should be admitted as the HALF-OPEN probe.
 	openedAt time.Time
 
+	// statementRejections counts the ClickHouse rejections classified as
+	// breakerScopeStatement (the server parsed and answered the statement)
+	// since the breaker last tripped. It never influences the state machine —
+	// that is the entire point of the classification — and exists so the trip
+	// log can say how many bad statements were in flight around the trip.
+	// Reset to 0 on each CLOSED->OPEN trip so the number a trip reports is
+	// scoped to the run-up to that trip and not to all of process history.
+	statementRejections int
+
 	// probeInFlight is set when a HALF-OPEN probe has been admitted
 	// and not yet completed. Concurrent allow() calls during the
 	// HALF-OPEN window see it set and short-circuit to
@@ -190,6 +197,18 @@ func (b *breaker) resolveOpenInterval() time.Duration {
 		return b.openInterval
 	}
 	return breakerOpenInterval
+}
+
+// noteStatementRejection records that ClickHouse rejected one statement while
+// remaining demonstrably alive. It takes b.mu because record's own critical
+// section has not begun at the point it is called (the classification runs
+// before the lock so the neutral paths never contend), and it deliberately
+// touches NOTHING but the counter: a statement rejection must not advance,
+// reset, or reorder any part of the state machine.
+func (b *breaker) noteStatementRejection() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.statementRejections++
 }
 
 // nowOrTime returns b.now() if set, otherwise time.Now(). Kept as a
@@ -338,67 +357,36 @@ func (b *breaker) record(ctx context.Context, err error) {
 		return
 	}
 
-	// A ClickHouse MEMORY_LIMIT_EXCEEDED rejection (code 241) is a
-	// per-query resource cap doing its job, not CH being down: the
-	// server answered with a typed exception, which is positive proof
-	// it is alive and healthy. Count it as a SUCCESS so a burst of
-	// over-broad queries (e.g. several wide-window matrix panels fired
-	// concurrently by a dashboard refresh) can never trip the breaker
-	// and 503 unrelated traffic. This mirrors the sample-budget
-	// contract (ErrTooManySamples), which stays out of the failure
-	// count by construction because it surfaces post-open via
-	// cursor.Err(); the memory cap can additionally reject at query
-	// open, so it needs the explicit filter here.
-	if err != nil && isMemoryLimitExceeded(err) {
-		err = nil
-	}
-
-	// A ClickHouse TIMEOUT_EXCEEDED rejection (code 159) is the
-	// wall-clock sibling of the memory cap above: the server enforcing
-	// the per-query `max_execution_time` cerberus stamps (with
-	// timeout_overflow_mode=throw) on a query that ran too long. The
-	// server answering with a typed exception is positive proof it is
-	// alive and healthy — a deliberately-slow / pathological query is
-	// not a CH outage. Count it as a SUCCESS so a burst of over-long
-	// queries can never trip the breaker and 503 unrelated traffic,
-	// exactly as the code-241 memory rejection is handled.
-	if err != nil && isQueryTimeoutExceeded(err) {
-		err = nil
-	}
-
-	// A deliberate, emitter-planted throwIf guard (code 395) is the clearest
-	// case of all: cerberus PUT that rejection in the SQL itself — the
-	// resource-bound ceilings, the shape-fault assertions — so the server
-	// raising it is not merely proof CH is alive, it is proof cerberus's own
-	// pre-flight logic worked exactly as designed.
+	// SCOPE CLASSIFICATION. Whose condition does this failure report? Only an
+	// error that is evidence about the SERVER may advance the failure counter;
+	// an error that is evidence about the STATEMENT (the server parsed it and
+	// answered with a typed code) or about this process (a local pool acquire
+	// timed out) is neutralised to a SUCCESS, exactly as the hand-enumerated
+	// code-241 / code-159 / code-395 / acquire-timeout arms this replaces did.
 	//
-	// This became load-bearing when the RangeBucketGridNative density bound
-	// was recalibrated to the measured OOM cliff (#2681). While that bound
-	// was several times too permissive, guard rejections were rare enough
-	// that counting them never tripped anything; an honest bound fires on
-	// every genuinely-oversized query, so a dashboard refresh with a few wide
-	// panels would open the breaker and 503 unrelated traffic — the same
-	// failure mode the code-241 carve-out above exists to prevent, reached by
-	// a different door.
-	if err != nil && isThrowIfGuard(err) {
-		err = nil
-	}
-
-	// A pool acquire-timeout (clickhouse.ErrAcquireConnTimeout) is NOT a
-	// ClickHouse-health failure: it means every connection in the local
-	// pool is busy and the acquire blocked past DialTimeout without one
-	// freeing up. That is a local pool-sizing signal — the cerberus
-	// replica is asking CH for more concurrency than MaxOpenConns
-	// allows — and says nothing about whether ClickHouse is alive. The
-	// sharded-pushdown solver's fan-out makes this reachable under
-	// healthy CH, so counting it would let a too-small pool trip the
-	// breaker and 503 traffic against a perfectly healthy backend. Treat
-	// it as a SUCCESS so it can never advance the failure counter, the
-	// same way the code-241 memory-limit rejection is handled above. The
-	// fix for a recurring acquire-timeout is to raise MaxOpenConns, not
-	// to fail CH health.
-	if err != nil && errors.Is(err, clickhouse.ErrAcquireConnTimeout) {
-		err = nil
+	// The arms were replaced because they were four instances of one argument
+	// — "the server answered, so it is alive" — rediscovered one incident at a
+	// time, and code 704 was the fifth instance nobody had had an incident for
+	// yet (#2900: ~21 statement rejections became 1015 divergences). The
+	// argument now lives in breaker_classify.go as the rule, so an unseen code
+	// is classified on arrival instead of after an outage.
+	//
+	// Neutralising to SUCCESS rather than to "no verdict" is the pre-existing
+	// contract and is deliberate: under HALF-OPEN, a server that answers a
+	// statement HAS demonstrated it is serving, which is what the probe asked.
+	outcome := breakerOutcome{Scope: breakerScopeServerHealth, Code: chCodeNoServerAnswer}
+	if err != nil {
+		outcome = classifyBreakerOutcome(err)
+		if outcome.Scope == breakerScopeStatement {
+			// Standing signal: statement rejections no longer trip anything,
+			// so without their own stream a storm of them is invisible in the
+			// telemetry — the 32-hour blind spot of #2895.
+			b.metrics.recordStatementRejection(b.head)
+			b.noteStatementRejection()
+		}
+		if outcome.Scope != breakerScopeServerHealth {
+			err = nil
+		}
 	}
 
 	// Client-initiated cancellation is not a ClickHouse health
@@ -505,11 +493,34 @@ func (b *breaker) record(ctx context.Context, err error) {
 			b.openedAt = now
 			b.failures = 0
 			b.failureWindowStart = time.Time{}
-			b.metrics.recordTrip(b.head)
-			breakerLogger().Warn("ch circuit breaker tripped OPEN: fast-failing all queries (503) until recovery",
+			b.metrics.recordTrip(b.head, outcome.tripCause())
+			// Name the cause on the trip line itself. A trip 503s every query
+			// behind this head, so misattributing it is expensive: during
+			// #2895 a compat score that read like a total engine regression
+			// masked ~21 bad statements for 32 hours. `cause` says whether the
+			// backend went silent or answered with a server-condition code;
+			// `statement_rejections_since_last_trip` says how many
+			// statement-scoped rejections were neutralised alongside, so a
+			// triager can see at a glance whether the two are related.
+			args := []any{
 				"from", "closed", "to", "open",
 				"threshold", b.resolveThreshold(),
-				"window", b.resolveWindow().String())
+				"window", b.resolveWindow().String(),
+				"cause", outcome.tripCause(),
+				"statement_rejections_since_last_trip", b.statementRejections,
+			}
+			// Only a server-condition trip HAS a ClickHouse code. Omitting the
+			// fields entirely on a no-answer trip beats logging `ch_code=0`,
+			// which reads as a real code and would send a triager looking up
+			// error 0.
+			if outcome.Code != chCodeNoServerAnswer {
+				args = append(args, "ch_code", int(outcome.Code), "ch_code_name", outcome.codeName())
+			}
+			breakerLogger().Warn(
+				"ch circuit breaker tripped OPEN: fast-failing all queries (503) until recovery",
+				args...,
+			)
+			b.statementRejections = 0
 		}
 		return
 

--- a/internal/chclient/breaker_classify.go
+++ b/internal/chclient/breaker_classify.go
@@ -1,0 +1,338 @@
+package chclient
+
+import (
+	"errors"
+
+	"github.com/ClickHouse/ch-go"
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// breaker_classify.go — WHOSE condition does a failed ClickHouse call report?
+//
+// The circuit breaker exists for exactly one purpose: stop hammering a backend
+// that is failing to serve. Every error it counts must therefore be evidence
+// about the SERVER. An error that is evidence about the STATEMENT — this one
+// query asked for something the server declined — carries no such evidence, and
+// counting it converts a handful of bad queries into a shed-everything outage.
+//
+// That is not hypothetical. During #2895 roughly 21 queries carried an
+// unsatisfiable result-cache setting combination and came back as ClickHouse
+// code 704 (QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS). The server was
+// entirely healthy and answered every other query at the same instant, but the
+// breaker counted the 704s, tripped, and 503'd everything behind it: 144 LogQL
+// and 871 PromQL compat divergences from ~21 real failures, and a compat score
+// that read like a total engine regression for 32 hours.
+//
+// # Why this file exists rather than a fourth hand-written arm
+//
+// Before #2900 breaker.record neutralised exceptions by hand-enumerated code,
+// one incident at a time: 241 MEMORY_LIMIT_EXCEEDED, then 159 TIMEOUT_EXCEEDED,
+// then 395 FUNCTION_THROW_IF_VALUE_IS_NON_ZERO. Each arm carried its own
+// paragraph, and every paragraph made the SAME argument — "the server answered
+// with a typed exception, which is positive proof it is alive and healthy".
+// Code 704 is the fourth member of that class and it was missed only because
+// nobody had had that incident yet. Adding a 704 arm would have set up the
+// fifth. So the shared argument is promoted here into the rule itself, and the
+// codes stop being a list of incidents.
+//
+// # The rule, and its source of truth
+//
+// The load-bearing observation is transport-level, not semantic: a decoded
+// server exception can only exist if ClickHouse accepted the connection,
+// received the statement, parsed and analysed it, and wrote a typed error
+// packet back. A backend that does that is serving. Whatever else is wrong,
+// it is not "down", and shedding unrelated traffic protects nothing — the
+// rejection cost the server a parse, not a scan.
+//
+// So:
+//
+//   - No decoded server exception (dial refused, EOF, broken pipe, TLS
+//     failure, read timeout, an unrecognised driver error) => the backend did
+//     not answer => SERVER scope, counted. These are the shapes a genuine
+//     outage actually wears.
+//   - A decoded server exception => STATEMENT scope by default, neutral.
+//   - Except for a curated minority of codes that, although decoded and
+//     answered, describe a condition of the SERVER or its cluster that
+//     outlives the statement — saturation, coordination loss, allocator
+//     failure. Those are named in breakerServerHealthCodes below, each with
+//     the reason it is there.
+//
+// ClickHouse publishes no machine-readable server/statement taxonomy: its
+// ErrorCodes.cpp is a flat `M(code, NAME)` list with no category field, and
+// neither driver exposes one. A curated set is therefore unavoidable, and
+// pretending otherwise would be dishonest. What is avoidable is an unreasoned
+// list of bare numbers, so the set below is keyed by ch-go's own named
+// constants (chproto.Err*, generated from ErrorCodes.cpp) and every entry
+// carries the sentence that justifies it. The set is the EXCEPTION to a
+// principled default, not a replacement for one — it is the small side of the
+// split, and a code that is not in it is still classified, not unhandled.
+//
+// # The default for an unknown code, and why it is the safe direction
+//
+// A code nobody has enumerated is treated as STATEMENT-scoped: neutral.
+//
+// The alternative — unknown means server-health, count it — preserves the
+// breaker's protective reflex, but it is the rule that produced #2895 and it
+// re-arms itself for every code ClickHouse adds. The two failure modes are not
+// symmetric:
+//
+//   - Getting an unknown code wrong in the "count it" direction costs a total
+//     outage from a handful of bad statements, with no protective benefit,
+//     because the server demonstrably had capacity to answer. That is the
+//     realised, observed cost.
+//   - Getting an unknown code wrong in the "neutral" direction costs a delayed
+//     trip. It cannot cost a MISSED trip, because a backend sick enough to
+//     stop serving stops producing decoded exceptions: it refuses the dial,
+//     drops the connection, or times out the read, and every one of those
+//     paths is counted under the default above. The residual exposure is the
+//     narrow band where a server is simultaneously healthy enough to parse SQL
+//     and answer with a typed code, yet unhealthy enough that cerberus should
+//     shed load — and that band is precisely what breakerServerHealthCodes
+//     enumerates, extendable on evidence.
+//
+// New ClickHouse releases add statement-semantics codes constantly and
+// server-condition codes rarely; the default is aimed at the common case, and
+// the rare case has a named home. TestBreakerClassify_UnknownCodeIsStatementScoped
+// pins the default so it cannot be flipped silently.
+
+// breakerScope names whose condition a failed call reports. It is the verdict
+// breaker.record acts on: only breakerScopeServerHealth advances the failure
+// counter.
+type breakerScope int
+
+const (
+	// breakerScopeServerHealth — the error is evidence that ClickHouse
+	// cannot serve this replica's traffic: it never answered, or it
+	// answered with a code naming a server/cluster condition that outlives
+	// the statement. Counted toward the breaker.
+	breakerScopeServerHealth breakerScope = iota
+
+	// breakerScopeStatement — ClickHouse received, parsed and answered THIS
+	// statement with a typed exception. Positive proof the backend is alive;
+	// the next statement may well succeed. Never counted.
+	breakerScopeStatement
+
+	// breakerScopeClient — the call failed without ever becoming a question
+	// ClickHouse was asked (a local pool acquire timed out). Says nothing
+	// about the backend either way. Never counted.
+	breakerScopeClient
+)
+
+// String renders the scope for logs and the trip metric's cause attribute.
+// The vocabulary is stable: dashboards and runbooks key on these strings.
+func (s breakerScope) String() string {
+	switch s {
+	case breakerScopeServerHealth:
+		return "server-health"
+	case breakerScopeStatement:
+		return "statement"
+	case breakerScopeClient:
+		return "client"
+	default:
+		return "unknown"
+	}
+}
+
+// chCodeNoServerAnswer is the sentinel [breakerOutcome.Code] value meaning the
+// error carried no decoded ClickHouse exception at all — the server never got
+// far enough to name a code. ClickHouse reserves 0 for OK, so it can never
+// collide with a real exception code.
+const chCodeNoServerAnswer chproto.Error = 0
+
+// breakerOutcome is the classification of a single failed call: the scope that
+// decides whether it counts, plus the ClickHouse code that produced the
+// verdict so a trip can say WHY it tripped.
+type breakerOutcome struct {
+	// Scope is the verdict. Only breakerScopeServerHealth counts.
+	Scope breakerScope
+	// Code is the ClickHouse error code the server answered with, or
+	// chCodeNoServerAnswer when the error carried no decoded exception.
+	Code chproto.Error
+}
+
+// Trip causes: the reason a counted failure was counted. They ride the trip
+// counter as the `cause` attribute and the trip log as a field, and they are
+// the two questions a triager asks first. The vocabulary is stable —
+// dashboards and runbooks key on these strings.
+const (
+	// tripCauseNoServerAnswer — the backend never answered: a refused dial, a
+	// dropped connection, a read that timed out, an unrecognised driver
+	// failure. The backend is down or unreachable.
+	tripCauseNoServerAnswer = "no-server-answer"
+	// tripCauseServerCondition — the backend answered, but with a code naming
+	// a server or cluster condition (saturation, coordination loss, allocator
+	// failure). The backend is up and cannot serve.
+	tripCauseServerCondition = "server-condition"
+)
+
+// allTripCauses is the closed vocabulary, used to zero-initialise the trip
+// counter's streams so a healthy replica renders a flat 0 rather than "No
+// data" for every cause. Keep it in sync with [breakerOutcome.tripCause] —
+// TestBreakerMetrics_TripCauseVocabularyIsClosed pins that it is.
+var allTripCauses = []string{tripCauseNoServerAnswer, tripCauseServerCondition}
+
+// tripCause renders the reason this counted failure is counted.
+//
+// A trip can never be caused by bad statements, because statement-scoped
+// rejections are not counted at all — that is the whole point of this file —
+// but the trip log additionally names how many were neutralised alongside, so
+// a triager is not left guessing whether the two are related.
+func (o breakerOutcome) tripCause() string {
+	if o.Code == chCodeNoServerAnswer {
+		return tripCauseNoServerAnswer
+	}
+	return tripCauseServerCondition
+}
+
+// codeName renders the ClickHouse code's symbolic name (UNKNOWN_TABLE,
+// SERVER_OVERLOADED, …) for the trip log, using ch-go's generated
+// code-to-name table. An unrecognised code stringifies to its numeric form
+// rather than an empty label. Returns "" when no server exception was decoded.
+func (o breakerOutcome) codeName() string {
+	if o.Code == chCodeNoServerAnswer {
+		return ""
+	}
+	return o.Code.String()
+}
+
+// breakerServerHealthCodes is the curated minority: ClickHouse error codes
+// that arrive as a decoded server exception — so the server DID answer — yet
+// report a condition of the server or its cluster rather than of the
+// statement. A code in this set is counted toward the breaker; every other
+// decoded exception is statement-scoped and neutral (see the file header for
+// why that default is the safe direction).
+//
+// Keyed by ch-go's own generated constants so no bare number appears here and
+// each entry names itself. The value is the sentence that earns the entry its
+// place: a code with no defensible reason does not belong in the set.
+//
+// Membership criterion, applied to every entry: retrying a DIFFERENT,
+// well-formed statement against this server would fail the same way, because
+// the condition belongs to the server, not to the SQL. That is exactly the
+// situation the breaker was built to shed load for.
+var breakerServerHealthCodes = map[chproto.Error]string{
+	chproto.ErrCannotAllocateMemory: "the server's own allocator failed; the host is out of memory and the next " +
+		"statement will fail identically",
+	chproto.ErrDNSError: "the server cannot resolve a name it needs (cluster peer, external source); a property " +
+		"of the deployment, not of the SQL",
+	chproto.ErrTooManySimultaneousQueries: "the server is at its concurrency ceiling and is shedding load; backing " +
+		"off until it drains is precisely what a breaker is for",
+	chproto.ErrNoFreeConnection: "the server exhausted its own outbound connection pool to a remote shard; a " +
+		"server-side capacity limit no statement can dodge",
+	chproto.ErrSocketTimeout: "a socket the SERVER owns timed out mid-answer; the backend could not complete the " +
+		"exchange it started",
+	chproto.ErrNetworkError: "the server failed talking to a peer replica or shard; the cluster, not the query, " +
+		"is broken",
+	chproto.ErrAborted: "the server aborted the work, characteristically while shutting down; it is on its way " +
+		"out of service",
+	chproto.ErrNoAvailableReplica: "a distributed read found no live replica to serve it; the cluster cannot " +
+		"answer any query for that data",
+	chproto.ErrAllConnectionTriesFailed: "the server could not reach a shard after exhausting its retries; the " +
+		"cluster topology is degraded",
+	chproto.ErrAllReplicasLost: "every replica for the data is gone; the condition is total and statement-" +
+		"independent",
+	chproto.ErrSystemError: "a syscall-level failure inside the server; the process itself is in trouble",
+	chproto.ErrCannotScheduleTask: "the server's thread pool could not accept the work; it is saturated and the " +
+		"next statement will be too",
+	chproto.ErrAuthenticationFailed: "the backend refuses this replica's credentials; every subsequent statement " +
+		"fails identically until the deployment is fixed, so failing fast is correct",
+	chproto.ErrTableIsBeingRestarted: "the table is temporarily out of service server-side; no statement can read " +
+		"it until the restart completes",
+	chproto.ErrServerOverloaded: "the server is explicitly signalling overload and asking callers to back off; " +
+		"ignoring it would be the opposite of what a breaker is for",
+	chproto.ErrKeeperException: "the coordination layer (Keeper/ZooKeeper) is unavailable; replicated tables " +
+		"cannot be served regardless of the statement",
+}
+
+// classifyBreakerOutcome derives the [breakerOutcome] for a non-nil error
+// observed by the breaker. err is the RAW error the driver returned — the
+// breaker classifies before chclient's own wrapping runs — so both dials are
+// normalised here rather than at the call sites.
+//
+// Ordering is deliberate:
+//
+//  1. A local pool acquire timeout never became a question ClickHouse was
+//     asked, so it is decided before anything tries to read a server code.
+//  2. Everything else is reduced to "did the server answer with a typed
+//     exception, and if so which code", which decides the rest.
+//
+// Cancellation belongs to record rather than to this function: a caller
+// walking away has its own half-open probe semantics (release the probe slot
+// rather than resolve it either way). See record's cancellation arm.
+func classifyBreakerOutcome(err error) breakerOutcome {
+	// A pool acquire timeout means every connection in the LOCAL pool was
+	// busy and the acquire blocked past DialTimeout without one freeing up.
+	// That is a cerberus-side sizing signal — this replica is asking for more
+	// concurrency than MaxOpenConns allows — and says nothing about whether
+	// ClickHouse is alive. The solver's sharded fan-out makes it reachable
+	// against a perfectly healthy backend, so counting it would let a
+	// too-small pool 503 traffic CH was ready to serve. The fix for a
+	// recurring acquire timeout is to raise MaxOpenConns, not to fail CH
+	// health.
+	if errors.Is(err, clickhouse.ErrAcquireConnTimeout) {
+		return breakerOutcome{Scope: breakerScopeClient, Code: chCodeNoServerAnswer}
+	}
+
+	// The columnar sample-budget sentinel is cerberus's OWN stop signal: the
+	// decoder latched a *TooManySamplesError and returned errBudgetExceeded
+	// purely to unwind ch-go's pool.Do. ClickHouse was mid-answer and
+	// perfectly healthy; this process chose to stop reading. Classified here
+	// rather than filtered at the columnar call site so every caller of record
+	// gets one verdict from one place.
+	if isBudgetErr(err) {
+		return breakerOutcome{Scope: breakerScopeClient, Code: chCodeNoServerAnswer}
+	}
+
+	code, answered := serverExceptionCode(err)
+	if !answered {
+		// The backend never named a code: a refused dial, a dropped
+		// connection, a read that timed out, a driver failure. These are the
+		// shapes a real outage wears, and they are the reason the breaker
+		// exists.
+		return breakerOutcome{Scope: breakerScopeServerHealth, Code: chCodeNoServerAnswer}
+	}
+	if _, serverScoped := breakerServerHealthCodes[code]; serverScoped {
+		return breakerOutcome{Scope: breakerScopeServerHealth, Code: code}
+	}
+	// The server parsed this statement and answered it with a typed code.
+	// Whatever it objected to belongs to the statement, and the backend
+	// proved it is serving in the act of saying so.
+	return breakerOutcome{Scope: breakerScopeStatement, Code: code}
+}
+
+// serverExceptionCode extracts the ClickHouse error code err carries, and
+// reports whether the server answered with a typed exception at all.
+//
+// It accepts every shape the same rejection wears in this package:
+//
+//   - the row dial's *clickhouse.Exception, raw off clickhouse-go/v2;
+//   - the columnar dial's ch-go *proto.Exception, which carries the identical
+//     wire code under a different Go type (the breaker sees the RAW ch-go
+//     error there — see columnarQuery — so normalising only at the row path
+//     would leave the columnar dial classifying every server rejection as an
+//     outage);
+//   - chclient's own already-wrapped forms, *MemoryLimitError and
+//     *QueryTimeoutError, whose Cause is normally the exception but is
+//     permitted to be nil (the constructors accept a nil Cause), leaving the
+//     sentinel as the only evidence. Those two sentinels are by construction
+//     codes 241 and 159 — per-query resource caps the server enforced — so
+//     they resolve to those codes rather than to "no answer".
+func serverExceptionCode(err error) (chproto.Error, bool) {
+	var ex *clickhouse.Exception
+	if errors.As(err, &ex) {
+		return chproto.Error(ex.Code), true
+	}
+	if chEx, ok := ch.AsException(err); ok {
+		return chEx.Code, true
+	}
+	// Sentinel-only fallbacks. errors.Is rather than errors.As because these
+	// sentinels are what survives when the wrapper was built without a Cause.
+	if errors.Is(err, ErrMemoryLimitExceeded) {
+		return chproto.ErrMemoryLimitExceeded, true
+	}
+	if errors.Is(err, ErrQueryTimeout) {
+		return chproto.ErrTimeoutExceeded, true
+	}
+	return chCodeNoServerAnswer, false
+}

--- a/internal/chclient/breaker_classify_test.go
+++ b/internal/chclient/breaker_classify_test.go
@@ -1,0 +1,580 @@
+package chclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/ch-go"
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// Breaker scope-classification tests (#2900).
+//
+// The defect these pin: ~21 queries rejected with ClickHouse code 704
+// (QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS) tripped the breaker,
+// which then 503'd everything behind it — 144 LogQL and 871 PromQL compat
+// divergences from ~21 real failures. The server was healthy throughout and
+// answered every other query at the same instant.
+//
+// Both directions are pinned, because a guard that can only fail one way is
+// half a guard:
+//
+//   - statement-scoped rejections must NOT trip, however many arrive;
+//   - server-health failures must STILL trip.
+//
+// Each test names, in its own doc comment, the source mutation that turns it
+// red — the evidence it is not vacuous.
+
+// rowDialException builds the *clickhouse.Exception shape the clickhouse-go/v2
+// row dial hands the breaker.
+func rowDialException(code chproto.Error) error {
+	return &clickhouse.Exception{
+		Code:    int32(code),
+		Name:    code.String(),
+		Message: "synthetic " + code.String(),
+	}
+}
+
+// columnarDialException builds the ch-go *Exception shape the columnar dial
+// hands the breaker. It is a DIFFERENT Go type carrying the identical wire
+// code, and before #2900 the breaker's code checks could not see through it at
+// all — every columnar server rejection classified as an outage.
+func columnarDialException(code chproto.Error) error {
+	return &ch.Exception{
+		Code:    code,
+		Name:    code.String(),
+		Message: "synthetic " + code.String(),
+	}
+}
+
+// dialShapes returns both wire shapes of the same ClickHouse code, so every
+// classification assertion runs against the row dial AND the columnar dial.
+func dialShapes(code chproto.Error) map[string]error {
+	return map[string]error{
+		"row-dial":      rowDialException(code),
+		"columnar-dial": columnarDialException(code),
+		// The wrapped form the stack produces once an error has travelled a
+		// stage or two; classification must survive wrapping.
+		"wrapped-row-dial": fmt.Errorf("chclient: query: %w", rowDialException(code)),
+	}
+}
+
+// chCodeUnallocatedFuture is a ClickHouse error code that does not exist in the
+// ch-go generated table — the stand-in for "a code nobody has classified yet",
+// which is the exact situation 704 was in before this change. Chosen far above
+// the allocated range so a real ClickHouse release cannot quietly give it a
+// meaning.
+const chCodeUnallocatedFuture chproto.Error = 60000
+
+// TestBreakerClassify_StatementScopedStreamDoesNotTrip is acceptance criterion
+// 1: a SUSTAINED stream of per-statement rejections leaves the breaker CLOSED.
+// It runs far past the trip threshold for each code, on both dial shapes.
+//
+// NON-VACUITY: adding any one of these codes to breakerServerHealthCodes (or
+// flipping classifyBreakerOutcome's default from breakerScopeStatement to
+// breakerScopeServerHealth) turns that subtest red — the stream then counts and
+// the breaker reports "open".
+func TestBreakerClassify_StatementScopedStreamDoesNotTrip(t *testing.T) {
+	t.Parallel()
+
+	codes := []chproto.Error{
+		// The code that caused #2895's amplification. This is the regression.
+		chproto.ErrQueryCacheUsedWithNondeterministicFunctions,
+		// Its sibling, named in #2900 and never yet observed in an incident —
+		// the point being that it needs no incident to be classified.
+		chproto.ErrQueryCacheUsedWithSystemTable,
+		// The malformed-statement classes: a bad query is not backend illness.
+		chproto.ErrSyntaxError,
+		chproto.ErrUnknownIdentifier,
+		chproto.ErrTypeMismatch,
+		chproto.ErrUnknownTable,
+		chproto.ErrIllegalTypeOfArgument,
+		// The three codes that used to have hand-written arms in record. Their
+		// behaviour must be byte-identical after the unification.
+		chproto.ErrMemoryLimitExceeded,
+		chproto.ErrTimeoutExceeded,
+		chproto.ErrFunctionThrowIfValueIsNonZero,
+		// The unclassified future code: the default, exercised.
+		chCodeUnallocatedFuture,
+	}
+
+	for _, code := range codes {
+		t.Run(code.String(), func(t *testing.T) {
+			t.Parallel()
+			for shape, err := range dialShapes(code) {
+				t.Run(shape, func(t *testing.T) {
+					t.Parallel()
+					b := &breaker{}
+					// Ten times the threshold, with no intervening success —
+					// there is no window-rollover escape hatch here.
+					for i := 0; i < breakerThreshold*10; i++ {
+						_ = b.allow()
+						b.record(context.Background(), err)
+					}
+					if got := b.currentState(); got != "closed" {
+						t.Fatalf("%s (%d) via %s: breaker went %q after %d rejections; a statement-scoped "+
+							"rejection was counted as backend ill-health — this is the #2895 amplification",
+							code.String(), int(code), shape, got, breakerThreshold*10)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestBreakerClassify_ServerHealthStreamTrips is acceptance criterion 2: the
+// breaker still fires. Every code in the curated server-health set, plus the
+// no-server-answer shapes a real outage wears, must open the circuit within the
+// threshold.
+//
+// The expectation is an INDEPENDENT list, not a walk of
+// breakerServerHealthCodes. A test that iterates the very map it is checking
+// cannot notice an entry going missing — deleting the entry merely deletes the
+// subtest, and the suite stays green while the breaker quietly stops firing on
+// that condition. The map walk survives below as a separate, weaker check (each
+// entry must actually trip and must carry a reason), but the guard that can go
+// red is this list.
+//
+// NON-VACUITY: deleting any entry named in mustTripCodes from
+// breakerServerHealthCodes turns its subtest red — the code falls through to
+// the statement-scoped default, stops being counted, and the breaker stays
+// "closed".
+func TestBreakerClassify_ServerHealthStreamTrips(t *testing.T) {
+	t.Parallel()
+
+	// mustTripCodes are ClickHouse codes that MUST count toward the breaker.
+	// Each is a condition of the server or its cluster that outlives the
+	// statement: retrying different, well-formed SQL against this backend
+	// would fail the same way, which is exactly what shedding load is for.
+	mustTripCodes := []chproto.Error{
+		chproto.ErrServerOverloaded,
+		chproto.ErrTooManySimultaneousQueries,
+		chproto.ErrKeeperException,
+		chproto.ErrAllConnectionTriesFailed,
+		chproto.ErrNoAvailableReplica,
+		chproto.ErrAllReplicasLost,
+		chproto.ErrNetworkError,
+		chproto.ErrSocketTimeout,
+		chproto.ErrSystemError,
+		chproto.ErrCannotAllocateMemory,
+		chproto.ErrCannotScheduleTask,
+		chproto.ErrNoFreeConnection,
+		chproto.ErrDNSError,
+		chproto.ErrAborted,
+		chproto.ErrAuthenticationFailed,
+		chproto.ErrTableIsBeingRestarted,
+	}
+
+	t.Run("must-trip-codes", func(t *testing.T) {
+		t.Parallel()
+		for _, code := range mustTripCodes {
+			t.Run(code.String(), func(t *testing.T) {
+				t.Parallel()
+				for shape, err := range dialShapes(code) {
+					t.Run(shape, func(t *testing.T) {
+						t.Parallel()
+						b := &breaker{}
+						for i := 0; i < breakerThreshold; i++ {
+							_ = b.allow()
+							b.record(context.Background(), err)
+						}
+						if got := b.currentState(); got != "open" {
+							t.Fatalf("%s (%d) via %s: breaker is %q after %d failures; a server-condition "+
+								"code stopped counting and the breaker can no longer protect the backend",
+								code.String(), int(code), shape, got, breakerThreshold)
+						}
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("curated-set-entries-are-reasoned-and-live", func(t *testing.T) {
+		t.Parallel()
+		if len(breakerServerHealthCodes) == 0 {
+			t.Fatal("breakerServerHealthCodes is empty: the breaker can no longer fire on any answered code")
+		}
+		for code, reason := range breakerServerHealthCodes {
+			t.Run(code.String(), func(t *testing.T) {
+				t.Parallel()
+				// Every entry earns its place with a sentence. An unreasoned
+				// number is precisely the hand-list this change removed, and a
+				// blank reason would let one back in.
+				if strings.TrimSpace(reason) == "" {
+					t.Fatalf("%s carries no reason; an unreasoned entry is the hand-list this change removed",
+						code.String())
+				}
+				// And every entry is live: being in the set must actually
+				// produce the server-health verdict, so a typo'd key cannot
+				// sit in the map documenting behaviour it does not cause.
+				if got := classifyBreakerOutcome(rowDialException(code)).Scope; got != breakerScopeServerHealth {
+					t.Fatalf("%s is in breakerServerHealthCodes but classifies %v", code.String(), got)
+				}
+			})
+		}
+	})
+
+	// The shapes a backend that never answered wears. None carries a decoded
+	// exception, and every one of them must still count.
+	t.Run("no-server-answer", func(t *testing.T) {
+		t.Parallel()
+		cases := map[string]error{
+			"dial-refused":   errors.New("dial tcp 127.0.0.1:9000: connect: connection refused"),
+			"eof":            errors.New("unexpected EOF"),
+			"broken-pipe":    errors.New("write tcp 127.0.0.1:9000: write: broken pipe"),
+			"read-timeout":   errors.New("read tcp 127.0.0.1:9000: i/o timeout"),
+			"deadline":       context.DeadlineExceeded,
+			"driver-unknown": errors.New("clickhouse: unexpected packet 42 from server"),
+		}
+		for name, err := range cases {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				b := &breaker{}
+				for i := 0; i < breakerThreshold; i++ {
+					_ = b.allow()
+					b.record(context.Background(), err)
+				}
+				if got := b.currentState(); got != "open" {
+					t.Fatalf("%s: breaker is %q after %d failures; the breaker no longer fires on a backend "+
+						"that never answered", name, got, breakerThreshold)
+				}
+			})
+		}
+	})
+}
+
+// TestBreakerClassify_UnknownCodeIsStatementScoped pins the DEFAULT direction
+// on its own, separately from the sustained-stream test, so a change of default
+// cannot hide behind a table entry. An unallocated code is statement-scoped:
+// the server answered it, therefore the server is serving.
+//
+// NON-VACUITY: flipping classifyBreakerOutcome's fall-through return from
+// breakerScopeStatement to breakerScopeServerHealth turns this red.
+func TestBreakerClassify_UnknownCodeIsStatementScoped(t *testing.T) {
+	t.Parallel()
+	if _, listed := breakerServerHealthCodes[chCodeUnallocatedFuture]; listed {
+		t.Fatalf("code %d is in breakerServerHealthCodes; pick a genuinely unallocated code for this test",
+			int(chCodeUnallocatedFuture))
+	}
+	got := classifyBreakerOutcome(rowDialException(chCodeUnallocatedFuture))
+	if got.Scope != breakerScopeStatement {
+		t.Fatalf("unknown code %d classified %v, want %v: an unenumerated code must default to "+
+			"statement-scoped, or every future ClickHouse code re-arms the #2895 amplification",
+			int(chCodeUnallocatedFuture), got.Scope, breakerScopeStatement)
+	}
+	if got.Code != chCodeUnallocatedFuture {
+		t.Fatalf("classified code = %d, want %d", int(got.Code), int(chCodeUnallocatedFuture))
+	}
+}
+
+// TestBreakerClassify_BothDialsAgree pins that the row dial's
+// *clickhouse.Exception and the columnar dial's ch-go *Exception reach the
+// SAME verdict for the same wire code. Before #2900 they did not: the breaker's
+// code checks only understood *clickhouse.Exception, so every server rejection
+// on the columnar dial — code 241 and 159 included — classified as an outage.
+//
+// NON-VACUITY: deleting the ch.AsException branch from serverExceptionCode
+// turns this red on every columnar case (they all collapse to
+// no-server-answer / server-health).
+func TestBreakerClassify_BothDialsAgree(t *testing.T) {
+	t.Parallel()
+	codes := []chproto.Error{
+		chproto.ErrQueryCacheUsedWithNondeterministicFunctions,
+		chproto.ErrMemoryLimitExceeded,
+		chproto.ErrTimeoutExceeded,
+		chproto.ErrFunctionThrowIfValueIsNonZero,
+		chproto.ErrServerOverloaded,
+		chproto.ErrKeeperException,
+		chCodeUnallocatedFuture,
+	}
+	for _, code := range codes {
+		t.Run(code.String(), func(t *testing.T) {
+			t.Parallel()
+			row := classifyBreakerOutcome(rowDialException(code))
+			columnar := classifyBreakerOutcome(columnarDialException(code))
+			if row != columnar {
+				t.Fatalf("dial disagreement for %s (%d): row=%+v columnar=%+v; the same server rejection "+
+					"must reach the same verdict on both dials", code.String(), int(code), row, columnar)
+			}
+			if row.Code != code {
+				t.Fatalf("%s: classified code = %d, want %d", code.String(), int(row.Code), int(code))
+			}
+		})
+	}
+}
+
+// TestBreakerClassify_ClientScopedNeverCounts pins the third scope: failures
+// that never became a question ClickHouse was asked. Both are pre-existing
+// carve-outs the unification absorbed, kept here so absorbing them cannot
+// quietly drop them.
+func TestBreakerClassify_ClientScopedNeverCounts(t *testing.T) {
+	t.Parallel()
+	cases := map[string]error{
+		"pool-acquire-timeout":         clickhouse.ErrAcquireConnTimeout,
+		"wrapped-pool-acquire-timeout": fmt.Errorf("chclient: query: %w", clickhouse.ErrAcquireConnTimeout),
+		"columnar-sample-budget":       errBudgetExceeded,
+	}
+	for name, err := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyBreakerOutcome(err).Scope; got != breakerScopeClient {
+				t.Fatalf("%s classified %v, want %v", name, got, breakerScopeClient)
+			}
+			b := &breaker{}
+			for i := 0; i < breakerThreshold*3; i++ {
+				_ = b.allow()
+				b.record(context.Background(), err)
+			}
+			if got := b.currentState(); got != "closed" {
+				t.Fatalf("%s: breaker went %q; a client-scoped failure was counted as backend ill-health",
+					name, got)
+			}
+		})
+	}
+}
+
+// TestBreakerTripCause_VocabularyIsClosed pins that every cause
+// [breakerOutcome.tripCause] can produce is present in allTripCauses — the
+// slice the trip counter zero-initialises from. A cause missing from the slice
+// exports no baseline stream and renders "No data" instead of a flat 0 until
+// its first trip.
+func TestBreakerTripCause_VocabularyIsClosed(t *testing.T) {
+	t.Parallel()
+	seen := map[string]bool{}
+	outcomes := []breakerOutcome{
+		{Scope: breakerScopeServerHealth, Code: chCodeNoServerAnswer},
+		{Scope: breakerScopeServerHealth, Code: chproto.ErrServerOverloaded},
+		{Scope: breakerScopeStatement, Code: chproto.ErrQueryCacheUsedWithNondeterministicFunctions},
+		{Scope: breakerScopeClient, Code: chCodeNoServerAnswer},
+	}
+	for _, o := range outcomes {
+		seen[o.tripCause()] = true
+	}
+	known := map[string]bool{}
+	for _, c := range allTripCauses {
+		known[c] = true
+	}
+	for c := range seen {
+		if !known[c] {
+			t.Fatalf("tripCause %q is not in allTripCauses; its trip stream will have no zero-init baseline", c)
+		}
+	}
+	if len(known) != len(allTripCauses) {
+		t.Fatalf("allTripCauses contains duplicates: %v", allTripCauses)
+	}
+}
+
+// TestBreakerTrip_CarriesCauseContext is acceptance criterion 3: a trip event
+// says enough to route the triage. It asserts on BOTH channels a responder
+// reaches for — the trip counter's `cause` attribute and the WARN log line —
+// and it asserts the two trip flavours are DISTINGUISHABLE, which is the whole
+// requirement: during #2895 the only available signal (a collapsed compat
+// score) pointed at the wrong subsystem for 32 hours.
+//
+// NON-VACUITY: dropping the `cause` attribute from recordTrip turns the
+// counter half red (both trips land on one stream and the two flavours become
+// indistinguishable); dropping the `cause` / ch_code_name fields from the trip
+// log turns the log half red.
+func TestBreakerTrip_CarriesCauseContext(t *testing.T) {
+	// NOT parallel: captureBreakerLogs swaps the package-level breakerLogger,
+	// and the trip-line assertion requires exclusive ownership of it.
+
+	t.Run("server-condition-trip-names-the-code", func(t *testing.T) {
+		logs := captureBreakerLogs(t)
+		reader := sdkmetric.NewManualReader()
+		b := &breaker{
+			head:    HeadProm,
+			metrics: newBreakerMetrics(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))),
+		}
+		for i := 0; i < breakerThreshold; i++ {
+			_ = b.allow()
+			b.record(context.Background(), rowDialException(chproto.ErrServerOverloaded))
+		}
+		if got := b.currentState(); got != "open" {
+			t.Fatalf("breaker is %q, want open", got)
+		}
+		if got := tripsByCause(t, reader)[tripCauseServerCondition]; got != 1 {
+			t.Fatalf("trips{cause=%s} = %d, want 1; a triager cannot tell WHY the breaker opened",
+				tripCauseServerCondition, got)
+		}
+		if got := tripsByCause(t, reader)[tripCauseNoServerAnswer]; got != 0 {
+			t.Fatalf("trips{cause=%s} = %d, want 0; the two trip flavours are not distinguishable",
+				tripCauseNoServerAnswer, got)
+		}
+		line := logs.tripLine(t)
+		for _, want := range []string{tripCauseServerCondition, "SERVER_OVERLOADED"} {
+			if !strings.Contains(line, want) {
+				t.Fatalf("trip log does not mention %q: %s", want, line)
+			}
+		}
+	})
+
+	t.Run("no-answer-trip-reports-neutralised-statements", func(t *testing.T) {
+		logs := captureBreakerLogs(t)
+		reader := sdkmetric.NewManualReader()
+		b := &breaker{
+			head:    HeadLoki,
+			metrics: newBreakerMetrics(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))),
+		}
+		// The #2895 shape: statement rejections flowing alongside a genuine
+		// outage. The rejections must not contribute to the trip, but the trip
+		// must SAY they happened so the responder is not left guessing.
+		const rejections = 3
+		for i := 0; i < rejections; i++ {
+			_ = b.allow()
+			b.record(context.Background(),
+				rowDialException(chproto.ErrQueryCacheUsedWithNondeterministicFunctions))
+		}
+		for i := 0; i < breakerThreshold; i++ {
+			_ = b.allow()
+			b.record(context.Background(), errors.New("dial tcp 127.0.0.1:9000: connection refused"))
+		}
+		if got := b.currentState(); got != "open" {
+			t.Fatalf("breaker is %q, want open", got)
+		}
+		if got := tripsByCause(t, reader)[tripCauseNoServerAnswer]; got != 1 {
+			t.Fatalf("trips{cause=%s} = %d, want 1", tripCauseNoServerAnswer, got)
+		}
+		line := logs.tripLine(t)
+		if !strings.Contains(line, tripCauseNoServerAnswer) {
+			t.Fatalf("trip log does not name the cause: %s", line)
+		}
+		if !strings.Contains(line, fmt.Sprintf("statement_rejections_since_last_trip=%d", rejections)) {
+			t.Fatalf("trip log does not report the %d neutralised statement rejections: %s", rejections, line)
+		}
+		// A no-answer trip has no ClickHouse code; logging ch_code=0 would
+		// send a responder looking up error 0.
+		if strings.Contains(line, "ch_code=") {
+			t.Fatalf("no-answer trip log invented a ClickHouse code: %s", line)
+		}
+	})
+}
+
+// TestBreakerMetrics_StatementRejectionsCounted pins the standing "we sent bad
+// statements" signal. After this change a rejection storm produces NO trip at
+// all, so without its own stream the #2895 defect would be invisible in the
+// telemetry exactly as it was for 32 hours.
+//
+// NON-VACUITY: removing the recordStatementRejection call from record turns
+// the first assertion red; counting rejections toward the breaker (the old
+// behaviour) turns the second red.
+func TestBreakerMetrics_StatementRejectionsCounted(t *testing.T) {
+	t.Parallel()
+	reader := sdkmetric.NewManualReader()
+	b := &breaker{
+		head:    HeadProm,
+		metrics: newBreakerMetrics(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))),
+	}
+	const rejections = 21 // the #2895 incident's own count
+	for i := 0; i < rejections; i++ {
+		_ = b.allow()
+		b.record(context.Background(),
+			rowDialException(chproto.ErrQueryCacheUsedWithNondeterministicFunctions))
+	}
+	if got := statementRejectionsTotal(t, reader); got != rejections {
+		t.Fatalf("statement_rejections_total = %d, want %d; the bad-statement signal is missing",
+			got, rejections)
+	}
+	if got := breakerTripsTotal(t, reader); got != 0 {
+		t.Fatalf("trips_total = %d, want 0; statement rejections tripped the breaker", got)
+	}
+	if got := b.currentState(); got != "closed" {
+		t.Fatalf("breaker is %q, want closed", got)
+	}
+}
+
+// tripsByCause reads cerberus_ch_breaker_trips_total keyed by its `cause`
+// attribute, summing across heads.
+func tripsByCause(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+	return sumCounterBy(t, reader, "cerberus_ch_breaker_trips_total", "cause")
+}
+
+// statementRejectionsTotal reads the cumulative
+// cerberus_ch_breaker_statement_rejections_total across every head.
+func statementRejectionsTotal(t *testing.T, reader *sdkmetric.ManualReader) int64 {
+	t.Helper()
+	var sum int64
+	for _, v := range sumCounterBy(t, reader, "cerberus_ch_breaker_statement_rejections_total", "head") {
+		sum += v
+	}
+	return sum
+}
+
+// sumCounterBy collects a monotonic Int64 counter from a manual-reader snapshot
+// and sums its data points grouped by the named attribute. It fails the test if
+// the metric is absent (an unexported stream is a silent observability hole) or
+// if a data point is missing the attribute.
+func sumCounterBy(t *testing.T, reader *sdkmetric.ManualReader, name, attr string) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	out := map[string]int64{}
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			found = true
+			s, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("%s data: want Sum[int64], got %T", name, m.Data)
+			}
+			for _, dp := range s.DataPoints {
+				v, ok := dp.Attributes.Value(attribute.Key(attr))
+				if !ok {
+					t.Fatalf("%s data point missing %q attribute: %v", name, attr, dp.Attributes.ToSlice())
+				}
+				out[v.AsString()] += dp.Value
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("%s not exported", name)
+	}
+	return out
+}
+
+// breakerLogCapture collects the WARN transition lines the breaker emits, so a
+// test can assert on the trip line's fields.
+type breakerLogCapture struct{ buf *strings.Builder }
+
+// captureBreakerLogs swaps breakerLogger for a text handler writing into the
+// returned capture, restoring the previous logger when the test ends. Tests
+// using it must NOT be parallel: breakerLogger is a package var.
+func captureBreakerLogs(t *testing.T) *breakerLogCapture {
+	t.Helper()
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	prev := breakerLogger
+	breakerLogger = func() *slog.Logger { return logger }
+	t.Cleanup(func() { breakerLogger = prev })
+	return &breakerLogCapture{buf: &buf}
+}
+
+// tripLine returns the single CLOSED->OPEN trip line, failing the test if the
+// breaker logged no trip or more than one.
+func (c *breakerLogCapture) tripLine(t *testing.T) string {
+	t.Helper()
+	var hits []string
+	for _, line := range strings.Split(c.buf.String(), "\n") {
+		if strings.Contains(line, "tripped OPEN") {
+			hits = append(hits, line)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("want exactly 1 trip log line, got %d:\n%s", len(hits), c.buf.String())
+	}
+	return hits[0]
+}

--- a/internal/chclient/breaker_metrics.go
+++ b/internal/chclient/breaker_metrics.go
@@ -23,6 +23,20 @@ const breakerMeterName = "github.com/tsouza/cerberus/internal/chclient"
 // bare-metric / `sum()`-style panels that don't pivot on it.
 const attrBreakerHead = attribute.Key("head")
 
+// attrBreakerCause labels every trip sample with WHY the breaker tripped —
+// `no-server-answer` (the backend never answered) or `server-condition` (it
+// answered with a code naming a server/cluster condition). See
+// [breakerOutcome.tripCause].
+//
+// It exists because a trip's blast radius (503 on every query behind that
+// head) makes misattribution expensive: during #2895 a score that looked like
+// a total engine regression masked ~21 bad statements for 32 hours. Statement
+// rejections can no longer trip the breaker at all, so a trip is always a
+// backend problem — this label says which KIND, and
+// cerberus_ch_breaker_statement_rejections_total carries the other side of the
+// picture so "we sent bad statements" is visible even when nothing trips.
+const attrBreakerCause = attribute.Key("cause")
+
 // breakerState gauge values. The gauge is a single 0/1/2 level so a dashboard
 // can render the current phase as a state-timeline without needing three
 // separate boolean series; the numeric mapping matches the breakerState iota
@@ -69,8 +83,20 @@ type breakerMetrics struct {
 	// trips is the cumulative count of CLOSED->OPEN trips — the
 	// highest-blast-radius event (one trip 503s all three heads and
 	// flips /readyz). Monotonic counter so `increase(...[5m])` resolves
-	// to the number of outages in the window.
+	// to the number of outages in the window. Attributed by `head` and by
+	// `cause` (see attrBreakerCause), so a panel says not just that a head
+	// tripped but whether the backend went silent or answered with a
+	// server-condition code.
 	trips metric.Int64Counter
+	// statementRejections is the cumulative count of per-statement ClickHouse
+	// rejections the breaker classified as breakerScopeStatement and did NOT
+	// count (see breaker_classify.go). It is the "we sent bad statements"
+	// signal, and it is deliberately a STANDING stream rather than a field on
+	// a trip event: after #2900 a statement-rejection storm produces no trip
+	// at all, so a trip-only signal would show a flat, silent, entirely
+	// healthy-looking breaker while the heads returned wrong answers. During
+	// #2895 exactly that class of defect stayed invisible for 32 hours.
+	statementRejections metric.Int64Counter
 }
 
 // newBreakerMetrics builds the breaker instrument set off mp. The trips
@@ -118,15 +144,40 @@ func newBreakerMetrics(mp metric.MeterProvider) *breakerMetrics {
 	if err != nil {
 		panic("chclient: build breaker trips counter: " + err.Error())
 	}
-	m := &breakerMetrics{meter: meter, state: state, trips: trips}
-	// Zero-init the trips counter so increase() has a baseline — for EVERY
-	// head (#94). OTel sync counters export nothing until their first Add, so
-	// without a per-head seed a healthy replica whose loki breaker never trips
-	// would export NO head="loki" trips series at all and a `sum by(head)`
-	// panel would silently miss the healthy heads. The state gauge needs no
-	// such seed: its observable callback reports every head every interval.
+	rejections, err := meter.Int64Counter(
+		"cerberus_ch_breaker_statement_rejections_total",
+		metric.WithDescription(
+			"Cumulative per-statement ClickHouse rejections the circuit "+
+				"breaker classified as statement-scoped and did NOT count "+
+				"toward tripping. A rising rate here with a flat "+
+				"cerberus_ch_breaker_trips_total means cerberus is sending "+
+				"statements ClickHouse declines, NOT that the backend is "+
+				"unhealthy.",
+		),
+		metric.WithUnit("{rejection}"),
+	)
+	if err != nil {
+		panic("chclient: build breaker statement-rejections counter: " + err.Error())
+	}
+	m := &breakerMetrics{meter: meter, state: state, trips: trips, statementRejections: rejections}
+	// Zero-init the counters so increase() has a baseline — for EVERY head
+	// (#94), and for every trip cause. OTel sync counters export nothing until
+	// their first Add, so without a per-head seed a healthy replica whose loki
+	// breaker never trips would export NO head="loki" trips series at all and
+	// a `sum by(head)` panel would silently miss the healthy heads. The same
+	// argument applies per `cause`: a replica that has only ever tripped on
+	// no-server-answer must still render a flat 0 for server-condition rather
+	// than "No data", or a triager cannot tell "never happened" from "not
+	// instrumented". The state gauge needs no such seed: its observable
+	// callback reports every head every interval.
 	for _, h := range allHeads {
-		m.trips.Add(context.Background(), 0, metric.WithAttributes(
+		for _, cause := range allTripCauses {
+			m.trips.Add(context.Background(), 0, metric.WithAttributes(
+				attrBreakerHead.String(h.String()),
+				attrBreakerCause.String(cause),
+			))
+		}
+		m.statementRejections.Add(context.Background(), 0, metric.WithAttributes(
 			attrBreakerHead.String(h.String()),
 		))
 	}
@@ -177,15 +228,31 @@ func (m *breakerMetrics) registerStateCallback(breakers ...*breaker) {
 	}
 }
 
-// recordTrip increments the CLOSED->OPEN trip counter for head. A nil receiver
-// is the no-telemetry no-op for the zero-value breaker. Increment is on the
-// CLOSED->OPEN edge ONLY (not the HALF-OPEN->OPEN re-open), so rate() over the
-// counter reads as "new outages/sec per head".
-func (m *breakerMetrics) recordTrip(head Head) {
+// recordTrip increments the CLOSED->OPEN trip counter for head, attributed by
+// the cause of the failure that crossed the threshold (see
+// [breakerOutcome.tripCause]). A nil receiver is the no-telemetry no-op for
+// the zero-value breaker. Increment is on the CLOSED->OPEN edge ONLY (not the
+// HALF-OPEN->OPEN re-open), so rate() over the counter reads as "new
+// outages/sec per head".
+func (m *breakerMetrics) recordTrip(head Head, cause string) {
 	if m == nil {
 		return
 	}
 	m.trips.Add(context.Background(), 1, metric.WithAttributes(
+		attrBreakerHead.String(head.String()),
+		attrBreakerCause.String(cause),
+	))
+}
+
+// recordStatementRejection increments the per-statement-rejection counter for
+// head — a ClickHouse exception the breaker classified as statement-scoped and
+// deliberately did not count. A nil receiver is the no-telemetry no-op for the
+// zero-value breaker.
+func (m *breakerMetrics) recordStatementRejection(head Head) {
+	if m == nil {
+		return
+	}
+	m.statementRejections.Add(context.Background(), 1, metric.WithAttributes(
 		attrBreakerHead.String(head.String()),
 	))
 }

--- a/internal/chclient/breaker_perhead_test.go
+++ b/internal/chclient/breaker_perhead_test.go
@@ -64,7 +64,10 @@ func breakerHeadStates(t *testing.T, reader *sdkmetric.ManualReader) map[string]
 }
 
 // breakerHeadTrips collects the cumulative cerberus_ch_breaker_trips_total per
-// head= label from a manual-reader snapshot.
+// head= label from a manual-reader snapshot, SUMMING every data point that
+// carries the head — the counter is also attributed by `cause` (#2900), so one
+// head owns one stream per trip cause and reading a single data point would
+// report whichever stream the SDK happened to emit last.
 func breakerHeadTrips(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
 	t.Helper()
 	var rm metricdata.ResourceMetrics
@@ -86,7 +89,7 @@ func breakerHeadTrips(t *testing.T, reader *sdkmetric.ManualReader) map[string]i
 				if !ok {
 					t.Fatalf("breaker_trips_total data point missing head attribute: %v", dp.Attributes.ToSlice())
 				}
-				out[h.AsString()] = dp.Value
+				out[h.AsString()] += dp.Value
 			}
 		}
 	}

--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -308,23 +308,17 @@ func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql
 	// error and success paths below keep the span). A shape-mismatch returns
 	// above before this, since it carried no real result.
 	pe.stamp(span)
-	breakerErr := runErr
-	if isBudgetErr(runErr) || isThrowIfGuard(translateCHGoErr(runErr)) {
-		// Both are the caller asking for too much, not an outage. A throwIf
-		// guard (code 395) is cerberus's OWN emitted rejection — a resource
-		// ceiling or a shape assertion this process planted in the SQL — so
-		// ClickHouse raising it is proof the backend is healthy, exactly as
-		// breaker.record's own code-241 / code-159 carve-outs argue. The
-		// error is normalised through translateCHGoErr first because this
-		// dial is ch-go: runErr carries a *proto.Exception, not the
-		// *clickhouse.Exception shape the code check reads. This
-		// became load-bearing once the RangeBucketGridNative density bound was
-		// recalibrated to the measured OOM cliff (#2681): an honest bound
-		// fires on every oversized query, so without this a dashboard refresh
-		// with a few wide panels trips the breaker and 503s unrelated traffic.
-		breakerErr = nil
-	}
-	c.br.record(ctx, breakerErr)
+	// The raw ch-go error goes to the breaker unfiltered. It used to be
+	// pre-filtered here for the sample-budget sentinel and the code-395
+	// throwIf guard, normalising through translateCHGoErr first because this
+	// dial yields a *proto.Exception rather than the *clickhouse.Exception the
+	// old code checks read. Both filters now live in classifyBreakerOutcome,
+	// which accepts BOTH exception shapes — so this dial no longer needs its
+	// own copy of the argument, and the codes it silently failed to neutralise
+	// (241, 159, and every statement-scoped rejection, none of which the row
+	// path's carve-outs could see through a *proto.Exception) are classified
+	// here too. One verdict, one place, both dials.
+	c.br.record(ctx, runErr)
 	if rec != nil {
 		rec.flush()
 	}

--- a/internal/chclient/memlimit.go
+++ b/internal/chclient/memlimit.go
@@ -21,8 +21,8 @@ const chCodeMemoryLimitExceeded = 241
 // memory limit (CH error code 241, MEMORY_LIMIT_EXCEEDED). It is the
 // memory-side sibling of [ErrTooManySamples]: a per-query resource
 // rejection, NOT a transport failure — ClickHouse is alive and healthy
-// when it enforces a cap, so these errors are breaker-neutral (see
-// breaker.record) and the API heads map them onto the same
+// when it enforces a cap, so these errors are breaker-neutral (they classify
+// as breakerScopeStatement — see breaker_classify.go) and the API heads map them onto the same
 // resource-exhausted wire shapes as the sample budget (prom 422
 // errorType=execution, loki 400 limit-style, tempo 422).
 //
@@ -86,17 +86,4 @@ func wrapMemoryLimit(err error, limit int64) error {
 		return &MemoryLimitError{Limit: limit, Cause: err}
 	}
 	return err
-}
-
-// isMemoryLimitExceeded reports whether err is a ClickHouse
-// MEMORY_LIMIT_EXCEEDED rejection — either already wrapped as a
-// *MemoryLimitError or still the raw *clickhouse.Exception with code
-// 241 (the form breaker.record sees, since the breaker observes the
-// driver error before chclient wraps it).
-func isMemoryLimitExceeded(err error) bool {
-	if errors.Is(err, ErrMemoryLimitExceeded) {
-		return true
-	}
-	var ex *clickhouse.Exception
-	return errors.As(err, &ex) && ex.Code == chCodeMemoryLimitExceeded
 }

--- a/internal/chclient/throwif.go
+++ b/internal/chclient/throwif.go
@@ -79,26 +79,6 @@ func wrapThrowIf(err error) error {
 	return err
 }
 
-// isThrowIfGuard reports whether err carries one of cerberus's own emitted
-// throwIf guards (ClickHouse code 395).
-//
-// Used by the circuit breaker to keep a guard rejection out of the
-// CH-health failure count: cerberus planted the guard, and the server
-// raising it proves the backend is alive and answering.
-//
-// Detection is on the *clickhouse.Exception code rather than on
-// *ThrowIfError, because the breaker observes the RAW driver error: every
-// data-plane method calls br.record(ctx, err) with what the driver returned
-// and only wraps through classifyDriverErr on its RETURN path, so a
-// *ThrowIfError does not exist yet at the point the breaker classifies.
-// Reading the code directly is correct at both layers — errors.As still
-// reaches the exception through ThrowIfError.Unwrap — and it matches how
-// isMemoryLimitExceeded already handles the identical ordering.
-func isThrowIfGuard(err error) bool {
-	var ex *clickhouse.Exception
-	return errors.As(err, &ex) && ex.Code == chCodeThrowIf
-}
-
 // ThrowIfMessage returns the guard message ClickHouse decoded for an emitted
 // throwIf rejection, and whether err is one at all.
 //

--- a/internal/chclient/timeout.go
+++ b/internal/chclient/timeout.go
@@ -42,8 +42,8 @@ const (
 // its wall-clock cap (CH error code 159, TIMEOUT_EXCEEDED). It is the
 // wall-clock sibling of [ErrMemoryLimitExceeded]: a per-query resource
 // rejection, NOT a transport failure — ClickHouse is alive and healthy
-// when it enforces a cap, so these errors are breaker-neutral (see
-// breaker.record) and the API heads map them onto the head-idiomatic
+// when it enforces a cap, so these errors are breaker-neutral (they classify
+// as breakerScopeStatement — see breaker_classify.go) and the API heads map them onto the head-idiomatic
 // timeout wire shapes (prom 503 errorType=timeout, loki/tempo
 // equivalents).
 //
@@ -106,19 +106,6 @@ func wrapQueryTimeout(err error, timeout time.Duration) error {
 		return &QueryTimeoutError{Timeout: timeout, Cause: err}
 	}
 	return err
-}
-
-// isQueryTimeoutExceeded reports whether err is a ClickHouse
-// TIMEOUT_EXCEEDED rejection — either already wrapped as a
-// *QueryTimeoutError or still the raw *clickhouse.Exception with code
-// 159 (the form breaker.record sees, since the breaker observes the
-// driver error before chclient wraps it).
-func isQueryTimeoutExceeded(err error) bool {
-	if errors.Is(err, ErrQueryTimeout) {
-		return true
-	}
-	var ex *clickhouse.Exception
-	return errors.As(err, &ex) && ex.Code == chCodeTimeoutExceeded
 }
 
 type queryTimeoutKeyType struct{}

--- a/internal/chclient/unknowntable.go
+++ b/internal/chclient/unknowntable.go
@@ -25,7 +25,7 @@ const chCodeUnknownTable = 60
 // 502.
 //
 // Detection is typed first — errors.As against *clickhouse.Exception,
-// mirroring isDatabaseAbsent / isMemoryLimitExceeded / IsQueryTimeout — with
+// mirroring isDatabaseAbsent / classifyBreakerOutcome / IsQueryTimeout — with
 // a narrow string-matching fallback for the case where the driver wraps the
 // exception opaquely enough to defeat errors.As. The phrases are
 // deliberately narrow to the UNKNOWN_TABLE vocabulary so a successful query

--- a/internal/chclient/unknowntable_test.go
+++ b/internal/chclient/unknowntable_test.go
@@ -21,7 +21,7 @@ func chUnknownTableException() *clickhouse.Exception {
 }
 
 // TestIsUnknownTable_Code60 — a typed *clickhouse.Exception carrying code
-// 60 is recognised via errors.As, mirroring isMemoryLimitExceeded /
+// 60 is recognised via errors.As, mirroring serverExceptionCode /
 // IsQueryTimeout.
 func TestIsUnknownTable_Code60(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What was wrong

During the #2895 incident ~21 individual query failures became 144 LogQL and 871 PromQL compat
divergences. The failing queries returned ClickHouse code **704
`QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS`** — a per-statement semantic rejection. The
server was entirely healthy and answered other queries at the same instant, but the breaker counted
those rejections, tripped, and returned `503 circuit breaker open` for everything behind it. The
compat score read `passed=97 total=968 percent=10.02`, which looks like an engine-wide regression,
and that masked the real ~21-query defect for 32 hours.

**The defect is not the missing 704 entry.** `breaker.record` neutralised exceptions by
hand-enumerated code, one incident at a time — 241 `MEMORY_LIMIT_EXCEEDED`, then 159
`TIMEOUT_EXCEEDED`, then 395 `FUNCTION_THROW_IF_VALUE_IS_NON_ZERO` — and each arm's paragraph made
the *same* argument: "the server answered with a typed exception, which is positive proof it is
alive and healthy". 704 is the fourth member of that class. Adding a 704 arm would have set up the
fifth.

## The taxonomy, and its source of truth

The load-bearing observation is transport-level rather than semantic: **a decoded server exception
can only exist if ClickHouse accepted the connection, received the statement, parsed and analysed
it, and wrote a typed error packet back.** A backend that does that is serving. Shedding unrelated
traffic protects nothing — the rejection cost the server a parse, not a scan.

New file `internal/chclient/breaker_classify.go` turns that into the rule:

| Input | Scope | Counted? |
| --- | --- | --- |
| No decoded server exception (refused dial, EOF, broken pipe, read timeout, unrecognised driver error) | `server-health` | yes |
| Decoded exception whose code is in the curated server-condition set | `server-health` | yes |
| Any other decoded exception | `statement` | no |
| Local pool acquire timeout, columnar sample-budget sentinel | `client` | no |

**Source of truth for the set.** ClickHouse publishes no machine-readable server/statement taxonomy
— `ErrorCodes.cpp` is a flat `M(code, NAME)` list with no category field, and neither driver exposes
one. A curated set is therefore unavoidable and the code says so explicitly. What is avoidable is an
unreasoned list of bare numbers, so the set is keyed by **ch-go's own generated `chproto.Err*`
constants** (no magic numbers, invariant 13) and every entry carries the sentence that earns its
place. Membership criterion, applied uniformly: *retrying a different, well-formed statement against
this server would fail the same way.* 16 entries: `SERVER_OVERLOADED`,
`TOO_MANY_SIMULTANEOUS_QUERIES`, `KEEPER_EXCEPTION`, `ALL_CONNECTION_TRIES_FAILED`,
`NO_AVAILABLE_REPLICA`, `ALL_REPLICAS_LOST`, `NETWORK_ERROR`, `SOCKET_TIMEOUT`, `SYSTEM_ERROR`,
`CANNOT_ALLOCATE_MEMORY`, `CANNOT_SCHEDULE_TASK`, `NO_FREE_CONNECTION`, `DNS_ERROR`, `ABORTED`,
`AUTHENTICATION_FAILED`, `TABLE_IS_BEING_RESTARTED`.

The set is the **exception to a principled default, not a replacement for one** — it is the small
side of the split, and it is the side that shrinks the blast radius rather than growing it.

### Where 704 and the three existing codes land

- **704** and **719** (`QUERY_CACHE_USED_WITH_SYSTEM_TABLE`, never yet seen in an incident) —
  statement-scoped by the default. No entry needed for either.
- **241 `MEMORY_LIMIT_EXCEEDED`**, **159 `TIMEOUT_EXCEEDED`**, **395 throwIf guard** — statement-
  scoped by the same default. Their three hand-written arms are **deleted**, not left standing
  beside the classifier: keeping them would be exactly the duplication this change removes. Their
  behaviour is byte-identical (still neutralised to a SUCCESS, so a HALF-OPEN probe still closes the
  circuit) and their existing tests pass unweakened — `TestBreaker_MemoryLimitNeutral_Closed`,
  `TestBreaker_QueryTimeoutNeutral_Closed`, `TestForHead_NeutralClassificationsPerHead` and the
  acquire-timeout/cancellation tests are untouched. The now-orphaned predicates
  `isMemoryLimitExceeded` / `isQueryTimeoutExceeded` / `isThrowIfGuard` are deleted; the `wrap*`
  functions they sat beside are still used on the return path and stay.

### The default for an unknown code, and why that direction

**An unenumerated code is statement-scoped: neutral.** The two failure modes are not symmetric.

- Wrong in the *count it* direction costs a total outage from a handful of bad statements, with no
  protective benefit, because the server demonstrably had capacity to answer. That is the realised,
  observed cost of #2895 — and it re-arms itself for every code ClickHouse adds.
- Wrong in the *neutral* direction costs a delayed trip. It cannot cost a **missed** trip: a backend
  sick enough to stop serving stops producing decoded exceptions — it refuses the dial, drops the
  connection, or times out the read — and every one of those paths is counted under the default. The
  residual exposure is the narrow band where a server is healthy enough to parse SQL yet unhealthy
  enough that cerberus should back off, which is precisely what the curated set enumerates.

New ClickHouse releases add statement-semantics codes constantly and server-condition codes rarely.
`TestBreakerClassify_UnknownCodeIsStatementScoped` pins the default so it cannot flip silently.

## Latent bug closed on the way

The columnar dial hands `br.record` the **raw ch-go error**, which carries a `*proto.Exception` — a
different Go type from the `*clickhouse.Exception` the old code checks read. So on that path codes
241 and 159 were **never actually neutralised**, and the call site carried its own hand-copy of the
395 argument with a `translateCHGoErr` normalisation. `serverExceptionCode` accepts both shapes, so
the call-site filter is gone and both dials get one verdict from one place.
`TestBreakerClassify_BothDialsAgree` pins it.

## Acceptance

1. **A sustained stream of statement-scoped rejections does NOT open the breaker** —
   `TestBreakerClassify_StatementScopedStreamDoesNotTrip`: 11 codes (704, 719, syntax,
   unknown-identifier, type-mismatch, unknown-table, illegal-argument-type, 241, 159, 395, and an
   unallocated future code) × 3 wire shapes (row dial, columnar dial, wrapped), each fired at 10×
   the trip threshold with no intervening success.
2. **Genuine server-health failures still DO open it** — `TestBreakerClassify_ServerHealthStreamTrips`:
   16 must-trip codes × 3 shapes, plus 6 no-server-answer shapes (refused dial, EOF, broken pipe,
   i/o timeout, deadline, unknown driver error).
3. **A breaker-open event carries triage context** — `TestBreakerTrip_CarriesCauseContext`. Reported
   through the channel trips already use (`breaker_metrics.go`), not a new one:
   `cerberus_ch_breaker_trips_total` gains a `cause` attribute (`no-server-answer` /
   `server-condition`), and the trip WARN log names the cause, the ClickHouse code and its symbolic
   name, plus `statement_rejections_since_last_trip`. A no-answer trip omits the code fields rather
   than logging `ch_code=0`. New counter
   `cerberus_ch_breaker_statement_rejections_total{head}` carries the other side: after this change a
   rejection storm produces **no trip at all**, so a trip-only signal would show a flat, healthy-
   looking breaker while the heads returned wrong answers — exactly the 32-hour blind spot.

## Non-vacuity evidence

Each mutation was applied to the source, the named test run, then reverted. Restored tree:
`go test -race ./internal/chclient/` → ok.

| # | Mutation | Test | Result |
| --- | --- | --- | --- |
| A | `classifyBreakerOutcome`'s fall-through returns `breakerScopeServerHealth` instead of `breakerScopeStatement` | `TestBreakerClassify_StatementScopedStreamDoesNotTrip`, `TestBreakerClassify_UnknownCodeIsStatementScoped` | **both FAIL** |
| B | `chproto.ErrServerOverloaded` entry deleted from `breakerServerHealthCodes` | `TestBreakerClassify_ServerHealthStreamTrips` | **FAIL** |
| C | `ch.AsException` branch neutered in `serverExceptionCode` | `TestBreakerClassify_BothDialsAgree` | **FAIL** |
| D | `cause` attribute dropped from `recordTrip` | `TestBreakerTrip_CarriesCauseContext` | **FAIL** |
| E | `recordStatementRejection` call removed from `record` | `TestBreakerMetrics_StatementRejectionsCounted` | **FAIL** |
| F | `statement_rejections_since_last_trip` dropped from the trip log | `TestBreakerTrip_CarriesCauseContext` | **FAIL** |

Mutation B is worth calling out because it **caught a gamed test in this PR's own first draft**. The
server-health test originally iterated `breakerServerHealthCodes` itself, so deleting an entry
merely deleted its subtest and the suite stayed green while the breaker quietly stopped firing on
that condition. It was rewritten around an independent `mustTripCodes` list — the map walk survives
only as a weaker check that each entry is reasoned and live. Mutation B is red because of that
rewrite, not in spite of it.

Also fixed: `breakerHeadTrips` in `breaker_perhead_test.go` assigned rather than summed per-head
data points, which would have silently mis-read the counter once `cause` split each head into two
streams.

## Docs

`docs/observability.md` gains a **ClickHouse circuit breaker** subsection — the three metrics were
previously absent from the inventory entirely — including the triage rule the incident needed:
rising `statement_rejections_total` with a flat `trips_total` means cerberus is emitting SQL
ClickHouse declines, and the backend is fine.

## Verification

- `go test -race ./internal/chclient/` — ok (136 new subtests)
- `go test -race ./internal/api/... ./internal/solver/ ./internal/engine/` — ok
- `CHECK=all node .github/scripts/forbid-skip.mjs`, `CHECK=root-allowlist node .github/scripts/repo-hygiene.mjs` — clean
- `markdownlint-cli2 docs/observability.md` — 0 errors

Closes #2900
