### PR TITLE
test(mutation): cite the construct a mutant lives on, and gate it

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -373,6 +373,27 @@ what actually runs.
   - Pins: `crawl-surface-inventory-purity.test.mjs` (`node --test`), which
     drives the real script and pairs every clean case with the dirty one it
     must catch, using the real defect rows the committed inventories carried.
+- **`verify-code-citations.mjs`** — `ci.yml`, the `forbid-skip` job step "Reject
+  source citations that name a line instead of a construct". Every `file.go:…`
+  citation in a Go comment or string must name the CONSTRUCT it is about
+  (``range_window.go:`numAnchors-1` ``, or
+  ``range_window.go:emitRangeWindow:`numAnchors-1` `` when the construct repeats
+  in the file), and the gate resolves it: the path must be a file in this
+  repository, and the construct must appear on exactly one CODE line of that
+  file, or of the named top-level func. Blank lines and whole-line `//` comments
+  are never searched, so a citation cannot resolve to one. A line number is
+  rejected outright — it is unverifiable, and measured over the 200 commits
+  before this gate it would have been invalidated 575 times with the construct
+  it named untouched in 573 of them (#2953). `.go:` followed by anything else
+  carries no address and is left alone: ordinary prose, a bare function
+  reference, and `test/rejection-parity`'s `path.go:func#hash` site ids.
+  - Env: `REPO_ROOT` (default `process.cwd()`), `PATHSPECS` (default `*.go`).
+  - Exit: `0` when every citation resolves; `1` on any violation or on a
+    pathspec that matches no Go file at all.
+  - Pins: `verify-code-citations.test.mjs` (`node --test`), which drives the
+    real CLI over a throwaway git repository and pairs every rejection with the
+    nearest-miss acceptance, so neither widening the gate into uselessness nor
+    narrowing it into noise passes.
 - **`generated-baseline-structural-guard.mjs`** — `ci.yml`, the `forbid-skip`
   job step "Structural sanity check over generated baseline shapes (#1568)".
   A fast, dependency-free structural pre-filter (unique key, sorted order,

--- a/.github/scripts/verify-code-citations.mjs
+++ b/.github/scripts/verify-code-citations.mjs
@@ -124,13 +124,14 @@ export function funcRanges(lines) {
   return out;
 }
 
-// parseCitations — every citation opener in `text`, with what follows it
-// classified. `text` is one logical unit (see units()); `line` is the 1-based
-// source line the unit starts at, used only for reporting.
-export function parseCitations(text, line) {
+// parseCitations — every citation opener in a unit, with what follows it
+// classified. Each result carries the source line the citation itself sits on.
+export function parseCitations(unit) {
+  const { text } = unit;
   const found = [];
   for (const m of text.matchAll(OPENER)) {
     const at = m.index;
+    const line = lineAt(unit, at);
     // Walk back over the path: the run of path characters before `.go`.
     const before = text.slice(0, at);
     const pathMatch = /([A-Za-z0-9_./-]+)$/.exec(before);
@@ -172,26 +173,40 @@ function readConstruct(after) {
 
 // units — the logical units of a Go file. A run of consecutive whole-line `//`
 // comments is one unit, so a citation may wrap across the comment's line breaks;
-// every other line is its own unit. Each unit carries the 1-based line it began
-// at.
+// every other line is its own unit. Each unit carries a `lines` array parallel
+// to `text`, giving the 1-based SOURCE line every character came from — a
+// citation inside a twenty-line note has to be reported at its own line, not at
+// the line the note happens to start on.
 export function units(lines) {
   const out = [];
   let block = null;
+  const flush = () => {
+    if (block) out.push(block);
+    block = null;
+  };
   lines.forEach((line, i) => {
+    const n = i + 1;
     if (line.trim().startsWith('//')) {
       const body = line.trim().replace(/^\/\/\s?/, '');
-      if (block) block.text += ` ${body}`;
-      else block = { line: i + 1, text: body };
+      if (!block) block = { text: '', lines: [] };
+      else {
+        block.text += ' ';
+        block.lines.push(n);
+      }
+      block.text += body;
+      for (let k = 0; k < body.length; k += 1) block.lines.push(n);
       return;
     }
-    if (block) {
-      out.push(block);
-      block = null;
-    }
-    out.push({ line: i + 1, text: line });
+    flush();
+    out.push({ text: line, lines: new Array(line.length).fill(n) });
   });
-  if (block) out.push(block);
+  flush();
   return out;
+}
+
+// lineAt — the source line a character index inside a unit came from.
+function lineAt(unit, index) {
+  return unit.lines[Math.min(index, unit.lines.length - 1)];
 }
 
 // resolveCited — the repo-relative path a citation names, or null. Tried
@@ -235,7 +250,7 @@ export function checkFile({ root, file }) {
   };
 
   for (const unit of units(text.split('\n'))) {
-    for (const c of parseCitations(unit.text, unit.line)) {
+    for (const c of parseCitations(unit)) {
       const where = `${file}:${c.line}`;
       if (c.kind === 'line-number') {
         violations.push(

--- a/.github/scripts/verify-code-citations.mjs
+++ b/.github/scripts/verify-code-citations.mjs
@@ -1,0 +1,322 @@
+// verify-code-citations.mjs — every source citation in a Go comment or string
+// must name a construct that still exists, not a line number that has drifted.
+//
+// WHY THIS EXISTS (#2953). Mutation-adjudication notes cite the mutant they are
+// about: `NOT KILLABLE` footers, `// TestX kills foo.go:…` headers, the
+// `CONDITIONALS_BOUNDARY at bar.go:…` strings inside `t.Fatalf`. Those citations
+// are the only way a reviewer, or a later agent, can re-check an equivalence
+// claim. A bare `file.go:613` is UNVERIFIABLE by machine — nothing about an
+// integer can be checked against intent — and it is invalidated by any edit that
+// inserts a line above it. Measured over the 200 first-parent commits before
+// this gate landed, a line-number citation would have been invalidated 575
+// times, and in 573 of those the construct it named was never touched: the
+// citation rotted purely because unrelated lines moved. 33% of the citations on
+// `main` had already rotted onto a comment or a blank line.
+//
+// THE FIX is to make the citation name the thing rather than the address:
+//
+//     range_window.go:`numAnchors-1`                  construct, unique in file
+//     range_window.go:emitRangeWindow:`numAnchors-1`  construct, unique in func
+//
+// which a gate CAN check — resolve the file, search its code lines, require
+// exactly one match. Naming the construct removes the drift class rather than
+// detecting it: inserting a line above the construct changes nothing, and the
+// only edit that invalidates the citation is one that changes the construct
+// itself — exactly when a human must re-read the note.
+//
+// FAIL CLOSED. Anything that looks like a citation and is not a well-formed one
+// is an error, never a skip:
+//   - `foo.go:613`, `foo.go:613:22`, `foo.go:108-109` — line-number citations.
+//   - a construct whose file does not resolve, including an upstream path such
+//     as `promql/engine.go:2114`. An upstream line number is unverifiable from
+//     this repository, so the convention forbids the form outright: name the
+//     upstream construct in prose instead.
+//   - a construct that matches no code line, or more than one.
+//   - an unterminated construct, or an empty one.
+// The scope is a git pathspec set — every Go file `git ls-files` reports as
+// tracked or as untracked-but-not-ignored — rather than a hand-maintained list
+// of files, so it cannot silently shrink the way an enumerated set does.
+//
+// SEARCH SPACE. Only CODE lines of the cited file are searched — blank lines and
+// whole-line `//` comments are excluded. That is what makes the pre-existing
+// provable-drift class (a citation resolving to a comment or a blank line)
+// unrepresentable rather than merely detected, and it lets a construct be quoted
+// in its own doc comment without colliding with itself.
+//
+// ENV CONTRACT
+//   REPO_ROOT   — repository root. Default `process.cwd()`.
+//   PATHSPECS   — whitespace-separated git pathspecs to scan.
+//                 Default `*.go` (every tracked Go file).
+//
+// Exit: 0 when every citation resolves, 1 otherwise.
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { isAbsolute, join, dirname, resolve, relative } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { error, log, notice, lsFiles } from './lib/gh.mjs';
+
+// The construct delimiter. Backticks already mark code spans in Go comments and
+// are legal inside the double-quoted strings `t.Fatalf` messages use, so the
+// citation reads the same in both places it appears.
+const DELIM = '`';
+
+// A citation opens at `.go:`. The grammar models exactly two shapes and ignores
+// every other follower:
+//
+//   `.go:<digit>`                       the banned line-number form
+//   `.go:DELIM…DELIM`                   a construct citation
+//   `.go:<ident>:DELIM…DELIM`           a construct citation scoped to a func
+//
+// Everything else is left alone because it carries no address and therefore
+// cannot suffer the drift this gate closes: ordinary prose ("see
+// range_window.go: the anchor grid…"), a bare function reference
+// (`lower.go:wrapRangeLatestPerSeries`), and the rejection-parity catalogue's
+// site identifiers (`internal/promql/lower.go:lowerHistogramNativeRoot#53e0f9b3`),
+// which are a DATA FORMAT rather than a citation — catalogue_test.go builds
+// deliberately fabricated ones (`internal/promql/a.go:fnA#0000aaaa`) that no
+// resolver should ever be asked to resolve.
+const OPENER = /\.go:/g;
+
+// normalise — collapse every whitespace run to one space so a citation may be
+// written with the spacing that reads best, independent of the source's
+// indentation and alignment.
+export function normalise(text) {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+// unescape — undo the two Go interpreted-string escapes a citation can acquire
+// purely by being written inside one. A `t.Fatalf` message citing a construct
+// that contains a double quote has to spell it `\\"` for the Go compiler; the
+// gate reads the file as text and would otherwise compare the escape against a
+// source line that never had one. Nothing else is unescaped: this undoes the
+// literal's encoding, it does not interpret the construct.
+export function unescape(text) {
+  return text.replace(/\\(["\\])/g, '$1');
+}
+
+// isCodeLine — a line that a mutation operator could apply to. Blank lines and
+// whole-line comments are not; a line with a trailing comment is.
+export function isCodeLine(line) {
+  const t = line.trim();
+  return t !== '' && !t.startsWith('//');
+}
+
+// funcRanges — the top-level function scopes of a Go file, as
+// name -> { start, end } 1-based inclusive line bounds. A top-level `func`
+// declaration starts at column 0; its scope runs to the line before the next
+// one. gofumpt is enforced repo-wide, so column-0 `func` is reliable.
+export function funcRanges(lines) {
+  const decls = [];
+  lines.forEach((line, i) => {
+    const m = /^func\s+(?:\([^)]*\)\s*)?([A-Za-z0-9_]+)/.exec(line);
+    if (m) decls.push({ name: m[1], start: i + 1 });
+  });
+  const out = new Map();
+  decls.forEach((d, i) => {
+    const end = i + 1 < decls.length ? decls[i + 1].start - 1 : lines.length;
+    // A name may be declared more than once across receivers; keep every range
+    // so a citation naming it searches all of them and still demands one hit.
+    if (!out.has(d.name)) out.set(d.name, []);
+    out.get(d.name).push({ start: d.start, end });
+  });
+  return out;
+}
+
+// parseCitations — every citation opener in `text`, with what follows it
+// classified. `text` is one logical unit (see units()); `line` is the 1-based
+// source line the unit starts at, used only for reporting.
+export function parseCitations(text, line) {
+  const found = [];
+  for (const m of text.matchAll(OPENER)) {
+    const at = m.index;
+    // Walk back over the path: the run of path characters before `.go`.
+    const before = text.slice(0, at);
+    const pathMatch = /([A-Za-z0-9_./-]+)$/.exec(before);
+    const path = `${pathMatch ? pathMatch[1] : ''}.go`;
+    const rest = text.slice(at + m[0].length);
+    const head = rest[0];
+
+    if (head === undefined) continue; // `.go:` at end of unit — prose.
+    if (/[0-9]/.test(head)) {
+      found.push({ line, path, kind: 'line-number', detail: rest.slice(0, 24) });
+      continue;
+    }
+    if (head === DELIM) {
+      found.push({ line, path, kind: 'construct', scope: null, ...readConstruct(rest.slice(1)) });
+      continue;
+    }
+    const scoped = /^([A-Za-z0-9_]+):/.exec(rest);
+    if (scoped && rest[scoped[0].length] === DELIM) {
+      found.push({
+        line,
+        path,
+        kind: 'construct',
+        scope: scoped[1],
+        ...readConstruct(rest.slice(scoped[0].length + 1)),
+      });
+    }
+    // Every other follower carries no address — see the OPENER note above.
+  }
+  return found;
+}
+
+// readConstruct — the delimited construct text starting just past the opening
+// delimiter. Returns `{ construct }` or `{ unterminated: true }`.
+function readConstruct(after) {
+  const close = after.indexOf(DELIM);
+  if (close === -1) return { unterminated: true };
+  return { construct: after.slice(0, close) };
+}
+
+// units — the logical units of a Go file. A run of consecutive whole-line `//`
+// comments is one unit, so a citation may wrap across the comment's line breaks;
+// every other line is its own unit. Each unit carries the 1-based line it began
+// at.
+export function units(lines) {
+  const out = [];
+  let block = null;
+  lines.forEach((line, i) => {
+    if (line.trim().startsWith('//')) {
+      const body = line.trim().replace(/^\/\/\s?/, '');
+      if (block) block.text += ` ${body}`;
+      else block = { line: i + 1, text: body };
+      return;
+    }
+    if (block) {
+      out.push(block);
+      block = null;
+    }
+    out.push({ line: i + 1, text: line });
+  });
+  if (block) out.push(block);
+  return out;
+}
+
+// resolveCited — the repo-relative path a citation names, or null. Tried
+// relative to the citing file's own directory first (the common intra-package
+// case), then relative to the repository root (the cross-package case).
+export function resolveCited({ root, from, path }) {
+  const candidates = [join(dirname(from), path), path];
+  for (const c of candidates) {
+    const abs = resolve(root, c);
+    // Keep the resolution inside the repository: a `../..` path that escapes it
+    // is not a citation this gate can vouch for.
+    const rel = relative(root, abs);
+    if (rel.startsWith('..') || isAbsolute(rel)) continue;
+    if (existsSync(abs) && statSync(abs).isFile()) return rel;
+  }
+  return null;
+}
+
+// matchLines — the 1-based code lines of `lines` whose normalised text contains
+// the normalised construct, restricted to `ranges` when given.
+export function matchLines({ lines, construct, ranges }) {
+  const needle = normalise(unescape(construct));
+  const hits = [];
+  lines.forEach((line, i) => {
+    const n = i + 1;
+    if (ranges && !ranges.some((r) => n >= r.start && n <= r.end)) return;
+    if (!isCodeLine(line)) return;
+    if (normalise(line).includes(needle)) hits.push(n);
+  });
+  return hits;
+}
+
+// checkFile — every violation in one tracked file.
+export function checkFile({ root, file }) {
+  const text = readFileSync(resolve(root, file), 'utf8');
+  const violations = [];
+  const cache = new Map();
+  const load = (rel) => {
+    if (!cache.has(rel)) cache.set(rel, readFileSync(resolve(root, rel), 'utf8').split('\n'));
+    return cache.get(rel);
+  };
+
+  for (const unit of units(text.split('\n'))) {
+    for (const c of parseCitations(unit.text, unit.line)) {
+      const where = `${file}:${c.line}`;
+      if (c.kind === 'line-number') {
+        violations.push(
+          `${where}: line-number citation \`${c.path}:${c.detail.trim()}\` — a line number cannot be verified and drifts on every insertion above it. Name the construct: \`${c.path}:${DELIM}<construct>${DELIM}\`.`,
+        );
+        continue;
+      }
+      if (c.unterminated) {
+        violations.push(`${where}: unterminated construct in \`${c.path}\` citation — no closing ${DELIM}.`);
+        continue;
+      }
+      if (normalise(unescape(c.construct)) === '') {
+        violations.push(`${where}: empty construct in \`${c.path}\` citation.`);
+        continue;
+      }
+      const rel = resolveCited({ root, from: file, path: c.path });
+      if (rel === null) {
+        violations.push(
+          `${where}: citation names \`${c.path}\`, which does not resolve to a file in this repository. An out-of-repo line or construct cannot be verified here — name it in prose instead.`,
+        );
+        continue;
+      }
+      const lines = load(rel);
+      let ranges = null;
+      if (c.scope !== null) {
+        const found = funcRanges(lines).get(c.scope);
+        if (!found) {
+          violations.push(`${where}: citation scopes to \`${c.scope}\`, which is not a top-level func in ${rel}.`);
+          continue;
+        }
+        ranges = found;
+      }
+      const hits = matchLines({ lines, construct: c.construct, ranges });
+      const scopeNote = c.scope === null ? rel : `${rel} func ${c.scope}`;
+      if (hits.length === 0) {
+        violations.push(
+          `${where}: construct \`${c.construct}\` matches no code line in ${scopeNote}. The construct moved or changed — re-read the note before repointing it.`,
+        );
+        continue;
+      }
+      if (hits.length > 1) {
+        violations.push(
+          `${where}: construct \`${c.construct}\` matches ${hits.length} code lines in ${scopeNote} (${hits.join(', ')}). Widen it, or scope it with \`${c.path}:<func>:${DELIM}…${DELIM}\`.`,
+        );
+      }
+    }
+  }
+  return violations;
+}
+
+export function scan({ root = process.cwd(), pathspecs = ['*.go'] } = {}) {
+  const files = lsFiles(pathspecs, { cwd: root });
+  const violations = [];
+  for (const f of files) violations.push(...checkFile({ root, file: f }));
+  return { files: files.length, violations };
+}
+
+function main() {
+  const root = process.env.REPO_ROOT || process.cwd();
+  const pathspecs = (process.env.PATHSPECS || '*.go').split(/\s+/).filter(Boolean);
+  const { files, violations } = scan({ root, pathspecs });
+
+  if (files === 0) {
+    // A gate that passes because it found nothing to check reports the same
+    // green as a satisfied one.
+    error(`verify-code-citations: pathspec ${JSON.stringify(pathspecs)} matched no Go file — the scan is broken, not the tree`);
+    return 1;
+  }
+  if (violations.length > 0) {
+    for (const v of violations) log(v);
+    error(
+      `${violations.length} source citation(s) do not resolve. A citation names a construct, not a line: ` +
+        `\`file.go:${DELIM}construct${DELIM}\`, or \`file.go:func:${DELIM}construct${DELIM}\` when the construct repeats. See #2953.`,
+    );
+    return 1;
+  }
+  log(`verify-code-citations: ${files} Go file(s) scanned, every construct citation resolves.`);
+  notice(`verify-code-citations: every construct citation across ${files} Go file(s) resolves`);
+  return 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main());
+}

--- a/.github/scripts/verify-code-citations.mjs
+++ b/.github/scripts/verify-code-citations.mjs
@@ -104,22 +104,28 @@ export function isCodeLine(line) {
 }
 
 // funcRanges — the top-level function scopes of a Go file, as
-// name -> { start, end } 1-based inclusive line bounds. A top-level `func`
-// declaration starts at column 0; its scope runs to the line before the next
-// one. gofumpt is enforced repo-wide, so column-0 `func` is reliable.
+// name -> [{ start, end }] 1-based inclusive line bounds. A top-level `func`
+// declaration starts at column 0 and its body closes at the first following
+// line that is exactly `}` at column 0; gofumpt is enforced repo-wide, so both
+// anchors are reliable. Ending at the closing brace rather than at the next
+// declaration matters: otherwise a package-level `var` block sitting between
+// two funcs would be searchable under the name of the func above it.
 export function funcRanges(lines) {
-  const decls = [];
+  const out = new Map();
   lines.forEach((line, i) => {
     const m = /^func\s+(?:\([^)]*\)\s*)?([A-Za-z0-9_]+)/.exec(line);
-    if (m) decls.push({ name: m[1], start: i + 1 });
-  });
-  const out = new Map();
-  decls.forEach((d, i) => {
-    const end = i + 1 < decls.length ? decls[i + 1].start - 1 : lines.length;
+    if (!m) return;
+    let end = lines.length;
+    for (let k = i; k < lines.length; k += 1) {
+      if (lines[k] === '}') {
+        end = k + 1;
+        break;
+      }
+    }
     // A name may be declared more than once across receivers; keep every range
     // so a citation naming it searches all of them and still demands one hit.
-    if (!out.has(d.name)) out.set(d.name, []);
-    out.get(d.name).push({ start: d.start, end });
+    if (!out.has(m[1])) out.set(m[1], []);
+    out.get(m[1]).push({ start: i + 1, end });
   });
   return out;
 }

--- a/.github/scripts/verify-code-citations.mjs
+++ b/.github/scripts/verify-code-citations.mjs
@@ -86,14 +86,19 @@ export function normalise(text) {
   return text.replace(/\s+/g, ' ').trim();
 }
 
-// unescape — undo the two Go interpreted-string escapes a citation can acquire
-// purely by being written inside one. A `t.Fatalf` message citing a construct
-// that contains a double quote has to spell it `\\"` for the Go compiler; the
-// gate reads the file as text and would otherwise compare the escape against a
-// source line that never had one. Nothing else is unescaped: this undoes the
-// literal's encoding, it does not interpret the construct.
+// unescape — undo the escapes a citation can acquire purely by being written
+// inside a Go string. A `t.Fatalf` message citing a construct that contains a
+// double quote has to spell it `\\"` for the compiler, and one citing a construct
+// that contains `%` — a modulo, as in `ns%stepNS != 0` — has to spell it `%%` or
+// `go vet` rejects the format string. The gate reads the file as text and would
+// otherwise compare those escapes against a source line that never had them.
+//
+// Both are safe to undo unconditionally rather than only inside a string: `%%`
+// is not valid Go anywhere a construct could legitimately contain it, so a
+// comment-borne citation cannot mean a literal `%%`. Nothing else is unescaped —
+// this undoes the literal's encoding, it does not interpret the construct.
 export function unescape(text) {
-  return text.replace(/\\(["\\])/g, '$1');
+  return text.replace(/\\(["\\])/g, '$1').replace(/%%/g, '%');
 }
 
 // isCodeLine — a line that a mutation operator could apply to. Blank lines and

--- a/.github/scripts/verify-code-citations.test.mjs
+++ b/.github/scripts/verify-code-citations.test.mjs
@@ -1,0 +1,247 @@
+// Suite for verify-code-citations.mjs. Every case drives the real CLI over a
+// throwaway git repository, because the gate's scope comes from `git ls-files`
+// and a unit test that bypassed that would not be testing what CI runs.
+//
+// The suite's job is to prove the gate CAN FAIL, one modelled shape at a time —
+// a gate whose first green nobody has seen go red reports something other than
+// what a reader takes it to mean. Each rejection case is paired with the
+// nearest-miss acceptance case, so a regression that widens the gate into
+// uselessness (accept everything) and one that narrows it into noise (reject
+// everything) both show up here.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI = join(HERE, 'verify-code-citations.mjs');
+
+// The cited file every fixture shares. `guard` appears once; `dup` twice, once
+// in each of two funcs, so a citation naming it needs the func scope.
+const TARGET = [
+  'package fixture',
+  '',
+  '// numAnchors-1 is described here, in a comment, so the searcher must skip it.',
+  'func alpha(n int) int {',
+  '\tif n > 0 && n < 10 {',
+  '\t\treturn numAnchors - 1',
+  '\t}',
+  '\tif dupCond != nil {',
+  '\t\treturn 0',
+  '\t}',
+  '',
+  '\treturn 1',
+  '}',
+  '',
+  'func beta() error {',
+  '\tif dupCond != nil {',
+  '\t\treturn nil',
+  '\t}',
+  '\treturn errQuoted // rejects `"` in a name',
+  '}',
+  '',
+].join('\n');
+
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'verify-code-citations-'));
+  const git = (args) => {
+    const res = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    assert.equal(res.status, 0, `git ${args.join(' ')} failed: ${res.stderr}`);
+  };
+  git(['init', '--quiet']);
+  writeFileSync(join(dir, 'target.go'), TARGET);
+  git(['add', 'target.go']);
+  git(['-c', 'user.email=a@a', '-c', 'user.name=a', 'commit', '--quiet', '-m', 'seed']);
+  return {
+    dir,
+    write(path, source) {
+      mkdirSync(join(dir, dirname(path)), { recursive: true });
+      writeFileSync(join(dir, path), source);
+    },
+  };
+}
+
+function run(cwd, env = {}) {
+  const result = spawnSync(process.execPath, [CLI], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { status: result.status, output: `${result.stdout}${result.stderr}` };
+}
+
+// note — a Go file holding one comment-borne citation.
+const note = (citation) => `package fixture\n\n// A mutation note about ${citation} and why it survives.\nvar _ = 0\n`;
+
+test('accepts a construct that resolves to exactly one code line', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:`numAnchors - 1`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 0, r.output);
+});
+
+test('accepts a construct scoped to the func that makes it unique', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:beta:`dupCond != nil`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 0, r.output);
+});
+
+test('accepts a citation whose path is written relative to the repo root', () => {
+  const f = fixture();
+  f.write('sub/note.go', note('target.go:`numAnchors - 1`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 0, r.output);
+});
+
+test('accepts a construct written with different whitespace than the source', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:`if n > 0 && n < 10 {`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 0, r.output);
+});
+
+test('accepts a construct split across a wrapped comment block', () => {
+  const f = fixture();
+  f.write('note.go', 'package fixture\n\n// The guard at target.go:`if n > 0 &&\n// n < 10 {` survives because the arms agree.\nvar _ = 0\n');
+  const r = run(f.dir);
+  assert.equal(r.status, 0, r.output);
+});
+
+test('rejects a bare line-number citation — the shape that drifts', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:6'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /line-number citation/);
+});
+
+test('rejects a line:column citation', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:6:12'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /line-number citation/);
+});
+
+test('rejects a line-range citation', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:5-6'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /line-number citation/);
+});
+
+test('rejects a construct that matches nothing — the construct changed', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:`numAnchors - 2`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /matches no code line/);
+});
+
+test('rejects a construct that matches more than one code line', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:`dupCond != nil`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /matches 2 code lines/);
+});
+
+test('rejects a construct that lives only in a comment of the cited file', () => {
+  // The provable-drift class the issue measured: a citation that resolves to a
+  // comment line cannot be naming a construct a mutation operator applies to.
+  const f = fixture();
+  f.write('note.go', note('target.go:`described here, in a comment`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /matches no code line/);
+});
+
+test('rejects a citation whose file is not in this repository', () => {
+  const f = fixture();
+  f.write('note.go', note('promql/engine.go:`dropName := true`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /does not resolve to a file in this repository/);
+});
+
+test('rejects a path that escapes the repository root', () => {
+  const f = fixture();
+  f.write('note.go', note('../../etc/passwd.go:`root`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /does not resolve to a file in this repository/);
+});
+
+test('rejects a scope that is not a top-level func of the cited file', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:gamma:`dupCond != nil`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /is not a top-level func/);
+});
+
+test('rejects an unterminated construct rather than reading past it', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:`numAnchors - 1'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /unterminated construct/);
+});
+
+test('rejects an empty construct', () => {
+  const f = fixture();
+  f.write('note.go', note('target.go:``'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /empty construct/);
+});
+
+test('unescapes a construct written inside a Go string literal', () => {
+  // A citation in a `t.Fatalf` message has to spell a double quote `\"` for the
+  // compiler. The gate compares against a source line that never had the
+  // backslash, so it undoes that one escape — otherwise every string-borne
+  // citation of a quote-carrying construct would be unfixable.
+  const f = fixture();
+  f.write('note.go', 'package fixture\n\nfunc f() { panic("mutant at target.go:`errQuoted // rejects `+"`"+`\\"`+"`"+`` in a name`") }\n');
+  const r = run(f.dir);
+  assert.equal(r.status, 0, r.output);
+});
+
+test('leaves prose and the rejection-parity site-id format alone', () => {
+  // `.go:` followed by anything that is not a digit or a construct carries no
+  // address, so nothing can drift. The catalogue's `path.go:func#hash` site ids
+  // are a data format, and catalogue_test.go builds deliberately fabricated
+  // ones that no resolver should be asked to resolve.
+  const f = fixture();
+  f.write(
+    'note.go',
+    'package fixture\n\n// See target.go: the alpha guard, and target.go:alpha for the func.\n' +
+      'var site = "internal/promql/a.go:fnA#0000aaaa"\n',
+  );
+  const r = run(f.dir);
+  assert.equal(r.status, 0, r.output);
+});
+
+test('fails when the pathspec matches no Go file at all', () => {
+  // A gate that passes because it found nothing to check reports the same green
+  // as a satisfied one.
+  const f = fixture();
+  const r = run(f.dir, { PATHSPECS: 'no/such/dir/*.go' });
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /matched no Go file/);
+});
+
+test('reports every violation in one run rather than stopping at the first', () => {
+  const f = fixture();
+  f.write('a.go', note('target.go:6'));
+  f.write('b.go', note('target.go:`numAnchors - 2`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /2 source citation\(s\) do not resolve/);
+});

--- a/.github/scripts/verify-code-citations.test.mjs
+++ b/.github/scripts/verify-code-citations.test.mjs
@@ -41,6 +41,9 @@ const TARGET = [
   '\tif dupCond != nil {',
   '\t\treturn nil',
   '\t}',
+  '\tif ns%stepNS != 0 {',
+  '\t\treturn errModulo',
+  '\t}',
   '\treturn errQuoted // rejects `"` in a name',
   '}',
   '',
@@ -222,6 +225,16 @@ test('unescapes a construct written inside a Go string literal', () => {
   // citation of a quote-carrying construct would be unfixable.
   const f = fixture();
   f.write('note.go', 'package fixture\n\nfunc f() { panic("mutant at target.go:`errQuoted // rejects `+"`"+`\\"`+"`"+`` in a name`") }\n');
+  const r = run(f.dir);
+  assert.equal(r.status, 0, r.output);
+});
+
+test('unescapes a %% verb written inside a Go format string', () => {
+  // `go vet` rejects a lone `%` in a format string, so a construct containing a
+  // modulo has to be spelled `%%` there. Without the unescape it would be
+  // uncitable from the `t.Fatalf` messages that carry most of these notes.
+  const f = fixture();
+  f.write('note.go', 'package fixture\n\nfunc f() { panic("mutant at target.go:`ns%%stepNS != 0`") }\n');
   const r = run(f.dir);
   assert.equal(r.status, 0, r.output);
 });

--- a/.github/scripts/verify-code-citations.test.mjs
+++ b/.github/scripts/verify-code-citations.test.mjs
@@ -44,6 +44,8 @@ const TARGET = [
   '\treturn errQuoted // rejects `"` in a name',
   '}',
   '',
+  'var outsideAnyFunc = dupCond',
+  '',
 ].join('\n');
 
 function fixture() {
@@ -176,6 +178,17 @@ test('rejects a path that escapes the repository root', () => {
   const r = run(f.dir);
   assert.equal(r.status, 1, r.output);
   assert.match(r.output, /does not resolve to a file in this repository/);
+});
+
+test('rejects a construct that sits outside the named func, after its closing brace', () => {
+  // A func scope ends at its closing brace, not at the next declaration —
+  // otherwise a package-level var between two funcs would be searchable under
+  // the name of the func above it.
+  const f = fixture();
+  f.write('note.go', note('target.go:beta:`outsideAnyFunc`'));
+  const r = run(f.dir);
+  assert.equal(r.status, 1, r.output);
+  assert.match(r.output, /matches no code line/);
 });
 
 test('rejects a scope that is not a top-level func of the cited file', () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1124,6 +1124,22 @@ jobs:
       - name: Reject parity-enrolled fixtures seeding differing-value duplicate timestamps
         run: node .github/scripts/forbid-parity-duplicate-samples.mjs
 
+      # #2953: a mutation-adjudication note cites the mutant it is about, and
+      # that citation is the only way a reviewer re-checks an equivalence
+      # claim. Cited by LINE NUMBER it rots on every insertion above it —
+      # measured over the 200 commits before this gate, a line-number citation
+      # was invalidated 575 times and in 573 of those the construct it named
+      # was never touched, and a third of the citations on main had already
+      # rotted onto a comment or a blank line. The convention therefore names
+      # the CONSTRUCT, which this gate resolves against the cited file. The
+      # suite runs first: it is what proves the gate can go red, one modelled
+      # citation shape at a time.
+      - name: Assert the citation gate fires on every drifted citation shape
+        run: node --test .github/scripts/verify-code-citations.test.mjs
+
+      - name: Reject source citations that name a line instead of a construct
+        run: node .github/scripts/verify-code-citations.mjs
+
       # #1568: GitHub's server-side merge does NOT honour the `-merge`
       # .gitattributes driver (verified empirically — see the script's own
       # doc comment for the experiment). Most `-merge`-marked generated

--- a/compatibility/tempo/driver/seeder.go
+++ b/compatibility/tempo/driver/seeder.go
@@ -835,7 +835,7 @@ func decodeCerberusSpanCount(r io.Reader) (int, error) {
 //
 // The /api/search confirmation request still passes start/end covering
 // the fixture's span timestamps so the backend block search path is
-// exercised (modules/frontend/search_sharder.go:140 short-circuits when
+// exercised (modules/frontend/search_sharder.go short-circuits when
 // start or end is unset and queries the ingester only — useless on a
 // flushed live-store).
 //

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1325,6 +1325,50 @@ Prior PRs #504 and #664 carry pattern-#3 refactors. They are not
 reverted (their diffs are now load-bearing for the published
 thresholds), but new violations should follow remedy #1 or #2.
 
+### How a note cites the mutant it adjudicates
+
+A `NOT KILLABLE` footer, a `// TestX kills …` header and a
+`CONDITIONALS_BOUNDARY at …` failure message all point at the mutant
+they are about, and that pointer is the only way a reviewer — or a
+later agent — re-checks the claim. It names the **construct**, never a
+line number:
+
+```go
+// NOT KILLABLE — the arms are semantically identical.
+//   range_window.go:`numAnchors-1`
+//   range_window.go:emitRangeWindow:`ns%stepNS != 0`
+```
+
+The second form scopes the search to one top-level func, and is what to
+reach for when the construct repeats in the file. `.github/scripts/
+verify-code-citations.mjs`, a step of the required `forbid-skip` job,
+resolves every such citation: the path must name a file in this
+repository (relative to the citing file's directory, else to the
+repository root) and the construct must appear on exactly one **code**
+line of that file, or of the named func. Blank lines and whole-line
+comments are never searched, so a citation cannot resolve to one.
+
+A `file.go:613` citation is rejected outright, and so are its
+`file.go:613:22`, `file.go:108-109` and `file.go:97:23/29/38`
+variants. The reason is measurable rather than stylistic: replaying the
+200 first-parent commits before the gate landed against the citations
+they would have carried, a line-number citation was invalidated **575
+times, and in 573 of those the construct it named was never touched** —
+the number rotted because unrelated lines moved above it. Two commits
+in that window changed a cited line, which is exactly when a human must
+re-read the adjudication. A third of the citations on `main` had
+already drifted onto a comment or a blank line by the time this was
+measured (cerberus issue #2953). Naming the construct removes that
+class instead of detecting it.
+
+An **upstream** file cannot be cited this way at all: a line number in
+Prometheus, Loki, Tempo or Grafana is unverifiable from here and rots
+the same way, so upstream references name the file and describe the
+construct in prose, without a line number. `.go:` followed by anything
+other than a digit or a construct carries no address and is left alone,
+which is what keeps `test/rejection-parity`'s `path.go:func#hash` site
+identifiers — a data format, not a citation — out of the gate's way.
+
 ### Non-terminating mutants and a leg's irreducible ceiling
 
 A hand-written scanner — a lexer, a regex source walk, a replacement

--- a/internal/api/prom/handler_chdb_duplicate_labelset_test.go
+++ b/internal/api/prom/handler_chdb_duplicate_labelset_test.go
@@ -6,8 +6,8 @@
 //
 // Reference Prometheus refuses that query rather than answering it:
 // `Matrix.ContainsSameLabelset()` → `ev.errorf("vector cannot contain
-// metrics with the same labelset")` (promql/engine.go:2295, and the three
-// sibling sites at :1531 / :1552 / :4109). Cerberus reduces in ClickHouse,
+// metrics with the same labelset")` in promql/engine.go, and the three
+// sibling `ev.errorf` sites there. Cerberus reduces in ClickHouse,
 // where `GROUP BY Attributes` merges the two series by construction — so
 // without a guard the query returns a plausible-looking single row for a
 // question upstream declines to answer.

--- a/internal/api/prom/handler_chdb_instant_duplicate_labelset_test.go
+++ b/internal/api/prom/handler_chdb_instant_duplicate_labelset_test.go
@@ -10,7 +10,7 @@
 // two halves exist because cerberus lowers each operation into its own SQL
 // shape; upstream needs no such split, because `rangeEval` checks EVERY
 // step's output vector for a repeated label set from one generic site
-// (prometheus/promql/engine.go:1531, :1552) and every operation inherits
+// in prometheus/promql/engine.go, and every operation inherits
 // it. That asymmetry is the whole content of #1839: the guard was wired
 // into two lowering functions instead of into the property they share.
 //

--- a/internal/api/prom/handler_chdb_range_mode_test.go
+++ b/internal/api/prom/handler_chdb_range_mode_test.go
@@ -1788,7 +1788,7 @@ func TestQueryRange_RangeMode_AtModifier_Collapse_ChDB(t *testing.T) {
 // engine special-cases these two range functions out of the
 // `dropName` default for every other range-vector fn:
 //
-//	prometheus/prometheus@cerberus-parser/promql/engine.go:2114
+//	prometheus/prometheus@cerberus-parser/promql/engine.go
 //	`dropName := (e.Func.Name != "last_over_time" && e.Func.Name != "first_over_time")`
 //
 // They're position-shift reducers (pick a single sample from the

--- a/internal/api/prom/handler_chdb_subquery_name_test.go
+++ b/internal/api/prom/handler_chdb_subquery_name_test.go
@@ -4,7 +4,7 @@
 // `first_over_time` applied to a SUBQUERY.
 //
 // Prometheus keeps `__name__` on exactly two range functions
-// (promql/engine.go:2114, `dropName := (fn != "last_over_time" && fn !=
+// (promql/engine.go, `dropName := (fn != "last_over_time" && fn !=
 // "first_over_time")`) and resolves the surviving name PER SERIES from the
 // input series' own labels. For a subquery the input series come from
 // `evalSubquery`, so the outer reducer reads whatever name the INNER

--- a/internal/api/prom/histogram.go
+++ b/internal/api/prom/histogram.go
@@ -50,7 +50,7 @@ func histogramSample(ts time.Time, hv *chclient.HistogramValue) Sample {
 //     inclusive), one-sided-clamped exactly like the SQL emitter's
 //     zeroBandLower / zeroBandUpper when a distribution has
 //     observations on only one side of zero (reference Prometheus's
-//     promql/quantile.go:263-273 clamp): a distribution recording
+//     promql/quantile.go clamp): a distribution recording
 //     nothing on one side has no observation that could have produced
 //     a value there, so that edge collapses to 0 rather than spanning
 //     the full symmetric band.

--- a/internal/api/prom/histogram_wire_test.go
+++ b/internal/api/prom/histogram_wire_test.go
@@ -101,7 +101,7 @@ func TestHistogramFromValue_ZeroBucketSymmetric(t *testing.T) {
 }
 
 // TestHistogramFromValue_ZeroBucketOneSidedClamp pins reference
-// Prometheus's one-sided clamp (promql/quantile.go:263-273): a
+// Prometheus's one-sided clamp (in promql/quantile.go): a
 // distribution with observations on only ONE side of zero has its zero
 // band collapsed on the side it never recorded, rather than spanning
 // the full symmetric [-ZeroThreshold, +ZeroThreshold] band.

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -1003,7 +1003,7 @@ const (
 	// spans into one ScopeSpans per distinct (name, version) pair and
 	// emits a non-nil *commonv1.InstrumentationScope — Grafana 12's
 	// server-side trace transform dereferences ils.Scope.Name with no
-	// nil check (pkg/tsdb/tempo/trace_transform.go:137), so a nil
+	// nil check (pkg/tsdb/tempo/trace_transform.go), so a nil
 	// Scope panics the whole /api/ds/query trace-detail request.
 	// Reference Tempo always rehydrates a non-nil scope
 	// (tempodb/encoding/vparquet4/schema.go

--- a/internal/api/tempo/handler_trace_proto.go
+++ b/internal/api/tempo/handler_trace_proto.go
@@ -95,7 +95,7 @@ func groupBatchesProto(samples []chclient.Sample) *tempopb.Trace {
 		// Tempo's per-scope batching. Scope is ALWAYS non-nil (empty
 		// InstrumentationScope at minimum): Grafana 12's
 		// spanToSpanRow dereferences ils.Scope.Name / .Version with no
-		// nil check (trace_transform.go:137 — the exact panic that
+		// nil check (trace_transform.go — the exact panic that
 		// broke trace detail via /api/ds/query on the compose smoke),
 		// and reference Tempo's parquetToProtoInstrumentationScope
 		// always returns a non-nil scope. Spans inside each bucket

--- a/internal/api/tempo/handler_trace_proto_test.go
+++ b/internal/api/tempo/handler_trace_proto_test.go
@@ -385,8 +385,8 @@ func TestHandleTraceByID_AcceptJSON_KeepsJSONShape(t *testing.T) {
 
 // TestTraceByID_EmptyResourceAndScope_NonNilSubmessages is the
 // consumer-grade pin for the Grafana 12 server-side transform panic
-// (pkg/tsdb/tempo/trace_transform.go:137 — `libraryTags.Name` where
-// libraryTags = ils.Scope, plus resource.Attributes read at line 89,
+// (pkg/tsdb/tempo/trace_transform.go — `libraryTags.Name` where
+// libraryTags = ils.Scope, plus its `resource.Attributes` read,
 // neither nil-checked; compose-smoke run 27307929705). A span whose
 // row carries NO resource attributes and an empty ScopeName /
 // ScopeVersion must still marshal — on BOTH the v1 bare trace and the
@@ -458,7 +458,7 @@ func TestTraceByID_EmptyResourceAndScope_NonNilSubmessages(t *testing.T) {
 		}
 		ss := rs.ScopeSpans[0]
 		if ss.Scope == nil {
-			t.Fatalf("%s: ScopeSpans.Scope is nil after decode — the scope field is missing from the wire; Grafana 12 trace_transform.go:137 panics on it", label)
+			t.Fatalf("%s: ScopeSpans.Scope is nil after decode — the scope field is missing from the wire; Grafana 12 trace_transform.go panics on it", label)
 		}
 		if ss.Scope.Name != "" || ss.Scope.Version != "" {
 			t.Errorf("%s: empty scope columns must yield an EMPTY InstrumentationScope, got name=%q version=%q", label, ss.Scope.Name, ss.Scope.Version)

--- a/internal/api/tempo/search_tags_test.go
+++ b/internal/api/tempo/search_tags_test.go
@@ -407,7 +407,7 @@ func TestSearchTagsV2_InvalidScope(t *testing.T) {
 // enum_attributes.go) maps only "", "none", "trace", "span",
 // "resource", "event", "link" and "instrumentation" to a real scope;
 // everything else folds to AttributeScopeUnknown, and
-// `pkg/api.ParseSearchTagsRequest` (pkg/api/search_tags.go:392) turns
+// `pkg/api.ParseSearchTagsRequest` (in pkg/api/search_tags.go) turns
 // that into `invalid scope: <v>` — the same shape it produces for
 // upstream's own `scope=blerg` test case.
 //

--- a/internal/chplan/duplicate_labelset.go
+++ b/internal/chplan/duplicate_labelset.go
@@ -4,7 +4,7 @@ package chplan
 // construct raises when two input series that differed ONLY by `__name__`
 // collapse onto one label set. It is the verbatim reference-engine text:
 //
-//	prometheus/prometheus@cerberus-parser/promql/engine.go:2295
+//	prometheus/prometheus@cerberus-parser/promql/engine.go
 //	`ev.errorf("vector cannot contain metrics with the same labelset")`
 //
 // Upstream reaches it from `Matrix.ContainsSameLabelset()` right after a

--- a/internal/chplan/gremlins_kill_test.go
+++ b/internal/chplan/gremlins_kill_test.go
@@ -29,7 +29,7 @@ import (
 // equal_invariants_test.go; they sit here as a single mutation-budget
 // file so the kill set is easy to audit against the gremlins report.
 
-// --- cross_join.go:27:30 — `Left.Equal(o.Left) && Right.Equal(o.Right)` ---
+// --- cross_join.go:`c.Left.Equal(o.Left) && c.Right.Equal(o.Right)` ---
 
 // TestCrossJoin_Equal_Negative_RightOnly / _LeftOnly exercise the
 // `Left && Right` tail of CrossJoin.Equal. A mutant flipping `&&` to
@@ -87,10 +87,13 @@ func TestNaryVectorSetOp_Equal_Positive(t *testing.T) {
 
 // TestNaryVectorSetOp_Equal_Negative_Fields exercises each disjunct in
 // NaryVectorSetOp.Equal individually:
-//   - nary_vector_set_op.go:72 — `Op != || !Match.Equal || StepAligned !=`
-//   - nary_vector_set_op.go:75/76/77 — the
-//     `MetricNameColumn != || AttributesColumn != || TimestampColumn !=
-//     || ValueColumn !=` chain
+//   - nary_vector_set_op.go:`s.Op != o.Op || !s.Match.Equal(o.Match)` — the
+//     Op / Match / StepAligned disjunct chain
+//   - nary_vector_set_op.go:`s.MetricNameColumn != o.MetricNameColumn`,
+//     nary_vector_set_op.go:`s.AttributesColumn != o.AttributesColumn`,
+//     nary_vector_set_op.go:`s.TimestampColumn != o.TimestampColumn` and
+//     nary_vector_set_op.go:`s.ValueColumn != o.ValueColumn` — the column
+//     chain
 //
 // Each row diverges in exactly ONE field; with `||` → `&&` the mutant
 // would require every column to differ before reporting not-Equal, so a
@@ -191,10 +194,11 @@ func TestRangeBucketFanout_Equal_Negative_Fields(t *testing.T) {
 	}
 }
 
-// TestRangeBucketFanout_Equal_Negative_InputOneNil pins the `Input ==
-// nil || o.Input == nil` short-circuit (range_bucket_fanout.go:129). A
-// `||` → `&&` flip would skip the early-out when exactly one Input is
-// nil, walking into Input.Equal on a nil receiver / mis-reporting.
+// TestRangeBucketFanout_Equal_Negative_InputOneNil pins the
+// range_bucket_fanout.go:`r.Input == nil || o.Input == nil`
+// short-circuit. A `||` → `&&` flip would skip the early-out when
+// exactly one Input is nil, walking into Input.Equal on a nil receiver
+// / mis-reporting.
 func TestRangeBucketFanout_Equal_Negative_InputOneNil(t *testing.T) {
 	t.Parallel()
 	a := fanoutFixture()
@@ -208,7 +212,7 @@ func TestRangeBucketFanout_Equal_Negative_InputOneNil(t *testing.T) {
 	}
 }
 
-// --- step_grid.go:38 — `Start.Equal && End.Equal && Step ==` ---
+// --- step_grid.go:`s.Start.Equal(o.Start) && s.End.Equal(o.End) && s.Step == o.Step` ---
 
 func TestStepGrid_Equal_Positive(t *testing.T) {
 	t.Parallel()
@@ -259,7 +263,7 @@ func TestStepGrid_Equal_Negative_Fields(t *testing.T) {
 // --- reanchor.go widen arithmetic + grid-prediction guards ---
 
 // TestReanchorRange_LWRWidenArithmetic kills the membership-window widen
-// math at reanchor.go:126 — `start.Add(-v.Offset - v.Lookback)`. The
+// math at reanchor.go:`c.Start.Add(-v.Offset-v.Lookback)`. The
 // outer RangeLWR's Input is itself an (unpinned) RangeLWR, so the
 // widened start is RECORDED as the inner node's Start and can be
 // asserted exactly. Offset and Lookback are distinct non-zero durations
@@ -321,11 +325,11 @@ func TestReanchorRange_LWRWidenArithmetic(t *testing.T) {
 }
 
 // TestReanchorRange_RejectsPartialPin kills the matrix-window grid guards
-// at reanchor.go:185 (`Start.IsZero() && End.IsZero()`). A partially-
-// pinned node — Start zero, End pinned OFF the predicted grid — must be
-// rejected with ErrReanchorGridMismatch. With `&&` → `||` the unpinned
-// early-return would fire (Start.IsZero() alone is enough), wrongly
-// accepting the off-grid End.
+// at reanchor.go:checkPredictedGrid:`r.Start.IsZero() && r.End.IsZero()`.
+// A partially-pinned node — Start zero, End pinned OFF the predicted grid
+// — must be rejected with ErrReanchorGridMismatch. With `&&` → `||` the
+// unpinned early-return would fire (Start.IsZero() alone is enough),
+// wrongly accepting the off-grid End.
 func TestReanchorRange_RejectsPartialPin(t *testing.T) {
 	t.Parallel()
 
@@ -340,8 +344,8 @@ func TestReanchorRange_RejectsPartialPin(t *testing.T) {
 	}
 }
 
-// TestReanchorRange_LWRRejectsPartialPinZeroStart kills the LWR
-// unpinned guard at reanchor.go:209 (`Start.IsZero() && End.IsZero()`):
+// TestReanchorRange_LWRRejectsPartialPinZeroStart kills the LWR unpinned
+// guard reanchor.go:checkPredictedGridLWR:`r.Start.IsZero() && r.End.IsZero()`:
 // Start zero, End off-grid → reject. `&&` → `||` would accept on the
 // zero Start alone.
 func TestReanchorRange_LWRRejectsPartialPinZeroStart(t *testing.T) {
@@ -356,8 +360,9 @@ func TestReanchorRange_LWRRejectsPartialPinZeroStart(t *testing.T) {
 }
 
 // TestReanchorRange_LWRRejectsGriddedStartOffGridEnd kills the LWR
-// already-gridded guard at reanchor.go:212 (`Start.Equal(predStart) &&
-// End.Equal(predEnd)`): Start sits exactly on the predicted grid but End
+// already-gridded guard
+// reanchor.go:checkPredictedGridLWR:`r.Start.Equal(predStart) && r.End.Equal(predEnd)`:
+// Start sits exactly on the predicted grid but End
 // diverges → reject. With `&&` → `||` the matching Start alone would
 // satisfy the guard and wrongly accept the off-grid End.
 func TestReanchorRange_LWRRejectsGriddedStartOffGridEnd(t *testing.T) {

--- a/internal/chplan/gremlins_rewrite_mutants_test.go
+++ b/internal/chplan/gremlins_rewrite_mutants_test.go
@@ -7,8 +7,8 @@
 // code and the mutated branch produce observably different `changed`
 // flags or output trees.
 //
-// Mutant IDs use gremlins's `file:line:col` notation from the
-// phase3-optimizer workflow logs.
+// Mutants are named by the construct they rewrite rather than by the
+// `file:line:col` address the phase3-optimizer workflow logs report.
 package chplan
 
 import (
@@ -16,7 +16,7 @@ import (
 )
 
 // TestRewriteLeftRight_RebuildsWhenOnlyLeftChanges pins the
-// `if !lch && !rch` early-return guard at rule.go:251 inside
+// rewrite_children.go:`!lch && !rch` early-return guard inside
 // rewriteLeftRight. The condition means "neither child changed — hand
 // back the original node". Flipping `&&` to `||` (gremlins
 // INVERT_LOGICAL) would early-return whenever EITHER child is unchanged,
@@ -55,8 +55,10 @@ func TestRewriteLeftRight_RebuildsWhenOnlyLeftChanges(t *testing.T) {
 }
 
 // TestRewriteIrregular_TopK_RecursesIntoKExprWhenInputUnchanged pins the
-// `if v.KExpr != nil` guard at rule.go:463 inside rewriteIrregularNode's
-// TopK case. The guard means "only recurse into KExpr when it exists".
+// rewrite_children.go:`optional != nil` guard in rewriteOptionalPair,
+// which rewriteIrregularNode's TopK case reaches with KExpr as the
+// optional child. The guard means "only recurse into KExpr when it
+// exists".
 // Flipping `!= nil` to `== nil` (gremlins CONDITIONALS_NEGATION) inverts
 // it: a non-nil KExpr would be bypassed (and a nil KExpr would be fed to
 // fn). So a TopK whose KExpr carries the only rewrite target — and whose
@@ -64,9 +66,9 @@ func TestRewriteLeftRight_RebuildsWhenOnlyLeftChanges(t *testing.T) {
 // rewrite.
 //
 // Input: TopK{Input: plain Scan (unchanged), KExpr: sentinel}. Original:
-// kCh=true → rebuild with rewritten KExpr. Mutant (`== nil`): KExpr is
-// non-nil so the branch is bypassed, kCh=false, Input unchanged → returns
-// the original unchanged.
+// optCh=true → rebuild with rewritten KExpr. Mutant (`== nil`): KExpr is
+// non-nil so the branch is bypassed, optCh=false, Input unchanged →
+// returns the original unchanged.
 func TestRewriteIrregular_TopK_RecursesIntoKExprWhenInputUnchanged(t *testing.T) {
 	t.Parallel()
 
@@ -95,17 +97,18 @@ func TestRewriteIrregular_TopK_RecursesIntoKExprWhenInputUnchanged(t *testing.T)
 }
 
 // TestRewriteIrregular_MetricsCompare_RebuildsWhenOnlyRootLookupChanges
-// pins the `if !innerCh && !rootCh` early-return guard at rule.go:507
-// inside rewriteIrregularNode's MetricsCompare case. The condition means
-// "neither child changed — hand back the original". Flipping `&&` to
-// `||` (gremlins INVERT_LOGICAL) would early-return whenever EITHER child
-// is unchanged, so a MetricsCompare whose RootLookup rewrote but whose
-// Inner did not would be returned UNCHANGED, dropping the RootLookup
-// rewrite.
+// pins the rewrite_children.go:`primaryCh || optCh` changed-flag
+// disjunction in rewriteOptionalPair, which rewriteIrregularNode's
+// MetricsCompare case reaches with RootLookup as the optional child. The
+// disjunction means "either child changed — rebuild". Flipping `||` to
+// `&&` (gremlins INVERT_LOGICAL) would report unchanged whenever EITHER
+// child is unchanged, so a MetricsCompare whose RootLookup rewrote but
+// whose Inner did not would be returned UNCHANGED, dropping the
+// RootLookup rewrite.
 //
 // Input: MetricsCompare{Inner: plain Scan (unchanged), RootLookup:
-// sentinel}. innerCh=false, rootCh=true. Original: `!false && !true` =
-// false → rebuild. Mutant: `!false || !true` = true → return unchanged.
+// sentinel}. primaryCh=false, optCh=true. Original: `false || true` =
+// true → rebuild. Mutant: `false && true` = false → return unchanged.
 func TestRewriteIrregular_MetricsCompare_RebuildsWhenOnlyRootLookupChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chsql/aggregate_range_lwr_fusion_eligibility_test.go
+++ b/internal/chsql/aggregate_range_lwr_fusion_eligibility_test.go
@@ -298,7 +298,7 @@ func TestEmitAggregateRangeLWRFused_DeclinedShapeStillEmits(t *testing.T) {
 }
 
 // TestGroupBySelectFrags_BucketKeyContinuesLoop kills the INVERT_LOOPCTRL
-// mutant at aggregate_range_lwr_fusion.go:259 (`continue` -> `break`) inside
+// mutant at aggregate_range_lwr_fusion.go:`continue` (`continue` -> `break`) inside
 // groupBySelectFrags. rangeLWRFusionTestAggregate puts the anchor/bucket key
 // LAST in GroupBy, which makes a `break` mutant a no-op there (nothing
 // follows it to skip) — this reorders the bucket key to FIRST so a `break`

--- a/internal/chsql/builder_error_latch_mutation_test.go
+++ b/internal/chsql/builder_error_latch_mutation_test.go
@@ -102,7 +102,7 @@ func TestMutation_Subquery_PropagatesNestedError(t *testing.T) {
 // guard: an outer Builder that has ALREADY failed keeps its own error when a
 // spliced subquery fails too.
 //
-// Kills builder.go:2001:17 INVERT_LOGICAL (`&&` -> `||`), which fires on every
+// Kills builder.go:`b.sb.WriteString(p2)` INVERT_LOGICAL (`&&` -> `||`), which fires on every
 // non-nil nested error and so replaces the outer Builder's first error with
 // the subquery's.
 func TestMutation_Subquery_KeepsOuterFirstError(t *testing.T) {

--- a/internal/chsql/builder_error_latch_mutation_test.go
+++ b/internal/chsql/builder_error_latch_mutation_test.go
@@ -51,7 +51,8 @@ func failingSubquery() *QueryBuilder {
 // ordering is the contract — the first failure is the root cause; everything
 // after it is rendered against a Builder already known to be broken.
 //
-// Kills builder.go:298:17 INVERT_LOGICAL (`&&` -> `||`): the mutated guard is
+// Kills INVERT_LOGICAL (`&&` -> `||`) on
+// builder.go:Expr:`err != nil && b.err == nil`: the mutated guard is
 // `err != nil || b.err == nil`, which fires on EVERY non-nil err, so the
 // second rejection overwrites the first and Build reports the ScalarSubquery
 // error instead of the Lambda one.
@@ -83,10 +84,10 @@ func TestMutation_Expr_LatchKeepsFirstError(t *testing.T) {
 // stream by the time it returns, so dropping the error hands the caller a
 // query that cannot parse and no indication why.
 //
-// Kills builder.go:2001:10 CONDITIONALS_NEGATION (`err != nil` -> `err == nil`)
-// and 2001:26 CONDITIONALS_NEGATION (`b.err == nil` -> `b.err != nil`): under
-// either the outer latch is never given its first value, and Build reports
-// success.
+// Kills both CONDITIONALS_NEGATION mutants of
+// builder.go:Subquery:`err != nil && b.err == nil` (`err != nil` ->
+// `err == nil`, `b.err == nil` -> `b.err != nil`): under either the outer
+// latch is never given its first value, and Build reports success.
 func TestMutation_Subquery_PropagatesNestedError(t *testing.T) {
 	t.Parallel()
 
@@ -102,7 +103,8 @@ func TestMutation_Subquery_PropagatesNestedError(t *testing.T) {
 // guard: an outer Builder that has ALREADY failed keeps its own error when a
 // spliced subquery fails too.
 //
-// Kills builder.go:`b.sb.WriteString(p2)` INVERT_LOGICAL (`&&` -> `||`), which fires on every
+// Kills INVERT_LOGICAL (`&&` -> `||`) on
+// builder.go:Subquery:`err != nil && b.err == nil`, which fires on every
 // non-nil nested error and so replaces the outer Builder's first error with
 // the subquery's.
 func TestMutation_Subquery_KeepsOuterFirstError(t *testing.T) {
@@ -126,8 +128,9 @@ func TestMutation_Subquery_KeepsOuterFirstError(t *testing.T) {
 // TestMutation_Subquery_PropagatesNestedError for Spliced, whose guard is a
 // verbatim copy carrying its own mutants.
 //
-// Kills builder.go:2023:10 CONDITIONALS_NEGATION (`err != nil` -> `err == nil`)
-// and 2023:26 CONDITIONALS_NEGATION (`b.err == nil` -> `b.err != nil`).
+// Kills both CONDITIONALS_NEGATION mutants of
+// builder.go:Spliced:`err != nil && b.err == nil` (`err != nil` ->
+// `err == nil`, `b.err == nil` -> `b.err != nil`).
 func TestMutation_Spliced_PropagatesNestedError(t *testing.T) {
 	t.Parallel()
 
@@ -142,7 +145,8 @@ func TestMutation_Spliced_PropagatesNestedError(t *testing.T) {
 // TestMutation_Spliced_KeepsOuterFirstError is
 // TestMutation_Subquery_KeepsOuterFirstError for Spliced.
 //
-// Kills builder.go:2023:17 INVERT_LOGICAL (`&&` -> `||`).
+// Kills INVERT_LOGICAL (`&&` -> `||`) on
+// builder.go:Spliced:`err != nil && b.err == nil`.
 func TestMutation_Spliced_KeepsOuterFirstError(t *testing.T) {
 	t.Parallel()
 
@@ -167,9 +171,10 @@ func TestMutation_Spliced_KeepsOuterFirstError(t *testing.T) {
 // label_replace whose source expression cannot render emits
 // `extractGroups(<nothing>, '…')[1]` and reports success.
 //
-// Kills builder.go:1116:33 CONDITIONALS_NEGATION (`err != nil` -> `err == nil`)
-// and 1116:50 CONDITIONALS_NEGATION (`srcErr == nil` -> `srcErr != nil`):
-// under either, srcErr never takes a non-nil value and the method returns nil.
+// Kills both CONDITIONALS_NEGATION mutants of
+// builder.go:`err != nil && srcErr == nil` (`err != nil` -> `err == nil`,
+// `srcErr == nil` -> `srcErr != nil`): under either, srcErr never takes a
+// non-nil value and the method returns nil.
 func TestMutation_LabelReplaceSegment_SrcErrorPropagates(t *testing.T) {
 	t.Parallel()
 
@@ -210,8 +215,8 @@ func TestMutation_LabelReplaceSegment_RendersCaptureGroup(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// builder.go:1116:40 (INVERT_LOGICAL, `&&` -> `||` in labelReplaceSegment's
-// srcErr latch) is EQUIVALENT. The mutated guard is
+// builder.go:`err != nil && srcErr == nil` (INVERT_LOGICAL, `&&` -> `||` in
+// labelReplaceSegment's srcErr latch) is EQUIVALENT. The mutated guard is
 // `err != nil || srcErr == nil`, which differs from the original in exactly
 // one state: srcErr already non-nil AND err non-nil, where the mutant
 // overwrites srcErr with the later error instead of keeping the first. Every

--- a/internal/chsql/builder_mutation_test.go
+++ b/internal/chsql/builder_mutation_test.go
@@ -15,13 +15,13 @@ func renderFragToSQL(f Frag) string {
 
 // TestMutation_WriteCTEs_NonRecursiveHead pins the WITH-head selection for a
 // chain that holds ONLY a non-recursive (Body-only) CTE: Anchor == nil and
-// Recursive == nil, so the recursive-detection condition at builder.go:2073
-// (`c.Anchor != nil || c.Recursive != nil`) must evaluate false and the head
-// must render bare "WITH " (never "WITH RECURSIVE ").
+// Recursive == nil, so the recursive-detection condition
+// builder.go:`c.Anchor != nil || c.Recursive != nil` must evaluate false and
+// the head must render bare "WITH " (never "WITH RECURSIVE ").
 //
-// Kills builder.go:2073:15 (CONDITIONALS_NEGATION `c.Anchor != nil` ->
-// `c.Anchor == nil`) and 2073:37 (CONDITIONALS_NEGATION `c.Recursive != nil`
-// -> `c.Recursive == nil`): under either negation both operands of the OR flip
+// Kills both CONDITIONALS_NEGATION mutants of that condition
+// (`c.Anchor != nil` -> `c.Anchor == nil`, `c.Recursive != nil` ->
+// `c.Recursive == nil`): under either negation both operands of the OR flip
 // from false to true, so `recursive` becomes true and the head wrongly renders
 // "WITH RECURSIVE ".
 func TestMutation_WriteCTEs_NonRecursiveHead(t *testing.T) {
@@ -51,10 +51,12 @@ func TestMutation_WriteCTEs_NonRecursiveHead(t *testing.T) {
 // With the original `Anchor != nil || Recursive != nil` the left operand is
 // true, so `recursive` is true and the head renders "WITH RECURSIVE ".
 //
-// Kills builder.go:2073:22 (INVERT_LOGICAL `||` -> `&&`): `true && false`
-// becomes false, dropping the RECURSIVE keyword. Also kills 2073:15
-// (CONDITIONALS_NEGATION `Anchor != nil` -> `Anchor == nil`): `false || false`
-// becomes false, likewise dropping RECURSIVE.
+// Kills INVERT_LOGICAL (`||` -> `&&`) on
+// builder.go:`c.Anchor != nil || c.Recursive != nil`: `true && false`
+// becomes false, dropping the RECURSIVE keyword. Also kills the
+// CONDITIONALS_NEGATION on the same condition (`Anchor != nil` ->
+// `Anchor == nil`): `false || false` becomes false, likewise dropping
+// RECURSIVE.
 func TestMutation_WriteCTEs_RecursiveOrLeftBranch(t *testing.T) {
 	t.Parallel()
 
@@ -73,14 +75,15 @@ func TestMutation_WriteCTEs_RecursiveOrLeftBranch(t *testing.T) {
 }
 
 // TestMutation_ArrayJoin_CommaSeparator pins the comma-joining of a multi-term
-// ARRAY JOIN. With two terms the loop at builder.go:2153 must emit the first
-// term with no leading comma (i == 0) and the second with ", " (i > 0),
-// producing "ARRAY JOIN <a>, <b>".
+// ARRAY JOIN. With two terms the loop
+// builder.go:`for i, f := range s.arrayJoin` must emit the first term with no
+// leading comma (i == 0) and the second with ", " (i > 0), producing
+// "ARRAY JOIN <a>, <b>".
 //
-// Kills builder.go:2154:9 CONDITIONALS_BOUNDARY (`i > 0` -> `i >= 0`: a comma
-// is wrongly prefixed before the first term -> "ARRAY JOIN , a, b") and
-// CONDITIONALS_NEGATION (`i > 0` -> `i <= 0`: comma before first term and none
-// between -> "ARRAY JOIN , ab").
+// Kills that loop's separator guard under CONDITIONALS_BOUNDARY (`i > 0` ->
+// `i >= 0`: a comma is wrongly prefixed before the first term -> "ARRAY JOIN
+// , a, b") and CONDITIONALS_NEGATION (`i > 0` -> `i <= 0`: comma before first
+// term and none between -> "ARRAY JOIN , ab").
 func TestMutation_ArrayJoin_CommaSeparator(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chsql/emit_node_aggregate_mutation_test.go
+++ b/internal/chsql/emit_node_aggregate_mutation_test.go
@@ -16,8 +16,9 @@ import (
 // clause — accepting the combination would silently DROP the predicate, so a
 // `sum(x) > 5`-style filter would stop filtering.
 //
-// Kills emit_node.go:`return fmt.Errorf("%w: Aggregate.Having combined with DropEmptyOnNoGroup", ErrUnsupported)` CONDITIONALS_NEGATION (`len(a.GroupBy) == 0` ->
-// `!= 0`): the mutated guard fires only for GROUPED aggregates, so this
+// Kills the CONDITIONALS_NEGATION on `len(a.GroupBy) == 0` (-> `!= 0`) in
+// emit_node.go:`a.Having != nil && len(a.GroupBy) == 0 && a.DropEmptyOnNoGroup`:
+// the mutated guard fires only for GROUPED aggregates, so this
 // ungrouped plan sails past it into emitAggregateNoGroup and emits SQL.
 func TestMutation_EmitAggregate_HavingWithDropEmptyIsRejected(t *testing.T) {
 	t.Parallel()
@@ -39,7 +40,9 @@ func TestMutation_EmitAggregate_HavingWithDropEmptyIsRejected(t *testing.T) {
 // DropEmptyOnNoGroup is simply inert (the flag only speaks about the no-group
 // case).
 //
-// Also kills emit_node.go:`return fmt.Errorf("%w: Aggregate.Having combined with DropEmptyOnNoGroup", ErrUnsupported)` CONDITIONALS_NEGATION from the other side:
+// Also kills that same CONDITIONALS_NEGATION on
+// emit_node.go:`a.Having != nil && len(a.GroupBy) == 0 && a.DropEmptyOnNoGroup`
+// from the other side:
 // the mutated guard rejects exactly this plan.
 func TestMutation_EmitAggregate_HavingWithGroupKeysIsAccepted(t *testing.T) {
 	t.Parallel()

--- a/internal/chsql/emit_node_aggregate_mutation_test.go
+++ b/internal/chsql/emit_node_aggregate_mutation_test.go
@@ -16,7 +16,7 @@ import (
 // clause — accepting the combination would silently DROP the predicate, so a
 // `sum(x) > 5`-style filter would stop filtering.
 //
-// Kills emit_node.go:519:39 CONDITIONALS_NEGATION (`len(a.GroupBy) == 0` ->
+// Kills emit_node.go:`return fmt.Errorf("%w: Aggregate.Having combined with DropEmptyOnNoGroup", ErrUnsupported)` CONDITIONALS_NEGATION (`len(a.GroupBy) == 0` ->
 // `!= 0`): the mutated guard fires only for GROUPED aggregates, so this
 // ungrouped plan sails past it into emitAggregateNoGroup and emits SQL.
 func TestMutation_EmitAggregate_HavingWithDropEmptyIsRejected(t *testing.T) {
@@ -39,7 +39,7 @@ func TestMutation_EmitAggregate_HavingWithDropEmptyIsRejected(t *testing.T) {
 // DropEmptyOnNoGroup is simply inert (the flag only speaks about the no-group
 // case).
 //
-// Also kills emit_node.go:519:39 CONDITIONALS_NEGATION from the other side:
+// Also kills emit_node.go:`return fmt.Errorf("%w: Aggregate.Having combined with DropEmptyOnNoGroup", ErrUnsupported)` CONDITIONALS_NEGATION from the other side:
 // the mutated guard rejects exactly this plan.
 func TestMutation_EmitAggregate_HavingWithGroupKeysIsAccepted(t *testing.T) {
 	t.Parallel()

--- a/internal/chsql/emit_node_project_mutation_test.go
+++ b/internal/chsql/emit_node_project_mutation_test.go
@@ -50,8 +50,8 @@ func TestMutation_EmitProject_ReplacementsOnlyRenderStarReplace(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// emit_node.go:504:52 (CONDITIONALS_BOUNDARY, `len(p.Replacements) > 0` ->
-// `>= 0`) is EQUIVALENT. The two guards can only disagree on a Project with
+// emit_node.go:`len(p.Replacements) > 0` (CONDITIONALS_BOUNDARY,
+// `len(p.Replacements) > 0` -> `>= 0`) is EQUIVALENT. The two guards can only disagree on a Project with
 // NO projections and NO replacements, and there both renderings are the same
 // bytes:
 //

--- a/internal/chsql/emit_size_bound_mutation_test.go
+++ b/internal/chsql/emit_size_bound_mutation_test.go
@@ -6,7 +6,7 @@ package chsql
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// emit_size_bound.go:251:23 (CONDITIONALS_BOUNDARY, `d > deepest` ->
+// emit_size_bound.go:`d > deepest` (CONDITIONALS_BOUNDARY, `d > deepest` ->
 // `d >= deepest` in gridCarrierNesting's per-child running-maximum update)
 // is EQUIVALENT. The mutation only changes behaviour when `d == deepest`:
 // the original skips the assignment (already equal, nothing to update) and

--- a/internal/chsql/emit_size_bound_mutation_test.go
+++ b/internal/chsql/emit_size_bound_mutation_test.go
@@ -6,8 +6,8 @@ package chsql
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// emit_size_bound.go:`d > deepest` (CONDITIONALS_BOUNDARY, `d > deepest` ->
-// `d >= deepest` in gridCarrierNesting's per-child running-maximum update)
+// emit_size_bound.go:`d > deepest` (CONDITIONALS_BOUNDARY, `>` -> `>=` in
+// gridCarrierNesting's per-child running-maximum update)
 // is EQUIVALENT. The mutation only changes behaviour when `d == deepest`:
 // the original skips the assignment (already equal, nothing to update) and
 // the mutant runs `deepest = d`, which assigns the SAME int value back to

--- a/internal/chsql/exemplars_misc_mutation_test.go
+++ b/internal/chsql/exemplars_misc_mutation_test.go
@@ -18,7 +18,7 @@ import (
 // that cap.
 //
 // It does NOT kill the CONDITIONALS_BOUNDARY mutant on the guard it
-// exercises (exemplars.go:`if maxPerSeries > 0`, `if maxPerSeries > 0` -> `>= 0`); see the
+// exercises (exemplars.go:`if maxPerSeries > 0` -> `>= 0`); see the
 // NOT KILLABLE note at the foot of this file for why that mutant is
 // equivalent. The contract is worth pinning regardless — it is the
 // difference between "uncapped" and "every bucket capped to zero rows".
@@ -64,7 +64,7 @@ func TestExemplarsMaxPerSeriesZeroNoLimit(t *testing.T) {
 }
 
 // TestRangeBucketFanoutEmptyGroupBy kills the ARITHMETIC_BASE mutant at
-// range_bucket_fanout.go:160 (`make([]Frag, 0, len(r.GroupBy)+1)` ->
+// range_bucket_fanout.go:`make([]Frag, 0, len(r.GroupBy)+1)` (->
 // `... len(r.GroupBy)-1`).
 //
 // The collapse GROUP BY slot is pre-sized to len(GroupBy)+1 (the user
@@ -246,8 +246,8 @@ func TestExemplarsRateAndCountIgnoreAttr(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// exemplars.go:`if maxPerSeries > 0` (CONDITIONALS_BOUNDARY, `if maxPerSeries > 0` ->
-// `>= 0`). The two forms differ only at maxPerSeries == 0, where the mutant
+// exemplars.go:`if maxPerSeries > 0` (CONDITIONALS_BOUNDARY, `>` -> `>=`).
+// The two forms differ only at maxPerSeries == 0, where the mutant
 // enters the block and calls `outerSb.Limit(0)` followed by
 // `outerSb.LimitBy(...)`. QueryBuilder.Limit records `hasLimit = n > 0`, so
 // Limit(0) leaves hasLimit false, and the renderer emits the whole LIMIT /
@@ -256,8 +256,8 @@ func TestExemplarsRateAndCountIgnoreAttr(t *testing.T) {
 // byte-identical statement and an identical args slice; only two dead
 // allocations differ. (A negative maxPerSeries fails both forms alike.)
 //
-// exemplars.go:235:51 (ARITHMETIC_BASE, `make([]Frag, 0,
-// len(groupAliases)*2+6)` -> `len(groupAliases)/2+6`). The mutated operand
+// exemplars.go:`len(groupAliases)*2+6` (ARITHMETIC_BASE,
+// `make([]Frag, 0, len(groupAliases)*2+6)` -> `len(groupAliases)/2+6`). The mutated operand
 // is the Attributes-map slice's capacity HINT, which append grows on
 // demand; `len/2 + 6` is non-negative for every input, so it cannot even
 // panic the way the sibling `+6` -> `-6` mutant does. Capacity is

--- a/internal/chsql/exemplars_misc_mutation_test.go
+++ b/internal/chsql/exemplars_misc_mutation_test.go
@@ -18,7 +18,7 @@ import (
 // that cap.
 //
 // It does NOT kill the CONDITIONALS_BOUNDARY mutant on the guard it
-// exercises (exemplars.go:298, `if maxPerSeries > 0` -> `>= 0`); see the
+// exercises (exemplars.go:`if maxPerSeries > 0`, `if maxPerSeries > 0` -> `>= 0`); see the
 // NOT KILLABLE note at the foot of this file for why that mutant is
 // equivalent. The contract is worth pinning regardless — it is the
 // difference between "uncapped" and "every bucket capped to zero rows".
@@ -246,7 +246,7 @@ func TestExemplarsRateAndCountIgnoreAttr(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// exemplars.go:298:18 (CONDITIONALS_BOUNDARY, `if maxPerSeries > 0` ->
+// exemplars.go:`if maxPerSeries > 0` (CONDITIONALS_BOUNDARY, `if maxPerSeries > 0` ->
 // `>= 0`). The two forms differ only at maxPerSeries == 0, where the mutant
 // enters the block and calls `outerSb.Limit(0)` followed by
 // `outerSb.LimitBy(...)`. QueryBuilder.Limit records `hasLimit = n > 0`, so

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -27,7 +27,7 @@ import (
 //     scope and gets killed.
 
 // TestSortRankFor_ContinueVsBreak kills the `continue` → `break` flip
-// at prewhere.go:128. Input order matters: an unknown column ahead of
+// in prewhere.go:`r < 0`. Input order matters: an unknown column ahead of
 // a known one only resolves to the known column's rank if the loop
 // keeps iterating (continue) rather than bailing on the first miss
 // (break).
@@ -46,7 +46,8 @@ func TestSortRankFor_ContinueVsBreak(t *testing.T) {
 }
 
 // TestSortRankFor_BestNegativeBoundary kills the `<` ↔ `<=` boundary
-// flip at prewhere.go:130:11 (`best < 0`). With the mutant `best <= 0`
+// flip on `best < 0` in prewhere.go:`best < 0 || r < best`. With the
+// mutant `best <= 0`
 // the loop overwrites the rank-0 best when it sees any larger rank,
 // returning the wrong (later) sort column.
 func TestSortRankFor_BestNegativeBoundary(t *testing.T) {
@@ -59,11 +60,11 @@ func TestSortRankFor_BestNegativeBoundary(t *testing.T) {
 	}
 }
 
-// TestOrderedConjuncts_StableSortLogicalOr kills the `||` → `&&` flip
-// at prewhere.go:183:23 inside the insertion-sort swap condition. When
-// the rank-comparison conjunct disagrees with the index-tiebreaker the
-// original `||` swaps; the mutant `&&` requires both, which never
-// holds at the same time, so the swap never happens.
+// TestOrderedConjuncts_StableSortLogicalOr kills the flips of the
+// insertion-sort swap condition
+// prewhere.go:`prefix[j-1].rank > prefix[j].rank`. When the rank
+// comparison holds the original swaps the pair; a flipped comparison
+// never swaps, so an out-of-order pair is left in input order.
 func TestOrderedConjuncts_StableSortLogicalOr(t *testing.T) {
 	t.Parallel()
 	shape := TableShape{SortColumns: []string{"ServiceName", "Timestamp"}}
@@ -79,7 +80,8 @@ func TestOrderedConjuncts_StableSortLogicalOr(t *testing.T) {
 }
 
 // TestIsCheapPredicate_AsymmetricBinary kills the `&&` → `||` flip in
-// `isCheapPredicate` for `Binary` (prewhere.go:90). Setting one side
+// prewhere.go:`isCheapPredicate(v.Left) && isCheapPredicate(v.Right)`.
+// Setting one side
 // cheap and the other side not-cheap distinguishes:
 //   - original (&&): false (not both cheap → predicate not cheap)
 //   - mutant   (||): true  (at least one side cheap → wrongly cheap)
@@ -106,8 +108,8 @@ func TestIsCheapPredicate_AsymmetricBinary(t *testing.T) {
 }
 
 // TestIsCheapPredicate_AsymmetricMapAccess kills the `&&` → `||` flip
-// at prewhere.go:92 — same pattern as the Binary case but for the
-// MapAccess shape. Synthesising a non-cheap Map side requires a
+// at prewhere.go:`isCheapPredicate(v.Map) && isCheapPredicate(v.Key)` —
+// same pattern as the Binary case but for the MapAccess shape. Synthesising a non-cheap Map side requires a
 // FuncCall in the Map slot.
 func TestIsCheapPredicate_AsymmetricMapAccess(t *testing.T) {
 	t.Parallel()
@@ -205,7 +207,7 @@ func TestClassifyPredicate_CheapAndWide(t *testing.T) {
 }
 
 // TestPartitionPrewhere_EmptyConjunctsBoundary kills the
-// `len(prewhere) > 0` boundary at prewhere.go:225. With empty
+// prewhere.go:`len(prewhere) > 0` boundary. With empty
 // conjuncts, the post-loop guard must NOT enter; the mutant `>= 0`
 // would index prewhere[-1] and panic.
 func TestPartitionPrewhere_EmptyConjunctsBoundary(t *testing.T) {
@@ -278,7 +280,7 @@ func TestProjectionTouchesWide_BoundaryCases(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_StepBoundary kills the `<=` ↔ `<` boundary
-// flip at exemplars.go:58 (`rw.Step <= 0`). The boundary case Step=0
+// flip at exemplars.go:`rw.Step <= 0`. The boundary case Step=0
 // must error; the mutant `< 0` would let it through.
 func TestEmitMetricsExemplars_StepBoundary(t *testing.T) {
 	t.Parallel()
@@ -302,8 +304,8 @@ func TestEmitMetricsExemplars_StepBoundary(t *testing.T) {
 	}
 }
 
-// TestEmitMetricsExemplars_NilInner pins the `m.Inner == nil` guard
-// (exemplars.go:63). Killing both negation and the implied boundary
+// TestEmitMetricsExemplars_NilInner pins the
+// exemplars.go:`m.Inner == nil` guard. Killing both negation and the implied boundary
 // requires asserting the error AND asserting success when Inner is
 // supplied.
 func TestEmitMetricsExemplars_NilInner(t *testing.T) {
@@ -326,7 +328,7 @@ func TestEmitMetricsExemplars_NilInner(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_NilMetricsAggregate pins the early-return
-// on m==nil (exemplars.go:48).
+// on exemplars.go:`m == nil`.
 func TestEmitMetricsExemplars_NilMetricsAggregate(t *testing.T) {
 	t.Parallel()
 	rw := &chplan.RangeWindow{
@@ -361,7 +363,7 @@ func TestEmitMetricsExemplars_EmptyTimestampColumn(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_RangeDurationFallback kills the `==` flip
-// at exemplars.go:104 (`rangeDur == 0`). When Range is unset, the
+// at exemplars.go:`rangeDur == 0`. When Range is unset, the
 // fallback uses Step. With the negation-mutant the fallback runs when
 // Range is set instead, producing a different windowTsLowerBound.
 func TestEmitMetricsExemplars_RangeDurationFallback(t *testing.T) {
@@ -427,8 +429,8 @@ func TestEmitMetricsExemplars_RangeDurationFallback(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_NumAnchorsBoundary kills both
-// CONDITIONAL_BOUNDARY at exemplars.go:115 and ARITHMETIC mutators at
-// 118 (`span/stepNS + 1` and surrounds). End == Start hits the
+// CONDITIONAL_BOUNDARY at exemplars.go:`span < 0` and the ARITHMETIC
+// mutators at exemplars.go:`span/stepNS + 1`. End == Start hits the
 // boundary: span == 0 → numAnchors = 0/step + 1 = 1.
 func TestEmitMetricsExemplars_NumAnchorsBoundary(t *testing.T) {
 	t.Parallel()
@@ -489,9 +491,9 @@ func TestEmitMetricsExemplars_NumAnchorsBoundary(t *testing.T) {
 	}
 }
 
-// TestEmitMetricsExemplars_GroupByDisplayNamesFallback kills the `!=
-// ""` mutant at exemplars.go:`numAnchors, err := exemplarNumAnchors(rw, stepNS)`. The branch falls back to the SQL
-// alias only when the display name slot is empty; when both alias and
+// TestEmitMetricsExemplars_GroupByDisplayNamesFallback kills the `!= ""`
+// mutant at exemplars.go:`m.GroupByDisplayNames[i] != ""`. The branch
+// falls back to the SQL alias only when the display name slot is empty; when both alias and
 // display name are present, the display name wins. The check inspects
 // the bound args (the labels render as `?` placeholders bound to
 // string args).
@@ -551,10 +553,11 @@ func TestEmitMetricsExemplars_GroupByDisplayNamesFallback(t *testing.T) {
 	}
 }
 
-// TestEmitMetricsExemplars_MetricArgEmission_Op154 kills the three
-// `==` ↔ `!=` flips and the `&&` ↔ `||` flip at exemplars.go:154 —
-// `m.Op != Rate && m.Op != CountOverTime && m.Attr != nil`. The
-// boundary is whether `metric_arg` appears in the inner SELECT.
+// TestEmitMetricsExemplars_MetricArgEmission_Op154 kills the flips of
+// exemplars.go:`!metricsOpCountsRowsRatherThanOperand(m.Op) && m.Attr != nil`
+// — the gate deciding whether the exemplar stream reduces over the
+// operand column. The boundary is whether `metric_arg` appears in the
+// inner SELECT.
 func TestEmitMetricsExemplars_MetricArgEmission_Op154(t *testing.T) {
 	t.Parallel()
 
@@ -661,7 +664,7 @@ func TestEmitMetricsExemplars_ValueExprOpEquality(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_MaxPerSeriesBoundary kills the boundary
-// flip at exemplars.go:229 (`maxPerSeries > 0`). maxPerSeries=0 must
+// flip at exemplars.go:`maxPerSeries > 0`. maxPerSeries=0 must
 // disable LIMIT BY; the mutant `>= 0` would emit `LIMIT 0 BY ...`.
 func TestEmitMetricsExemplars_MaxPerSeriesBoundary(t *testing.T) {
 	t.Parallel()
@@ -710,10 +713,11 @@ func TestEmitMetricsExemplars_MaxPerSeriesBoundary(t *testing.T) {
 	})
 }
 
-// TestEmitMetricsAggregate_GroupByBoundary kills both mutants at
-// range_window.go:85 — boundary `>` ↔ `>=` and negation `>` ↔ `<=` on
-// `len(m.GroupBy) > 0`. Distinguishes the path that emits a `GROUP
-// BY` head (groupBy=[X]) from the empty-groupBy path.
+// TestEmitMetricsAggregate_GroupByBoundary kills the boundary and
+// negation mutants of the empty-GroupBy decision
+// range_window.go:groupKeyFrags:`len(groupBy) == 0`. Distinguishes the
+// path that emits a `GROUP BY` head (groupBy=[X]) from the empty-groupBy
+// path.
 func TestEmitMetricsAggregate_GroupByBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -732,7 +736,7 @@ func TestEmitMetricsAggregate_GroupByBoundary(t *testing.T) {
 			plan := &chplan.MetricsAggregate{
 				Op:         chplan.MetricsOpQuantileOverTime,
 				Attr:       &chplan.ColumnRef{Name: "Duration"},
-				Quantiles:  []float64{0.5, 0.9}, // multi-quantile → exercises the GroupBy branch in range_window.go:85
+				Quantiles:  []float64{0.5, 0.9}, // multi-quantile → exercises the GroupBy branch
 				GroupBy:    c.groupBy,
 				ValueAlias: "Value",
 				Inner:      &chplan.Scan{Table: "otel_traces"},
@@ -750,9 +754,10 @@ func TestEmitMetricsAggregate_GroupByBoundary(t *testing.T) {
 }
 
 // TestOuterGroupAliases_AliasFallback kills the boundary and negation
-// mutants at range_window.go:1037 (`i < len(aliases) && aliases[i] !=
-// ""`). The function falls back to `g<i>` when either the slice runs
-// out OR the alias is empty.
+// mutants at
+// range_window.go:outerGroupAliases:`i < len(aliases) && aliases[i] != ""`.
+// The function falls back to `g<i>` when either the slice runs out OR
+// the alias is empty.
 func TestOuterGroupAliases_AliasFallback(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -805,8 +810,9 @@ func TestOuterGroupAliases_AliasFallback(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_GroupAliasFallback_Iter1039 hits the
-// INVERT_LOOPCTRL at range_window.go:1039 (`continue` flip inside
-// outerGroupAliases) by exercising the second branch — empty alias →
+// INVERT_LOOPCTRL on the `continue` in
+// range_window.go:outerGroupAliases:`i < len(aliases) && aliases[i] != ""`
+// by exercising the second branch — empty alias →
 // fallback to "g<i>". A break-mutant would terminate the loop early
 // and leave the second entry unfilled (panic on out-of-range slice
 // access in the caller).
@@ -841,11 +847,11 @@ func TestEmitMetricsExemplars_GroupAliasFallback_Iter1039(t *testing.T) {
 	}
 }
 
-// TestEmitMetricsAggregate_LogicalAndOnMetricArg kills three negation
-// mutants and one logical mutant at range_window.go:767 (mirror of
-// the exemplars.go:154 cluster). Same matrix-path branch: emit
-// `metric_arg` only when Op is neither Rate nor CountOverTime AND Attr
-// is non-nil.
+// TestEmitMetricsAggregate_LogicalAndOnMetricArg kills the negation and
+// logical mutants of range_window.go:`!zeroFill && m.Attr != nil` — the
+// matrix-path mirror of exemplars.go's own metric_arg gate. Same branch:
+// emit `metric_arg` only when the Op does not zero-fill empty buckets AND
+// Attr is non-nil.
 func TestEmitMetricsAggregate_LogicalAndOnMetricArg(t *testing.T) {
 	t.Parallel()
 
@@ -892,8 +898,9 @@ func TestEmitMetricsAggregate_LogicalAndOnMetricArg(t *testing.T) {
 	}
 }
 
-// TestEmitMetricsAggregate_BadStartEndPin kills the boundary mutants
-// on `span < 0` at range_window.go:736 (mirror of exemplars.go:`span < 0`).
+// TestEmitMetricsAggregate_BadStartEndPin kills the boundary mutants on
+// range_window.go:emitRangeWindowMetrics:`span < 0` (mirror of
+// exemplars.go:`span < 0`).
 // End < Start must error; End == Start must succeed (boundary case).
 func TestEmitMetricsAggregate_BadStartEndPin(t *testing.T) {
 	t.Parallel()
@@ -937,7 +944,8 @@ func TestEmitMetricsAggregate_BadStartEndPin(t *testing.T) {
 }
 
 // TestEmitStructuralJoin_RequiredColumnsTriple kills both
-// INVERT_LOGICAL mutants at structural_join.go:48 (`||` flips). With
+// INVERT_LOGICAL mutants (`||` flips) at
+// structural_join.go:`j.TraceIDColumn == "" || j.SpanIDColumn == ""`. With
 // exactly one of the three columns empty, the original returns
 // ErrUnsupported; the `&&` mutants would let it through.
 func TestEmitStructuralJoin_RequiredColumnsTriple(t *testing.T) {
@@ -976,9 +984,11 @@ func TestEmitStructuralJoin_RequiredColumnsTriple(t *testing.T) {
 }
 
 // TestEmitMetricsHistogramOverTimeBucketAliasFallback covers the
-// `BucketAlias == ""` boundary at histogram_over_time.go:69 and 76
-// (mirror checks for valueAlias). The negation mutant `BucketAlias !=
-// ""` would skip the default, producing an unquoted empty alias.
+// histogram_over_time.go:emitMetricsHistogramOverTime:`bucketAlias == ""`
+// boundary and its mirror
+// histogram_over_time.go:emitMetricsHistogramOverTime:`valueAlias == ""`.
+// The negation mutant `bucketAlias != ""` would skip the default,
+// producing an unquoted empty alias.
 func TestEmitMetricsHistogramOverTimeBucketAliasFallback(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1043,7 +1053,7 @@ func TestEmitMetricsHistogramOverTimeBucketAliasFallback(t *testing.T) {
 }
 
 // TestEmitMetricsHistogramOverTime_GroupAliasFallback exercises the
-// `i < len(m.GroupByAliases)` guard at histogram_over_time.go:62 — the
+// histogram_over_time.go:`i < len(m.GroupByAliases)` guard — the
 // boundary mutant turns into `<=`, causing an out-of-range
 // slice access on the boundary index when fewer aliases are supplied.
 func TestEmitMetricsHistogramOverTime_GroupAliasFallback(t *testing.T) {
@@ -1076,7 +1086,7 @@ func TestEmitMetricsHistogramOverTime_GroupAliasFallback(t *testing.T) {
 }
 
 // TestEmitMetricsHistogramOverTime_RangeFallback kills the negation
-// mutant at histogram_over_time.go:178 (`rangeDur == 0`). When Range
+// mutant at histogram_over_time.go:`rangeDur == 0`. When Range
 // is unset, the fallback uses Step; otherwise Range is used directly.
 func TestEmitMetricsHistogramOverTime_RangeFallback(t *testing.T) {
 	t.Parallel()
@@ -1126,7 +1136,7 @@ func TestEmitMetricsHistogramOverTime_RangeFallback(t *testing.T) {
 }
 
 // TestEmitMetricsHistogramOverTime_NumAnchorsBoundary kills the
-// histogram_over_time.go:189 boundary on `span < 0` (mirror of the
+// histogram_over_time.go:`span < 0` boundary (mirror of the
 // exemplars / range_window check).
 func TestEmitMetricsHistogramOverTime_NumAnchorsBoundary(t *testing.T) {
 	t.Parallel()
@@ -1171,7 +1181,7 @@ func TestEmitMetricsHistogramOverTime_NumAnchorsBoundary(t *testing.T) {
 }
 
 // TestEmitMetricsHistogramOverTime_BadStartEndErrors kills the matrix
-// negation at histogram_over_time.go:189 by hitting the error path.
+// negation at histogram_over_time.go:`span < 0` by hitting the error path.
 func TestEmitMetricsHistogramOverTime_BadStartEndErrors(t *testing.T) {
 	t.Parallel()
 	inner := &chplan.MetricsHistogramOverTime{
@@ -1196,9 +1206,9 @@ func TestEmitMetricsHistogramOverTime_BadStartEndErrors(t *testing.T) {
 }
 
 // TestEmitMetricsSecondStage_PartitionByBoundary kills the boundary
-// at metrics_second_stage.go:69 (`len(m.PartitionBy) > 0`). The
-// mutant `>= 0` would emit a LIMIT BY clause even when
-// PartitionBy is empty, breaking the global top-K shape.
+// on metrics_second_stage.go:`sb.LimitBy(parts...)`. An empty
+// PartitionBy must render no `LIMIT … BY` keys at all; emitting one
+// would break the global top-K shape.
 func TestEmitMetricsSecondStage_PartitionByBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1245,8 +1255,8 @@ func TestEmitMetricsSecondStage_PartitionByBoundary(t *testing.T) {
 }
 
 // TestEmitVectorJoin_LogicalOr kills the INVERT_LOGICAL at
-// vector_join.go:362 (`manySide == "" || len(j.Include) == 0`). With
-// the `&&` mutant only one side suffices for the "OneToOne / bare
+// vector_join.go:`manySide == ""` and vector_join.go:`len(j.Include) == 0`.
+// With the `&&` mutant only one side suffices for the "OneToOne / bare
 // group" branch; we verify the asymmetric case.
 func TestEmitVectorJoin_LogicalOr(t *testing.T) {
 	t.Parallel()
@@ -1284,10 +1294,10 @@ func TestEmitVectorJoin_LogicalOr(t *testing.T) {
 	}
 }
 
-// TestEmitScan_NoColumnsBoundary kills the boundary at emit_node.go:66
-// (`len(s.Columns) > 0`). Without explicit Columns, the SELECT must be
-// the bare `SELECT *`; the mutant `>= 0` would emit an empty SELECT
-// list (invalid SQL).
+// TestEmitScan_NoColumnsBoundary kills the boundary mutants on
+// emit_node.go:`make([]Frag, 0, len(s.Columns))`. Without explicit
+// Columns, the SELECT must be the bare `SELECT *`; a mutated column
+// list would emit an empty SELECT list (invalid SQL).
 func TestEmitScan_NoColumnsBoundary(t *testing.T) {
 	t.Parallel()
 	t.Run("no columns → SELECT *", func(t *testing.T) {
@@ -1314,9 +1324,9 @@ func TestEmitScan_NoColumnsBoundary(t *testing.T) {
 	})
 }
 
-// TestEmitProject_NoProjectionsBoundary kills emit_node.go:300 — `if
-// len(p.Projections) > 0`. With no projections the SELECT degenerates
-// to bare `SELECT *`.
+// TestEmitProject_NoProjectionsBoundary kills the mutants of
+// emit_node.go:`for _, pr := range p.Projections`. With no projections
+// the SELECT degenerates to bare `SELECT *`.
 func TestEmitProject_NoProjectionsBoundary(t *testing.T) {
 	t.Parallel()
 	plan := &chplan.Project{
@@ -1332,9 +1342,9 @@ func TestEmitProject_NoProjectionsBoundary(t *testing.T) {
 	}
 }
 
-// TestEmitLimit_NonPositiveBoundary kills emit_node.go:487 — `if
-// l.Count > 0`. Count==0 must skip the LIMIT clause; the mutant `>=`
-// would emit `LIMIT 0`.
+// TestEmitLimit_NonPositiveBoundary kills the boundary mutants reaching
+// emit_node.go:`sb.Limit(l.Count)`. Count==0 must skip the LIMIT clause;
+// a `>=`-style flip would emit `LIMIT 0`.
 func TestEmitLimit_NonPositiveBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1373,7 +1383,7 @@ func TestEmitLimit_NonPositiveBoundary(t *testing.T) {
 }
 
 // TestEmitAggregateNoGroup_BoundaryAt245 kills the boundary at
-// emit_node.go:245 (`len(scan.Columns) > 0` inside emitFilter). A
+// emit_node.go:`make([]Frag, 0, len(scan.Columns))` (inside emitFilter). A
 // Filter on a Scan with no explicit Columns must omit the SELECT list;
 // with explicit Columns those names appear.
 func TestEmitAggregateNoGroup_BoundaryAt245(t *testing.T) {
@@ -1409,7 +1419,7 @@ func TestEmitAggregateNoGroup_BoundaryAt245(t *testing.T) {
 }
 
 // TestHistogramQuantileNative_AliasFallback kills the boundary at
-// histogram_quantile_native.go:106 (`i < len(h.GroupByAliases)`). With
+// histogram_quantile_native.go:`i < len(h.GroupByAliases)`. With
 // fewer aliases than group keys, the missing-alias entry must render
 // bare.
 func TestHistogramQuantileNative_AliasFallback(t *testing.T) {
@@ -1443,9 +1453,9 @@ func TestHistogramQuantileNative_AliasFallback(t *testing.T) {
 }
 
 // TestWithRecursive_AnchorOrRecursiveNil kills the INVERT_LOGICAL
-// mutant at builder.go:1654 (`c.Anchor == nil || c.Recursive == nil`).
-// The original panics if either is nil; the `&&` mutant requires
-// both, so a single-nil call slips through.
+// mutant at builder.go:`case c.Anchor != nil && c.Recursive != nil`.
+// The original panics if either is nil; the `||` mutant accepts a
+// single non-nil, so a single-nil call slips through.
 func TestWithRecursive_AnchorOrRecursiveNil(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1473,7 +1483,8 @@ func TestWithRecursive_AnchorOrRecursiveNil(t *testing.T) {
 }
 
 // TestEmitWindowedExtrapolated_StepBoundary kills the
-// `r.Step <= 0` boundary at range_window.go:1437. Triggered by a
+// range_window.go:emitWindowedArrayExtrapolated:`r.Step <= 0` boundary.
+// Triggered by a
 // `rate()` lowering with OuterRange > 0 but Step missing.
 func TestEmitWindowedExtrapolated_StepBoundary(t *testing.T) {
 	t.Parallel()
@@ -1496,8 +1507,8 @@ func TestEmitWindowedExtrapolated_StepBoundary(t *testing.T) {
 }
 
 // TestEmitWindowedArray_StepBoundary kills the matching
-// `r.Step <= 0` boundary at range_window.go:1810 inside
-// emitWindowedArray (the values-only / matrix path). Triggered by a
+// range_window.go:emitWindowedArray:`r.Step <= 0` boundary (the
+// values-only / matrix path). Triggered by a
 // `sum_over_time` lowering with OuterRange > 0 but Step missing.
 func TestEmitWindowedArray_StepBoundary(t *testing.T) {
 	t.Parallel()
@@ -1517,8 +1528,9 @@ func TestEmitWindowedArray_StepBoundary(t *testing.T) {
 }
 
 // TestEmitWindowedExtrapolated_GroupByBoundary kills the
-// `len(groupFrags) > 0` boundary at range_window.go:1463 inside
-// emitWindowedArrayExtrapolated. Two cases: with and without GroupBy.
+// mutants of the innermost GROUP BY
+// range_window.go:emitWindowedArrayExtrapolated:`innermost.GroupBy(groupFrags...)`.
+// Two cases: with and without GroupBy.
 func TestEmitWindowedExtrapolated_GroupByBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1610,8 +1622,8 @@ func TestEmitWindowedArrayMatrix_GroupByBoundary(t *testing.T) {
 }
 
 // TestEmitWindowedArrayMatrix_MinWindowBoundary kills the
-// `minWindowSize > 0` boundary at range_window.go:1947 inside
-// emitWindowedArrayMatrix. The matrix-path mirror of
+// range_window.go:emitWindowedArrayMatrix:`minWindowSize > 0` boundary.
+// The matrix-path mirror of
 // TestEmitWindowedArray_MinWindowBoundary.
 func TestEmitWindowedArrayMatrix_MinWindowBoundary(t *testing.T) {
 	t.Parallel()
@@ -1644,9 +1656,9 @@ func TestEmitWindowedArrayMatrix_MinWindowBoundary(t *testing.T) {
 }
 
 // TestEmitWindowedArrayPairsMatrix_GroupByBoundary kills the
-// boundary at range_window.go:487 (emitWindowedArrayPairs inside the
-// pairs-path matrix variant). The condition mirrors the
-// values-only emission.
+// boundary on the pairs-path matrix regroup
+// range_window.go:emitWindowedArrayPairsMatrix:`regroup.GroupBy(regroupKeys...)`.
+// The condition mirrors the values-only emission.
 func TestEmitWindowedArrayPairsMatrix_GroupByBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1682,9 +1694,9 @@ func TestEmitWindowedArrayPairsMatrix_GroupByBoundary(t *testing.T) {
 }
 
 // TestEmitWindowedArray_MinWindowBoundary kills the
-// `minWindowSize > 0` boundary at range_window.go:504 inside
-// emitWindowedArrayPairs. `changes` / `resets` use minWindowSize 0
-// (no drop), while `deriv` uses 2.
+// range_window.go:emitWindowedArrayPairsAnchoredWithExtra:`minWindowSize > 0`
+// boundary. `changes` / `resets` use minWindowSize 0 (no drop), while
+// `deriv` uses 2.
 func TestEmitWindowedArray_MinWindowBoundary(t *testing.T) {
 	t.Parallel()
 	t.Run("deriv → window_pairs >= 2 emitted", func(t *testing.T) {
@@ -1726,7 +1738,7 @@ func TestEmitWindowedArray_MinWindowBoundary(t *testing.T) {
 }
 
 // TestEmitAggregate_LogicalAndOnEmptyGuard kills the INVERT_LOGICAL
-// at emit_node.go:337 (`len(a.GroupBy) == 0 && len(a.AggFuncs) == 0`).
+// at emit_node.go:`len(a.GroupBy) == 0 && len(a.AggFuncs) == 0`.
 // With the `||` mutant, asking for an aggregate with GroupBy populated
 // but no AggFuncs would still error; original would proceed.
 func TestEmitAggregate_LogicalAndOnEmptyGuard(t *testing.T) {
@@ -1771,8 +1783,9 @@ func TestEmitAggregate_LogicalAndOnEmptyGuard(t *testing.T) {
 }
 
 // TestEmitAggregate_DropEmptyGuard kills the INVERT_LOGICAL +
-// CONDITIONALS_NEGATION at emit_node.go:353 (`len(a.GroupBy) == 0 &&
-// a.DropEmptyOnNoGroup`). The branch selects the count-guarded shape
+// CONDITIONALS_NEGATION at
+// emit_node.go:`if len(a.GroupBy) == 0 && a.DropEmptyOnNoGroup`.
+// The branch selects the count-guarded shape
 // only when both conditions hold; otherwise the plain aggregate path
 // runs.
 func TestEmitAggregate_DropEmptyGuard(t *testing.T) {
@@ -1854,8 +1867,8 @@ func TestEmitMetricsExemplars_ArithmeticBoundary118(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_AttributesMapCapacity185 kills the
-// ARITHMETIC_BASE mutant at exemplars.go:185 (`len(groupAliases)*2 +
-// 4`). That value sizes the attrMapFrags slice; the slice still grows
+// ARITHMETIC_BASE mutant at exemplars.go:`len(groupAliases)*2+6`.
+// That value sizes the attrMapFrags slice; the slice still grows
 // implicitly under append, so the capacity expression is observation-
 // equivalent to the original at the SQL surface — the eventual map(...)
 // call lays out the same key/value pairs regardless. Pinning the exit
@@ -1915,8 +1928,9 @@ func TestEmitMetricsExemplars_AttributesMapCapacity185(t *testing.T) {
 }
 
 // TestEmitVectorJoin_OutputAttrsBareVsMerge kills the INVERT_LOGICAL
-// flip at vector_join.go:362 (`manySide == "" || len(j.Include) == 0`).
-// Original `||` takes the bare-side branch when EITHER cardinality is
+// flip on vector_join.go:`manySide == ""` /
+// vector_join.go:`len(j.Include) == 0`. Original `||` takes the bare-side
+// branch when EITHER cardinality is
 // OneToOne OR no Include labels are supplied; the `&&` mutant only
 // takes that branch when BOTH hold. We drive a `CardOneToOne` plan
 // with a non-empty Include slice and pin that the bare branch fires:
@@ -1953,9 +1967,9 @@ func TestEmitVectorJoin_OutputAttrsBareVsMerge(t *testing.T) {
 
 // TestEmitMetricsHistogramOverTimeMatrix_AliasFallbackDistinct kills
 // the two CONDITIONALS_NEGATION mutants at
-// histogram_over_time.go:203 (`bucketAlias == ""`) and 207
-// (`valueAlias == ""`) inside the matrix path
-// (emitRangeWindowHistogram). The pre-existing
+// histogram_over_time.go:emitRangeWindowHistogram:`bucketAlias == ""`
+// and histogram_over_time.go:emitRangeWindowHistogram:`valueAlias == ""`
+// inside the matrix path. The pre-existing
 // TestEmitMetricsHistogramOverTimeBucketAliasFallback hits only the
 // INSTANT path; the matrix mutants survived because no test wraps a
 // MetricsHistogramOverTime in a RangeWindow while supplying
@@ -2041,7 +2055,7 @@ func TestEmitMetricsHistogramOverTimeMatrix_AliasFallbackDistinct(t *testing.T) 
 }
 
 // TestEmitAggregateNoGroup_AliasPreservation kills the
-// CONDITIONALS_NEGATION at emit_node.go:409 (`alias == ""`). With the
+// CONDITIONALS_NEGATION at emit_node.go:`alias == ""`. With the
 // `!=` mutant: a non-empty user alias is OVERWRITTEN by the synthetic
 // `_cerb_agg_<i>` fallback (the assignment now runs for non-empty
 // strings), and the outer SELECT references the synthetic name. With
@@ -2074,9 +2088,9 @@ func TestEmitAggregateNoGroup_AliasPreservation(t *testing.T) {
 }
 
 // TestWithRecursive_NilPanicMessage kills the INVERT_LOGICAL flip at
-// builder.go:1654:23 (`c.Anchor == nil || c.Recursive == nil`). The
+// builder.go:`case c.Anchor != nil && c.Recursive != nil`. The
 // pre-existing TestWithRecursive_AnchorOrRecursiveNil only checks that
-// SOME panic happens — with the `&&` mutant, the "anchor nil only"
+// SOME panic happens — with the `||` mutant, the "anchor nil only"
 // case skips the explicit guard, falls through to `c.Anchor.writeInto`
 // and panics on the nil dereference instead. Both original and mutant
 // panic; gremlins called the mutant LIVED. Pinning the panic MESSAGE
@@ -2117,7 +2131,7 @@ func TestWithRecursive_NilPanicMessage(t *testing.T) {
 }
 
 // TestPartitionPrewhere_LastWhereRetainsExactConjunct kills the
-// CONDITIONALS_BOUNDARY at emit_node.go:262 (`len(whereExprs) > 0`)
+// CONDITIONALS_BOUNDARY at emit_node.go:`len(whereExprs) > 0`
 // and indirectly hardens partitionPrewhere's "promote-all-but-last"
 // guard. The mutant `>= 0` would emit an empty `WHERE` clause as
 // `WHERE ` (no operand) which CH rejects. We assert the SQL contains
@@ -2207,8 +2221,8 @@ func TestEmitWindowedArrayMatrix_LogRateMinWindowOne(t *testing.T) {
 }
 
 // TestEmitWindowedArrayPairsAnchored_MinWindowZero kills the
-// `minWindowSize > 0` boundary at range_window.go:504 inside
-// emitWindowedArrayPairsAnchored. The instant pairs path is
+// range_window.go:emitWindowedArrayPairsAnchoredWithExtra:`minWindowSize > 0`
+// boundary. The instant pairs path is
 // reached by deriv / irate / last_over_time / predict_linear /
 // holt_winters, all of which pass minWindowSize ∈ {1, 2}. Every
 // production call exercises the >0 branch, so the mutant `>= 0`
@@ -2243,7 +2257,8 @@ func TestEmitWindowedArrayPairsAnchored_MinWindowZero(t *testing.T) {
 }
 
 // TestEmitWindowedArrayPairsAnchored_OuterRangeStepGuard kills the
-// `r.Step <= 0` boundary at range_window.go:463. The OuterRange>0 path
+// range_window.go:emitWindowedArrayPairsAnchoredWithExtra:`r.Step <= 0`
+// boundary. The OuterRange>0 path
 // requires Step>0 to drive the anchor fanout; the guard rejects Step=0
 // loudly so the downstream `OuterRange.Nanoseconds() / stepNS` doesn't
 // divide by zero. The boundary mutant `< 0` lets Step=0 slip through
@@ -2280,8 +2295,9 @@ func TestEmitWindowedArrayPairsAnchored_OuterRangeStepGuard(t *testing.T) {
 }
 
 // TestEmitWindowedArrayPairsMatrix_AnchorArithmetic kills two
-// ARITHMETIC_BASE mutants at range_window.go:542
-// (`r.OuterRange.Nanoseconds()/stepNS + 1`). The `/` becomes `*` /
+// ARITHMETIC_BASE mutants at
+// range_window.go:emitWindowedArrayPairsMatrix:`r.OuterRange.Nanoseconds()/stepNS + 1`.
+// The `/` becomes `*` /
 // `%` / `-` / `+`; the `+` becomes `-` / `*` / `%` / `/`. The matrix
 // emitter rendered by emitWindowedArrayPairsMatrix is reached from
 // predict_linear / holt_winters / deriv when OuterRange>0; pinning the
@@ -2328,8 +2344,9 @@ func TestEmitWindowedArrayPairsMatrix_AnchorArithmetic(t *testing.T) {
 }
 
 // TestEmitWindowedArrayPairsMatrix_GroupByNegation kills the
-// CONDITIONALS_NEGATION at range_window.go:559 (`len(groupFrags) > 0`
-// inverted). With a non-empty GroupBy the original emits `GROUP BY`
+// CONDITIONALS_NEGATION reaching
+// range_window.go:emitWindowedArrayPairsMatrix:`regroup.GroupBy(regroupKeys...)`.
+// With a non-empty GroupBy the original emits `GROUP BY`
 // in the innermost SELECT so the per-series groupArray collapses each
 // series into one array; the mutant `<= 0` skips the GROUP BY and
 // rolls every input row into a single super-series — wrong shape, no
@@ -2362,8 +2379,9 @@ func TestEmitWindowedArrayPairsMatrix_GroupByNegation(t *testing.T) {
 }
 
 // TestEmitWindowedArrayPairsMatrix_MinWindowNegation kills the
-// CONDITIONALS_NEGATION at range_window.go:592 (`minWindowSize > 0`
-// inverted). Every production caller passes minWindowSize ∈ {1, 2},
+// CONDITIONALS_NEGATION at
+// range_window.go:emitWindowedArrayPairsMatrix:`minWindowSize > 0`
+// (inverted). Every production caller passes minWindowSize ∈ {1, 2},
 // so the original emits a `WHERE length(window_pairs) >= N` clause to
 // drop empty-window anchors. The mutant `<= 0` evaluates false for
 // every production minWindowSize and skips the WHERE, leaking empty
@@ -2392,7 +2410,8 @@ func TestEmitWindowedArrayPairsMatrix_MinWindowNegation(t *testing.T) {
 }
 
 // TestEmitRangeWindowMetricsQuantileBuckets_SpanBoundary kills the
-// CONDITIONALS_BOUNDARY at range_window.go:911 (`if span < 0`). The
+// CONDITIONALS_BOUNDARY at
+// range_window.go:emitRangeWindowMetricsQuantileBuckets:`span < 0`. The
 // mutant flips `<` to `<=`, which rejects Start == End (span == 0) — a
 // legitimate single-anchor grid the original accepts. We assert that
 // Start == End succeeds (the original branch) and Start > End errors
@@ -2451,8 +2470,9 @@ func TestEmitRangeWindowMetricsQuantileBuckets_SpanBoundary(t *testing.T) {
 }
 
 // TestEmitRangeWindowMetricsQuantileBuckets_SpanAnchorArithmetic kills
-// the two ARITHMETIC_BASE mutants at range_window.go:914
-// (`span/stepNS + 1`). The `/` mutates to `*` / `%` / `-` / `+`; the
+// the two ARITHMETIC_BASE mutants at
+// range_window.go:emitRangeWindowMetricsQuantileBuckets:`span/stepNS + 1`.
+// The `/` mutates to `*` / `%` / `-` / `+`; the
 // `+` mutates to `-` / `*` / `%` / `/`. Setup: Start=t0, End=t0+4m,
 // Step=1m → span = 240s (in ns), span/stepNS = 4, numAnchors = 5.
 // Pinning the `range(0, 5)` literal in the emitted SQL distinguishes
@@ -2496,7 +2516,8 @@ func TestEmitRangeWindowMetricsQuantileBuckets_SpanAnchorArithmetic(t *testing.T
 }
 
 // TestEmitWindowedArray_MinWindowZeroBoundary kills the
-// CONDITIONALS_BOUNDARY at range_window.go:2098 (`minWindowSize > 0`).
+// CONDITIONALS_BOUNDARY at
+// range_window.go:emitWindowedArray:`minWindowSize > 0`.
 // The mutant flips `>` to `>=`; with minWindowSize=0 the mutant adds
 // `WHERE length(window_vals) >= 0` (always true) while the original
 // skips the WHERE entirely. Production callers all pass minWindowSize
@@ -2526,8 +2547,9 @@ func TestEmitWindowedArray_MinWindowZeroBoundary(t *testing.T) {
 }
 
 // TestEmitWindowedArrayMatrix_MinWindowZeroBoundary kills the
-// CONDITIONALS_BOUNDARY at range_window.go:2192 (`minWindowSize > 0`)
-// inside emitWindowedArrayMatrix. Same shape as the non-matrix kill
+// CONDITIONALS_BOUNDARY at
+// range_window.go:emitWindowedArrayMatrix:`minWindowSize > 0`.
+// Same shape as the non-matrix kill
 // above: with minWindowSize=0 the mutant `>= 0` leaks an
 // always-true `WHERE length(window_vals) >= 0`; the original skips
 // the WHERE entirely. Reached via OuterRange > 0 with Step > 0 so the
@@ -2556,10 +2578,11 @@ func TestEmitWindowedArrayMatrix_MinWindowZeroBoundary(t *testing.T) {
 }
 
 // TestValidateScanShape_BothEmpty kills the CONDITIONALS_NEGATION at
-// emit_node.go:86 (`len(s.UnionTables) == 0`). With both Table and
-// UnionTables empty the emitter has nothing to read from and must
-// reject the Scan. The mutant flips the equality so the both-empty
-// case slips through, then L89's check also passes (Table is "") and
+// emit_node.go:`s.Table == "" && len(s.UnionTables) == 0`. With both
+// Table and UnionTables empty the emitter has nothing to read from and
+// must reject the Scan. The mutant flips the equality so the both-empty
+// case slips through, then the both-set check also passes (Table is "")
+// and
 // validateScanShape returns nil — the emitter then renders an empty
 // FROM clause that ClickHouse parses as `SELECT *` over the literal
 // “ (the bare Col(""))` which CH rejects at parse time with a
@@ -2577,7 +2600,8 @@ func TestValidateScanShape_BothEmpty(t *testing.T) {
 }
 
 // TestValidateScanShape_BothSet kills the CONDITIONALS_NEGATION at
-// emit_node.go:89 (`s.Table != ""`). The mutant flips the inequality
+// emit_node.go:`s.Table != "" && len(s.UnionTables) > 0`. The mutant
+// flips the inequality
 // so a Scan with BOTH Table and UnionTables set is no longer rejected
 // — the emitter would then route to the merge() table function and
 // silently drop the Table field, masking a planning bug. Asserting
@@ -2597,7 +2621,8 @@ func TestValidateScanShape_BothSet(t *testing.T) {
 }
 
 // TestValidateScanShape_BothSet_FilterScan kills the same
-// CONDITIONALS_NEGATION at emit_node.go:89 reached via the
+// CONDITIONALS_NEGATION at
+// emit_node.go:`s.Table != "" && len(s.UnionTables) > 0` reached via the
 // emitFilterScan path (which re-validates so a Filter(Scan{...})
 // node can't smuggle a malformed Scan past). Filter-with-Scan input
 // is the codegen-specialised PREWHERE shape and a separate caller of
@@ -2625,7 +2650,9 @@ func TestValidateScanShape_BothSet_FilterScan(t *testing.T) {
 }
 
 // TestValidateScanShape_BothEmpty_FilterScan kills the
-// CONDITIONALS_NEGATION at emit_node.go:`sql, args, err := b.Build()` reached via emitFilterScan.
+// CONDITIONALS_NEGATION at
+// emit_node.go:`s.Table == "" && len(s.UnionTables) == 0` reached via
+// emitFilterScan.
 // With both Table and UnionTables empty the Filter path must surface
 // the same error as the bare-Scan path.
 func TestValidateScanShape_BothEmpty_FilterScan(t *testing.T) {
@@ -2648,31 +2675,18 @@ func TestValidateScanShape_BothEmpty_FilterScan(t *testing.T) {
 }
 
 // TestEmitFilterScan_UnionTablesShapeLookup kills the cluster of
-// mutants at emit_node.go:341 — the `shapeKey == "" && len(scan.
-// UnionTables) > 0` guard that resolves the table shape from the
-// first member of a UnionTables Scan. The mutants:
-//
-//   - CONDITIONALS_NEGATION col 14 (`==` → `!=`): with Table empty,
-//     mutant condition becomes false; shapeKey stays "" and
-//     tableShapeFor("") returns the zero TableShape. No wide columns
-//     means projectionTouchesWide returns false → all conjuncts route
-//     to WHERE and no PREWHERE is emitted.
-//   - CONDITIONALS_NEGATION col 45 (`>` → `<=`): same observable —
-//     the guard becomes false, shapeKey stays "", PREWHERE drops.
+// mutants at emit_node.go:`shapeKey == ""` — the guard that resolves the
+// table shape from the first member of a UnionTables Scan. Under
+// CONDITIONALS_NEGATION (`==` → `!=`) and with Table empty the mutated
+// condition is false, so shapeKey stays "" and tableShapeFor("") returns
+// the zero TableShape. No wide columns means projectionTouchesWide
+// returns false → all conjuncts route to WHERE and no PREWHERE is
+// emitted.
 //
 // The original behaviour shape-looks-up against UnionTables[0]
 // (otel_metrics_gauge — registered with the metrics shape) so a cheap
 // non-wide predicate is promoted to PREWHERE. Asserting the PREWHERE
-// keyword in the rendered SQL kills both mutants in one shot.
-//
-// The companion INVERT_LOGICAL col 20 (`&&` → `||`) and
-// CONDITIONALS_BOUNDARY col 45 (`>` → `>=`) at the same site cannot
-// observationally diverge from the original after validateScanShape:
-// the Table-empty path forces both conjuncts true, the Table-set path
-// is rejected outright when UnionTables is also set, and the
-// Table-set + UnionTables-empty path leaves the second conjunct false
-// either way. Killing the two reachable mutants is sufficient to drop
-// LIVED below the phase2 threshold.
+// keyword in the rendered SQL kills the mutant.
 func TestEmitFilterScan_UnionTablesShapeLookup(t *testing.T) {
 	t.Parallel()
 	// A wide-column-touching projection (no explicit Columns →
@@ -2814,8 +2828,10 @@ func compareNodeInternal() *chplan.MetricsCompare {
 }
 
 // TestCompareOutAliasFallbacks kills the four CONDITIONALS_NEGATION
-// mutants at metrics_compare.go:126,133,140,147 — the `m.SelAlias != ""`
-// / `AttrAlias` / `ValAlias` / `ValueAlias` guards that fall back to the
+// mutants at metrics_compare.go:`m.SelAlias != ""`,
+// metrics_compare.go:`m.AttrAlias != ""`,
+// metrics_compare.go:`m.ValAlias != ""` and
+// metrics_compare.go:`m.ValueAlias != ""` — the guards that fall back to the
 // canonical default name when the alias is empty. The mutant `== ""`
 // would return the (empty) alias instead of the default; we assert both
 // the empty→default mapping AND the explicit→passthrough mapping so the
@@ -2862,7 +2878,7 @@ func TestCompareOutAliasFallbacks(t *testing.T) {
 }
 
 // TestEmitRangeWindowCompare_RangeFallback kills the
-// CONDITIONALS_NEGATION at metrics_compare.go:212 (`if rangeDur == 0`).
+// CONDITIONALS_NEGATION at metrics_compare.go:`rangeDur == 0`.
 // When the RangeWindow carries no explicit Range, rangeDur falls back to
 // Step, so the inner scan-bound pushdown subtracts one Step (60s) from
 // End. The mutant `!= 0` would skip the fallback, leaving rangeDur=0 and
@@ -2992,8 +3008,9 @@ func TestEmitRangeWindowCompare_OuterRangePath(t *testing.T) {
 }
 
 // TestEmitRangeWindowCompare_RootLookupTraceIDGuard covers + kills the
-// NOT_COVERED CONDITIONALS_NEGATION at metrics_compare.go:95
-// (`if m.TraceIDColumn == ""` inside the RootLookup branch). With a
+// NOT_COVERED CONDITIONALS_NEGATION at
+// metrics_compare.go:`m.TraceIDColumn == ""` (inside the RootLookup
+// branch). With a
 // RootLookup set but no TraceIDColumn the emitter must error; a non-empty
 // TraceIDColumn must render the LEFT JOIN on the qualified id columns.
 func TestEmitRangeWindowCompare_RootLookupTraceIDGuard(t *testing.T) {
@@ -3046,9 +3063,10 @@ func exemplarArgsContain(args []any, want string) bool {
 }
 
 // TestEmitMetricsExemplars_OuterRangeNumAnchors covers + kills the
-// CONDITIONALS_BOUNDARY/NEGATION at exemplars.go:112 (`case rw.OuterRange
-// > 0`) and the ARITHMETIC_BASE at 113 (`OuterRange.Nanoseconds()/stepNS
-// + 1`). The existing NumAnchorsBoundary test only exercises the
+// CONDITIONALS_BOUNDARY/NEGATION at exemplars.go:`case rw.OuterRange > 0`
+// and the ARITHMETIC_BASE at
+// exemplars.go:`rw.OuterRange.Nanoseconds()/stepNS + 1`.
+// The existing NumAnchorsBoundary test only exercises the
 // Start/End span branch; this one drives the OuterRange branch.
 //
 // OuterRange=4m, Step=1m → numAnchors = 4/1 + 1 = 5 → `least(5,`.
@@ -3076,9 +3094,9 @@ func TestEmitMetricsExemplars_OuterRangeNumAnchors(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_QuantileKeyBranch covers + kills the
-// CONDITIONALS_NEGATION / INVERT_LOGICAL mutants at exemplars.go:215
-// (`m.Op == QuantileOverTime && len(m.Quantiles) == 1`) and the
-// ARITHMETIC/format at 219. A single-quantile quantile_over_time exemplar
+// CONDITIONALS_NEGATION / INVERT_LOGICAL mutants at
+// exemplars.go:`m.Op == chplan.MetricsOpQuantileOverTime && len(m.Quantiles) == 1`
+// and the phi formatting it guards. A single-quantile quantile_over_time exemplar
 // must carry a `p="<phi>"` Attributes entry; a non-quantile op must NOT.
 func TestEmitMetricsExemplars_QuantileKeyBranch(t *testing.T) {
 	t.Parallel()
@@ -3131,8 +3149,9 @@ func TestEmitMetricsExemplars_QuantileKeyBranch(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_UngroupedNameKeyBranch covers + kills the
-// CONDITIONALS_NEGATION / INVERT_LOGICAL mutants at exemplars.go:221
-// (`len(groupAliases) == 0 && m.Op != QuantileOverTime`). An ungrouped
+// CONDITIONALS_NEGATION / INVERT_LOGICAL mutants at
+// exemplars.go:`len(groupAliases) == 0 && m.Op != chplan.MetricsOpQuantileOverTime`.
+// An ungrouped
 // non-quantile op must carry a `__name__="<op>"` Attributes entry; a
 // grouped op must NOT (the group labels key the series instead).
 func TestEmitMetricsExemplars_UngroupedNameKeyBranch(t *testing.T) {
@@ -3194,9 +3213,10 @@ func nsAnnotateInternal() *chplan.NestedSetAnnotate {
 }
 
 // TestEmitNestedSetAnnotate_ColumnGuardDisjunction kills the four
-// INVERT_LOGICAL mutants at nested_set_annotate.go:108-109 — the
-// `SpansTable == "" || TraceIDColumn == "" || SpanIDColumn == "" ||
-// ParentSpanIDColumn == "" || TimestampColumn == ""` guard. Each `||`
+// INVERT_LOGICAL mutants of the required-column guard
+// nested_set_annotate.go:`n.SpansTable == ""` (`SpansTable == "" ||
+// TraceIDColumn == "" || SpanIDColumn == "" || ParentSpanIDColumn == "" ||
+// TimestampColumn == ""`). Each `||`
 // flip to `&&` is killed by an input that blanks exactly ONE column:
 // with the disjunction the emitter must still error (one empty column is
 // enough); the `&&` mutant would require ALL columns empty to error, so
@@ -3237,8 +3257,9 @@ func TestEmitNestedSetAnnotate_ColumnGuardDisjunction(t *testing.T) {
 }
 
 // TestProjectsBareColumn_ContinueScansAllProjections kills the
-// INVERT_LOOPCTRL mutant at nested_set_annotate.go:379 (`continue` →
-// `break` inside projectsBareColumn). A non-matching projection AHEAD of
+// INVERT_LOOPCTRL mutant (`continue` → `break`) on
+// nested_set_annotate.go:`ref.Name != col || ref.Qualifier != ""` inside
+// projectsBareColumn. A non-matching projection AHEAD of
 // the matching one must be passed over (continue), not abort the scan
 // (break). The break mutant returns false because it bails at the first
 // non-match before ever reaching the bare column.
@@ -3270,7 +3291,7 @@ func TestProjectsBareColumn_ContinueScansAllProjections(t *testing.T) {
 }
 
 // TestWriteOptQualCol_QualifierBranch kills the CONDITIONALS_NEGATION
-// mutant at nested_set_annotate.go:391 (`if qual == ""`). The empty-qual
+// mutant at nested_set_annotate.go:writeOptQualCol:`qual == ""`. The empty-qual
 // branch must emit a BARE backtick-quoted identifier; the non-empty
 // branch a `qual`.`col` pair. The `!=` mutant swaps the two, so the
 // empty-qual call would render the broken “ “.`col` “ form.
@@ -3299,9 +3320,10 @@ func TestWriteOptQualCol_QualifierBranch(t *testing.T) {
 // --- prewhere.go survivors ------------------------------------------------
 
 // TestOrderedConjuncts_SkipBucketContinue kills the INVERT_LOOPCTRL
-// mutant at prewhere.go:193 (`continue` → `break` after appending a
-// skip-index conjunct). A skip-bucket conjunct ahead of a plain "rest"
-// conjunct must NOT abort the loop — the `break` mutant would drop every
+// mutant (`continue` → `break`) after
+// prewhere.go:`skip = append(skip, c)` appends a skip-index conjunct. A
+// skip-bucket conjunct ahead of a plain "rest" conjunct must NOT abort the
+// loop — the `break` mutant would drop every
 // conjunct after the first skip hit, losing them from the output.
 //
 // The shape registers a SkipIndexColumn but no SortColumns, so the first
@@ -3323,14 +3345,14 @@ func TestOrderedConjuncts_SkipBucketContinue(t *testing.T) {
 }
 
 // TestOrderedConjuncts_StableSameRankTiebreak kills the insertion-sort
-// tiebreaker mutants at prewhere.go:201 (CONDITIONALS_NEGATION on the
-// `rank ==` equality + CONDITIONALS_BOUNDARY on the `idx >` tiebreaker)
-// and the INVERT_LOOPCTRL at 203 (`continue` → `break` after a swap).
+// mutants of prewhere.go:`prefix[j-1].rank > prefix[j].rank` — the
+// comparison flips plus the INVERT_LOOPCTRL on the `continue` after a
+// swap.
 //
 // Three conjuncts all reference the SAME sort column (ServiceName, rank
-// 0), so the rank comparison is always a tie and the stable sort must
-// fall back to the idx (input-order) tiebreaker. The original keeps them
-// in input order; a broken tiebreaker or an early `break` permutes them.
+// 0), so the rank comparison is always a tie and the strict `>` must
+// leave them alone. The original keeps them in input order; a flipped
+// comparison or an early `break` permutes them.
 func TestOrderedConjuncts_StableSameRankTiebreak(t *testing.T) {
 	t.Parallel()
 	shape := TableShape{SortColumns: []string{"ServiceName"}}
@@ -3345,9 +3367,9 @@ func TestOrderedConjuncts_StableSameRankTiebreak(t *testing.T) {
 }
 
 // TestIsSkipIndexColumn_Match kills the CONDITIONALS_NEGATION at
-// tableshape.go:60 (`c == name` → `!=`). With a matching name the lookup
-// must report true; a non-member must report false. Also covers the same
-// equality flip at tableshape.go:26 (IsSortColumn) below.
+// tableshape.go:IsSkipIndexColumn:`c == name` (→ `!=`). With a matching
+// name the lookup must report true; a non-member must report false. Also
+// covers the same equality flip in IsSortColumn below.
 func TestIsSkipIndexColumn_Match(t *testing.T) {
 	t.Parallel()
 	shape := TableShape{SkipIndexColumns: []string{"TraceId", "SpanId"}}
@@ -3360,7 +3382,7 @@ func TestIsSkipIndexColumn_Match(t *testing.T) {
 }
 
 // TestIsSortColumn_Match kills the CONDITIONALS_NEGATION at
-// tableshape.go:26 (`c == name` → `!=`) in IsSortColumn.
+// tableshape.go:IsSortColumn:`c == name` (→ `!=`).
 func TestIsSortColumn_Match(t *testing.T) {
 	t.Parallel()
 	shape := TableShape{SortColumns: []string{"ServiceName", "Timestamp"}}
@@ -3375,9 +3397,10 @@ func TestIsSortColumn_Match(t *testing.T) {
 // --- vector_join.go / vector_set_op.go column-validation switches ---------
 
 // TestValidateVectorJoinCols_EachEmptyErrors covers + kills the four
-// CONDITIONALS_NEGATION mutants at vector_join.go:97-103 — the
+// CONDITIONALS_NEGATION mutants of the validateVectorJoinCols switch
+// starting at vector_join.go:`case j.AttributesColumn == ""` — the
 // `AttributesColumn`/`MetricNameColumn`/`TimestampColumn`/`ValueColumn ==
-// ""` switch cases. Each blank-one-column variant must surface
+// ""` cases. Each blank-one-column variant must surface
 // ErrUnsupported; the fully-populated control must not.
 func TestValidateVectorJoinCols_EachEmptyErrors(t *testing.T) {
 	t.Parallel()
@@ -3426,9 +3449,9 @@ func TestValidateVectorJoinCols_EachEmptyErrors(t *testing.T) {
 }
 
 // TestValidateVectorSetOpCols_EachEmptyErrors covers + kills the four
-// CONDITIONALS_NEGATION mutants at vector_set_op.go:371-377 plus the
-// `if err != nil` guard at 50 — the column-validation switch on a
-// VectorSetOp. Same blank-one-column shape as the VectorJoin test.
+// CONDITIONALS_NEGATION mutants of the column-validation switch on a
+// VectorSetOp, starting at vector_set_op.go:`case s.AttributesColumn == ""`,
+// plus the `if err != nil` guard on its caller. Same blank-one-column shape as the VectorJoin test.
 func TestValidateVectorSetOpCols_EachEmptyErrors(t *testing.T) {
 	t.Parallel()
 	base := func() *chplan.VectorSetOp {
@@ -3662,9 +3685,9 @@ func TestEmitStructuralRecursiveUnion_InverseClosureMaxDepth(t *testing.T) {
 }
 
 // TestEmitStructuralSiblingJoin_Succeeds covers + kills the
-// CONDITIONALS_NEGATION mutants at structural_join.go:184 and 188 (the
-// `if err != nil` guards around the left/right subqueryFrag calls in
-// emitStructuralSiblingJoin). A valid sibling (`~`) join must emit
+// CONDITIONALS_NEGATION mutants on the `if err != nil` guards around the
+// left/right subqueryFrag calls in
+// structural_join.go:emitStructuralSiblingJoin. A valid sibling (`~`) join must emit
 // non-empty SQL that joins L and R on shared parent; the `err == nil`
 // mutant would return early (empty SQL) on the success path.
 func TestEmitStructuralSiblingJoin_Succeeds(t *testing.T) {
@@ -4017,7 +4040,7 @@ func TestWindowFrag_PartitionByBoundary(t *testing.T) {
 // --- range_window.go predict_linear slope-column dispatch (411:5) ---
 
 // TestPredictLinear_SlopeColumnDispatch kills the CONDITIONALS_NEGATION
-// mutant at range_window.go:411 (`r.PredictLinearSlopeColumn == ""`).
+// mutant at range_window.go:`r.PredictLinearSlopeColumn == ""`.
 // An empty slope column must route through the plain single-value writer
 // (only the `Value` column projected); a non-empty one must route through
 // the "with extra" writer, projecting a SECOND column that reads the
@@ -4075,7 +4098,7 @@ func TestPredictLinear_SlopeColumnDispatch(t *testing.T) {
 // --- range_window.go anchorGridCeilIdxFrag arithmetic (1812:41) ---
 
 // TestAnchorGridCeilIdxFrag_ShiftsAddNSDownByOne kills the ARITHMETIC_BASE
-// mutant at range_window.go:1812 (`addNS-1` → `addNS+1`) inside
+// mutant at range_window.go:`addNS-1` (→ `addNS+1`) inside
 // anchorGridCeilIdxFrag. The ceiling index is documented to equal the
 // floor index with its addend shifted down by exactly one nanosecond;
 // this pins that relationship directly against anchorGridFloorIdxFrag
@@ -4109,8 +4132,9 @@ func TestAnchorGridCeilIdxFrag_ShiftsAddNSDownByOne(t *testing.T) {
 // --- range_window.go prefixAnchorIndexFrag arithmetic (1733:37) ---
 
 // TestPrefixAnchorIndexFrag_NegatesRangeNS kills both the INVERT_NEGATIVES
-// and ARITHMETIC_BASE mutants at range_window.go:1733:37 (the `-rangeNS`
-// unary expression passed as anchorGridFloorIdxFrag's addNS argument). A
+// and ARITHMETIC_BASE mutants at
+// range_window.go:prefixAnchorIndexFrag:`-rangeNS` (the unary expression
+// passed as anchorGridFloorIdxFrag's addNS argument). A
 // mutant that drops or otherwise flips that sign feeds anchorGridFloorIdxFrag
 // a POSITIVE offset instead — its own `addNS > 0` branch then renders an
 // ADDITION (`dist + rangeNS`) instead of the correct SUBTRACTION
@@ -4140,7 +4164,8 @@ func TestPrefixAnchorIndexFrag_NegatesRangeNS(t *testing.T) {
 			Sub(anchorGridFloorIdxFrag(dist, rangeNS, stepNS), InlineLit(int64(1)))),
 	))
 	if got == positiveOffset {
-		t.Errorf("prefixAnchorIndexFrag matches the POSITIVE-rangeNS form (line 1733 sign flipped?): %s", got)
+		t.Errorf("prefixAnchorIndexFrag matches the POSITIVE-rangeNS form "+
+			"(the `-rangeNS` sign flipped?): %s", got)
 	}
 }
 
@@ -4156,11 +4181,13 @@ func instantDeltaPrefixSourceStubWindow() *QueryBuilder {
 }
 
 // TestInstantDeltaPrefixSource_GuardNilBranch kills the CONDITIONALS_NEGATION
-// mutant at range_window.go:3562:11 (`guard != nil` -> `== nil`). Production
+// mutant at range_window.go:instantDeltaPrefixSource:`guard != nil`
+// (-> `== nil`). Production
 // never reaches instantDeltaPrefixSource with an empty TemporalityColumn
 // (emitWindowedArrayExtrapolated's needsDeltaFirstLevel gate requires
 // hasTemporality), so this calls it directly to force
-// deltaPresenceGuardFrag's nil branch (range_window.go:3498-3499) and
+// deltaPresenceGuardFrag's nil branch
+// (range_window.go:deltaPresenceGuardFrag:`r.TemporalityColumn == ""`) and
 // exercise the guard==nil path the mutant inverts. A `== nil` mutant would
 // instead call prefix.Where(nil) here, and that nil Frag panics the moment
 // it is invoked during Build() — a difference this test would catch as a
@@ -4196,7 +4223,9 @@ func TestInstantDeltaPrefixSource_GuardNilBranch(t *testing.T) {
 }
 
 // TestInstantDeltaPrefixSource_JoinDispatch kills the CONDITIONALS_NEGATION
-// mutant at range_window.go:3574:23 (`len(groupColumns) == 0` -> `!= 0`). A
+// mutant at
+// range_window.go:instantDeltaPrefixSource:`len(groupColumns) == 0`
+// (-> `!= 0`). A
 // grouped call must LEFT JOIN the prefix scan back keyed on the group
 // columns; an ungrouped call must CROSS JOIN it (there is nothing to key
 // on). The mutant swaps which shape each case takes.
@@ -4256,7 +4285,8 @@ func TestInstantDeltaPrefixSource_JoinDispatch(t *testing.T) {
 // --- range_window.go plainGroupColumnNames validation (5104:10, 5104:33) ---
 
 // TestPlainGroupColumnNames_EmptyNameRejected kills the INVERT_LOGICAL
-// mutant at range_window.go:5104:33 (the outer `||` between
+// mutant on the outer `||` of
+// range_window.go:`!ok || ref.Qualifier != "" || ref.Name == ""` (between
 // `ref.Qualifier != ""` and `ref.Name == ""`). A bare ColumnRef with an
 // empty Name is otherwise well-formed (ok==true, Qualifier==""), so only
 // the third disjunct can catch it; an `&&` mutant there requires the first
@@ -4271,8 +4301,10 @@ func TestPlainGroupColumnNames_EmptyNameRejected(t *testing.T) {
 }
 
 // TestPlainGroupColumnNames_NonColumnRefNoPanic kills the INVERT_LOGICAL
-// mutant at range_window.go:5104:10 (the inner `||` between `!ok` and
-// `ref.Qualifier != ""`). When the group key is not a *chplan.ColumnRef at
+// mutant on the inner `||` of
+// range_window.go:`!ok || ref.Qualifier != "" || ref.Name == ""` (between
+// `!ok` and `ref.Qualifier != ""`). When the group key is not a
+// *chplan.ColumnRef at
 // all, `ref` is a nil *chplan.ColumnRef and only short-circuit evaluation
 // (the original `||`) keeps `ref.Qualifier` from ever being dereferenced.
 // An `&&` mutant forces evaluation of the second operand whenever `!ok` is

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -130,7 +130,7 @@ func TestIsCheapPredicate_AsymmetricMapAccess(t *testing.T) {
 }
 
 // TestFlattenAnd_NonAndOp kills the `bin.Op != chplan.OpAnd` → `==`
-// flip at prewhere.go:13 (the negation mutator on the conjunction
+// flip at prewhere.go:`bin.Op != chplan.OpAnd` (the negation mutator on the conjunction
 // type-switch guard). A Binary{OpOr} or Binary{OpEq} must be treated
 // as a single opaque leaf — flattenAnd must not recurse through it.
 func TestFlattenAnd_NonAndOp(t *testing.T) {
@@ -490,7 +490,7 @@ func TestEmitMetricsExemplars_NumAnchorsBoundary(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_GroupByDisplayNamesFallback kills the `!=
-// ""` mutant at exemplars.go:139:65. The branch falls back to the SQL
+// ""` mutant at exemplars.go:`numAnchors, err := exemplarNumAnchors(rw, stepNS)`. The branch falls back to the SQL
 // alias only when the display name slot is empty; when both alias and
 // display name are present, the display name wins. The check inspects
 // the bound args (the labels render as `?` placeholders bound to
@@ -893,7 +893,7 @@ func TestEmitMetricsAggregate_LogicalAndOnMetricArg(t *testing.T) {
 }
 
 // TestEmitMetricsAggregate_BadStartEndPin kills the boundary mutants
-// on `span < 0` at range_window.go:736 (mirror of exemplars.go:115).
+// on `span < 0` at range_window.go:736 (mirror of exemplars.go:`span < 0`).
 // End < Start must error; End == Start must succeed (boundary case).
 func TestEmitMetricsAggregate_BadStartEndPin(t *testing.T) {
 	t.Parallel()
@@ -1813,7 +1813,7 @@ func TestEmitAggregate_DropEmptyGuard(t *testing.T) {
 }
 
 // TestEmitMetricsExemplars_ArithmeticBoundary118 kills the two
-// ARITHMETIC_BASE mutants at exemplars.go:118 (`span/stepNS + 1`). The
+// ARITHMETIC_BASE mutants at exemplars.go:`span/stepNS + 1`. The
 // formula divides the half-window span by stepNS, then adds 1 for the
 // end-inclusive anchor count. Mutants:
 //   - `+` → `-`: yields one fewer anchor (e.g. 5 instead of 6).
@@ -2625,7 +2625,7 @@ func TestValidateScanShape_BothSet_FilterScan(t *testing.T) {
 }
 
 // TestValidateScanShape_BothEmpty_FilterScan kills the
-// CONDITIONALS_NEGATION at emit_node.go:86 reached via emitFilterScan.
+// CONDITIONALS_NEGATION at emit_node.go:`sql, args, err := b.Build()` reached via emitFilterScan.
 // With both Table and UnionTables empty the Filter path must surface
 // the same error as the bare-Scan path.
 func TestValidateScanShape_BothEmpty_FilterScan(t *testing.T) {

--- a/internal/chsql/histogram_projection_mutation_test.go
+++ b/internal/chsql/histogram_projection_mutation_test.go
@@ -30,7 +30,8 @@ func histogramProjectionPlan(groupBy []chplan.Expr, aliases []string) *chplan.Hi
 // so a plan carrying more keys than aliases must render the surplus keys bare
 // rather than indexing off the end of the alias slice.
 //
-// Kills histogram_projection.go:54:8 under BOTH mutators of `i < len(...)`:
+// Kills histogram_projection.go:`i < len(h.GroupByAliases)` under BOTH of its
+// mutators:
 //
 //   - CONDITIONALS_BOUNDARY (`i <= len(...)`): at i == 1 with one alias the
 //     mutated guard is `1 <= 1`, so it reads GroupByAliases[1] out of a
@@ -55,7 +56,8 @@ func TestMutation_HistogramProjection_FewerAliasesThanGroupKeys(t *testing.T) {
 // list, because that alias is the label name the decode side binds the group
 // column by.
 //
-// Kills histogram_projection.go:54:8 CONDITIONALS_NEGATION (`i >= len(...)`)
+// Kills histogram_projection.go:`i < len(h.GroupByAliases)` under
+// CONDITIONALS_NEGATION (`i >= len(...)`)
 // without relying on an out-of-range panic: with two keys and two aliases the
 // inverted guard is false at every index, so both keys render bare.
 func TestMutation_HistogramProjection_EveryAliasProjected(t *testing.T) {

--- a/internal/chsql/histogram_quantile.go
+++ b/internal/chsql/histogram_quantile.go
@@ -72,7 +72,8 @@ type hqClassicHelperColumns struct {
 // (see the helper-column block above); step 5's interpolation reads them
 // as plain columns.
 //
-// Prom edge cases mirrored (quantile.go:114-119):
+// Prom edge cases mirrored (`bucketQuantile`'s domain guards in
+// quantile.go):
 //
 //   - total = 0 (empty histogram) → NaN.
 //   - phi < 0 → -Inf (out of domain).
@@ -269,8 +270,8 @@ func histogramQuantileValueFrag(h *chplan.HistogramQuantile, helpers hqClassicHe
 	//         if(phi < 0, -inf,
 	//            if(phi > 1, inf, idxBranch))))
 	//
-	// Prometheus semantics (quantile.go:114-119): phi < 0 → -Inf, phi > 1
-	// → +Inf are OUT of domain. phi == 0 and phi == 1 are IN domain and
+	// Prometheus semantics (`bucketQuantile`'s domain guards in quantile.go):
+	// phi < 0 → -Inf, phi > 1 → +Inf are OUT of domain. phi == 0 and phi == 1 are IN domain and
 	// fall through to idxBranch: phi == 0 → target 0 → idx 1 → lower edge
 	// 0.0; phi == 1 → target observations → idx == length(cum) → highest finite
 	// bound. ClickHouse parses the bare `inf` / `-inf` tokens as Float64.

--- a/internal/chsql/histogram_quantile_fanout_nonfinite_bound_chdb_test.go
+++ b/internal/chsql/histogram_quantile_fanout_nonfinite_bound_chdb_test.go
@@ -37,8 +37,9 @@ import (
 
 // hqFanoutNonFiniteQuery is the issue's own PromQL repro: a classic-bucket
 // selector, summed by(le) over a sum_over_time window — the shape that
-// lowers through lowerHistogramQuantileAgg's classicBucketMergeShaping
-// merge fold (histogram_quantile.go:1412 / :1462), not the native path.
+// lowers through lowerHistogramQuantileAgg's merge fold
+// (internal/promql/histogram_quantile.go:classicBucketMergeShaping), not
+// the native path.
 const hqFanoutNonFiniteQuery = `histogram_quantile(0.5, sum by(le) (sum_over_time(http_server_request_duration_bucket[5m])))`
 
 // hqFanoutNonFiniteRows is the issue's own repro data: row 2's

--- a/internal/chsql/histogram_quantile_native.go
+++ b/internal/chsql/histogram_quantile_native.go
@@ -31,7 +31,8 @@
 //     target = phi * rankBase.
 //  4. idx = the 1-based position the rank walk stops on. Reference
 //     Prometheus walks the buckets in one of TWO directions depending
-//     on phi AND on whether Sum is NaN (quantile.go:243-262), so
+//     on phi AND on whether Sum is NaN (quantile.go's
+//     `if math.IsNaN(h.Sum) || q < 0.5` walk-direction split), so
 //     cerberus does too:
 //     - phi < reverseWalkPhi, OR Sum is NaN: forward, rank =
 //     phi * rankBase, stopping at
@@ -109,11 +110,12 @@
 //     lands just inside the stop bucket or just outside it. Reference's
 //     own forms are also structurally bounded to [0, 1], since the walk
 //     broke at this bucket and not at the one before it.
-//  6. Edge cases (Prometheus quantile.go:114-119), tested in THIS order —
+//  6. Edge cases (`bucketQuantile`'s domain guards in Prometheus
+//     quantile.go), tested in THIS order —
 //     out-of-domain phi is checked before the empty-histogram case, so a
 //     `phi` outside [0, 1] answers ±Inf even for an empty histogram
-//     (cerberus issue #2067; reference quantile.go:222-232 checks
-//     `q < 0` / `q > 1` before `h.Count == 0`):
+//     (cerberus issue #2067; reference quantile.go's `HistogramQuantile`
+//     checks `q < 0` / `q > 1` before `h.Count == 0`):
 //     - phi < 0 → -Inf (out of domain).
 //     - phi > 1 → +Inf (out of domain).
 //     - rankBase (stored Count) = 0 → NaN (empty histogram).
@@ -134,7 +136,8 @@
 //     reaching the rank" case from step 4. Reference answers NaN there
 //     only when Sum is NaN; with a finite Sum it returns the upper bound
 //     of the bucket its iterator was left sitting on
-//     (quantile.go:296-305, prometheus/prometheus#16578), which is the
+//     (quantile.go's exhausted-walk fallback to `bucket.Upper`,
+//     prometheus/prometheus#16578), which is the
 //     LAST position that iterator yielded: the top of the walk order on
 //     the forward arm, the bottom of it on the backward one. Those are
 //     the step-7 upper edges read at an array end rather than at the
@@ -160,7 +163,8 @@
 //     The band is `[-ZeroThreshold, +ZeroThreshold]` only when the
 //     distribution can hold observations on both sides of zero. A
 //     one-sided distribution clamps the side that cannot
-//     (quantile.go:263-273): with no negative buckets the band starts
+//     (quantile.go's one-sided zero-bucket clamp): with no negative
+//     buckets the band starts
 //     at 0, with no positive buckets it ends at 0. Without the clamp a
 //     positive-only histogram answers any phi in the lower half of its
 //     zero bucket with a NEGATIVE value — a number no observation in it
@@ -424,8 +428,8 @@ func histogramQuantileNativeValueFrag(h *chplan.HistogramQuantileNative, helpers
 
 	// Exhausted walk: no running count ever reached the rank, which the
 	// index functions report with their "not found" sentinel 0. Reference
-	// answers NaN there only when Sum is NaN (quantile.go:296-305, added for
-	// prometheus/prometheus#16578); with a finite Sum it falls back to the
+	// answers NaN there only when Sum is NaN (quantile.go's exhausted-walk
+	// fallback to `bucket.Upper`, added for prometheus/prometheus#16578); with a finite Sum it falls back to the
 	// upper bound of the bucket its iterator was left sitting on, which is
 	// the LAST position that iterator yielded — the top of the walk order
 	// going forward, the bottom of it going backward. Cerberus answered NaN
@@ -439,7 +443,8 @@ func histogramQuantileNativeValueFrag(h *chplan.HistogramQuantileNative, helpers
 		If(w.emptyWalk(), zeroBandOrigin(),
 			w.armSelectFiniteSum(upperEdgeAt(w.lastIterated), upperEdgeAt(w.firstIterated))))
 
-	// Outer chain (Prometheus quantile.go:222-232, 114-119). Out-of-domain
+	// Outer chain (`HistogramQuantile` and `bucketQuantile`'s domain guards
+	// in Prometheus quantile.go). Out-of-domain
 	// phi is checked OUTERMOST, above the empty-histogram case, matching
 	// reference's own `q < 0` / `q > 1` / `h.Count == 0` order — cerberus
 	// issue #2067. rankBase = 0 ranks against the histogram's STORED
@@ -529,7 +534,7 @@ func zeroBandOrigin() Frag { return verbatim("0.") }
 
 // reverseWalkPhi is the phi at which reference Prometheus's rank walk
 // flips from the forward bucket iterator to the reverse one
-// (promql/quantile.go:243-252, `if math.IsNaN(h.Sum) || q < 0.5`).
+// (promql/quantile.go's `if math.IsNaN(h.Sum) || q < 0.5`).
 // Walking in from the nearer end keeps the accumulated rank small, so
 // the subtraction that rebases it into the stop bucket loses fewer
 // significant digits.
@@ -664,7 +669,7 @@ func attachHQNativeRankWalk(w *hqNativeWriters, h *chplan.HistogramQuantileNativ
 	// one, each accumulated in reference's own order (see w.revCum).
 	//
 	// `least(..., rankBase)` is reference's own clamp
-	// (quantile.go:286-290, "Due to numerical inaccuracies, we could end
+	// (quantile.go, "Due to numerical inaccuracies, we could end
 	// up with a higher count than h.Count"): the accumulated total can
 	// drift a few ULPs above the stored Count once a rate()/increase()
 	// window fold has scaled every bucket, and reference caps it before
@@ -693,7 +698,8 @@ func attachHQNativeRankWalk(w *hqNativeWriters, h *chplan.HistogramQuantileNativ
 			w.rankBase()))
 	}
 	// rebasedRank is reference's `rank` after it has been rebased into
-	// the stop bucket — the fraction's NUMERATOR (quantile.go:310-314):
+	// the stop bucket — the fraction's NUMERATOR (quantile.go's `rank`
+	// rebase):
 	//
 	//	forward:  rank -= count - bucket.Count
 	//	backward: rank  = count - rank
@@ -868,7 +874,7 @@ func newHQNativeWriters(h *chplan.HistogramQuantileNative, helpers hqNativeHelpe
 		return Col(zt)
 	}
 	// The zero bucket's band edges, with reference Prometheus's
-	// one-sided clamp applied (promql/quantile.go:263-273):
+	// one-sided clamp applied (promql/quantile.go):
 	//
 	//	if !h.UsesCustomBuckets() && bucket.Lower < 0 && bucket.Upper > 0 {
 	//	    case len(NegativeBuckets) == 0 && len(PositiveBuckets) > 0:

--- a/internal/chsql/histogram_quantile_native_mutation_test.go
+++ b/internal/chsql/histogram_quantile_native_mutation_test.go
@@ -50,11 +50,13 @@ const hqFirstIteratedEdge = "if(if(length(`NegativeBucketCounts`) > 0 OR `ZeroCo
 // emit time — a literal phi is query shape, not per-row data, so no runtime
 // branch belongs in the SQL.
 //
-// Kills histogram_quantile_native.go:645:13 CONDITIONALS_NEGATION
-// (`h.Phi < reverseWalkPhi` -> `>=`), which picks the backward arm's
-// firstIterated edge for phi = 0.25, and :644:16 CONDITIONALS_NEGATION
-// (`h.PhiExpr == nil` -> `!= nil`), which drops through to the computed-phi
-// form and emits a runtime `if(0.25 < 0.5, …)` over two constant-folded arms.
+// Kills, in
+// histogram_quantile_native.go:`w.armSelectFiniteSum = func(fwd, rev Frag) Frag`,
+// the CONDITIONALS_NEGATION on `h.Phi < reverseWalkPhi` (-> `>=`), which picks
+// the backward arm's firstIterated edge for phi = 0.25, and the
+// CONDITIONALS_NEGATION on `h.PhiExpr == nil` (-> `!= nil`), which drops
+// through to the computed-phi form and emits a runtime `if(0.25 < 0.5, …)`
+// over two constant-folded arms.
 func TestMutation_HQNativeArmSelectFiniteSum_ForwardBelowReverseWalkPhi(t *testing.T) {
 	t.Parallel()
 
@@ -70,10 +72,12 @@ func TestMutation_HQNativeArmSelectFiniteSum_ForwardBelowReverseWalkPhi(t *testi
 // `q < 0.5` test, so phi EQUAL to it belongs to the backward arm — its
 // fallback edge is the FIRST position the walk order yields.
 //
-// Kills histogram_quantile_native.go:645:13 CONDITIONALS_BOUNDARY
-// (`h.Phi < reverseWalkPhi` -> `<=`), the only mutant that changes behaviour
-// at exactly phi == 0.5, and again :645:13 CONDITIONALS_NEGATION (`>=`, also
-// forward here) and :644:16 CONDITIONALS_NEGATION (which emits the runtime
+// Kills, in the same
+// histogram_quantile_native.go:`w.armSelectFiniteSum = func(fwd, rev Frag) Frag`,
+// the CONDITIONALS_BOUNDARY on `h.Phi < reverseWalkPhi` (-> `<=`), the only
+// mutant that changes behaviour at exactly phi == 0.5, and again its
+// CONDITIONALS_NEGATION (`>=`, also forward here) and the
+// CONDITIONALS_NEGATION on `h.PhiExpr == nil` (which emits the runtime
 // `if(0.5 < 0.5, …)` form instead).
 func TestMutation_HQNativeArmSelectFiniteSum_BackwardAtReverseWalkPhi(t *testing.T) {
 	t.Parallel()
@@ -97,8 +101,10 @@ func TestMutation_HQNativeArmSelectFiniteSum_BackwardAtReverseWalkPhi(t *testing
 // to avoid.
 //
 // Kills the three surviving CONDITIONALS_NEGATION mutants of that test:
-// :775:21 (`helpers.revCum != ""`), :838:23 (`helpers.valueIdx != ""`) and
-// :851:17 (`helperCol != ""`, shared by firstPopulated and lastPopulated).
+// histogram_quantile_native.go:`helpers.revCum != ""`,
+// histogram_quantile_native.go:`helpers.valueIdx != ""` and
+// histogram_quantile_native.go:`helperCol != ""` (shared by firstPopulated
+// and lastPopulated).
 //
 // phi is at reverseWalkPhi so reachesReverseArm holds and the revCum stage is
 // actually projected.

--- a/internal/chsql/histogram_quantile_test.go
+++ b/internal/chsql/histogram_quantile_test.go
@@ -25,9 +25,10 @@ func TestHistogramQuantileValueFrag_DividesRankBeforeWidth(t *testing.T) {
 }
 
 // TestHistogramQuantileValueFrag_PhiExprGating kills the two
-// CONDITIONALS_NEGATION mutants at histogram_quantile.go:457
-// (`h.PhiExpr != nil`, inside the arrayFirstIndex predicate) and :266
-// (`h.PhiExpr == nil`, the early return before the isNaN wrapper).
+// CONDITIONALS_NEGATION mutants on `h.PhiExpr != nil` inside the
+// arrayFirstIndex predicate (histogram_quantile.go:`w.idx = func() Frag`) and
+// on histogram_quantile.go:`h.PhiExpr == nil`, the early return before the
+// isNaN wrapper.
 //
 // The literal-Phi path (h.PhiExpr == nil) must render the BARE `c >=
 // <target>` comparison as the arrayFirstIndex predicate and must NOT
@@ -80,17 +81,19 @@ func TestHistogramQuantileValueFrag_PhiExprGating(t *testing.T) {
 			t.Errorf("computed phi must wrap the predicate as (if(c >= ..., 1, 0) = 1) (line 457 flipped?):\n%s", sql)
 		}
 		if !strings.Contains(sql, "= 1),") {
-			t.Errorf("computed phi predicate must close with `= 1)` (line 457 flipped?):\n%s", sql)
+			t.Errorf("computed phi predicate must close with `= 1)` "+
+				"(histogram_quantile.go:`w.idx = func() Frag` flipped?):\n%s", sql)
 		}
 		if !strings.HasPrefix(sql, "if(isNaN(") {
-			t.Errorf("computed phi must lead with the isNaN(phi) guard (line 266 flipped?):\n%s", sql)
+			t.Errorf("computed phi must lead with the isNaN(phi) guard "+
+				"(histogram_quantile.go:`h.PhiExpr == nil` flipped?):\n%s", sql)
 		}
 	})
 }
 
 // TestEmitHistogramQuantile_RequiredColumns kills the INVERT_LOGICAL mutant
-// at histogram_quantile.go:92:32 (`h.BucketCountsColumn == "" ||
-// h.ExplicitBoundsColumn == ""` -> `&&`). Each column empty ALONE must
+// at histogram_quantile.go:`h.BucketCountsColumn == "" ||
+// h.ExplicitBoundsColumn == ""` (`||` -> `&&`). Each column empty ALONE must
 // still error; an `&&` mutant would require BOTH to be empty
 // simultaneously, letting a plan missing just one of the two through.
 func TestEmitHistogramQuantile_RequiredColumns(t *testing.T) {
@@ -126,9 +129,8 @@ func TestEmitHistogramQuantile_RequiredColumns(t *testing.T) {
 
 // TestEmitHistogramQuantile_GroupByAliasFallback kills both the
 // CONDITIONALS_BOUNDARY (`<` -> `<=`) and CONDITIONALS_NEGATION (`<` ->
-// `>=`) mutants at histogram_quantile.go:152:8 (`i <
-// len(h.GroupByAliases)`). Placing the alias slice ONE ENTRY SHORT of
-// GroupBy hits the exact boundary index (i == len(h.GroupByAliases)):
+// `>=`) mutants at histogram_quantile.go:`i < len(h.GroupByAliases)`.
+// Placing the alias slice ONE ENTRY SHORT of GroupBy hits the exact boundary index (i == len(h.GroupByAliases)):
 // under either mutant that index tries h.GroupByAliases[i], which is out
 // of range and panics; under the original code it falls back to an
 // unaliased projection.

--- a/internal/chsql/lwr_fanout_bound.go
+++ b/internal/chsql/lwr_fanout_bound.go
@@ -46,8 +46,9 @@ import "context"
 // Lookback=5m [261 samples/series over a 1h05m seed window], 1h query
 // window, `histogram_quantile(0.95, sum by (le, route) (increase(<bucket>
 // [5m])))` — `by(le, ...)`, not a bare `by(route)`, is REQUIRED to reach
-// the array-domain groupArray path at all (histogramAggShapeLowerable,
-// histogram_quantile.go:1058); a by-clause omitting `le` legitimately
+// the array-domain groupArray path at all
+// (internal/promql/histogram_quantile.go:histogramAggShapeLowerable); a
+// by-clause omitting `le` legitimately
 // resolves to the empty ordinary-float-bucket fallback instead. A unique
 // query_id per run, per #2429's own harness-pitfall lesson):
 //

--- a/internal/chsql/prewhere_mutation_test.go
+++ b/internal/chsql/prewhere_mutation_test.go
@@ -130,7 +130,7 @@ func TestSortRankForMinimum(t *testing.T) {
 }
 
 // TestIsNarrowIntegerDiscriminatorFinalReturnLogical defends
-// isNarrowIntegerDiscriminator's final return (prewhere.go:287): the chain
+// isNarrowIntegerDiscriminator's final return (prewhere.go:`if !ok || (binary.Op != chplan.OpEq && binary.Op != chplan.OpNe)`): the chain
 // `columnOK && literalOK && column.Qualifier == "" && shape.IsInteger...
 // && sortRankFor(...) < 0`.
 //

--- a/internal/chsql/prewhere_mutation_test.go
+++ b/internal/chsql/prewhere_mutation_test.go
@@ -10,10 +10,11 @@ import (
 // PREWHERE-promotion helpers in prewhere.go so that the gremlins mutation
 // lane (phase2 scope ./internal/chsql) cannot flip an operator or a
 // loop-control token without a test going red. Each test names the
-// prewhere.go line it defends.
+// prewhere.go construct it defends.
 
-// TestOrderedConjunctsSortContinue defends prewhere.go:203 (the `continue`
-// inside the stable insertion sort over the sort-prefix bucket).
+// TestOrderedConjunctsSortContinue defends the `continue` inside the stable
+// insertion sort over the sort-prefix bucket
+// (prewhere.go:`if prefix[j-1].rank > prefix[j].rank`).
 //
 // Mutation INVERT_LOOPCTRL turns that `continue` into `break`. The original
 // keeps bubbling the inserted element left until it reaches its rank slot;
@@ -47,8 +48,8 @@ func TestOrderedConjunctsSortContinue(t *testing.T) {
 	}
 }
 
-// TestIsLeadingSortKeyEqualityLogical defends prewhere.go:269 (the
-// `!ok || bin.Op != chplan.OpEq` short-circuit).
+// TestIsLeadingSortKeyEqualityLogical defends the
+// prewhere.go:`!ok || bin.Op != chplan.OpEq` short-circuit.
 //
 // Mutation INVERT_LOGICAL turns `||` into `&&`. With `&&`, a binary whose
 // operator is NOT `=` no longer returns early as "not a leading-sort-key
@@ -80,8 +81,9 @@ func TestIsLeadingSortKeyEqualityLogical(t *testing.T) {
 	}
 }
 
-// TestOrderedConjunctsSingleFastPath defends prewhere.go:167
-// (`if len(conjuncts) <= 1 { return conjuncts }`).
+// TestOrderedConjunctsSingleFastPath defends
+// prewhere.go:`len(conjuncts) <= 1` (`if len(conjuncts) <= 1 { return
+// conjuncts }`).
 //
 // Mutation CONDITIONALS_BOUNDARY turns `<=` into `<`, so a single conjunct
 // no longer takes the fast path: it is rebuilt through the bucket/sort
@@ -105,12 +107,12 @@ func TestOrderedConjunctsSingleFastPath(t *testing.T) {
 }
 
 // TestSortRankForMinimum defends sortRankFor's running-minimum update
-// (prewhere.go:148). It pins that sortRankFor returns the LOWEST matching
+// (prewhere.go:`best < 0 || r < best`). It pins that sortRankFor returns the LOWEST matching
 // rank across a predicate's columns regardless of the order the columns are
 // discovered — i.e. a later, larger rank never overwrites an earlier rank-0
 // (and would catch a `best < 0`→`best <= 0` flip, which lets a larger rank
-// clobber an existing rank-0 minimum). The `r < best`→`r <= best` boundary at
-// this same line is a separate, genuinely equivalent mutation — see this
+// clobber an existing rank-0 minimum). The `r < best`→`r <= best` boundary in
+// that same condition is a separate, genuinely equivalent mutation — see this
 // file's own "NOT KILLABLE" footer below for why.
 func TestSortRankForMinimum(t *testing.T) {
 	t.Parallel()
@@ -130,7 +132,8 @@ func TestSortRankForMinimum(t *testing.T) {
 }
 
 // TestIsNarrowIntegerDiscriminatorFinalReturnLogical defends
-// isNarrowIntegerDiscriminator's final return (prewhere.go:`if !ok || (binary.Op != chplan.OpEq && binary.Op != chplan.OpNe)`): the chain
+// isNarrowIntegerDiscriminator's final return
+// (prewhere.go:`columnOK && literalOK`): the chain
 // `columnOK && literalOK && column.Qualifier == "" && shape.IsInteger...
 // && sortRankFor(...) < 0`.
 //
@@ -171,7 +174,7 @@ func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 
 // CI-TIMING NOISE, not a test gap — cerberus issue #2741.
 //
-// prewhere.go:287:18 (INVERT_LOGICAL, the same mutation
+// prewhere.go:`columnOK && literalOK` (INVERT_LOGICAL, the same mutation
 // TestIsNarrowIntegerDiscriminatorFinalReturnLogical above defends) showed
 // LIVED on the v1.19.0 release-gate's phase2-other run despite this test
 // existing and being correct. Reproduced locally per cerberus issue #2730's
@@ -188,16 +191,19 @@ func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 //
 // NOT KILLABLE — documented, not defended by a test.
 //
-// prewhere.go:131:4, :187:5 and :207:4 (INVERT_LOOPCTRL) each swap a
-// terminal `break` for `continue` guarding a "found it, stop" boolean latch
-// (touchesWide / hitsSkip) or the stable-insertion-sort early exit. In
+// The INVERT_LOOPCTRL mutants of the three terminal `break`s —
+// prewhere.go:`touchesWide = true`, prewhere.go:`hitsSkip = true` and the
+// stable-insertion-sort early exit at
+// prewhere.go:`if prefix[j-1].rank > prefix[j].rank` — each swap that `break`
+// for a `continue`, guarding a "found it, stop" boolean latch (touchesWide /
+// hitsSkip) or the sort's early exit. In
 // every case the flag is set exactly once and never reset, or (for the
 // sort) the insertion-sort invariant guarantees every comparison below the
 // break point is already in order, so scanning further with `continue`
 // instead of `break` can never change the final return value — only the
 // iteration count. No observable-behaviour test can distinguish them.
 //
-// prewhere.go:283:15 (INVERT_LOGICAL, `||`→`&&` in
+// prewhere.go:`!columnOK || !literalOK` (INVERT_LOGICAL, `||`→`&&` in
 // isNarrowIntegerDiscriminator's swap guard) is equivalent for the same
 // structural reason as the min-tracking boundary above: a chplan.Expr value
 // has exactly one concrete type, so whichever of columnOK/literalOK is
@@ -206,7 +212,8 @@ func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 // the branch this condition guards can only ever produce the SAME final
 // (columnOK, literalOK) pair whether or not the swap runs.
 //
-// prewhere.go:148:20 (CONDITIONALS_BOUNDARY, `r < best` → `r <= best` in
+// prewhere.go:`best < 0 || r < best` (CONDITIONALS_BOUNDARY, `r < best` →
+// `r <= best` in
 // sortRankFor's running-minimum update) is equivalent because the boundary
 // (`r == best`) is unreachable for two DISTINCT columns under any
 // TableShape: SortRank(name) returns the index of name's first match in

--- a/internal/chsql/range_bucket_fanout_mutation_test.go
+++ b/internal/chsql/range_bucket_fanout_mutation_test.go
@@ -37,8 +37,8 @@ func fanoutMinSamplesPlan(minSamples int) *chplan.RangeBucketFanout {
 }
 
 // TestMutation_RangeBucketFanout_MinSamplesFilterThreshold defends
-// range_bucket_fanout.go:159 (`if r.MinSamples > fanoutNoMinSampleFilter`, the
-// gate on the collapse HAVING).
+// range_bucket_fanout.go:`r.MinSamples > fanoutNoMinSampleFilter` (the gate on
+// the collapse HAVING).
 //
 // fanoutNoMinSampleFilter is 1: an anchor whose window holds no sample already
 // receives no fanned row and so produces no GROUP BY row, which makes "at

--- a/internal/chsql/range_bucket_grid_native_mutation_test.go
+++ b/internal/chsql/range_bucket_grid_native_mutation_test.go
@@ -57,7 +57,7 @@ func requireGridNativeRejected(t *testing.T, node *chplan.RangeBucketGridNative)
 }
 
 // TestEmitRangeBucketGridNativeRejectsZeroStep defends
-// range_bucket_grid_native.go:197 (`if r.Step <= 0`).
+// range_bucket_grid_native.go:`if r.Step <= 0`.
 //
 // Mutation CONDITIONALS_BOUNDARY turns `<=` into `<`, so Step == 0 no
 // longer trips the guard: the emitter would proceed to build a grid whose
@@ -71,7 +71,7 @@ func TestEmitRangeBucketGridNativeRejectsZeroStep(t *testing.T) {
 }
 
 // TestEmitRangeBucketGridNativeRejectsZeroRange defends
-// range_bucket_grid_native.go:200 (`if r.Range <= 0`).
+// range_bucket_grid_native.go:`if r.Range <= 0`.
 //
 // Mutation CONDITIONALS_BOUNDARY turns `<=` into `<`, so Range == 0 no
 // longer trips the guard: the emitter would proceed to build a lookback
@@ -85,7 +85,7 @@ func TestEmitRangeBucketGridNativeRejectsZeroRange(t *testing.T) {
 }
 
 // TestEmitRangeBucketGridNativeRejectsPartialZeroStartOrEnd defends
-// range_bucket_grid_native.go:203 (`if r.Start.IsZero() || r.End.IsZero()`).
+// range_bucket_grid_native.go:`if r.Start.IsZero() || r.End.IsZero()`.
 //
 // Mutation INVERT_LOGICAL turns `||` into `&&`, so the guard only fires
 // when BOTH Start and End are zero. A plan with exactly one endpoint zero
@@ -109,7 +109,7 @@ func TestEmitRangeBucketGridNativeRejectsPartialZeroStartOrEnd(t *testing.T) {
 }
 
 // TestEmitRangeBucketGridNativeRejectsPartialEmptyCols defends
-// range_bucket_grid_native.go:212
+// range_bucket_grid_native.go:`if r.BucketCountsCol == "" || r.ExplicitBoundsCol == ""`
 // (`if r.BucketCountsCol == "" || r.ExplicitBoundsCol == ""`).
 //
 // Mutation INVERT_LOGICAL turns `||` into `&&`, so the guard only fires

--- a/internal/chsql/range_lwr_test.go
+++ b/internal/chsql/range_lwr_test.go
@@ -107,10 +107,10 @@ func TestEmitRangeLWR_RejectsZeroStep(t *testing.T) {
 }
 
 // TestEmitRangeLWR_FanoutLimitIsMaxRowsPlusOne kills the two ARITHMETIC_BASE
-// mutants at lwr_fanout_bound.go:213:24 and :224:22 (`maxRows + 1`, in
-// lwrFanoutBoundedSourceFrag's bounded-read LIMIT and its independent
-// truncation-probe LIMIT). The "+1" is the whole truncation-detection
-// mechanism: a returned probe count landing exactly on maxRows+1 can only
+// mutants on `maxRows + 1` in lwrFanoutBoundedSourceFrag's bounded-read LIMIT
+// (lwr_fanout_bound.go:`bounded.Limit(maxRows + 1)`) and its independent
+// truncation-probe LIMIT (lwr_fanout_bound.go:`probe.Limit(maxRows + 1)`).
+// The "+1" is the whole truncation-detection mechanism: a returned probe count landing exactly on maxRows+1 can only
 // happen if the true fanned-out row count reached or exceeded that LIMIT. A
 // `+`->`-` flip renders `maxRows - 1` instead, a directly observable
 // literal change in the emitted SQL (maxRangeLWRFanoutRows = 40_000_000, so

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -3758,8 +3758,8 @@ func (e *emitter) emitRangeWindowQuantileOverTime(r *chplan.RangeWindow) error {
 //  3. whether the factor is per-second (rate only — Prom's isRate
 //     branch).
 //
-// Mirrors prometheus/promql/functions.go::extrapolatedRate, lines
-// 188-314 (the helper funcDelta / funcRate / funcIncrease share).
+// Mirrors prometheus/promql/functions.go::extrapolatedRate (the helper
+// funcDelta / funcRate / funcIncrease share).
 type extrapolationKind int
 
 const (
@@ -4187,7 +4187,7 @@ func (e *emitter) deltaPrefixAggregateSource(
 //
 // The `<factor>` is `(sampled_interval + duration_to_start + duration_to_end) / sampled_interval`,
 // matching Prom's `factor := (sampledInterval + durationToStart + durationToEnd) / sampledInterval`
-// at functions.go:304.
+// in functions.go's `extrapolatedRate`.
 //
 // `<raw_result>` is `counter_delta` for rate / increase (Prom's
 // counter-reset-aware accumulator) and `(last_val - first_val)` for
@@ -5064,7 +5064,8 @@ func deltaFirstValFrag(temporality, reconstructedLevel, rawFirst Frag) Frag {
 
 // rangeStartFrag renders `<end> - toIntervalNanosecond(<rangeNS>)` —
 // Prom's `rangeStart = enh.Ts - durationMilliseconds(ms.Range+vs.Offset)`
-// (functions.go:197). end may render arbitrary CH expressions; the
+// (functions.go's `extrapolatedRate`). end may render arbitrary CH
+// expressions; the
 // rangeNS bound is inline.
 func rangeStartFrag(end Frag, rangeNS int64) Frag {
 	return Sub(end, Call("toIntervalNanosecond", InlineLit(rangeNS)))
@@ -5086,7 +5087,8 @@ func secondsBetweenFrag(from, to Frag) Frag {
 // sampledIntervalFrag renders the per-window sampled interval in
 // seconds (Float64): `dateDiff('nanosecond', first_ts, last_ts) / 1e9`.
 // Mirrors Prom's `sampledInterval := float64(lastT-firstT) / 1000`
-// (functions.go:258), substituting nanosecond precision for the
+// (functions.go's `extrapolatedRate`), substituting nanosecond precision
+// for the
 // millisecond timebase Prom carries.
 func sampledIntervalFrag() Frag {
 	return secondsBetweenFrag(BareIdent("first_ts"), BareIdent("last_ts"))
@@ -5207,7 +5209,7 @@ func durationToEndRawFrag(rangeEnd Frag) Frag {
 // projecting a separate `last_val` alias.
 //
 // The optional `/ <range_seconds>` only applies to rate (Prom's
-// `isRate` branch at functions.go:305-307).
+// `isRate` branch in functions.go's `extrapolatedRate`).
 //
 // The parenthesisation is load-bearing, not cosmetic. Reference builds the
 // whole FACTOR first and applies it in a single multiplication

--- a/internal/chsql/range_window_matrix_delta_prefix_guard_test.go
+++ b/internal/chsql/range_window_matrix_delta_prefix_guard_test.go
@@ -82,8 +82,8 @@ func matrixDeltaGuardEmit(t *testing.T, r *chplan.RangeWindow) string {
 }
 
 // TestDeltaMatrixAggregateDailyFanout_GuardAppliedToAggregateTableScan kills
-// range_window.go:4067:11 (CONDITIONALS_NEGATION on `guard != nil` inside
-// deltaMatrixLevelSourceAggregateDailyFanout): for this window,
+// range_window.go:deltaMatrixLevelSourceAggregateDailyFanout:`guard != nil`
+// (CONDITIONALS_NEGATION): for this window,
 // r.TemporalityColumn is always set, so deltaPresenceGuardFrag always
 // returns a non-nil guard — flipping the check to `guard == nil` means
 // aggDaily.Where(guard) is never called, silently dropping the guard from
@@ -114,10 +114,11 @@ func TestDeltaMatrixAggregateDailyFanout_GuardAppliedToAggregateTableScan(t *tes
 }
 
 // TestApplyMatrixFanoutScanBoundAggregate_OrGuardAppliedToFanout kills BOTH
-// range_window.go:4324:9 (CONDITIONALS_NEGATION on `err != nil` — flipping it
-// to `err == nil` makes the error-free case return early, before the guard
-// clause is ever appended) and range_window.go:4327:11 (CONDITIONALS_NEGATION
-// on `guard != nil` — flipping it to `guard == nil` skips the same append,
+// range_window.go:applyMatrixFanoutScanBoundAggregate:`err != nil`
+// (CONDITIONALS_NEGATION — flipping it to `err == nil` makes the error-free
+// case return early, before the guard clause is ever appended) and
+// range_window.go:applyMatrixFanoutScanBoundAggregate:`guard != nil`
+// (CONDITIONALS_NEGATION — flipping it to `guard == nil` skips the same append,
 // since guard is always non-nil here). Either mutation removes the
 // `OR \`AggregationTemporality\` != 1` disjunct this PR's HIGH-severity fix
 // added to the raw sample fanout's own scan bound — see
@@ -172,9 +173,9 @@ func intervalNanosecondsAfter(t *testing.T, sqlText, marker string, n int) []int
 }
 
 // TestMatrixWindowScanBoundsFrags_EarliestAnchorArithmetic kills
-// range_window.go:4239:79 (ARITHMETIC_BASE and INVERT_NEGATIVES on the `-`
-// in `numAnchors-1`) and 4239:82 (ARITHMETIC_BASE on the `*` in
-// `(numAnchors-1)*stepNS`). matrixWindowScanBoundsFrags computes
+// range_window.go:matrixWindowScanBoundsFrags:`(numAnchors-1)*stepNS` under
+// ARITHMETIC_BASE and INVERT_NEGATIVES on the `-` in `numAnchors-1`, and
+// ARITHMETIC_BASE on the `*`. matrixWindowScanBoundsFrags computes
 // earliestAnchor = end - (numAnchors-1)*stepNS, consumed as the guard
 // subquery's own windowLo probe (`\`TimeUnix\` > <end literal> -
 // toIntervalNanosecond((numAnchors-1)*stepNS) - toIntervalNanosecond
@@ -208,8 +209,9 @@ func TestMatrixWindowScanBoundsFrags_EarliestAnchorArithmetic(t *testing.T) {
 }
 
 // TestApplyMatrixFanoutScanBoundAggregate_EarliestDayArithmetic kills
-// range_window.go:4316:79 (ARITHMETIC_BASE and INVERT_NEGATIVES on the `-`
-// in `numAnchors-1`) and 4316:82 (ARITHMETIC_BASE on the `*`) —
+// range_window.go:applyMatrixFanoutScanBoundAggregate:`(numAnchors-1)*stepNS`
+// under ARITHMETIC_BASE and INVERT_NEGATIVES on the `-` in `numAnchors-1`, and
+// ARITHMETIC_BASE on the `*` —
 // applyMatrixFanoutScanBoundAggregate's OWN local earliestAnchor
 // (identical source shape to matrixWindowScanBoundsFrags', but a distinct
 // call site / distinct mutant), which derives the raw fanout's own

--- a/internal/chsql/range_window_mutation_test.go
+++ b/internal/chsql/range_window_mutation_test.go
@@ -15,11 +15,14 @@ import (
 // is white-box (package chsql) so it can reach unexported emitter methods
 // where the public Emit surface alone wouldn't isolate the boundary.
 //
-// Mutant inventory (file:line:col → what the flip does):
-//   - range_window.go:423:28 / 425:28 — `1 - sf` / `1 - tf` → `1 + sf` / `1 + tf`
-//     (holt_winters smoothing weights): wrong (1∓w) factor in the recurrence.
-//   - range_window.go:662:19 — `minWindowSize > 0` → `>= 0`: spuriously emits the
-//     window-length WHERE filter when no minimum was requested.
+// Mutant inventory (construct → what the flip does):
+//   - range_window.go:`InlineLit(sf), InlineLit(1-sf)` and
+//     range_window.go:`InlineLit(tf), InlineLit(1-tf)` — `1 - sf` / `1 - tf` →
+//     `1 + sf` / `1 + tf` (holt_winters smoothing weights): wrong (1∓w) factor
+//     in the recurrence.
+//   - range_window.go:emitWindowedArrayPairsMatrix:`minWindowSize > 0` → `>= 0`:
+//     spuriously emits the window-length WHERE filter when no minimum was
+//     requested.
 //   - range_window.go, emitRangeWindowOverTimeDirect — `r.Step <= 0` → `< 0`: stops
 //     rejecting OuterRange>0 subqueries that forgot Step (would divide by zero /
 //     emit a degenerate grid).
@@ -69,7 +72,9 @@ func fusedOuter() *chplan.RangeWindow {
 	}
 }
 
-// TestHoltWintersSmoothingWeightsEmit kills range_window.go:423 + 425.
+// TestHoltWintersSmoothingWeightsEmit kills the flips on
+// range_window.go:`InlineLit(sf), InlineLit(1-sf)` and
+// range_window.go:`InlineLit(tf), InlineLit(1-tf)`.
 // With sf=0.25, tf=0.125 the (1−w) weights render as the exact literals
 // 0.75 and 0.875; the ARITHMETIC_BASE / INVERT_NEGATIVES flips (1+w) would
 // render 1.25 / 1.125 instead.
@@ -89,21 +94,24 @@ func TestHoltWintersSmoothingWeightsEmit(t *testing.T) {
 	}
 	// 1 - sf = 0.75 must appear; the +sf flip's 1.25 must not.
 	if !strings.Contains(sql, "0.75 *") {
-		t.Errorf("missing `1 - sf` weight (0.75 *) — line 423 flipped?\nSQL: %s", sql)
+		t.Errorf("missing `1 - sf` weight (0.75 *) — "+
+			"range_window.go:`InlineLit(sf), InlineLit(1-sf)` flipped?\nSQL: %s", sql)
 	}
 	if strings.Contains(sql, "1.25") {
-		t.Errorf("found 1.25 — `1 - sf` mutated to `1 + sf` (line 423)\nSQL: %s", sql)
+		t.Errorf("found 1.25 — `1 - sf` mutated to `1 + sf`\nSQL: %s", sql)
 	}
 	// 1 - tf = 0.875 must appear; the +tf flip's 1.125 must not.
 	if !strings.Contains(sql, "0.875 *") {
-		t.Errorf("missing `1 - tf` weight (0.875 *) — line 425 flipped?\nSQL: %s", sql)
+		t.Errorf("missing `1 - tf` weight (0.875 *) — "+
+			"range_window.go:`InlineLit(tf), InlineLit(1-tf)` flipped?\nSQL: %s", sql)
 	}
 	if strings.Contains(sql, "1.125") {
-		t.Errorf("found 1.125 — `1 - tf` mutated to `1 + tf` (line 425)\nSQL: %s", sql)
+		t.Errorf("found 1.125 — `1 - tf` mutated to `1 + tf`\nSQL: %s", sql)
 	}
 }
 
-// TestWindowedArrayPairsMatrixMinWindowBoundary kills range_window.go:662.
+// TestWindowedArrayPairsMatrixMinWindowBoundary kills
+// range_window.go:emitWindowedArrayPairsMatrix:`minWindowSize > 0`.
 // minWindowSize=0 must NOT emit the `length(window_pairs) >= 0` WHERE filter;
 // minWindowSize=2 must. The `> 0` → `>= 0` boundary flip adds the no-op
 // filter at 0, so the filter's presence is pinned to the boundary.
@@ -134,7 +142,7 @@ func TestWindowedArrayPairsMatrixMinWindowBoundary(t *testing.T) {
 		t.Fatalf("emitWindowedArrayPairsMatrix(min=0): %v", err)
 	}
 	if got := e0.b.String(); strings.Contains(got, lenFilterPrefix) {
-		t.Errorf("min=0 emitted a window-length filter (%q) — line 662 `> 0` flipped to `>= 0`\nSQL: %s",
+		t.Errorf("min=0 emitted a window-length filter (%q) — `minWindowSize > 0` flipped to `>= 0`\nSQL: %s",
 			lenFilterPrefix, got)
 	}
 
@@ -148,7 +156,8 @@ func TestWindowedArrayPairsMatrixMinWindowBoundary(t *testing.T) {
 	}
 }
 
-// TestOverTimeDirectRejectsZeroStepSubquery kills range_window.go:2346.
+// TestOverTimeDirectRejectsZeroStepSubquery kills
+// range_window.go:`r.OuterRange > 0 && r.Step <= 0`.
 // OuterRange>0 with Step==0 is the exact boundary: original (`<= 0`) returns
 // ErrUnsupported; the `< 0` flip would accept Step==0 and divide by zero.
 func TestOverTimeDirectRejectsZeroStepSubquery(t *testing.T) {
@@ -317,19 +326,21 @@ func TestFusedSubqueryOuterShapeGuard(t *testing.T) {
 }
 
 // TestFusedInstantInnerGate kills the inner-matrix gate in
-// tryEmitFusedSubquery (range_window_fused.go:102/113/122). Each case
-// starts from the fully-fusible fusedOuter() and perturbs ONE inner field so
-// the gate should reject (handled=false); the flip would proceed to fuse
-// (handled=true). The clean baseline fuses (handled=true).
+// tryEmitFusedSubquery. Each case starts from the fully-fusible fusedOuter()
+// and perturbs ONE inner field so the gate should reject (handled=false); the
+// flip would proceed to fuse (handled=true). The clean baseline fuses
+// (handled=true).
 //
-//   - 102:20 `inner.Identity || …` `||`→`&&`: Identity=true still rejects.
-//   - 102:40 `inner.OuterRange <= 0` `<=`→`<`: OuterRange==0 still rejects.
-//   - 102:45 `… || inner.Step <= 0` `||`→`&&`, and
-//     102:59 `inner.Step <= 0` `<=`→`<`: Step==0 still rejects.
-//   - 113:33 `TimestampColumn == "" || ValueColumn == ""` `||`→`&&`: an empty
-//     TimestampColumn (ValueColumn still set) still rejects.
-//   - 122:26 `inner.Start.IsZero() || inner.End.IsZero()` `||`→`&&`: a zero
-//     inner Start (End still set) still rejects.
+//   - range_window_fused.go:`inner.Identity || inner.OuterRange <= 0 || inner.Step <= 0`:
+//     the leading `||`→`&&` (Identity=true still rejects), the
+//     `inner.OuterRange <= 0` `<=`→`<` (OuterRange==0 still rejects), the
+//     second `||`→`&&` and the `inner.Step <= 0` `<=`→`<` (Step==0 still
+//     rejects).
+//   - range_window_fused.go:`inner.TimestampColumn == "" || inner.ValueColumn == ""`
+//     `||`→`&&`: an empty TimestampColumn (ValueColumn still set) still
+//     rejects.
+//   - range_window_fused.go:`inner.Start.IsZero() || inner.End.IsZero()`
+//     `||`→`&&`: a zero inner Start (End still set) still rejects.
 func TestFusedInstantInnerGate(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -365,11 +376,12 @@ func TestFusedInstantInnerGate(t *testing.T) {
 	}
 }
 
-// TestFusedInstantAnchorCount kills range_window_fused.go:158
-// `inner.OuterRange.Nanoseconds()/stepNS + 1`. With OuterRange=10m and Step=1m
-// the fused anchor grid is `range(11)`. The `/`→`*` flip (@158:46) overflows to
-// a wildly different count and the `+`→`-` flip (@158:54) yields `range(9)`, so
-// pinning the exact `range(11)` literal kills both arithmetic mutants.
+// TestFusedInstantAnchorCount kills
+// range_window_fused.go:`inner.OuterRange.Nanoseconds()/stepNS + 1`. With
+// OuterRange=10m and Step=1m the fused anchor grid is `range(11)`. The `/`→`*`
+// flip overflows to a wildly different count and the `+`→`-` flip yields
+// `range(9)`, so pinning the exact `range(11)` literal kills both arithmetic
+// mutants.
 func TestFusedInstantAnchorCount(t *testing.T) {
 	t.Parallel()
 	sql, _, err := Emit(context.Background(), fusedOuter())
@@ -378,15 +390,17 @@ func TestFusedInstantAnchorCount(t *testing.T) {
 	}
 	// OuterRange 10m / Step 1m + 1 = 11 anchors.
 	if !strings.Contains(sql, "range(11)") {
-		t.Errorf("fused anchor grid must be range(11) (OuterRange/Step + 1) — line 158 arithmetic flipped\nSQL: %s", sql)
+		t.Errorf("fused anchor grid must be range(11) (OuterRange/Step + 1) — "+
+			"`inner.OuterRange.Nanoseconds()/stepNS + 1` arithmetic flipped\nSQL: %s", sql)
 	}
 	if strings.Contains(sql, "range(9)") {
-		t.Errorf("found range(9) — `+ 1` mutated to `- 1` (line 158)\nSQL: %s", sql)
+		t.Errorf("found range(9) — `+ 1` mutated to `- 1`\nSQL: %s", sql)
 	}
 }
 
-// TestOverTimeDirectMatrixNoGroupBy kills range_window.go:2465. With an empty
-// GroupBy the regroup-key slice cap is `len(groupFrags)+1` = 1; the
+// TestOverTimeDirectMatrixNoGroupBy kills
+// range_window.go:emitRangeWindowOverTimeDirectMatrix:`len(groupFrags)+1`.
+// With an empty GroupBy the regroup-key slice cap is `len(groupFrags)+1` = 1; the
 // ARITHMETIC_BASE flip to `-1` makes `make([]Frag, 0, -1)`, which panics
 // (cap out of range) on this exact path. The original must emit clean SQL.
 func TestOverTimeDirectMatrixNoGroupBy(t *testing.T) {
@@ -414,8 +428,8 @@ func TestOverTimeDirectMatrixNoGroupBy(t *testing.T) {
 }
 
 // TestFusedSamplesQueryTemporalityGate kills the CONDITIONALS_NEGATION
-// mutant at range_window_fused.go:`g.temporality != nil` (`g.temporality != nil`, inside
-// samplesQuery). When the inner window carries a TemporalityColumn, the
+// mutant at range_window_fused.go:`g.temporality != nil`, inside
+// samplesQuery. When the inner window carries a TemporalityColumn, the
 // fused samples layer must read the series' single AggregationTemporality
 // via `any(...)` under windowTemporalityAlias; when it doesn't, that
 // projection must be absent entirely. The `!=` → `==` flip would invert
@@ -435,7 +449,8 @@ func TestFusedSamplesQueryTemporalityGate(t *testing.T) {
 			t.Fatalf("Emit: %v", err)
 		}
 		if !strings.Contains(sql, wantProjection) {
-			t.Errorf("expected %q in the fused samples layer (line 234 flipped?)\nSQL: %s", wantProjection, sql)
+			t.Errorf("expected %q in the fused samples layer "+
+				"(`g.temporality != nil` flipped?)\nSQL: %s", wantProjection, sql)
 		}
 	})
 
@@ -446,15 +461,16 @@ func TestFusedSamplesQueryTemporalityGate(t *testing.T) {
 			t.Fatalf("Emit: %v", err)
 		}
 		if strings.Contains(sql, wantProjection) {
-			t.Errorf("unexpected %q with no TemporalityColumn set (line 234 flipped?)\nSQL: %s", wantProjection, sql)
+			t.Errorf("unexpected %q with no TemporalityColumn set "+
+				"(`g.temporality != nil` flipped?)\nSQL: %s", wantProjection, sql)
 		}
 	})
 }
 
 // TestFusedMatrixOuterAnchorCount kills the ARITHMETIC_BASE mutants at
-// range_window_fused.go:408 (`r.OuterRange.Nanoseconds()/outerStepNS + 1`,
+// range_window_fused.go:`r.OuterRange.Nanoseconds()/outerStepNS + 1`,
 // emitFusedMatrixSubquery's OUTER anchor grid — distinct from the INNER
-// grid TestFusedInstantAnchorCount already pins at line 158). Choosing an
+// grid TestFusedInstantAnchorCount already pins. Choosing an
 // outer OuterRange/Step pair (6m / 2m) that differs from fusibleInner's
 // (10m / 1m) makes the outer count's literal unambiguous: a `/`→`*` flip
 // or a `+`→`-` flip on the outer arithmetic cannot hide behind the inner

--- a/internal/chsql/range_window_mutation_test.go
+++ b/internal/chsql/range_window_mutation_test.go
@@ -414,7 +414,7 @@ func TestOverTimeDirectMatrixNoGroupBy(t *testing.T) {
 }
 
 // TestFusedSamplesQueryTemporalityGate kills the CONDITIONALS_NEGATION
-// mutant at range_window_fused.go:234 (`g.temporality != nil`, inside
+// mutant at range_window_fused.go:`g.temporality != nil` (`g.temporality != nil`, inside
 // samplesQuery). When the inner window carries a TemporalityColumn, the
 // fused samples layer must read the series' single AggregationTemporality
 // via `any(...)` under windowTemporalityAlias; when it doesn't, that

--- a/internal/chsql/range_window_variants_test.go
+++ b/internal/chsql/range_window_variants_test.go
@@ -224,7 +224,7 @@ func TestFusedVariantValueLayout(t *testing.T) {
 
 // TestEmitFusedVariants_InstantVsMatrixDispatch kills the
 // CONDITIONALS_NEGATION / CONDITIONALS_BOUNDARY mutants at
-// range_window_variants.go:114 (`r.OuterRange > 0`) in
+// range_window_variants.go:`r.OuterRange > 0` in
 // emitRangeWindowVariants. The instant shape (OuterRange == 0) has no
 // anchor grid at all — no `anchor_ts` column anywhere in the emitted
 // SQL — while the matrix shape fans out across one. A `>` → `<=` flip
@@ -261,7 +261,7 @@ func TestEmitFusedVariants_InstantVsMatrixDispatch(t *testing.T) {
 }
 
 // TestEmitFusedVariantsMatrix_TimestampColumnAnchorTsAlias kills the
-// CONDITIONALS_NEGATION mutant at range_window_variants.go:351
+// CONDITIONALS_NEGATION mutant at range_window_variants.go:`r.TimestampColumn != "anchor_ts"`
 // (`r.TimestampColumn != "anchor_ts"`). The matrix outer layer always
 // selects the raw `anchor_ts` column; it additionally re-projects it
 // under the schema timestamp column's own alias UNLESS that alias
@@ -297,7 +297,7 @@ func TestEmitFusedVariantsMatrix_TimestampColumnAnchorTsAlias(t *testing.T) {
 }
 
 // TestVariantValsFrag_TupleSlotArithmetic kills the ARITHMETIC_BASE mutant
-// at range_window_variants.go:151 (`valueSlot + firstValueSlot`). Tuple
+// at range_window_variants.go:`valueSlot + firstValueSlot`. Tuple
 // slot 1 is always the timestamp, so value slot 0 must read tuple index 2
 // and value slot 1 must read tuple index 3; a `+`→`-` flip would read
 // negative/zero indices and a `+`→`*` flip would collide slot 0 onto index
@@ -327,7 +327,7 @@ func TestVariantValsFrag_TupleSlotArithmetic(t *testing.T) {
 }
 
 // TestEmitFusedVariantsMatrix_AnchorCountArithmetic kills the
-// ARITHMETIC_BASE mutants at range_window_variants.go:293
+// ARITHMETIC_BASE mutants at range_window_variants.go:`r.OuterRange.Nanoseconds()/stepNS + 1`
 // (`r.OuterRange.Nanoseconds()/stepNS + 1`). fusedTestWindow's OuterRange
 // (1m) / Step (30s) + 1 = 3 anchors, surfacing as the sample-fanout's
 // `least(3, ...)` upper clamp. A `/`→`*` flip overflows to a huge count;
@@ -347,7 +347,7 @@ func TestEmitFusedVariantsMatrix_AnchorCountArithmetic(t *testing.T) {
 }
 
 // TestGroupArrayVariantTupleFrag_EmptyValCols kills the ARITHMETIC_BASE
-// mutant at range_window_variants.go:129:39 (`len(valCols)+1`, the capacity
+// mutant at range_window_variants.go:`len(valCols)+1` (`len(valCols)+1`, the capacity
 // hint for the tuple-parts slice). With valCols empty, len(valCols)+1 == 1,
 // a harmless capacity; a `+`->`-` flip instead computes -1, which panics
 // make() immediately. Production never calls this with an empty valCols
@@ -395,7 +395,7 @@ func TestEmitFusedVariantsInstant_CompletesAllSteps(t *testing.T) {
 }
 
 // TestEmitFusedVariantsMatrix_UngroupedRegroupKeysCapacity kills the
-// ARITHMETIC_BASE mutant at range_window_variants.go:333:48
+// ARITHMETIC_BASE mutant at range_window_variants.go:`len(groupFrags)+1`
 // (`len(groupFrags)+1`, the capacity hint for regroupKeys). An ungrouped
 // fused matrix window has zero groupFrags, so len(groupFrags)+1 == 1 (the
 // anchor_ts key alone); a `+`->`-` flip computes -1, panicking make()

--- a/internal/chsql/range_window_variants_test.go
+++ b/internal/chsql/range_window_variants_test.go
@@ -171,7 +171,8 @@ func TestEmitFusedVariantsRejectsIllFormed(t *testing.T) {
 		"stepless anchor grid": func(r *chplan.RangeWindow) {
 			r.Step = 0
 		},
-		// checkFusedVariants.go:92 — the fused emitter drives only the
+		// range_window_variants.go:`len(r.Scalars) > 0 || len(r.ScalarExprs) > 0`
+		// (checkFusedVariants) — the fused emitter drives only the
 		// *_over_time array reducers, which take no scalar parameters.
 		// A scalar argument here is untested territory: the guard's
 		// condition is EVALUATED on every fused Emit (both operands are
@@ -181,7 +182,8 @@ func TestEmitFusedVariantsRejectsIllFormed(t *testing.T) {
 		"scalar argument present": func(r *chplan.RangeWindow) {
 			r.Scalars = []float64{1}
 		},
-		// checkFusedVariants.go:95 — the fused emitter consults no
+		// range_window_variants.go:`r.TemporalityColumn != ""`
+		// (checkFusedVariants) — the fused emitter consults no
 		// temporality column (each arm's own reducer never reads
 		// windowTemporalityRef). Same coverage gap as the scalar case.
 		"temporality column present": func(r *chplan.RangeWindow) {
@@ -368,9 +370,9 @@ func TestGroupArrayVariantTupleFrag_EmptyValCols(t *testing.T) {
 }
 
 // TestEmitFusedVariantsInstant_CompletesAllSteps kills the four
-// CONDITIONALS_NEGATION mutants at range_window_variants.go:232:9, 236:9,
-// 249:9 and 256:66 — the four `if err != nil { return err }` guards inside
-// emitRangeWindowVariantsInstant. Every one of those checks genuinely
+// CONDITIONALS_NEGATION mutants on the four `if err != nil { return err }`
+// guards inside range_window_variants.go:emitRangeWindowVariantsInstant.
+// Every one of those checks genuinely
 // succeeds on this well-formed plan, so a `!= nil` -> `== nil` mutant at any
 // one of them turns "keep going on success" into "return nil immediately
 // after this step succeeds" — the function would return before ever

--- a/internal/chsql/scan_resource_bound_mutation_test.go
+++ b/internal/chsql/scan_resource_bound_mutation_test.go
@@ -19,7 +19,7 @@ import (
 //     `emitterSpansTable == "" || table != emitterSpansTable`. Negating either
 //     conjunct, or turning `||` into `&&`, would either reject a scoped-out
 //     table or wave through an unbounded scan over the enforced table.
-//   - scan_resource_bound.go:129:22 — the requireInnerSpansScanBound guard
+//   - scan_resource_bound.go:`spansTable == "" || findScanTable(inner) != spansTable` — the requireInnerSpansScanBound guard
 //     `spansTable == "" || findScanTable(inner) != spansTable`. `||`→`&&` would
 //     reject a non-spans inner (or wave through the windowless spans inner).
 //   - scan_resource_bound.go:211:19/25/34/60 — the requireSpansScanWindow guard
@@ -35,7 +35,7 @@ const (
 	scanBoundTSColumn      = "Timestamp"
 )
 
-// TestRequireScanResourceBound_GuardBranches pins scan_resource_bound.go:97.
+// TestRequireScanResourceBound_GuardBranches pins scan_resource_bound.go:`table != emitterSpansTable`.
 func TestRequireScanResourceBound_GuardBranches(t *testing.T) {
 	t.Parallel()
 	none := scanResourceBound{}  // zero value → kind spansBoundNone
@@ -66,7 +66,7 @@ func TestRequireScanResourceBound_GuardBranches(t *testing.T) {
 	}
 }
 
-// TestRequireInnerSpansScanBound_GuardBranch pins scan_resource_bound.go:129.
+// TestRequireInnerSpansScanBound_GuardBranch pins scan_resource_bound.go:`if spansTable == "" || findScanTable(inner) != spansTable`.
 func TestRequireInnerSpansScanBound_GuardBranch(t *testing.T) {
 	t.Parallel()
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/chsql/scan_resource_bound_mutation_test.go
+++ b/internal/chsql/scan_resource_bound_mutation_test.go
@@ -14,20 +14,22 @@ import (
 // coverage that isolates every branch, so each disjunct and boundary is pinned
 // directly. Tests are white-box (package chsql) to reach the unexported guards.
 //
-// Mutant inventory (file:line:col → what the flip does):
-//   - scan_resource_bound.go:97:23/29/38 — the requireScanResourceBound guard
-//     `emitterSpansTable == "" || table != emitterSpansTable`. Negating either
-//     conjunct, or turning `||` into `&&`, would either reject a scoped-out
-//     table or wave through an unbounded scan over the enforced table.
-//   - scan_resource_bound.go:`spansTable == "" || findScanTable(inner) != spansTable` — the requireInnerSpansScanBound guard
-//     `spansTable == "" || findScanTable(inner) != spansTable`. `||`→`&&` would
-//     reject a non-spans inner (or wave through the windowless spans inner).
-//   - scan_resource_bound.go:211:19/25/34/60 — the requireSpansScanWindow guard
-//     `ctxSpansTable == "" || table != ctxSpansTable || tsCol == ""`.
-//   - scan_resource_bound.go:214:15/20/31 — the windowless-scan check
-//     `startNano == 0 && endNano == 0`. `&&`→`||` would reject a one-sided
-//     (still-pruning) window; negating either half would miss the both-zero
-//     genuinely-windowless case.
+// Mutant inventory (construct → what the flip does):
+//   - the requireScanResourceBound guard
+//     scan_resource_bound.go:`emitterSpansTable == "" || table != emitterSpansTable`.
+//     Negating either conjunct, or turning `||` into `&&`, would either reject
+//     a scoped-out table or wave through an unbounded scan over the enforced
+//     table.
+//   - the requireInnerSpansScanBound guard
+//     scan_resource_bound.go:`spansTable == "" || findScanTable(inner) != spansTable`.
+//     `||`→`&&` would reject a non-spans inner (or wave through the windowless
+//     spans inner).
+//   - the requireSpansScanWindow guard
+//     scan_resource_bound.go:`ctxSpansTable == "" || table != ctxSpansTable || tsCol == ""`.
+//   - the windowless-scan check
+//     scan_resource_bound.go:`startNano == 0 && endNano == 0`. `&&`→`||` would
+//     reject a one-sided (still-pruning) window; negating either half would
+//     miss the both-zero genuinely-windowless case.
 
 const (
 	scanBoundEnforcedTable = "otel_traces"
@@ -35,15 +37,16 @@ const (
 	scanBoundTSColumn      = "Timestamp"
 )
 
-// TestRequireScanResourceBound_GuardBranches pins scan_resource_bound.go:`table != emitterSpansTable`.
+// TestRequireScanResourceBound_GuardBranches pins
+// scan_resource_bound.go:`emitterSpansTable == "" || table != emitterSpansTable`.
 func TestRequireScanResourceBound_GuardBranches(t *testing.T) {
 	t.Parallel()
 	none := scanResourceBound{}  // zero value → kind spansBoundNone
 	bounded := traceIDSetBound() // kind spansBoundTraceIDSet → a real bound
 
-	// A none witness over a DIFFERENT table is scoped out → nil. `||`→`&&`
-	// (@97:29) or negating `table != emitterSpansTable` (@97:38) would proceed
-	// to the bound check and reject.
+	// A none witness over a DIFFERENT table is scoped out → nil. `||`→`&&`, or
+	// negating `table != emitterSpansTable`, would proceed to the bound check
+	// and reject.
 	if err := requireScanResourceBound(scanBoundEnforcedTable, scanBoundOtherTable, none); err != nil {
 		t.Fatalf("none witness over a scoped-out table must return nil, got %v", err)
 	}
@@ -94,22 +97,24 @@ func TestRequireInnerSpansScanBound_GuardBranch(t *testing.T) {
 	}
 }
 
-// TestRequireSpansScanWindow_GuardBranches pins scan_resource_bound.go:211+214.
+// TestRequireSpansScanWindow_GuardBranches pins
+// scan_resource_bound.go:`ctxSpansTable == "" || table != ctxSpansTable || tsCol == ""`
+// and scan_resource_bound.go:`startNano == 0 && endNano == 0`.
 func TestRequireSpansScanWindow_GuardBranches(t *testing.T) {
 	t.Parallel()
 
 	// Disabled enforcement via the FIRST disjunct (ctxSpansTable == "", table
-	// also "" so `table != ctxSpansTable` is false) → nil. `||`→`&&` (@211:25)
-	// or negating `ctxSpansTable == ""` (@211:19) would fall to the window check
-	// and reject the both-zero window.
+	// also "" so `table != ctxSpansTable` is false) → nil. `||`→`&&`, or negating
+	// `ctxSpansTable == ""`, would fall to the window check and reject the
+	// both-zero window.
 	if err := requireSpansScanWindow("", "", scanBoundTSColumn, 0, 0); err != nil {
 		t.Fatalf("disabled enforcement must return nil, got %v", err)
 	}
 	// Enforced table + opted-in tsCol + both bounds zero → windowless scan
 	// rejected. This is the only input reaching the window check with all guard
-	// disjuncts false, so it pins the table/tsCol negations (@211:34/60 — each
-	// would flip the guard true and return nil) and the both-zero negations
-	// (@214:15/31 — each would drop the both-zero case out of the error arm).
+	// disjuncts false, so it pins the table/tsCol negations (each would flip the
+	// guard true and return nil) and the both-zero negations (each would drop the
+	// both-zero case out of the error arm).
 	if err := requireSpansScanWindow(scanBoundEnforcedTable, scanBoundEnforcedTable, scanBoundTSColumn, 0, 0); !errors.Is(err, ErrUnboundedSpansScan) {
 		t.Fatalf("windowless recursive spans scan must be rejected, got %v", err)
 	}

--- a/internal/chsql/set_op_mutation_test.go
+++ b/internal/chsql/set_op_mutation_test.go
@@ -60,8 +60,9 @@ func fusedIntersectWindowedArm(col, val string) chplan.Node {
 }
 
 // TestMutation_FusedIntersect_UnfilteredArmDoesNotEndTheGateLoop defends
-// set_op.go:436 (the `continue` that skips an arm whose residual predicate is
-// nil while emitting the QUALIFY gate for every other arm).
+// the `continue` in set_op.go:`for _, pred := range residuals` that skips an
+// arm whose residual predicate is nil while emitting the QUALIFY gate for
+// every other arm.
 //
 // Mutation INVERT_LOOPCTRL turns that `continue` into `break`, which abandons
 // the whole gate loop at the FIRST nil residual instead of skipping just that

--- a/internal/chsql/set_op_mutation_test.go
+++ b/internal/chsql/set_op_mutation_test.go
@@ -85,7 +85,7 @@ func TestMutation_FusedIntersect_UnfilteredArmDoesNotEndTheGateLoop(t *testing.T
 }
 
 // TestMutation_SplitCommonConjuncts_FactorsTheSharedConjunct defends
-// set_op.go:497 (`if len(common) == 0 { return nil, arms }`, the "nothing is
+// set_op.go:`if len(common) == 0` (`if len(common) == 0 { return nil, arms }`, the "nothing is
 // shared, keep every arm whole" bail-out).
 //
 // Mutation CONDITIONALS_NEGATION turns `== 0` into `!= 0`, inverting the
@@ -129,7 +129,7 @@ func TestMutation_SplitCommonConjuncts_FactorsTheSharedConjunct(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// set_op.go:327:35 (CONDITIONALS_BOUNDARY, `i < j` -> `i <= j` in
+// set_op.go:`i < j` (CONDITIONALS_BOUNDARY, `i < j` -> `i <= j` in
 // filterChainOverScan's in-place reversal of the collected Filter
 // predicates). The extra iteration the mutant runs is the one where
 // `i == j`, whose body is `preds[i], preds[j] = preds[j], preds[i]` with
@@ -140,7 +140,7 @@ func TestMutation_SplitCommonConjuncts_FactorsTheSharedConjunct(t *testing.T) {
 // mutant produces a byte-identical `preds` and therefore an identical
 // conjunction — only the iteration count differs.
 //
-// set_op.go:490:5 (INVERT_LOOPCTRL, `break` -> `continue` in
+// set_op.go:`break` (INVERT_LOOPCTRL, `break` -> `continue` in
 // splitCommonConjuncts' shared-conjunct scan). The break guards a boolean
 // latch: `shared[i]` is set true once before the inner loop and the loop
 // body's only write sets it false. Continuing instead of breaking keeps

--- a/internal/chsql/structural_join_anchor_mutation_test.go
+++ b/internal/chsql/structural_join_anchor_mutation_test.go
@@ -147,8 +147,9 @@ func TestEmitStructuralRecursive_InverseAnchorUnrestrictedHasNoSeedWhere(t *test
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// structural_join.go:738:69 (CONDITIONALS_BOUNDARY, `if seedWhere :=
-// structuralAnchorWhere(j, rightSub); len(seedWhere) > 0` -> `>= 0`). The
+// structural_join.go:`len(seedWhere) > 0` (CONDITIONALS_BOUNDARY,
+// `if seedWhere := structuralAnchorWhere(j, rightSub); len(seedWhere) > 0`
+// -> `>= 0`). The
 // forms differ only when seedWhere is empty, where the mutant runs
 // `anchor = anchor.Where()`. QueryBuilder.Where is variadic and its body is
 // `s.where = append(s.where, conds...)`, so a zero-argument call appends
@@ -157,8 +158,8 @@ func TestEmitStructuralRecursive_InverseAnchorUnrestrictedHasNoSeedWhere(t *test
 // mutant on this same comparison is a real defect, and the three tests
 // above kill it.)
 //
-// structural_join.go:525:53 (CONDITIONALS_BOUNDARY, `if cols :=
-// structuralUnionOutputCols(j); len(cols) > 0` -> `>= 0` in
+// structural_join.go:`len(cols) > 0` (CONDITIONALS_BOUNDARY,
+// `if cols := structuralUnionOutputCols(j); len(cols) > 0` -> `>= 0` in
 // emitStructuralSpanUnion). structuralUnionOutputCols returns either nil or
 // the three join keys plus the extra projection columns, so len(cols) is
 // either 0 or at least 3 and the forms can differ only at 0. There the

--- a/internal/chsql/vector_set_op_output_cols_mutation_test.go
+++ b/internal/chsql/vector_set_op_output_cols_mutation_test.go
@@ -7,15 +7,16 @@ import (
 )
 
 // TestMutation_VectorSetOpOutputCols_MixedOrVsMixedAnd pins
-// vectorSetOpOutputCols's own guard at vector_set_op.go:710
-// (`s.Mixed && s.Op != chplan.VectorSetOr`): a Mixed VectorSetOr never
+// vectorSetOpOutputCols's own guard
+// vector_set_op.go:`s.Mixed && s.Op != chplan.VectorSetOr`: a Mixed
+// VectorSetOr never
 // widens the column list here — real callers always render that shape
 // through emitMixedVectorSetOp instead, whose own
 // mixedVectorSetOpOutputCols does the widening — while a Mixed
 // VectorSetAnd (the forwarded-Left shape cerberus issue #2555 added)
 // DOES widen here, since it never reaches emitMixedVectorSetOp.
 //
-// Kills vector_set_op.go:710:21 (CONDITIONALS_NEGATION `s.Op !=
+// Kills the CONDITIONALS_NEGATION on that guard (`s.Op !=
 // chplan.VectorSetOr` -> `s.Op == chplan.VectorSetOr`): under that
 // mutation a Mixed VectorSetOr would ALSO widen (the guard flips to
 // true), which this test's Or case catches, and a Mixed VectorSetAnd

--- a/internal/logql/binary.go
+++ b/internal/logql/binary.go
@@ -65,7 +65,7 @@ func lowerBinary(b *syntax.BinOpExpr, s schema.Logs, lc lowerCtx) (chplan.Node, 
 	switch {
 	case lhsIsLit && rhsIsLit:
 		// Upstream Loki's parser folds literal-vs-literal at parse
-		// time via reduceBinOp (see syntax/ast.go:1817 mustNewBinOpExpr).
+		// time via reduceBinOp (see mustNewBinOpExpr in syntax/ast.go).
 		// If one reaches us anyway it's an internal invariant break — surface
 		// rather than silently re-folding.
 		return nil, fmt.Errorf("logql: scalar-only binary expression not folded (op %s) — internal invariant violation", b.Op)

--- a/internal/logql/detected_level_test.go
+++ b/internal/logql/detected_level_test.go
@@ -446,13 +446,12 @@ var canonicalLevelGroups = []struct {
 
 // TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape kills the two
 // adjacent ARITHMETIC_BASE mutants reported by the gremlins phase-4
-// run at `detected_level.go:143:44` (the `*` in `len(groups)*2+1`)
-// and `:143:46` (the `+` in the same expression). The mutation site
-// is the slice-capacity hint passed to `make([]chplan.Expr, 0,
-// len(groups)*2+1)` — `*` flipping to `/` (or `%`) and `+` flipping
-// to `-` (or `*`) change the pre-allocated capacity but `append`
-// silently grows past it, so a semantic-only test cannot observe the
-// difference. This test pins:
+// run on the slice-capacity hint
+// detected_level.go:`(len(levelNormalizationGroups)+1)*2+1` — the `*`
+// and the trailing `+` of that expression. `*` flipping to `/` (or
+// `%`) and `+` flipping to `-` (or `*`) change the pre-allocated
+// capacity but `append` silently grows past it, so a semantic-only
+// test cannot observe the difference. This test pins:
 //
 //  1. `len(Args) == 2*len(canonicalLevelGroups)+1` (the load-bearing
 //     count: 7 (cond, literal) pairs plus the trailing default
@@ -462,7 +461,7 @@ var canonicalLevelGroups = []struct {
 //     `make([]T, 0, N)` returns a slice with `cap == N` before any
 //     append, and the 15 subsequent appends never exceed that
 //     capacity — so the final `cap` equals the hint). Any
-//     ARITHMETIC_BASE mutation on `*` or `+` at col 44/46 shifts the
+//     ARITHMETIC_BASE mutation on that `*` or `+` shifts the
 //     allocated capacity, triggers an `append`-driven re-allocation
 //     with Go's runtime growth strategy, and produces a final `cap`
 //     that is NOT 15 (the original mutants would yield e.g. 4, 8,
@@ -503,7 +502,7 @@ func TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape(t *testing.T) {
 	// both produce a final cap different from the exact arg count.
 	// Asserting cap == wantLen pins the arithmetic.
 	if got, want := cap(fn.Args), wantLen; got != want {
-		t.Fatalf("cap(multiIf.Args) = %d; want %d (mutant `*` → `/`/`%%` or `+` → `-`/`*` at detected_level.go:143:44 / :143:46 would shift the capacity hint and re-allocate via append's growth schedule)", got, want)
+		t.Fatalf("cap(multiIf.Args) = %d; want %d (mutant `*` → `/`/`%%` or `+` → `-`/`*` in detected_level.go:`(len(levelNormalizationGroups)+1)*2+1` would shift the capacity hint and re-allocate via append's growth schedule)", got, want)
 	}
 }
 

--- a/internal/logql/jsonpath_mutation_test.go
+++ b/internal/logql/jsonpath_mutation_test.go
@@ -125,14 +125,14 @@ func TestJSONPathParse_NonDigitInsideIndexRejected(t *testing.T) {
 // Two scanInt/scanStr mutants are GENUINELY EQUIVALENT w.r.t. the parser's
 // reachable input domain and are documented (not pinned) here:
 //
-//   - jsonpath.go:245:30 CONDITIONALS_BOUNDARY `len(digits) > 0` → `>= 0`
+//   - jsonpath.go:`len(digits) > 0` CONDITIONALS_BOUNDARY `len(digits) > 0` → `>= 0`
 //     in scanInt's float-index guard. scanInt is only ever entered from
 //     next() AFTER a digit is detected and unread, so the first rune it
 //     reads is always a digit and len(digits) >= 1 by the time a '.' can
 //     appear. The `> 0` qualifier therefore never evaluates at len == 0 in
 //     any reachable path; `>= 0` yields identical behaviour. (A leading '.'
 //     is tokenised as jpDot by next(), never routed to scanInt.)
-//   - jsonpath.go:218:9 INVERT_LOGICAL `!ok || r != '"'` → `&&` in scanStr's
+//   - jsonpath.go:`!ok || r != '"'` INVERT_LOGICAL `!ok || r != '"'` → `&&` in scanStr's
 //     opening-quote guard. scanStr is only ever entered from next() after a
 //     '"' is detected and unread, so its first read is always a successful
 //     '"' (ok == true, r == '"'); both operands are false and the `||`/`&&`

--- a/internal/logql/jsonpath_mutation_test.go
+++ b/internal/logql/jsonpath_mutation_test.go
@@ -125,14 +125,14 @@ func TestJSONPathParse_NonDigitInsideIndexRejected(t *testing.T) {
 // Two scanInt/scanStr mutants are GENUINELY EQUIVALENT w.r.t. the parser's
 // reachable input domain and are documented (not pinned) here:
 //
-//   - jsonpath.go:`len(digits) > 0` CONDITIONALS_BOUNDARY `len(digits) > 0` → `>= 0`
+//   - jsonpath.go:`len(digits) > 0` CONDITIONALS_BOUNDARY `> 0` → `>= 0`
 //     in scanInt's float-index guard. scanInt is only ever entered from
 //     next() AFTER a digit is detected and unread, so the first rune it
 //     reads is always a digit and len(digits) >= 1 by the time a '.' can
 //     appear. The `> 0` qualifier therefore never evaluates at len == 0 in
 //     any reachable path; `>= 0` yields identical behaviour. (A leading '.'
 //     is tokenised as jpDot by next(), never routed to scanInt.)
-//   - jsonpath.go:`!ok || r != '"'` INVERT_LOGICAL `!ok || r != '"'` → `&&` in scanStr's
+//   - jsonpath.go:`!ok || r != '"'` INVERT_LOGICAL `||` → `&&` in scanStr's
 //     opening-quote guard. scanStr is only ever entered from next() after a
 //     '"' is detected and unread, so its first read is always a successful
 //     '"' (ok == true, r == '"'); both operands are false and the `||`/`&&`

--- a/internal/logql/lsyntax/ast_test.go
+++ b/internal/logql/lsyntax/ast_test.go
@@ -540,8 +540,8 @@ func TestMustNewVectorAggregationExpr_UnparseableTopKParameter(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// ast.go:218:8 (INCREMENT_DECREMENT, validateExtractedLabels' `named++` ->
-// `named--`). `named` is initialised to 0, is written only by this statement,
+// ast.go:`named++` (INCREMENT_DECREMENT, validateExtractedLabels' `named++`
+// -> `named--`). `named` is initialised to 0, is written only by this statement,
 // and is read only by the `if named == 0` post-condition three lines later.
 // The original leaves it at +k and the mutant at -k, where k is the number of
 // non-empty entries in regex.SubexpNames(); both are zero exactly when k is

--- a/internal/logql/lsyntax/lexer_test.go
+++ b/internal/logql/lsyntax/lexer_test.go
@@ -486,7 +486,7 @@ func TestLexScanIdentToEOF(t *testing.T) {
 // mutated form from the original. Each was re-applied and the whole package
 // suite re-run to confirm it survives rather than merely lacking a test.
 //
-// lexer.go:556:8 (CONDITIONALS_BOUNDARY, `if b >= utf8.RuneSelf` -> `>`). The
+// lexer.go:`b >= utf8.RuneSelf` (CONDITIONALS_BOUNDARY, `>=` -> `>`). The
 // two forms differ on exactly one byte value, b == 0x80, which is not a legal
 // UTF-8 start byte. The original decodes it to (utf8.RuneError, 1) and asks
 // runeOK; the mutant falls through to the ASCII arm and asks
@@ -496,7 +496,7 @@ func TestLexScanIdentToEOF(t *testing.T) {
 // take their break with j unchanged, and the ASCII arm's other two tests
 // (isDigit, `b == '.'`) are false for 0x80 as well.
 //
-// lexer.go:606:8 (CONDITIONALS_BOUNDARY, scanIdent's `for j < len(l.src)` ->
+// lexer.go:scanIdent:`for j < len(l.src)` (CONDITIONALS_BOUNDARY, `<` ->
 // `<=`). The extra iteration the mutant admits runs at j == len(l.src), where
 // `l.src[j:]` is the empty string — a legal slice, not a panic — and
 // utf8.DecodeRuneInString("") returns (utf8.RuneError, 0). isIdentPart
@@ -505,7 +505,7 @@ func TestLexScanIdentToEOF(t *testing.T) {
 // it), so the mutant breaks at the same j the original's loop condition
 // stopped at.
 //
-// lexer.go:706:11 (CONDITIONALS_BOUNDARY `if end < len(l.src)` -> `<=`, and
+// lexer.go:`if end < len(l.src)` (CONDITIONALS_BOUNDARY `<` -> `<=`, and
 // CONDITIONALS_NEGATION -> `>=`). `end` is `i + len(kw)` guarded by a
 // HasPrefix on `l.src[i:]`, so end > len(l.src) is unreachable and both
 // mutants differ from the original only over end <= len(l.src).
@@ -522,8 +522,10 @@ func TestLexScanIdentToEOF(t *testing.T) {
 //     `l.src[end] == '('`. '(' is not an identPart either, so the mutant
 //     returns false as well.
 //
-// lexer.go:709:6 (INVERT_LOOPCTRL, isFunction's whole-word `continue` ->
-// `break`). The `continue` advances to the next keyword in
+// lexer.go:isFunction:`if isIdentPart(r)` (INVERT_LOOPCTRL on the whole-word
+// `continue` this guard wraps, -> `break`). The guard is what the citation
+// names because the mutated statement is a bare `continue`, which no construct
+// can single out. The `continue` advances to the next keyword in
 // []string{"by", "without"}, and reaching it means HasPrefix already matched
 // the current one. "by" and "without" share no prefix, so a source that
 // matched one cannot match the other; and a `continue` out of the last

--- a/internal/logql/range_aggregation_mutation_test.go
+++ b/internal/logql/range_aggregation_mutation_test.go
@@ -19,19 +19,20 @@ import (
 // EQUIVALENCE verdicts (no killing test possible — left documented here so
 // a future agent doesn't burn time re-attempting them):
 //
-//   - range_aggregation.go:438:36 CONDITIONALS_BOUNDARY
-//     `if len(e.Left.Unwrap.PostFilters) > 0` → `>= 0`. The mutant differs
-//     from the original ONLY at len==0. At that point `inner` is always a
-//     *chplan.Filter (line 432's andFilter unconditionally wraps it), so
-//     applyUnwrapPostFilters with an empty filter slice destructures that
-//     Filter (`pred = f.Predicate; inner = f.Input`) and reconstructs an
-//     identical `&chplan.Filter{Input: f.Input, Predicate: f.Predicate}`,
-//     while wrapLabelsWithMarks(labelsExpr, nil) returns labelsExpr
-//     verbatim (duration.go:288) and the hasMarks return stays false. The
-//     emitted plan is structurally identical, so no assertion can observe
-//     the flip. Genuinely equivalent.
+//   - range_aggregation.go:`len(e.Left.Unwrap.PostFilters) > 0`
+//     CONDITIONALS_BOUNDARY `> 0` → `>= 0`. The mutant differs from the
+//     original ONLY at len==0. At that point `inner` is always a
+//     *chplan.Filter (the andFilter call just above unconditionally wraps
+//     it), so applyUnwrapPostFilters with an empty filter slice
+//     destructures that Filter (`pred = f.Predicate; inner = f.Input`) and
+//     reconstructs an identical
+//     `&chplan.Filter{Input: f.Input, Predicate: f.Predicate}`, while
+//     wrapLabelsWithMarks(labelsExpr, nil) returns labelsExpr verbatim
+//     (duration.go:`len(marks) == 0`) and the hasMarks return stays false.
+//     The emitted plan is structurally identical, so no assertion can
+//     observe the flip. Genuinely equivalent.
 //
-//   - range_aggregation.go:797:55 ARITHMETIC_BASE
+//   - range_aggregation.go:`len(e.Grouping.Groups)*2` ARITHMETIC_BASE
 //     `make([]chplan.Expr, 0, len(e.Grouping.Groups)*2)` → `/2`. The `*2`
 //     is a slice CAPACITY pre-allocation hint; the loop appends exactly
 //     two entries per group regardless, so the resulting slice's contents,
@@ -40,10 +41,8 @@ import (
 //     "slice-capacity hints are out of scope" rule).
 
 // TestAbsentOverTimeExtendsMatcherWindowByIntervalPlusOffset pins the
-// ARITHMETIC_BASE mutant at range_aggregation.go:291:59 inside
-// [lowerAbsentOverTime]:
-//
-//	innerLc := lc.withMatcherWindowExtension(e.Left.Interval + e.Left.Offset)
+// ARITHMETIC_BASE mutant on
+// range_aggregation.go:lowerAbsentOverTime:`lc.withMatcherWindowExtension(e.Left.Interval + e.Left.Offset)`.
 //
 // This is the absent_over_time twin of the per-series window-extension
 // arithmetic already pinned for the ordinary path by
@@ -104,7 +103,8 @@ func TestAbsentOverTimeExtendsMatcherWindowByIntervalPlusOffset(t *testing.T) {
 }
 
 // TestAbsentSynthLabelsLogicalConjunction pins BOTH INVERT_LOGICAL mutants
-// on range_aggregation.go:347 inside [absentSynthLabels]:
+// on range_aggregation.go:`m.Type == labels.MatchEqual && !seen &&
+// !dropped[m.Name]` inside [absentSynthLabels]:
 //
 //	if _, seen := values[m.Name]; m.Type == labels.MatchEqual && !seen && !dropped[m.Name] {
 //	                                                          ^col61      ^col70
@@ -156,7 +156,8 @@ func TestAbsentSynthLabelsLogicalConjunction(t *testing.T) {
 }
 
 // TestAbsentSynthLabelsDuplicateEqualityDropped is a second, independent
-// guard on the same range_aggregation.go:347 conjunction, exercising the
+// guard on the same range_aggregation.go:`m.Type == labels.MatchEqual &&
+// !seen && !dropped[m.Name]` conjunction, exercising the
 // `!seen` operand directly (the col61/col70 fixture above only flexes the
 // non-equality path). A duplicate equality matcher on the same name must
 // drop the label entirely.
@@ -193,12 +194,13 @@ func TestAbsentSynthLabelsDuplicateEqualityDropped(t *testing.T) {
 }
 
 // isErrorBypassIdentity reports whether `e` is the exact
-// errorBypassIdentityExpr shape (range_aggregation.go:460):
+// errorBypassIdentityExpr shape:
 //
 //	if(mapContains(<fullLabels>, '__error__'), withDetectedLevel(...), identity)
 //
 // This shape is produced ONLY when applyUnwrapPostFilters returns
-// hasMarks=true (range_aggregation.go:509 -> :445 -> :147 -> :189). The
+// hasMarks=true (applyUnwrapPostFilters -> applyUnwrapRowSemantics ->
+// lowerRangeAggregation -> errorBypassIdentityExpr). The
 // ordinary identity projection is a `mapConcat(...)` from
 // withDetectedLevelAndColumns, which never matches this predicate, so the
 // helper cleanly distinguishes "error-bypass applied" from "not applied".
@@ -239,14 +241,13 @@ func rangeWindowIdentityExpr(t *testing.T, n chplan.Node) chplan.Expr {
 }
 
 // TestUnwrapPostFilterMarksGateErrorBypass_Negation pins the
-// CONDITIONALS_NEGATION half of range_aggregation.go:509:79 inside
-// [applyUnwrapPostFilters]:
+// CONDITIONALS_NEGATION half of the [applyUnwrapPostFilters] hasMarks
+// return
+// range_aggregation.go:`&chplan.Filter{Input: inner, Predicate: pred}, labelsExpr, len(marks) > 0, nil`:
 //
-//	return &chplan.Filter{Input: inner, Predicate: pred}, labelsExpr, len(marks) > 0, nil
-//
-// The `len(marks) > 0` hasMarks return flows up to unwrapHasErrorMarks
-// (:445 -> :147), which gates wrapping the series identity in
-// errorBypassIdentityExpr (:189). A NEGATION flip `> 0` → `<= 0` reports
+// That `len(marks) > 0` hasMarks return flows up to unwrapHasErrorMarks
+// (via applyUnwrapRowSemantics), which gates wrapping the series identity
+// in errorBypassIdentityExpr. A NEGATION flip `> 0` → `<= 0` reports
 // hasMarks=false even though the numeric post-filter stamped a mark, so
 // the error-bypass identity wrapper disappears.
 //
@@ -292,15 +293,17 @@ func TestUnwrapPostFilterMarksGateErrorBypass_Negation(t *testing.T) {
 }
 
 // TestUnwrapPostFilterNoMarksSkipErrorBypass_Boundary pins the
-// CONDITIONALS_BOUNDARY half of range_aggregation.go:509:79. A flip
-// `len(marks) > 0` → `>= 0` reports hasMarks=true even when NO mark was
-// stamped, so the error-bypass wrapper is applied spuriously.
+// CONDITIONALS_BOUNDARY half of that same
+// range_aggregation.go:`&chplan.Filter{Input: inner, Predicate: pred}, labelsExpr, len(marks) > 0, nil`
+// return. A flip `len(marks) > 0` → `>= 0` reports hasMarks=true even
+// when NO mark was stamped, so the error-bypass wrapper is applied
+// spuriously.
 //
 // Fixture `sum_over_time({app="api"} | logfmt | unwrap latency | foo = "bar" [5m])`:
 //   - `| foo = "bar"` is a StringLabelFilter post-filter → produces NO
 //     marks (labelFiltererLower returns nil marks for string filters).
 //   - The post-filter slice is non-empty so applyUnwrapPostFilters is
-//     called and reaches the line-509 return with marks==0; `inner` is a
+//     called and reaches that return with marks==0; `inner` is a
 //     Filter so `pred` is non-nil and the `> 0` return path executes.
 //   - bare `unwrap latency` adds no mark either, so unwrapHasErrorMarks is
 //     false on the original → identity is NOT error-bypass-wrapped.

--- a/internal/logql/vector_aggregation_mutation_test.go
+++ b/internal/logql/vector_aggregation_mutation_test.go
@@ -35,8 +35,10 @@ import (
 // whether the synthesised augmented-identity map carries `target` as a
 // surfaced key. A top-level outer-by column (e.g. ServiceName) is
 // surfaced into that map ONLY when sortableShapedInner threads it down
-// via withOuterByLabels — which is exactly the behaviour line 390
-// guards.
+// via withOuterByLabels — which is exactly the behaviour the outer-by
+// threading guard
+// vector_aggregation.go:sortableShapedInner:`e.Grouping != nil && !e.Grouping.Without && len(e.Grouping.Groups) > 0`
+// controls.
 //
 // The identity projection shape is
 //
@@ -102,13 +104,10 @@ func lowerTopKIdentityExpr(t *testing.T, query string, s schema.Logs) chplan.Exp
 	return idProj.Projections[0].Expr
 }
 
-// TestSortableShapedInnerThreadsOuterByColumn kills the mutants on
-// vector_aggregation.go:390
-//
-//	if e.Grouping != nil && !e.Grouping.Without && len(e.Grouping.Groups) > 0 {
-//		innerLc = lc.withOuterByLabels(e.Grouping.Groups)
-//	}
-//
+// TestSortableShapedInnerThreadsOuterByColumn kills the mutants on the
+// outer-by threading guard
+// vector_aggregation.go:sortableShapedInner:`e.Grouping != nil && !e.Grouping.Without && len(e.Grouping.Groups) > 0`,
+// which guards `innerLc = lc.withOuterByLabels(e.Grouping.Groups)`,
 // in sortableShapedInner (the shared topk/sort front half). For
 // `topk(K, rate(...)) by (ServiceName)` all three sub-conditions are
 // true, so the outer-by label `ServiceName` (a top-level OTel-CH column)
@@ -133,22 +132,23 @@ func TestSortableShapedInnerThreadsOuterByColumn(t *testing.T) {
 
 	identity := requireCanonicalIdentity(t, lowerTopKIdentityExpr(t, query, s))
 	if !surfacedIdentityHasKey(t, identity, s.ServiceNameColumn) {
-		t.Fatalf("topk by (ServiceName): inner identity map is missing the surfaced %q key — outer-by threading guard (line 390) leaked: a NEGATION mutant skipped withOuterByLabels", s.ServiceNameColumn)
+		t.Fatalf("topk by (ServiceName): inner identity map is missing the surfaced %q key — outer-by threading guard leaked: a NEGATION mutant skipped withOuterByLabels", s.ServiceNameColumn)
 	}
 }
 
 // TestSortableShapedInnerSkipsThreadingForWithout kills the
-// INVERT_LOGICAL mutants on vector_aggregation.go:390.
+// INVERT_LOGICAL mutants on
+// vector_aggregation.go:sortableShapedInner:`e.Grouping != nil && !e.Grouping.Without && len(e.Grouping.Groups) > 0`.
 //
 // For `topk(K, rate(...)) without (ServiceName)` the `without` clause
 // makes !e.Grouping.Without false, so the ORIGINAL guard is false and
 // ServiceName is NOT threaded into the inner identity map.
 //
 // Mutants this pins:
-//   - 390:23 INVERT_LOGICAL (first `&&` → `||`): Grouping != nil is true,
+//   - INVERT_LOGICAL on the first `&&` (→ `||`): Grouping != nil is true,
 //     so `nil!=… || …` short-circuits true ⇒ withOuterByLabels(Groups)
 //     runs ⇒ ServiceName surfaced. Assertion (absent) fails.
-//   - 390:46 INVERT_LOGICAL (second `&&` → `||`): becomes
+//   - INVERT_LOGICAL on the second `&&` (→ `||`): becomes
 //     `Grouping!=nil && (!Without || len>0)` = `true && (false || true)`
 //     = true ⇒ withOuterByLabels runs ⇒ ServiceName surfaced. Assertion
 //     (absent) fails.
@@ -160,17 +160,13 @@ func TestSortableShapedInnerSkipsThreadingForWithout(t *testing.T) {
 
 	identity := requireCanonicalIdentity(t, lowerTopKIdentityExpr(t, query, s))
 	if surfacedIdentityHasKey(t, identity, s.ServiceNameColumn) {
-		t.Fatalf("topk without (ServiceName): inner identity map unexpectedly surfaced the %q key — the without-clause must NOT thread outer-by labels (line 390 INVERT_LOGICAL mutant flipped && to ||)", s.ServiceNameColumn)
+		t.Fatalf("topk without (ServiceName): inner identity map unexpectedly surfaced the %q key — the without-clause must NOT thread outer-by labels (an INVERT_LOGICAL mutant flipped && to ||)", s.ServiceNameColumn)
 	}
 }
 
-// TestTopKPartitionNilForUngrouped kills the INVERT_LOGICAL mutant on
-// vector_aggregation.go:337
-//
-//	if g == nil || (!g.Without && len(g.Groups) == 0) {
-//		return nil
-//	}
-//
+// TestTopKPartitionNilForUngrouped kills the INVERT_LOGICAL mutant on the
+// early-return guard
+// vector_aggregation.go:`g == nil || (!g.Without && len(g.Groups) == 0)`
 // in topKPartition. The LogQL parser materialises a non-nil empty
 // Grouping for an ungrouped `topk(K, v)` (mustNewVectorAggregationExpr
 // defaults gr = &Grouping{}), so for `topk(2, rate(...))`:
@@ -198,6 +194,6 @@ func TestTopKPartitionNilForUngrouped(t *testing.T) {
 
 	got := topKPartition(vae)
 	if got != nil {
-		t.Fatalf("topKPartition(ungrouped topk) = %#v (len %d), want nil — the no-meaningful-grouping guard (line 337) was inverted, building a spurious partition slice", got, len(got))
+		t.Fatalf("topKPartition(ungrouped topk) = %#v (len %d), want nil — the no-meaningful-grouping guard was inverted, building a spurious partition slice", got, len(got))
 	}
 }

--- a/internal/optimizer/fold_property_test.go
+++ b/internal/optimizer/fold_property_test.go
@@ -347,7 +347,7 @@ func TestFoldFloatFloat_Comparison(t *testing.T) {
 
 // TestFoldFloatFloat_Division pins float64 division semantics. Unlike
 // the int helper, the float helper still declines the rewrite when the
-// divisor is exactly zero (`r == 0`) — see constant_fold.go:317. That
+// divisor is exactly zero — see constant_fold.go:`r == 0`. That
 // keeps the IEEE-754 ±Inf / NaN result out of the plan IR: the
 // emitter handles division-by-zero at execution time so the runtime
 // vector engine and the plan-time fold stay in sync.

--- a/internal/optimizer/gremlins_mutants_test.go
+++ b/internal/optimizer/gremlins_mutants_test.go
@@ -4,9 +4,9 @@
 // mutated branch, so the test fails when the mutant is applied and the
 // mutant is reported KILLED.
 //
-// See `.gremlins.yaml` for the mutation operators in play; the mutant
-// IDs in each test's doc comment refer to gremlins's `file:line:col`
-// notation as printed in the workflow logs.
+// See `.gremlins.yaml` for the mutation operators in play; each test's
+// doc comment names the construct the gremlins report's `file:line:col`
+// pointed at.
 package optimizer_test
 
 import (
@@ -17,11 +17,9 @@ import (
 )
 
 // TestFilterAggregateTranspose_SkipsNonColumnRefGroupKeyButKeepsLater
-// pins the `continue` at filter_aggregate_transpose.go:99 inside
-// passthroughGroupKeys. The check
-//
-//	if !ok || cr.Qualifier != "" { continue }
-//
+// pins the `continue` under the
+// filter_aggregate_transpose.go:`!ok || cr.Qualifier != ""` check inside
+// passthroughGroupKeys. That check
 // skips one ill-shaped group key while still considering the remaining
 // keys; flipping the `continue` to `break` (gremlins INVERT_LOOPCTRL)
 // would abort the loop on the first non-bare key and drop every later
@@ -70,11 +68,8 @@ func TestFilterAggregateTranspose_SkipsNonColumnRefGroupKeyButKeepsLater(t *test
 }
 
 // TestFilterAggregateTranspose_EmptyAliasIsTreatedAsNoRename pins the
-// `alias != ""` half of the alias-mismatch guard at
-// filter_aggregate_transpose.go:103. The check
-//
-//	if alias != "" && alias != cr.Name { continue }
-//
+// `alias != ""` half of the alias-mismatch guard
+// filter_aggregate_transpose.go:`alias != "" && alias != cr.Name`, which
 // treats the empty string as "no rename" — the key still flows into
 // passthrough. Flipping `alias != ""` to `alias == ""` (gremlins
 // CONDITIONALS_NEGATION) would swap the meaning: an empty alias would
@@ -119,12 +114,9 @@ func TestFilterAggregateTranspose_EmptyAliasIsTreatedAsNoRename(t *testing.T) {
 }
 
 // TestFilterAggregateTranspose_RenamedAliasSkipsKeyButKeepsLater pins
-// the `continue` at filter_aggregate_transpose.go:104 inside the alias
-// branch:
-//
-//	if alias != "" && alias != cr.Name { continue }
-//
-// The loop must skip the renamed key but keep iterating; a `break`
+// the `continue` under
+// filter_aggregate_transpose.go:`alias != "" && alias != cr.Name` in the
+// alias branch. The loop must skip the renamed key but keep iterating; a `break`
 // mutant (gremlins INVERT_LOOPCTRL) would abort on the first renamed
 // key and drop every later valid bare-column entry from passthrough.
 //
@@ -170,8 +162,8 @@ func TestFilterAggregateTranspose_RenamedAliasSkipsKeyButKeepsLater(t *testing.T
 }
 
 // TestConstantFoldSemantic_MapAccessFoldsWhenOnlyMapChanges pins the
-// `if !mc && !kc` early-return guard at constant_fold.go:144 inside
-// foldExprSemantic's MapAccess case. The condition is "neither child
+// constant_fold.go:`!mc && !kc` early-return guard in the MapAccess case
+// of foldExprWith, reached here through foldExprSemantic. The condition is "neither child
 // changed — return the original Node unchanged"; flipping `&&` to `||`
 // (gremlins INVERT_LOGICAL) would early-return whenever EITHER child
 // is unchanged, which means a MapAccess whose Map sub-expression
@@ -224,8 +216,9 @@ func TestConstantFoldSemantic_MapAccessFoldsWhenOnlyMapChanges(t *testing.T) {
 }
 
 // TestConstantFoldHeuristic_MapAccessFoldsWhenOnlyMapChanges pins the
-// `if !mc && !kc` early-return guard at constant_fold.go:190 inside
-// foldExprHeuristic's MapAccess case. Same shape as the semantic test
+// constant_fold.go:`!mc && !kc` early-return guard in the MapAccess case
+// of foldExprWith, reached here through foldExprHeuristic. Same shape as
+// the semantic test
 // above, but exercises the boolean-identity heuristic instead of the
 // pure-literal arithmetic semantic pass.
 //
@@ -271,10 +264,9 @@ func TestConstantFoldHeuristic_MapAccessFoldsWhenOnlyMapChanges(t *testing.T) {
 	}
 }
 
-// TestCapturePattern_PreservesInnerBindings pins the `inner == nil`
-// branch at pattern.go:140 inside capturePattern.Match:
-//
-//	if inner == nil { inner = Bindings{} }
+// TestCapturePattern_PreservesInnerBindings pins the
+// pattern.go:`inner == nil` branch — whose body is `inner = Bindings{}`
+// — inside capturePattern.Match.
 //
 // Capture wraps an inner pattern and adds its own (name, node)
 // binding. When the inner pattern returns a non-nil Bindings map
@@ -316,8 +308,9 @@ func TestCapturePattern_PreservesInnerBindings(t *testing.T) {
 	}
 }
 
-// TestConstantFold_FloatLtIsStrictAtEquality pins the `l < r` fold at
-// constant_fold.go:327 inside foldFloatFloat's OpLt case. A gremlins
+// TestConstantFold_FloatLtIsStrictAtEquality pins the
+// constant_fold.go:`l < r` fold in foldNumeric's OpLt case, reached
+// through foldFloatFloat. A gremlins
 // CONDITIONALS_BOUNDARY mutant flips `<` to `<=`, which only changes the
 // result when the two operands are EQUAL: `5.0 < 5.0` is false but
 // `5.0 <= 5.0` is true. Every non-equal operand pair folds identically
@@ -359,7 +352,8 @@ func TestConstantFold_FloatLtIsStrictAtEquality(t *testing.T) {
 }
 
 // TestRunBatch_AnalyzerBranchCountsEachChange pins the `rulesApplied++`
-// at rule.go:187 inside runBatch's analyzer branch. A gremlins
+// that follows rule.go:`plan, changed = applyAnalyzerRule(plan, rule)`,
+// in runBatch's analyzer branch. A gremlins
 // INCREMENT_DECREMENT mutant flips `++` to `--`, so a changing analyzer
 // rule would DECREMENT the counter (driving it negative) rather than
 // incrementing it. Driver.Run only surfaces the counter via telemetry,
@@ -386,7 +380,8 @@ func TestRunBatch_AnalyzerBranchCountsEachChange(t *testing.T) {
 }
 
 // TestRunBatch_FixedPointBranchCountsEachChange pins the `rulesApplied++`
-// at rule.go:200 inside runBatch's FixedPoint branch. Same INCREMENT_
+// that follows rule.go:`iterationChanged = iterationChanged || changed`,
+// in runBatch's FixedPoint branch. Same INCREMENT_
 // DECREMENT mutant class as the analyzer-branch test above, but on the
 // iterative branch.
 //
@@ -410,7 +405,8 @@ func TestRunBatch_FixedPointBranchCountsEachChange(t *testing.T) {
 }
 
 // matchAllPattern is a Pattern that matches EVERY node, including nil,
-// recording nothing. It exists to witness the rule_pattern.go:`if n == nil || r == nil || r.Match == nil || r.Transform == nil` guard:
+// recording nothing. It exists to witness the nil-guard
+// rule_pattern.go:`n == nil || r == nil || r.Match == nil || r.Transform == nil`:
 // stock kindPattern.Match(nil) returns (nil,false), so it can't reveal
 // whether Apply's nil-guard short-circuited before calling Match. A
 // pattern that matches nil makes the difference observable.
@@ -421,11 +417,9 @@ func (matchAllPattern) Match(_ chplan.Node) (optimizer.Bindings, bool) {
 }
 
 // TestPatternRule_ApplyNilShortCircuitsBeforeMatch pins the leading
-// `n == nil ||` term of the nil-guard at rule_pattern.go:`n == nil ||`:
-//
-//	if n == nil || r == nil || r.Match == nil || r.Transform == nil {
-//		return n, false
-//	}
+// `n == nil` term of the nil-guard
+// rule_pattern.go:`n == nil || r == nil || r.Match == nil || r.Transform == nil`,
+// whose body is `return n, false`.
 //
 // A gremlins INVERT_LOGICAL mutant flips the first `||` to `&&`, yielding
 // `(n == nil && r == nil) || r.Match == nil || r.Transform == nil`. With

--- a/internal/optimizer/gremlins_mutants_test.go
+++ b/internal/optimizer/gremlins_mutants_test.go
@@ -410,7 +410,7 @@ func TestRunBatch_FixedPointBranchCountsEachChange(t *testing.T) {
 }
 
 // matchAllPattern is a Pattern that matches EVERY node, including nil,
-// recording nothing. It exists to witness the rule_pattern.go:53 guard:
+// recording nothing. It exists to witness the rule_pattern.go:`if n == nil || r == nil || r.Match == nil || r.Transform == nil` guard:
 // stock kindPattern.Match(nil) returns (nil,false), so it can't reveal
 // whether Apply's nil-guard short-circuited before calling Match. A
 // pattern that matches nil makes the difference observable.
@@ -421,7 +421,7 @@ func (matchAllPattern) Match(_ chplan.Node) (optimizer.Bindings, bool) {
 }
 
 // TestPatternRule_ApplyNilShortCircuitsBeforeMatch pins the leading
-// `n == nil ||` term of the nil-guard at rule_pattern.go:53:
+// `n == nil ||` term of the nil-guard at rule_pattern.go:`n == nil ||`:
 //
 //	if n == nil || r == nil || r.Match == nil || r.Transform == nil {
 //		return n, false

--- a/internal/promql/gremlins_kill_binary_lower_mixed_test.go
+++ b/internal/promql/gremlins_kill_binary_lower_mixed_test.go
@@ -4,8 +4,7 @@
 // phase4-promql-* mutation run (mutation.yml). Each test constructs an
 // input that observably differentiates the original code from the
 // mutated branch. See gremlins_kill_test.go's header for the shared
-// conventions (mutant IDs in each test's doc comment are gremlins's
-// `file:line:col`).
+// conventions, including how each doc comment cites its mutant's construct.
 package promql
 
 import (
@@ -71,9 +70,8 @@ func clampFamilyNewValue(t *testing.T, q string) chplan.Expr {
 // ---------------------------------------------------------------------
 
 // TestIsVectorTypedSyntheticOperand_ConjunctsAndGuard kills two mutants
-// on the same line, binary.go:`call, ok := e.(*parser.Call)`:
-//
-//	return ok && call.Func != nil && call.Func.Name == "vector"
+// on the same line,
+// binary.go:`return ok && call.Func != nil && call.Func.Name == "vector"`:
 //
 // INVERT_LOGICAL at col 14 flips the first `&&` to `||`. Go's `&&`/`||`
 // precedence is equal-left-to-right for this expression's grouping
@@ -112,19 +110,18 @@ func TestIsVectorTypedSyntheticOperand_ConjunctsAndGuard(t *testing.T) {
 	// make this false unconditionally.
 	vectorCall := mustParse(t, `vector(1)`)
 	if !isVectorTypedSyntheticOperand(vectorCall) {
-		t.Fatalf("isVectorTypedSyntheticOperand(vector(1)) = false, want true (mutant `!=`→`==` at binary.go:289:27 would always return false)")
+		t.Fatalf("isVectorTypedSyntheticOperand(vector(1)) = false, want true (mutant `!=`→`==` at " +
+			"binary.go:`return ok && call.Func != nil && call.Func.Name == \"vector\"` would always return false)")
 	}
 }
 
 // TestFoldSyntheticVectorBinary_ReturnBoolOnlyWrapsComparisons kills the
-// INVERT_LOGICAL mutant at binary.go:423:22:
+// INVERT_LOGICAL mutant at
+// binary.go:foldSyntheticVectorBinary:`if isComparison(op) && returnBool`,
+// which wraps newValue in a `chplan.FnToFloat64` FuncCall.
 //
-//	if isComparison(op) && returnBool {
-//	    newValue = &chplan.FuncCall{Fn: chplan.FnToFloat64, Args: ...}
-//	}
-//
-// Every REAL caller reaches this line only after the early return on
-// line 418 (`isComparison(op) && !returnBool` already handled) combined
+// Every REAL caller reaches that guard only after the early return on
+// `isComparison(op) && !returnBool` above it, combined
 // with PromQL's grammar-level invariant that `bool` only parses after a
 // comparison operator (returnBool=true implies isComparison(op)=true).
 // Together those two facts mean the only states reachable via normal
@@ -151,8 +148,9 @@ func TestFoldSyntheticVectorBinary_ReturnBoolOnlyWrapsComparisons(t *testing.T) 
 	// op=OpAdd (arithmetic) with returnBool=true never occurs via
 	// lowerVectorVector's real call path. Original:
 	// isComparison(false) && returnBool(true) = false, so newValue stays
-	// the raw Binary. Mutant `&&`→`||` at binary.go:423:22 would wrap it
-	// in toFloat64 regardless.
+	// the raw Binary. Mutant `&&`→`||` at
+	// binary.go:foldSyntheticVectorBinary:`if isComparison(op) && returnBool`
+	// would wrap it in toFloat64 regardless.
 	plan := foldSyntheticVectorBinary(synth, vec, vecExpr, chplan.OpAdd, true, true, s, lowerCtx{})
 	proj, ok := plan.(*chplan.Project)
 	if !ok {
@@ -163,7 +161,9 @@ func TestFoldSyntheticVectorBinary_ReturnBoolOnlyWrapsComparisons(t *testing.T) 
 	}
 	valueExpr := proj.Projections[len(proj.Projections)-1].Expr
 	if _, wrapped := valueExpr.(*chplan.FuncCall); wrapped {
-		t.Fatalf("Value = %#v, want *chplan.Binary (mutant `&&`→`||` at binary.go:423:22 wraps arithmetic ops in toFloat64 too when returnBool=true)", valueExpr)
+		t.Fatalf("Value = %#v, want *chplan.Binary (mutant `&&`→`||` at "+
+			"binary.go:foldSyntheticVectorBinary:`if isComparison(op) && returnBool` "+
+			"wraps arithmetic ops in toFloat64 too when returnBool=true)", valueExpr)
 	}
 	if _, ok := valueExpr.(*chplan.Binary); !ok {
 		t.Fatalf("Value = %T, want *chplan.Binary", valueExpr)
@@ -172,8 +172,9 @@ func TestFoldSyntheticVectorBinary_ReturnBoolOnlyWrapsComparisons(t *testing.T) 
 
 // TestLowerVectorScalar_ReturnBoolOnlyWrapsComparisons is the
 // vector-scalar sibling of the synthetic-vector-binary test above,
-// killing the INVERT_LOGICAL mutant at binary.go:856:22. The same
-// reachability argument applies: line 842's early return plus PromQL's
+// killing the INVERT_LOGICAL mutant at
+// binary.go:lowerVectorScalar:`if isComparison(op) && returnBool`. The same
+// reachability argument applies: that function's own early return plus PromQL's
 // grammar invariant means `isComparison(op) && returnBool` only ever
 // observes (true,true) or (false,false) via real parsing, so the kill
 // calls lowerVectorScalar directly with the otherwise-unreachable
@@ -195,7 +196,9 @@ func TestLowerVectorScalar_ReturnBoolOnlyWrapsComparisons(t *testing.T) {
 	}
 	valueExpr := proj.Projections[len(proj.Projections)-1].Expr
 	if _, wrapped := valueExpr.(*chplan.FuncCall); wrapped {
-		t.Fatalf("Value = %#v, want *chplan.Binary (mutant `&&`→`||` at binary.go:856:22 wraps arithmetic ops in toFloat64 too when returnBool=true)", valueExpr)
+		t.Fatalf("Value = %#v, want *chplan.Binary (mutant `&&`→`||` at "+
+			"binary.go:lowerVectorScalar:`if isComparison(op) && returnBool` "+
+			"wraps arithmetic ops in toFloat64 too when returnBool=true)", valueExpr)
 	}
 	if _, ok := valueExpr.(*chplan.Binary); !ok {
 		t.Fatalf("Value = %T, want *chplan.Binary", valueExpr)
@@ -204,12 +207,9 @@ func TestLowerVectorScalar_ReturnBoolOnlyWrapsComparisons(t *testing.T) {
 
 // TestLowerVectorSetOp_MixedOr_StepAlignedTracksStep kills the
 // CONDITIONALS_BOUNDARY (`>`→`>=`) and CONDITIONALS_NEGATION (`>`→`<=`)
-// mutants at binary.go:593:32:
-//
-//	StepAligned: ctx.step > 0,
-//
-// This line sits inside lowerVectorSetOp's `case leftMixed ||
-// rightMixed` arm (binary.go:578), reached only when at least one
+// mutants on the `StepAligned: ctx.step > 0` field of the
+// *chplan.VectorSetOp built in lowerVectorSetOp's
+// binary.go:`case leftMixed || rightMixed:` arm — reached only when at least one
 // operand of the `or` is ITSELF already a Mixed VectorSetOp (cerberus
 // issue #2555) — a bare `<histogram> or <float>` lands in the sibling
 // `leftHistogram != rightHistogram` case instead. The query below
@@ -239,7 +239,8 @@ func TestLowerVectorSetOp_MixedOr_StepAlignedTracksStep(t *testing.T) {
 		t.Fatalf("lower(%q) instant plan = %T, want *chplan.VectorSetOp", query, instantPlan)
 	}
 	if instantSetOp.StepAligned {
-		t.Fatalf("instant-mode (step=0) StepAligned = true, want false (mutants at binary.go:593:32 would set true)")
+		t.Fatalf("instant-mode (step=0) StepAligned = true, want false (the `StepAligned: ctx.step > 0` mutants in " +
+			"binary.go:`case leftMixed || rightMixed:` would set true)")
 	}
 
 	end := start.Add(5 * time.Minute)
@@ -252,7 +253,8 @@ func TestLowerVectorSetOp_MixedOr_StepAlignedTracksStep(t *testing.T) {
 		t.Fatalf("lower(%q) range plan = %T, want *chplan.VectorSetOp", query, rangePlan)
 	}
 	if !rangeSetOp.StepAligned {
-		t.Fatalf("range-mode (step=1m) StepAligned = false, want true (CONDITIONALS_NEGATION mutant `>`→`<=` at binary.go:593:32 would set false)")
+		t.Fatalf("range-mode (step=1m) StepAligned = false, want true (the CONDITIONALS_NEGATION `>`→`<=` mutant on " +
+			"`StepAligned: ctx.step > 0` in binary.go:`case leftMixed || rightMixed:` would set false)")
 	}
 }
 
@@ -261,10 +263,8 @@ func TestLowerVectorSetOp_MixedOr_StepAlignedTracksStep(t *testing.T) {
 // ---------------------------------------------------------------------
 
 // TestNativeTemporalityFilter_ProjectionsCapacityIsTight kills the two
-// adjacent mutants at lower_strategy.go:349:81 inside
-// nativeTemporalityFilter's slice-capacity hint:
-//
-//	projectCopy.Projections = make([]chplan.Projection, 0, len(project.Projections)-1)
+// adjacent mutants on nativeTemporalityFilter's slice-capacity hint,
+// lower_strategy.go:`projectCopy.Projections = make([]chplan.Projection, 0, len(project.Projections)-1)`.
 //
 // ARITHMETIC_BASE (`-`→`+`) and INVERT_NEGATIVES (`-1`→`+1`) both
 // enlarge the capacity by 2 relative to the tight fit (removing exactly
@@ -297,16 +297,16 @@ func TestNativeTemporalityFilter_ProjectionsCapacityIsTight(t *testing.T) {
 	// Original: cap == len(project.Projections)-1 == 3-1 == 2.
 	// Both mutants: cap == 3+1 == 4.
 	if got := cap(proj.Projections); got != wantLen {
-		t.Fatalf("cap(Projections) = %d, want %d (mutants `-`→`+` and `-1`→`+1` at lower_strategy.go:349:81 would yield cap=4)", got, wantLen)
+		t.Fatalf("cap(Projections) = %d, want %d (mutants `-`→`+` and `-1`→`+1` at "+
+			"lower_strategy.go:`projectCopy.Projections = make([]chplan.Projection, 0, len(project.Projections)-1)` "+
+			"would yield cap=4)", got, wantLen)
 	}
 }
 
 // TestNativePredictLinearHorizonEligible_GuardIsDisjunctive kills the
-// INVERT_LOGICAL mutant at lower_strategy.go:581:30:
-//
-//	if len(rw.ScalarExprs) != 0 || len(rw.Scalars) != 1 {
-//	    return false
-//	}
+// INVERT_LOGICAL mutant at
+// lower_strategy.go:`if len(rw.ScalarExprs) != 0 || len(rw.Scalars) != 1`,
+// whose body returns false.
 //
 // Each case below satisfies exactly one disjunct while leaving the
 // other false, so `||` (short-circuit: reject) and `&&` (mutant: only
@@ -339,7 +339,8 @@ func TestNativePredictLinearHorizonEligible_GuardIsDisjunctive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := nativePredictLinearHorizonEligible(tc.rw); got != tc.want {
-				t.Fatalf("nativePredictLinearHorizonEligible(ScalarExprs=%d, Scalars=%v) = %v, want %v (mutant `||`→`&&` at lower_strategy.go:581:30 would flip the first two cases)",
+				t.Fatalf("nativePredictLinearHorizonEligible(ScalarExprs=%d, Scalars=%v) = %v, want %v (mutant `||`→`&&` at "+
+					"lower_strategy.go:`if len(rw.ScalarExprs) != 0 || len(rw.Scalars) != 1` would flip the first two cases)",
 					len(tc.rw.ScalarExprs), tc.rw.Scalars, got, tc.want)
 			}
 		})
@@ -347,9 +348,8 @@ func TestNativePredictLinearHorizonEligible_GuardIsDisjunctive(t *testing.T) {
 }
 
 // TestNativePredictLinearHorizonEligible_ZeroHorizonIsEligible kills the
-// CONDITIONALS_BOUNDARY mutant at lower_strategy.go:585:11:
-//
-//	return t >= 0 && t == math.Trunc(t)
+// CONDITIONALS_BOUNDARY mutant at
+// lower_strategy.go:`return t >= 0 && t == math.Trunc(t)`.
 //
 // t=0 sits exactly on the boundary: `>= 0` is true (0 is a valid
 // non-negative horizon — `predict_linear(m[5m], 0)` is legal PromQL),
@@ -359,7 +359,8 @@ func TestNativePredictLinearHorizonEligible_ZeroHorizonIsEligible(t *testing.T) 
 
 	rw := &chplan.RangeWindow{Scalars: []float64{0}}
 	if !nativePredictLinearHorizonEligible(rw) {
-		t.Fatalf("nativePredictLinearHorizonEligible(t=0) = false, want true (mutant `>=`→`>` at lower_strategy.go:585:11 would reject t=0)")
+		t.Fatalf("nativePredictLinearHorizonEligible(t=0) = false, want true (mutant `>=`→`>` at " +
+			"lower_strategy.go:`return t >= 0 && t == math.Trunc(t)` would reject t=0)")
 	}
 }
 
@@ -385,13 +386,15 @@ func TestLowerClampOverMixedExpHistogramSetOp_ClampMinMaxPickCorrectFn(t *testin
 	minValue := clampFamilyNewValue(t, `clamp_min(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 5)`)
 	fc, ok := minValue.(*chplan.FuncCall)
 	if !ok || fc.Fn != chplan.FnGreatest {
-		t.Fatalf("clamp_min newValue = %#v, want FuncCall{Fn: FnGreatest} (mutant `==`→`!=` at histogram_native_mixed_or_math_fn.go:270:21 would pick FnLeast)", minValue)
+		t.Fatalf("clamp_min newValue = %#v, want FuncCall{Fn: FnGreatest} (mutant `==`→`!=` at "+
+			"histogram_native_mixed_or_math_fn.go:`if call.Func.Name == \"clamp_min\"` would pick FnLeast)", minValue)
 	}
 
 	maxValue := clampFamilyNewValue(t, `clamp_max(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 5)`)
 	fc, ok = maxValue.(*chplan.FuncCall)
 	if !ok || fc.Fn != chplan.FnLeast {
-		t.Fatalf("clamp_max newValue = %#v, want FuncCall{Fn: FnLeast} (mutant `==`→`!=` at histogram_native_mixed_or_math_fn.go:270:21 would pick FnGreatest)", maxValue)
+		t.Fatalf("clamp_max newValue = %#v, want FuncCall{Fn: FnLeast} (mutant `==`→`!=` at "+
+			"histogram_native_mixed_or_math_fn.go:`if call.Func.Name == \"clamp_min\"` would pick FnGreatest)", maxValue)
 	}
 }
 
@@ -413,14 +416,13 @@ func TestLowerClampOverMixedExpHistogramSetOp_MixedBoundsTakeRuntimePath(t *test
 	newValue := clampFamilyNewValue(t, `clamp(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 5, scalar(sum(up)))`)
 	fc, ok := newValue.(*chplan.FuncCall)
 	if !ok || fc.Fn != chplan.FnIf {
-		t.Fatalf("mixed literal/computed clamp newValue = %#v, want FuncCall{Fn: FnIf} (runtime-bounds path; mutant `&&`→`||` at histogram_native_mixed_or_math_fn.go:293:12 would take the literal degenerate-fold path instead)", newValue)
+		t.Fatalf("mixed literal/computed clamp newValue = %#v, want FuncCall{Fn: FnIf} (runtime-bounds path; mutant `&&`→`||` at "+
+			"histogram_native_mixed_or_math_fn.go:`if okMin && okMax` would take the literal degenerate-fold path instead)", newValue)
 	}
 }
 
 // TestLowerClampOverMixedExpHistogramSetOp_EqualLiteralBoundsNonDegenerate
-// kills both mutants at histogram_native_mixed_or_math_fn.go:298:12:
-//
-//	if maxB < minB {
+// kills both mutants at histogram_native_mixed_or_math_fn.go:`if maxB < minB`.
 //
 // minB == maxB == 5: equality is NOT less-than, so the original takes
 // the non-degenerate literal path (FuncCall{Fn: FnGreatest}).
@@ -433,7 +435,8 @@ func TestLowerClampOverMixedExpHistogramSetOp_EqualLiteralBoundsNonDegenerate(t 
 	newValue := clampFamilyNewValue(t, `clamp(latency_exp_hist or histogram_quantile(0.5, latency_exp_hist), 5, 5)`)
 	fc, ok := newValue.(*chplan.FuncCall)
 	if !ok || fc.Fn != chplan.FnGreatest {
-		t.Fatalf("equal-bounds clamp newValue = %#v, want FuncCall{Fn: FnGreatest} (mutants `<`→`<=` and `<`→`>=` at histogram_native_mixed_or_math_fn.go:298:12 would take the degenerate empty-clamp fold)", newValue)
+		t.Fatalf("equal-bounds clamp newValue = %#v, want FuncCall{Fn: FnGreatest} (mutants `<`→`<=` and `<`→`>=` at "+
+			"histogram_native_mixed_or_math_fn.go:`if maxB < minB` would take the degenerate empty-clamp fold)", newValue)
 	}
 }
 
@@ -478,12 +481,15 @@ func TestCountValuesOverMixedExpHistogramSetOp_RecognizesOnlyCountValues(t *test
 
 	cvExpr := mustParseExperimental(t, `count_values("v", `+mixedOrQuery+`)`)
 	if _, _, ok := countValuesOverMixedExpHistogramSetOp(cvExpr, s, lowerCtx{}); !ok {
-		t.Fatalf("count_values(...) over mixed-or not recognized (mutant `!=`→`==` at histogram_native_mixed_or_aggregate_count_values.go:76:19 would reject it)")
+		t.Fatalf("count_values(...) over mixed-or not recognized (mutant `!=`→`==` at " +
+			"histogram_native_mixed_or_aggregate_count_values.go:`if !ok || agg.Op != parser.COUNT_VALUES` would reject it)")
 	}
 
 	sumExpr := mustParseExperimental(t, `sum(`+mixedOrQuery+`)`)
 	if _, _, ok := countValuesOverMixedExpHistogramSetOp(sumExpr, s, lowerCtx{}); ok {
-		t.Fatalf("sum(...) over mixed-or wrongly recognized as count_values (mutant `!=`→`==` at histogram_native_mixed_or_aggregate_count_values.go:76:19 would accept any non-count_values aggregate)")
+		t.Fatalf("sum(...) over mixed-or wrongly recognized as count_values (mutant `!=`→`==` at " +
+			"histogram_native_mixed_or_aggregate_count_values.go:`if !ok || agg.Op != parser.COUNT_VALUES` " +
+			"would accept any non-count_values aggregate)")
 	}
 }
 
@@ -493,11 +499,8 @@ func TestCountValuesOverMixedExpHistogramSetOp_RecognizesOnlyCountValues(t *test
 
 // TestCountOrGroupOverMixedExpHistogramSetOp_RecognizesCountAndGroup
 // kills the three CONDITIONALS_NEGATION mutants on
-// histogram_native_mixed_or_aggregate_presence.go:`agg.Op != parser.COUNT`:
-//
-//	if !ok || (agg.Op != parser.COUNT && agg.Op != parser.GROUP) || agg.Param != nil {
-//	    return nil, nil, false
-//	}
+// histogram_native_mixed_or_aggregate_presence.go:`if !ok || (agg.Op != parser.COUNT && agg.Op != parser.GROUP) || agg.Param != nil`,
+// whose body returns the zero-value rejection tuple.
 //
 // col 20 (`agg.Op != parser.COUNT` → `==`): with Op=COUNT, the mutated
 // first conjunct becomes true, and (true && (COUNT != GROUP = true)) =
@@ -520,12 +523,18 @@ func TestCountOrGroupOverMixedExpHistogramSetOp_RecognizesCountAndGroup(t *testi
 
 	countExpr := mustParseExperimental(t, `count(`+mixedOrQuery+`)`)
 	if _, _, ok := countOrGroupOverMixedExpHistogramSetOp(countExpr, s, lowerCtx{}); !ok {
-		t.Fatalf("count(...) over mixed-or not recognized (mutants at histogram_native_mixed_or_aggregate_presence.go:66:20 / :66:76 would reject it)")
+		t.Fatalf("count(...) over mixed-or not recognized (the `agg.Op != parser.COUNT` and " +
+			"`agg.Param != nil` mutants on " +
+			"histogram_native_mixed_or_aggregate_presence.go:`if !ok || (agg.Op != parser.COUNT && agg.Op != parser.GROUP) || agg.Param != nil` " +
+			"would reject it)")
 	}
 
 	groupExpr := mustParseExperimental(t, `group(`+mixedOrQuery+`)`)
 	if _, _, ok := countOrGroupOverMixedExpHistogramSetOp(groupExpr, s, lowerCtx{}); !ok {
-		t.Fatalf("group(...) over mixed-or not recognized (mutants at histogram_native_mixed_or_aggregate_presence.go:66:46 / :66:76 would reject it)")
+		t.Fatalf("group(...) over mixed-or not recognized (the `agg.Op != parser.GROUP` and " +
+			"`agg.Param != nil` mutants on " +
+			"histogram_native_mixed_or_aggregate_presence.go:`if !ok || (agg.Op != parser.COUNT && agg.Op != parser.GROUP) || agg.Param != nil` " +
+			"would reject it)")
 	}
 
 	// Negative control: an aggregate op that is neither COUNT nor GROUP
@@ -580,11 +589,17 @@ func TestDateFnOverMixedExpHistogramSetOp_ArgCountAndTimestampExclusion(t *testi
 
 	yearCall := &parser.Call{Func: parser.MustGetFunction("year"), Args: parser.Expressions{binExpr}}
 	if _, ok := dateFnOverMixedExpHistogramSetOp(yearCall, s, lowerCtx{}); !ok {
-		t.Fatalf("year(<mixed or>) not recognized (mutants `!=`→`==` at histogram_native_mixed_or_datefn.go:58:17 or `==`→`!=` at :58:37 would reject it)")
+		t.Fatalf("year(<mixed or>) not recognized (the `len(c.Args) != 1`→`==` or " +
+			"`c.Func.Name == \"timestamp\"`→`!=` mutants on " +
+			"histogram_native_mixed_or_datefn.go:`if len(c.Args) != 1 || c.Func.Name == \"timestamp\"` " +
+			"would reject it)")
 	}
 
 	tsCall := &parser.Call{Func: parser.MustGetFunction("timestamp"), Args: parser.Expressions{binExpr}}
 	if _, ok := dateFnOverMixedExpHistogramSetOp(tsCall, s, lowerCtx{}); ok {
-		t.Fatalf("timestamp(<mixed or>) wrongly recognized (mutant `||`→`&&` at histogram_native_mixed_or_datefn.go:`if len(c.Args) != 1 || c.Func.Name == \"timestamp\"`, or `==`→`!=` at :58:37, would accept it)")
+		t.Fatalf("timestamp(<mixed or>) wrongly recognized (the `||`→`&&` or " +
+			"`c.Func.Name == \"timestamp\"`→`!=` mutants on " +
+			"histogram_native_mixed_or_datefn.go:`if len(c.Args) != 1 || c.Func.Name == \"timestamp\"` " +
+			"would accept it)")
 	}
 }

--- a/internal/promql/gremlins_kill_binary_lower_mixed_test.go
+++ b/internal/promql/gremlins_kill_binary_lower_mixed_test.go
@@ -71,7 +71,7 @@ func clampFamilyNewValue(t *testing.T, q string) chplan.Expr {
 // ---------------------------------------------------------------------
 
 // TestIsVectorTypedSyntheticOperand_ConjunctsAndGuard kills two mutants
-// on the same line, binary.go:289:
+// on the same line, binary.go:`call, ok := e.(*parser.Call)`:
 //
 //	return ok && call.Func != nil && call.Func.Name == "vector"
 //
@@ -369,7 +369,7 @@ func TestNativePredictLinearHorizonEligible_ZeroHorizonIsEligible(t *testing.T) 
 
 // TestLowerClampOverMixedExpHistogramSetOp_ClampMinMaxPickCorrectFn kills
 // the CONDITIONALS_NEGATION mutant at
-// histogram_native_mixed_or_math_fn.go:270:21:
+// histogram_native_mixed_or_math_fn.go:`if call.Func.Name == "clamp_min"`:
 //
 //	fnName := chplan.FnLeast
 //	if call.Func.Name == "clamp_min" {
@@ -397,7 +397,7 @@ func TestLowerClampOverMixedExpHistogramSetOp_ClampMinMaxPickCorrectFn(t *testin
 
 // TestLowerClampOverMixedExpHistogramSetOp_MixedBoundsTakeRuntimePath
 // kills the INVERT_LOGICAL mutant at
-// histogram_native_mixed_or_math_fn.go:293:12:
+// histogram_native_mixed_or_math_fn.go:`if okMin && okMax`:
 //
 //	if okMin && okMax {
 //
@@ -461,7 +461,7 @@ func TestLowerClampOverMixedExpHistogramSetOp_DegenerateLiteralBoundsAreEmpty(t 
 
 // TestCountValuesOverMixedExpHistogramSetOp_RecognizesOnlyCountValues
 // kills the CONDITIONALS_NEGATION mutant at
-// histogram_native_mixed_or_aggregate_count_values.go:76:19:
+// histogram_native_mixed_or_aggregate_count_values.go:`if !ok || agg.Op != parser.COUNT_VALUES`:
 //
 //	if !ok || agg.Op != parser.COUNT_VALUES {
 //	    return nil, nil, false
@@ -493,7 +493,7 @@ func TestCountValuesOverMixedExpHistogramSetOp_RecognizesOnlyCountValues(t *test
 
 // TestCountOrGroupOverMixedExpHistogramSetOp_RecognizesCountAndGroup
 // kills the three CONDITIONALS_NEGATION mutants on
-// histogram_native_mixed_or_aggregate_presence.go:66:
+// histogram_native_mixed_or_aggregate_presence.go:`agg.Op != parser.COUNT`:
 //
 //	if !ok || (agg.Op != parser.COUNT && agg.Op != parser.GROUP) || agg.Param != nil {
 //	    return nil, nil, false
@@ -541,7 +541,7 @@ func TestCountOrGroupOverMixedExpHistogramSetOp_RecognizesCountAndGroup(t *testi
 // ---------------------------------------------------------------------
 
 // TestDateFnOverMixedExpHistogramSetOp_ArgCountAndTimestampExclusion
-// kills the three mutants on histogram_native_mixed_or_datefn.go:58:
+// kills the three mutants on histogram_native_mixed_or_datefn.go:`if len(c.Args) != 1 || c.Func.Name == "timestamp"`:
 //
 //	if len(c.Args) != 1 || c.Func.Name == "timestamp" {
 //	    return nil, false
@@ -585,6 +585,6 @@ func TestDateFnOverMixedExpHistogramSetOp_ArgCountAndTimestampExclusion(t *testi
 
 	tsCall := &parser.Call{Func: parser.MustGetFunction("timestamp"), Args: parser.Expressions{binExpr}}
 	if _, ok := dateFnOverMixedExpHistogramSetOp(tsCall, s, lowerCtx{}); ok {
-		t.Fatalf("timestamp(<mixed or>) wrongly recognized (mutant `||`→`&&` at histogram_native_mixed_or_datefn.go:58:22, or `==`→`!=` at :58:37, would accept it)")
+		t.Fatalf("timestamp(<mixed or>) wrongly recognized (mutant `||`→`&&` at histogram_native_mixed_or_datefn.go:`if len(c.Args) != 1 || c.Func.Name == \"timestamp\"`, or `==`→`!=` at :58:37, would accept it)")
 	}
 }

--- a/internal/promql/gremlins_kill_histogram_binop_count_test.go
+++ b/internal/promql/gremlins_kill_histogram_binop_count_test.go
@@ -8,15 +8,15 @@
 // Two INVERT_LOGICAL mutants are NOT addressed with a dedicated test here —
 // both are provably equivalent, not coverage gaps:
 //
-//   - histogram_native_binop_eq.go:119:31 (`s.ExpHistogramTable == "" ||
-//     ctx.metadataFullRange` -> `&&` inside expHistogramHistogramCompareBinop).
+//   - histogram_native_binop_eq.go:expHistogramHistogramCompareBinop:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//     (`||` -> `&&`).
 //   - histogram_native_binop_eq.go:`s.ExpHistogramTable == "" || ctx.metadataFullRange || !b.ReturnBool` (the FIRST `||` of the three-way
 //     `s.ExpHistogramTable == "" || ctx.metadataFullRange || !b.ReturnBool`
 //     inside expHistogramHistogramCompareBoolBinop).
 //
 // Both functions re-validate the identical table/metadataFullRange
 // condition one level down, via isExpHistogramValuedShape(b.LHS/b.RHS, s,
-// ctx) a few lines later (line 140 / line 197) — and EVERY leaf recognizer
+// ctx) a few lines later — and EVERY leaf recognizer
 // isExpHistogramValuedShape dispatches to (bareExpHistogramSelector,
 // sumOrAvgOverExpHistogram, rangeFnOverExpHistogram, and so on) carries the
 // exact same `s.ExpHistogramTable == "" || ctx.metadataFullRange` guard.
@@ -41,7 +41,8 @@ import (
 
 // TestExpHistogramHistogramCompareBoolBinop_RequiresReturnBool kills the
 // CONDITIONALS_BOUNDARY... no — INVERT_LOGICAL mutant at
-// histogram_native_binop_eq.go:191:56, the SECOND `||` of
+// histogram_native_binop_eq.go:`s.ExpHistogramTable == "" || ctx.metadataFullRange || !b.ReturnBool`,
+// the SECOND `||` of
 //
 //	if s.ExpHistogramTable == "" || ctx.metadataFullRange || !b.ReturnBool {
 //
@@ -73,12 +74,14 @@ func TestExpHistogramHistogramCompareBoolBinop_RequiresReturnBool(t *testing.T) 
 	if _, _, _, _, ok := expHistogramHistogramCompareBoolBinop(b, s, lowerCtx{}); ok {
 		t.Fatalf("expected a non-bool histogram/histogram comparison to be rejected by the " +
 			"bool-modifier-only recognizer; got ok=true (mutant `||`->`&&` at " +
-			"histogram_native_binop_eq.go:191:56 would accept it despite ReturnBool=false)")
+			"histogram_native_binop_eq.go:`s.ExpHistogramTable == \"\" || ctx.metadataFullRange || !b.ReturnBool` " +
+			"would accept it despite ReturnBool=false)")
 	}
 }
 
 // TestExpHistogramHistogramCompareBoolBinop_BothSidesMustBeHistogramValued
-// kills the INVERT_LOGICAL mutant at histogram_native_binop_eq.go:197:47:
+// kills the INVERT_LOGICAL mutant at
+// histogram_native_binop_eq.go:expHistogramHistogramCompareBoolBinop:`!isExpHistogramValuedShape(b.LHS, s, ctx) || !isExpHistogramValuedShape(b.RHS, s, ctx)`:
 //
 //	if !isExpHistogramValuedShape(b.LHS, s, ctx) || !isExpHistogramValuedShape(b.RHS, s, ctx) {
 //
@@ -101,7 +104,9 @@ func TestExpHistogramHistogramCompareBoolBinop_BothSidesMustBeHistogramValued(t 
 	}
 	if _, _, _, _, ok := expHistogramHistogramCompareBoolBinop(b, s, lowerCtx{}); ok {
 		t.Fatalf("expected a histogram/float mismatched bool-compare to be rejected; got ok=true " +
-			"(mutant `||`->`&&` at histogram_native_binop_eq.go:197:47 would accept it as long as " +
+			"(mutant `||`->`&&` at histogram_native_binop_eq.go:expHistogramHistogramCompareBoolBinop:" +
+			"`!isExpHistogramValuedShape(b.LHS, s, ctx) || !isExpHistogramValuedShape(b.RHS, s, ctx)` " +
+			"would accept it as long as " +
 			"ONE side is histogram-valued)")
 	}
 }
@@ -162,12 +167,14 @@ func TestCountOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.T) {
 	expr := mustParse(t, `count(latency_exp_hist)`)
 	if _, _, ok := countOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
 		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true " +
-			"(mutant `||`->`&&` at histogram_native_count.go:73:31)")
+			"(mutant `||`->`&&` at histogram_native_count.go:countOverExpHistogram:" +
+			"`s.ExpHistogramTable == \"\" || ctx.metadataFullRange`)")
 	}
 }
 
 // TestCountOrGroupOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing
-// kills the INVERT_LOGICAL mutant at histogram_native_count.go:98:31.
+// kills the INVERT_LOGICAL mutant at
+// histogram_native_count.go:countOrGroupOverExpHistogramValue:`s.ExpHistogramTable == "" || ctx.metadataFullRange`.
 //
 // Unlike countOverExpHistogram above, countOrGroupOverExpHistogramValue
 // DOES re-validate the identical guard one level down: its own tail
@@ -199,14 +206,17 @@ func TestCountOrGroupOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing
 	if agg != nil {
 		t.Fatalf("expected countOrGroupOverExpHistogramValue to short-circuit BEFORE parsing the "+
 			"aggregate under metadataFullRange (agg == nil); got %#v — the mutant `||`->`&&` at "+
-			"histogram_native_count.go:98:31 would fall through to unwrapAggregateExpr and return a "+
+			"histogram_native_count.go:countOrGroupOverExpHistogramValue:"+
+			"`s.ExpHistogramTable == \"\" || ctx.metadataFullRange` would fall through to "+
+			"unwrapAggregateExpr and return a "+
 			"non-nil agg even though ok stays false via the recursive isExpHistogramValuedShape guard",
 			agg)
 	}
 }
 
 // TestCountValuesOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing
-// kills the INVERT_LOGICAL mutant at histogram_native_count_values.go:18:31
+// kills the INVERT_LOGICAL mutant at
+// histogram_native_count_values.go:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
 // — the SAME "agg persists past the masked guard" shape
 // TestCountOrGroupOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing
 // kills above, for countValuesOverExpHistogramValue's identical
@@ -223,14 +233,17 @@ func TestCountValuesOverExpHistogramValue_MetadataFullRangeRejectsBeforeParsing(
 	if agg != nil {
 		t.Fatalf("expected countValuesOverExpHistogramValue to short-circuit BEFORE parsing the "+
 			"aggregate under metadataFullRange (agg == nil); got %#v — the mutant `||`->`&&` at "+
-			"histogram_native_count_values.go:18:31 would fall through and return a non-nil agg "+
+			"histogram_native_count_values.go:`s.ExpHistogramTable == \"\" || ctx.metadataFullRange` "+
+			"would fall through and return a non-nil agg "+
 			"even though ok stays false via the recursive isExpHistogramValuedShape guard", agg)
 	}
 }
 
 // TestNativeHistogramBucketStrings_NegativeBoundsAreSignFlipped kills the
-// two adjacent mutants at histogram_native_count_values.go:116:79 and
-// :117:55 (ARITHMETIC_BASE `-`->`+` and INVERT_NEGATIVES `-1`->`1` — both
+// two adjacent mutants at
+// histogram_native_count_values.go:`histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, upperBound)`
+// and histogram_native_count_values.go:`histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, lowerBound)`
+// (ARITHMETIC_BASE `-`->`+` and INVERT_NEGATIVES `-1`->`1` — both
 // produce the identical observable effect, the multiplier flips from -1 to
 // 1) inside nativeHistogramBucketStrings's negative-bucket sign flip:
 //
@@ -291,9 +304,10 @@ func TestNativeHistogramBucketStrings_NegativeBoundsAreSignFlipped(t *testing.T)
 		}
 		lit, ok := mul.Left.(*chplan.LitFloat)
 		if !ok || lit.V != -1 {
-			t.Fatalf("%s multiplier = %#v, want LitFloat{-1} (mutants at "+
-				"histogram_native_count_values.go:116:79 and :117:55 would flip this to 1, "+
-				"dropping the negative-bucket sign flip)", label, mul.Left)
+			t.Fatalf("%s multiplier = %#v, want LitFloat{-1} (the mutants at "+
+				"histogram_native_count_values.go:`histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, upperBound)` "+
+				"and histogram_native_count_values.go:`histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, lowerBound)` "+
+				"would flip this to 1, dropping the negative-bucket sign flip)", label, mul.Left)
 		}
 	}
 	assertNegatedBound("lowerBound (rendered from the swapped upperBound expr)", body.Args[lowerBoundArgIdx])
@@ -367,9 +381,10 @@ func unwrapHqLetBoundValue(t *testing.T, e chplan.Expr) chplan.Expr {
 }
 
 // TestNativeHistogramBoundExpr_ScaleExponentIsNegated kills the two
-// adjacent mutants at histogram_native_count_values.go:187:107
+// adjacent mutants at
+// histogram_native_count_values.go:`histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, scale)`
 // (ARITHMETIC_BASE `-`->`+` and INVERT_NEGATIVES `-1`->`1`, the same
-// observable-effect pair as the 116/117 kill above) inside
+// observable-effect pair as the negative-bucket kill above) inside
 // nativeHistogramBoundExpr's growth-factor base:
 //
 //	base := histStringCall(chplan.FnPow, &chplan.LitFloat{V: 2},
@@ -420,7 +435,8 @@ func TestNativeHistogramBoundExpr_ScaleExponentIsNegated(t *testing.T) {
 	lit, ok := mul.Left.(*chplan.LitFloat)
 	if !ok || lit.V != -1 {
 		t.Fatalf("mul.Left = %#v, want LitFloat{-1} (mutants at "+
-			"histogram_native_count_values.go:187:107 would flip this to 1, negating the "+
+			"histogram_native_count_values.go:`histStringBinary(chplan.OpMul, &chplan.LitFloat{V: -1}, scale)` "+
+			"would flip this to 1, negating the "+
 			"exponent's sign)", mul.Left)
 	}
 	if !mul.Right.Equal(scale) {

--- a/internal/promql/gremlins_kill_histogram_binop_count_test.go
+++ b/internal/promql/gremlins_kill_histogram_binop_count_test.go
@@ -10,7 +10,7 @@
 //
 //   - histogram_native_binop_eq.go:119:31 (`s.ExpHistogramTable == "" ||
 //     ctx.metadataFullRange` -> `&&` inside expHistogramHistogramCompareBinop).
-//   - histogram_native_binop_eq.go:191:31 (the FIRST `||` of the three-way
+//   - histogram_native_binop_eq.go:`s.ExpHistogramTable == "" || ctx.metadataFullRange || !b.ReturnBool` (the FIRST `||` of the three-way
 //     `s.ExpHistogramTable == "" || ctx.metadataFullRange || !b.ReturnBool`
 //     inside expHistogramHistogramCompareBoolBinop).
 //
@@ -107,7 +107,7 @@ func TestExpHistogramHistogramCompareBoolBinop_BothSidesMustBeHistogramValued(t 
 }
 
 // TestProjectHistogramCompareSide_ProjectionsCapacityIsTight kills the
-// ARITHMETIC_BASE mutant at histogram_native_binop_eq.go:353:49 inside
+// ARITHMETIC_BASE mutant at histogram_native_binop_eq.go:`projs := make([]chplan.Projection, 0, len(cols)+1)` inside
 // projectHistogramCompareSide's slice-capacity hint:
 //
 //	projs := make([]chplan.Projection, 0, len(cols)+1)
@@ -137,13 +137,13 @@ func TestProjectHistogramCompareSide_ProjectionsCapacityIsTight(t *testing.T) {
 	}
 	if gotCap := cap(got.Projections); gotCap != wantLen {
 		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at "+
-			"histogram_native_binop_eq.go:353:49 would yield a different cap via forced regrowth)",
+			"histogram_native_binop_eq.go:`projs := make([]chplan.Projection, 0, len(cols)+1)` would yield a different cap via forced regrowth)",
 			gotCap, wantLen)
 	}
 }
 
 // TestCountOverExpHistogram_MetadataFullRangeShortCircuits kills the
-// INVERT_LOGICAL mutant at histogram_native_count.go:73:31, where
+// INVERT_LOGICAL mutant at histogram_native_count.go:countOverExpHistogram:`if s.ExpHistogramTable == "" || ctx.metadataFullRange`, where
 //
 //	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
 //

--- a/internal/promql/gremlins_kill_histogram_binop_drop_test.go
+++ b/internal/promql/gremlins_kill_histogram_binop_drop_test.go
@@ -22,9 +22,9 @@
 // own — it delegates to leaf recognizers (bareExpHistogramSelector,
 // sumOrAvgOverExpHistogram, rangeFnOverExpHistogram, and every other
 // producer isExpHistogramValuedShape tries), and EVERY one of those
-// leaves carries the identical `s.ExpHistogramTable == "" ||
-// ctx.metadataFullRange` guard (see e.g. bareExpHistogramSelector,
-// histogram_native_bare.go:68). So isExpHistogramValuedShape(expr, s,
+// leaves carries the identical guard (see e.g.
+// histogram_native_bare.go:bareExpHistogramSelector:`if s.ExpHistogramTable == "" || ctx.metadataFullRange`).
+// So isExpHistogramValuedShape(expr, s,
 // ctx) is unconditionally false for ANY expr whenever ctx.metadataFullRange
 // is true and s.ExpHistogramTable is non-empty — exactly the one
 // scenario where this function's own early `||`-vs-`&&` guard could

--- a/internal/promql/gremlins_kill_histogram_binop_drop_test.go
+++ b/internal/promql/gremlins_kill_histogram_binop_drop_test.go
@@ -7,7 +7,7 @@
 // gremlins_kill_test.go for the shared file-header convention this file
 // otherwise follows.
 //
-//   - histogram_native_binop.go:218:31, INVERT_LOGICAL (`||` -> `&&`)
+//   - histogram_native_binop.go:expHistogramDroppingHistogramBinop:`if s.ExpHistogramTable == "" || ctx.metadataFullRange`, INVERT_LOGICAL (`||` -> `&&`)
 //     inside expHistogramDroppingHistogramBinop:
 //
 //     if s.ExpHistogramTable == "" || ctx.metadataFullRange {

--- a/internal/promql/gremlins_kill_histogram_mixed_or_leaf_test.go
+++ b/internal/promql/gremlins_kill_histogram_mixed_or_leaf_test.go
@@ -11,7 +11,7 @@
 // recognizer itself. See gremlins_kill_test.go for the shared file-header
 // convention this file otherwise follows.
 //
-//   - histogram_native_mixed_or.go:123:31, INVERT_LOGICAL (`||` -> `&&`)
+//   - histogram_native_mixed_or.go:`if s.ExpHistogramTable == "" || ctx.metadataFullRange`, INVERT_LOGICAL (`||` -> `&&`)
 //     inside mixedExpHistogramSetOp:
 //
 //     if s.ExpHistogramTable == "" || ctx.metadataFullRange {

--- a/internal/promql/gremlins_kill_histogram_mixed_or_test.go
+++ b/internal/promql/gremlins_kill_histogram_mixed_or_test.go
@@ -63,7 +63,7 @@ func TestLabelCallOverMixedExpHistogramSetOp_LabelJoinMinArity(t *testing.T) {
 	if _, _, ok := labelCallOverMixedExpHistogramSetOp(call, s, lowerCtx{}); !ok {
 		t.Fatalf("expected minimum-arity (3-arg) label_join wrapping a mixed histogram/float `or` " +
 			"to be recognised; got ok=false (mutant `<`->`<=` at " +
-			"histogram_native_mixed_or_label.go:61:21)")
+			"histogram_native_mixed_or_label.go:`if len(call.Args) < 3`)")
 	}
 }
 
@@ -134,7 +134,7 @@ func TestLowerMixedVVCompareBool_HistCmpNegationMatchesOp(t *testing.T) {
 	}
 	if got := histCmpCombine(t, chplan.OpNe); got != chplan.OpOr {
 		t.Fatalf("op=NE: histCmp top combine = %s, want OR (ne=true) — mutant `==`->`!=` at "+
-			"histogram_native_mixed_or_vector_comparison.go:357:44 would pass ne=false here and use AND",
+			"histogram_native_mixed_or_vector_comparison.go:lowerMixedVVCompareBool:`histCmp := mixedVVHistogramFieldsExpr(op == chplan.OpNe)` would pass ne=false here and use AND",
 			got)
 	}
 }

--- a/internal/promql/gremlins_kill_histogram_mixed_or_test.go
+++ b/internal/promql/gremlins_kill_histogram_mixed_or_test.go
@@ -9,7 +9,7 @@
 // One CONDITIONALS_BOUNDARY mutant is NOT addressed with a dedicated test
 // here — it is provably equivalent, not a coverage gap:
 //
-//   - histogram_native_mixed_or_vector_comparison.go:163:36
+//   - histogram_native_mixed_or_vector_comparison.go:`len(b.VectorMatching.Include) > 0`
 //     (`len(b.VectorMatching.Include) > 0` -> `>= 0`, inside
 //     comparisonVectorVectorOverMixedExpHistogramSetOp).
 //
@@ -37,7 +37,7 @@ import (
 )
 
 // TestLabelCallOverMixedExpHistogramSetOp_LabelJoinMinArity kills the
-// CONDITIONALS_BOUNDARY mutant at histogram_native_mixed_or_label.go:61:21
+// CONDITIONALS_BOUNDARY mutant at histogram_native_mixed_or_label.go:`len(call.Args) < 3`
 // (`len(call.Args) < 3` -> `<= 3`) inside labelCallOverMixedExpHistogramSetOp's
 // label_join arm. The minimum valid label_join call has exactly 3 args
 // (vector, dst, separator, zero src labels) — label_fns.go's own arity
@@ -69,7 +69,7 @@ func TestLabelCallOverMixedExpHistogramSetOp_LabelJoinMinArity(t *testing.T) {
 
 // TestLowerMixedVVCompareBool_HistCmpNegationMatchesOp kills the
 // CONDITIONALS_NEGATION mutant at
-// histogram_native_mixed_or_vector_comparison.go:357:44
+// histogram_native_mixed_or_vector_comparison.go:lowerMixedVVCompareBool:`histCmp := mixedVVHistogramFieldsExpr(op == chplan.OpNe)`
 // (`op == chplan.OpNe` -> `!=`) inside lowerMixedVVCompareBool's
 // histogram,histogram branch:
 //
@@ -129,7 +129,7 @@ func TestLowerMixedVVCompareBool_HistCmpNegationMatchesOp(t *testing.T) {
 
 	if got := histCmpCombine(t, chplan.OpEq); got != chplan.OpAnd {
 		t.Fatalf("op=EQ: histCmp top combine = %s, want AND (ne=false) — mutant `==`->`!=` at "+
-			"histogram_native_mixed_or_vector_comparison.go:357:44 would pass ne=true here and use OR",
+			"histogram_native_mixed_or_vector_comparison.go:lowerMixedVVCompareBool:`histCmp := mixedVVHistogramFieldsExpr(op == chplan.OpNe)` would pass ne=true here and use OR",
 			got)
 	}
 	if got := histCmpCombine(t, chplan.OpNe); got != chplan.OpOr {
@@ -141,7 +141,7 @@ func TestLowerMixedVVCompareBool_HistCmpNegationMatchesOp(t *testing.T) {
 
 // TestHistogramValuedProducerCall_InfoAcceptsTwoArgs kills the
 // CONDITIONALS_BOUNDARY mutant at
-// histogram_native_value_producing_call.go:41:43 (`len(call.Args) > 2` ->
+// histogram_native_value_producing_call.go:`len(call.Args) > 2` (`len(call.Args) > 2` ->
 // `>= 2`) inside histogramValuedProducerCall's info() arm. info() accepts
 // 1 or 2 arguments; exactly 2 is the valid upper boundary and must NOT be
 // rejected.
@@ -159,13 +159,13 @@ func TestHistogramValuedProducerCall_InfoAcceptsTwoArgs(t *testing.T) {
 	if _, ok := histogramValuedProducerCall(call, s, lowerCtx{}); !ok {
 		t.Fatalf("expected info() with exactly 2 args over a histogram-valued base to be " +
 			"recognised; got ok=false (mutant `>`->`>=` at " +
-			"histogram_native_value_producing_call.go:41:43 would reject the 2-arg boundary)")
+			"histogram_native_value_producing_call.go:`if len(call.Args) < 1 || len(call.Args) > 2` would reject the 2-arg boundary)")
 	}
 }
 
 // TestHistogramValuedProducerCall_SortByLabelAcceptsSingleArg kills the
 // CONDITIONALS_BOUNDARY mutant at
-// histogram_native_value_producing_call.go:45:21 (`len(call.Args) < 1` ->
+// histogram_native_value_producing_call.go:`if len(call.Args) < 1 {` (`len(call.Args) < 1` ->
 // `<= 1`) inside histogramValuedProducerCall's sort_by_label(_desc) arm.
 // sort_by_label accepts the vector argument alone (zero label names); the
 // parser's own grammar allows this shape (no minimum label-name count),
@@ -181,6 +181,6 @@ func TestHistogramValuedProducerCall_SortByLabelAcceptsSingleArg(t *testing.T) {
 	if _, ok := histogramValuedProducerCall(call, s, lowerCtx{}); !ok {
 		t.Fatalf("expected sort_by_label() with exactly 1 arg (no label names) over a " +
 			"histogram-valued base to be recognised; got ok=false (mutant `<`->`<=` at " +
-			"histogram_native_value_producing_call.go:45:21 would reject the 1-arg boundary)")
+			"histogram_native_value_producing_call.go:`if len(call.Args) < 1 {` would reject the 1-arg boundary)")
 	}
 }

--- a/internal/promql/gremlins_kill_histogram_subquery_select_test.go
+++ b/internal/promql/gremlins_kill_histogram_subquery_select_test.go
@@ -11,8 +11,9 @@
 //   - histogram_native_subquery_select.go:`s.ExpHistogramTable == "" || ctx.metadataFullRange` (INVERT_LOGICAL,
 //     `s.ExpHistogramTable == "" || ctx.metadataFullRange` -> `&&` inside
 //     selectFnOverExpHistogramSubquery). This function re-validates the
-//     identical condition one level down at line 118's
-//     `!isExpHistogramValuedShape(sub.Expr, s, ctx)` — and EVERY leaf
+//     identical condition one level down, in the
+//     `!isExpHistogramValuedShape(sub.Expr, s, ctx)` disjunct of
+//     histogram_native_subquery_select.go:`sub.Range <= 0` — and EVERY leaf
 //     recognizer isExpHistogramValuedShape dispatches to carries the same
 //     guard, so whenever the top guard's condition holds,
 //     isExpHistogramValuedShape is unconditionally false regardless of
@@ -27,13 +28,13 @@
 //     `step < 0` -> `<= 0`). Two lines above, `if step == 0 { step =
 //     defaultSubqueryStep }` (defaultSubqueryStep = time.Minute, a positive
 //     constant) already eliminates step == 0 as a reachable value by the
-//     time line 170 runs — step is either the caller's own non-zero
+//     time `if step < 0` runs — step is either the caller's own non-zero
 //     sub.Step or the positive default. `<` and `<=` decide identically
 //     over every value except exactly 0, so no reachable input can make
 //     the two operators disagree (the same reasoning
 //     gremlins_kill_subquery_test.go's header gives for subquery.go:`step < 0`).
-//   - histogram_native_subquery_select.go:`!matched` (INVERT_LOGICAL, `!matched
-//     || chplan.RowShapeOf(input) != chplan.HistogramRowShape` -> `&&`).
+//   - histogram_native_subquery_select.go:`if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
+//     (INVERT_LOGICAL, `||` -> `&&`).
 //     lowerExpHistogramValuedShape's own contract (histogram_native_float_
 //     fn.go) guarantees `matched == false` if and only if its very last
 //     fallback ran, which always returns `input == nil` — and
@@ -92,7 +93,7 @@ func TestSelectFnOverExpHistogramSubquery_ZeroRangeRejected(t *testing.T) {
 	ctx := lowerCtx{start: at, end: at}
 	if _, ok := selectFnOverExpHistogramSubquery(call, s, ctx); ok {
 		t.Fatalf("expected zero-range subquery to be rejected; got ok=true " +
-			"(mutant `<=`->`<` at histogram_native_subquery_select.go:118:22)")
+			"(mutant `<=`->`<` at histogram_native_subquery_select.go:`sub.Range <= 0`)")
 	}
 }
 
@@ -118,8 +119,8 @@ func TestLowerSelectFnOverExpHistogramSubquery_ZeroStepDefaults(t *testing.T) {
 }
 
 // TestLowerSelectFnOverExpHistogramSubquery_InstantPinDoesNotBroadcast
-// kills the INVERT_LOGICAL mutant at histogram_native_subquery_select.go:
-// 200:21 (`ctx.rangeMode() && subqueryPinned(sub)` -> `||`). An
+// kills the INVERT_LOGICAL mutant (`&&` -> `||`) at
+// histogram_native_subquery_select.go:`if ctx.rangeMode() && subqueryPinned(sub)`. An
 // `@`-pinned histogram-preserving subquery (last_over_time) reached via a
 // plain instant LowerAt (ctx.rangeMode() == false) must take the ordinary
 // single-window branch. With OR, subqueryPinned(sub) alone satisfies the
@@ -159,7 +160,7 @@ func TestBareExpHistogramMatrixSelector_MetadataFullRangeShortCircuits(t *testin
 	expr := mustParse(t, `latency_exp_hist[5m]`)
 	if _, _, ok := bareExpHistogramMatrixSelector(expr, s, lowerCtx{metadataFullRange: true}); ok {
 		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true " +
-			"(mutant `||`->`&&` at histogram_native_bare.go:225:31)")
+			"(mutant `||`->`&&` at histogram_native_bare.go:bareExpHistogramMatrixSelector:`if s.ExpHistogramTable == \"\" || ctx.metadataFullRange`)")
 	}
 }
 

--- a/internal/promql/gremlins_kill_histogram_subquery_select_test.go
+++ b/internal/promql/gremlins_kill_histogram_subquery_select_test.go
@@ -8,7 +8,7 @@
 // Three mutants are NOT addressed with a dedicated test here — all three
 // are provably equivalent, not coverage gaps:
 //
-//   - histogram_native_subquery_select.go:102:31 (INVERT_LOGICAL,
+//   - histogram_native_subquery_select.go:`s.ExpHistogramTable == "" || ctx.metadataFullRange` (INVERT_LOGICAL,
 //     `s.ExpHistogramTable == "" || ctx.metadataFullRange` -> `&&` inside
 //     selectFnOverExpHistogramSubquery). This function re-validates the
 //     identical condition one level down at line 118's
@@ -23,7 +23,7 @@
 //     `histogramSubquerySelectShape{}, false` — never a partially built
 //     one — so the two branches converge on the exact same return value on
 //     every input.
-//   - histogram_native_subquery_select.go:170:10 (CONDITIONALS_BOUNDARY,
+//   - histogram_native_subquery_select.go:`step < 0` (CONDITIONALS_BOUNDARY,
 //     `step < 0` -> `<= 0`). Two lines above, `if step == 0 { step =
 //     defaultSubqueryStep }` (defaultSubqueryStep = time.Minute, a positive
 //     constant) already eliminates step == 0 as a reachable value by the
@@ -31,8 +31,8 @@
 //     sub.Step or the positive default. `<` and `<=` decide identically
 //     over every value except exactly 0, so no reachable input can make
 //     the two operators disagree (the same reasoning
-//     gremlins_kill_subquery_test.go's header gives for subquery.go:37:10).
-//   - histogram_native_subquery_select.go:185:14 (INVERT_LOGICAL, `!matched
+//     gremlins_kill_subquery_test.go's header gives for subquery.go:`step < 0`).
+//   - histogram_native_subquery_select.go:`!matched` (INVERT_LOGICAL, `!matched
 //     || chplan.RowShapeOf(input) != chplan.HistogramRowShape` -> `&&`).
 //     lowerExpHistogramValuedShape's own contract (histogram_native_float_
 //     fn.go) guarantees `matched == false` if and only if its very last
@@ -142,7 +142,7 @@ func TestLowerSelectFnOverExpHistogramSubquery_InstantPinDoesNotBroadcast(t *tes
 }
 
 // TestBareExpHistogramMatrixSelector_MetadataFullRangeShortCircuits kills
-// the INVERT_LOGICAL mutant at histogram_native_bare.go:225:31, where
+// the INVERT_LOGICAL mutant at histogram_native_bare.go:bareExpHistogramMatrixSelector:`if s.ExpHistogramTable == "" || ctx.metadataFullRange`, where
 //
 //	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
 //
@@ -164,7 +164,7 @@ func TestBareExpHistogramMatrixSelector_MetadataFullRangeShortCircuits(t *testin
 }
 
 // TestLowerExpHistogramBareMatrix_PinnedAtNotOverwrittenByQueryEnd kills
-// the INVERT_LOGICAL mutant at histogram_native_bare.go:265:25
+// the INVERT_LOGICAL mutant at histogram_native_bare.go:`anchor.End.IsZero() && !ctx.end.IsZero()`
 // (`anchor.End.IsZero() && !ctx.end.IsZero()` -> `||`).
 //
 // The original AND only back-fills anchor.End from ctx.end when the
@@ -202,13 +202,13 @@ func TestLowerExpHistogramBareMatrix_PinnedAtNotOverwrittenByQueryEnd(t *testing
 	}
 	if strings.Contains(got, "2030-05-05") {
 		t.Fatalf("emitted parameters leaked the query end (2030-05-05) instead of the pinned @ "+
-			"timestamp (mutant `&&`->`||` at histogram_native_bare.go:265:25 overwrites the pin "+
+			"timestamp (mutant `&&`->`||` at histogram_native_bare.go:`if anchor.End.IsZero() && !ctx.end.IsZero()` overwrites the pin "+
 			"with ctx.end):\n%s", got)
 	}
 }
 
 // TestLowerExpHistogramBareMatrix_PredicateAppliesFilter kills the
-// CONDITIONALS_NEGATION mutant at histogram_native_bare.go:277:10 (`pred
+// CONDITIONALS_NEGATION mutant at histogram_native_bare.go:lowerExpHistogramBareMatrix:`if pred != nil` (`pred
 // != nil` -> `== nil`) inside lowerExpHistogramBareMatrix:
 //
 //	if pred != nil {
@@ -239,7 +239,7 @@ func TestLowerExpHistogramBareMatrix_PredicateAppliesFilter(t *testing.T) {
 	}
 	if _, ok := hp.Input.(*chplan.Filter); !ok {
 		t.Fatalf("HistogramProjection.Input = %T, want *chplan.Filter (mutant `!=`->`==` at "+
-			"histogram_native_bare.go:277:10 would leave the scan unfiltered whenever a real "+
+			"histogram_native_bare.go:lowerExpHistogramBareMatrix:`if pred != nil` would leave the scan unfiltered whenever a real "+
 			"predicate exists)", hp.Input)
 	}
 }

--- a/internal/promql/gremlins_kill_mixed_or_subquery_aggregate_range_fn_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_aggregate_range_fn_test.go
@@ -7,9 +7,9 @@
 // Two mutants on this file are NOT addressed with a dedicated test here —
 // both are provably EQUIVALENT, not coverage gaps:
 //
-//   - :119:31, INVERT_LOGICAL (`||` -> `&&`) inside
-//     sumOrAvgMixedOrSubqueryOuterFnRecognized's
-//     `s.ExpHistogramTable == "" || ctx.metadataFullRange` guard. Under
+//   - INVERT_LOGICAL (`||` -> `&&`) on
+//     histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if s.ExpHistogramTable == "" || ctx.metadataFullRange`,
+//     sumOrAvgMixedOrSubqueryOuterFnRecognized's own guard. Under
 //     metadataFullRange=true this function's own later call chain —
 //     sumOrAvgOverMixedExpHistogramSetOp(sub.Expr, s, ctx), which calls
 //     mixedExpHistogramSetOp(agg.Expr, s, ctx) directly — independently
@@ -25,8 +25,9 @@
 //     and running `go test ./internal/promql/...` (this package) stays
 //     green.
 //
-//   - :181:10, CONDITIONALS_BOUNDARY (`<` -> `<=`) inside
-//     lowerSumOrAvgMixedOrSubqueryOuterFn:
+//   - CONDITIONALS_BOUNDARY (`<` -> `<=`) on
+//     histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if step < 0`,
+//     inside lowerSumOrAvgMixedOrSubqueryOuterFn:
 //
 //     step := sub.Step
 //     if step == 0 {
@@ -58,17 +59,20 @@ import (
 )
 
 // TestSumOrAvgMixedOrSubqueryOuterFnRecognized_PositiveMatch kills two
-// mutants on this file's line 119/122 at once:
-//   - :119:25, CONDITIONALS_NEGATION (`==` -> `!=`) on
-//     `s.ExpHistogramTable == ""`: with the negation, ANY non-empty
+// mutants on sumOrAvgMixedOrSubqueryOuterFnRecognized's first two guards
+// at once:
+//   - CONDITIONALS_NEGATION (`==` -> `!=`) on the `s.ExpHistogramTable == ""`
+//     operand of
+//     histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if s.ExpHistogramTable == "" || ctx.metadataFullRange`:
+//     with the negation, ANY non-empty
 //     ExpHistogramTable (the normal, default schema) makes the guard
 //     bail, so this test's ordinary DefaultOTelMetrics() schema alone
 //     differentiates.
-//   - :122:17, CONDITIONALS_NEGATION (`!=` -> `==`) on
-//     `len(c.Args) != 1`: the real call always carries exactly 1
+//   - CONDITIONALS_NEGATION (`!=` -> `==`) on
+//     histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if len(c.Args) != 1`: the real call always carries exactly 1
 //     argument (the subquery), so the negation would reject it.
 //
-// Unlike the :119:31 INVERT_LOGICAL guard this file's own header documents
+// Unlike the `||` INVERT_LOGICAL mutant this file's own header documents
 // as equivalent, neither of these two mutants is masked by the downstream
 // mixedExpHistogramSetOp call: they fire BEFORE that call ever runs, on a
 // perfectly ordinary, otherwise-recognisable positive-path query — so a
@@ -85,12 +89,15 @@ func TestSumOrAvgMixedOrSubqueryOuterFnRecognized_PositiveMatch(t *testing.T) {
 	}
 	if _, ok := sumOrAvgMixedOrSubqueryOuterFnRecognized(call, s, lowerCtx{}); !ok {
 		t.Fatalf("expected a well-formed 1-arg mixed-or subquery outer call to be recognised; "+
-			"got ok=false (mutants at %s:119:25 and :122:17)", "histogram_native_mixed_or_subquery_aggregate_range_fn.go")
+			"got ok=false (mutants at "+
+			"%s:`if s.ExpHistogramTable == \"\" || ctx.metadataFullRange` and %s:`if len(c.Args) != 1`)",
+			"histogram_native_mixed_or_subquery_aggregate_range_fn.go", "histogram_native_mixed_or_subquery_aggregate_range_fn.go")
 	}
 }
 
 // TestLowerSumOrAvgMixedOrSubqueryOuterFn_RangeModePinnedTakesBroadcastNotFanout
-// kills the INVERT_LOGICAL mutant at :203:22, where
+// kills the INVERT_LOGICAL mutant at
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if ctx.rangeMode() && !subqueryPinned(sub)`, where
 //
 //	if ctx.rangeMode() && !subqueryPinned(sub) {
 //	    return lowerSumOrAvgMixedOrSubqueryFoldFnRange(...)
@@ -131,15 +138,16 @@ func TestLowerSumOrAvgMixedOrSubqueryOuterFn_RangeModePinnedTakesBroadcastNotFan
 	if !found {
 		t.Fatalf("expected a CrossJoin (the pinned single-window broadcast path) for a " +
 			"range-mode query over an @-pinned mixed-or subquery; got none — mutant `&&`->`||` " +
-			"at :203:22 would route to the true fan-out lowering instead")
+			"at histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if ctx.rangeMode() && !subqueryPinned(sub)` " +
+			"would route to the true fan-out lowering instead")
 	}
 }
 
 // TestLowerSumOrAvgMixedOrSubqueryFoldFn_StepAlignedTracksCtxStep kills
-// both mutants at :283:76 (`ctx.step > 0`, CONDITIONALS_BOUNDARY `>`->`>=`
-// and CONDITIONALS_NEGATION `>`->`<=`) inside lowerSumOrAvgMixedOrSubqueryFoldFn:
-//
-//	return combineMixedAggregateBranches(histFolded, floatFolded, s, ctx.step > 0), nil
+// both mutants (CONDITIONALS_BOUNDARY `>`->`>=` and CONDITIONALS_NEGATION
+// `>`->`<=`) on the `ctx.step > 0` argument of
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:`return combineMixedAggregateBranches(histFolded, floatFolded, s, ctx.step > 0), nil`,
+// inside lowerSumOrAvgMixedOrSubqueryFoldFn:
 //
 // stepAligned threads straight into the returned *chplan.VectorSetOp's own
 // StepAligned field (combineMixedAggregateBranches / mixedOrShadowUnless,
@@ -147,7 +155,8 @@ func TestLowerSumOrAvgMixedOrSubqueryOuterFn_RangeModePinnedTakesBroadcastNotFan
 // so the root plan's StepAligned field is a direct, unmasked readout of
 // this expression. An instant query (ctx.step == 0) must publish
 // StepAligned=false; a range-mode `@`-pinned broadcast (ctx.step > 0, this
-// function's OTHER reachable caller state — see :203:22's own guard just
+// function's OTHER reachable caller state — see
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if ctx.rangeMode() && !subqueryPinned(sub)`'s own guard just
 // above) must publish StepAligned=true. Both CONDITIONALS_BOUNDARY
 // (`>=`, true at step==0) and CONDITIONALS_NEGATION (`<=`, also true at
 // step==0) disagree with the original ONLY at the instant-mode case, so a
@@ -169,7 +178,9 @@ func TestLowerSumOrAvgMixedOrSubqueryFoldFn_StepAlignedTracksCtxStep(t *testing.
 		t.Fatalf("instant plan = %T, want *chplan.VectorSetOp", instantPlan)
 	}
 	if vso.StepAligned {
-		t.Fatalf("instant-mode plan StepAligned = true, want false (mutants at :283:76)")
+		t.Fatalf("instant-mode plan StepAligned = true, want false (mutants on the `ctx.step > 0` argument of " +
+			"histogram_native_mixed_or_subquery_aggregate_range_fn.go:" +
+			"`return combineMixedAggregateBranches(histFolded, floatFolded, s, ctx.step > 0), nil`)")
 	}
 
 	end := at.Add(10 * time.Minute)
@@ -187,17 +198,17 @@ func TestLowerSumOrAvgMixedOrSubqueryFoldFn_StepAlignedTracksCtxStep(t *testing.
 }
 
 // TestLowerSumOrAvgMixedOrSubqueryFoldFnRange_StepAlignedFalseAtZeroStep
-// kills all six mutants across :351:105, :352:107 and :360:72 (each a
-// CONDITIONALS_BOUNDARY/CONDITIONALS_NEGATION pair on a `ctx.step > 0`
-// expression) inside lowerSumOrAvgMixedOrSubqueryFoldFnRange:
+// kills all six mutants (each a CONDITIONALS_BOUNDARY/CONDITIONALS_NEGATION
+// pair on a `ctx.step > 0` expression) across the three call sites inside
+// lowerSumOrAvgMixedOrSubqueryFoldFnRange:
 //
-//	histPure := mixedOrShadowUnless(histFoldedFanout, floatExists, true, chplan.VectorMatch{}, s, ctx.step > 0)   // :351
-//	floatPure := mixedOrShadowUnless(floatFoldedFanout, histExists, false, chplan.VectorMatch{}, s, ctx.step > 0) // :352
-//	return combineMixedAggregateBranches(histPure, floatPure, s, ctx.step > 0), nil                               // :360
+//	histogram_native_mixed_or_subquery_aggregate_range_fn.go:`histPure := mixedOrShadowUnless(histFoldedFanout, floatExists, true, chplan.VectorMatch{}, s, ctx.step > 0)`
+//	histogram_native_mixed_or_subquery_aggregate_range_fn.go:`floatPure := mixedOrShadowUnless(floatFoldedFanout, histExists, false, chplan.VectorMatch{}, s, ctx.step > 0)`
+//	histogram_native_mixed_or_subquery_aggregate_range_fn.go:`return combineMixedAggregateBranches(histPure, floatPure, s, ctx.step > 0), nil`
 //
 // This function is only reached, in production, via
-// lowerSumOrAvgMixedOrSubqueryOuterFn's own `ctx.rangeMode() &&
-// !subqueryPinned(sub)` dispatch (:203:22 above), which guarantees
+// lowerSumOrAvgMixedOrSubqueryOuterFn's own
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if ctx.rangeMode() && !subqueryPinned(sub)` dispatch above, which guarantees
 // ctx.step > 0 whenever this function runs — so BOTH mutant families
 // (`>=` and `<=`) agree with the original `>` on every value this
 // function's callER can ever supply, UNLESS this function is driven
@@ -215,9 +226,9 @@ func TestLowerSumOrAvgMixedOrSubqueryFoldFn_StepAlignedTracksCtxStep(t *testing.
 // resulting nodes' StepAligned field is a direct, unmasked readout of its
 // own call site's expression. The three nodes nest structurally:
 // combineMixedAggregateBranches returns
-// &VectorSetOp{Left: histPure, Right: floatPure, StepAligned: <:360>},
-// so :351/:352's own StepAligned values are read straight off that
-// node's two arms.
+// &VectorSetOp{Left: histPure, Right: floatPure, ...} carrying the combine
+// call's own stepAligned, so the histPure / floatPure call sites' own
+// StepAligned values are read straight off that node's two arms.
 func TestLowerSumOrAvgMixedOrSubqueryFoldFnRange_StepAlignedFalseAtZeroStep(t *testing.T) {
 	t.Parallel()
 
@@ -266,20 +277,25 @@ func TestLowerSumOrAvgMixedOrSubqueryFoldFnRange_StepAlignedFalseAtZeroStep(t *t
 		t.Fatalf("plan = %T, want *chplan.VectorSetOp", plan)
 	}
 	if top.StepAligned {
-		t.Fatalf("combine (mutants at :360:72) StepAligned = true, want false")
+		t.Fatalf("combine (mutants on histogram_native_mixed_or_subquery_aggregate_range_fn.go:" +
+			"`return combineMixedAggregateBranches(histPure, floatPure, s, ctx.step > 0), nil`) StepAligned = true, want false")
 	}
 	histPure, ok := top.Left.(*chplan.VectorSetOp)
 	if !ok {
 		t.Fatalf("top.Left = %T, want *chplan.VectorSetOp", top.Left)
 	}
 	if histPure.StepAligned {
-		t.Fatalf("histPure (mutants at :351:105) StepAligned = true, want false")
+		t.Fatalf("histPure (mutants on histogram_native_mixed_or_subquery_aggregate_range_fn.go:" +
+			"`histPure := mixedOrShadowUnless(histFoldedFanout, floatExists, true, chplan.VectorMatch{}, s, ctx.step > 0)`) " +
+			"StepAligned = true, want false")
 	}
 	floatPure, ok := top.Right.(*chplan.VectorSetOp)
 	if !ok {
 		t.Fatalf("top.Right = %T, want *chplan.VectorSetOp", top.Right)
 	}
 	if floatPure.StepAligned {
-		t.Fatalf("floatPure (mutants at :352:107) StepAligned = true, want false")
+		t.Fatalf("floatPure (mutants on histogram_native_mixed_or_subquery_aggregate_range_fn.go:" +
+			"`floatPure := mixedOrShadowUnless(floatFoldedFanout, histExists, false, chplan.VectorMatch{}, s, ctx.step > 0)`) " +
+			"StepAligned = true, want false")
 	}
 }

--- a/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
@@ -57,9 +57,10 @@ func mixedDiscriminatorProjected(n chplan.Node) bool {
 }
 
 // TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch
-// kills the CONDITIONALS_NEGATION mutant at :78:12 (`==` -> `!=`) inside
-// lowerHistogramOrMixedSubqueryOuterFnInput's last_over_time/first_over_time
-// case:
+// kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the
+// `if shape == chplan.HistogramRowShape` guard of
+// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`,
+// inside lowerHistogramOrMixedSubqueryOuterFnInput:
 //
 //	if shape == chplan.HistogramRowShape {
 //	    node, err = lowerSelectFnOverExpHistogramSubqueryInput(...)
@@ -85,7 +86,8 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 		t.Fatalf("histogram-shape: %v", err)
 	}
 	if mixedDiscriminatorProjected(histPlan) {
-		t.Fatalf("histogram-shape last_over_time took the Mixed path (mutant `==`->`!=` at :78:12)")
+		t.Fatalf("histogram-shape last_over_time took the Mixed path (mutant `==`->`!=` at " +
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`)")
 	}
 
 	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, lastOverTimeWindowFn, sub, s, ctx)
@@ -93,12 +95,14 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 		t.Fatalf("mixed-shape: %v", err)
 	}
 	if !mixedDiscriminatorProjected(mixedPlan) {
-		t.Fatalf("mixed-shape last_over_time took the Histogram path (mutant `==`->`!=` at :78:12)")
+		t.Fatalf("mixed-shape last_over_time took the Histogram path (mutant `==`->`!=` at " +
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`)")
 	}
 }
 
 // TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch
-// kills the CONDITIONALS_NEGATION mutant at :85:12 (`==` -> `!=`), the
+// kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on
+// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`, the
 // resets/changes sibling of the last_over_time/first_over_time dispatch
 // above. Both shapes ultimately produce the same four-column canonical
 // Project, so the two paths are told apart by whether the underlying
@@ -118,7 +122,8 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t 
 		t.Fatalf("histogram-shape: %v", err)
 	}
 	if mixedPairAggAlias(histPlan, mixedPairValueArrayAlias) {
-		t.Fatalf("histogram-shape resets took the Mixed path (mutant `==`->`!=` at :85:12)")
+		t.Fatalf("histogram-shape resets took the Mixed path (mutant `==`->`!=` at " +
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`)")
 	}
 
 	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, resetsWindowFn, sub, s, ctx)
@@ -126,12 +131,14 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t 
 		t.Fatalf("mixed-shape: %v", err)
 	}
 	if !mixedPairAggAlias(mixedPlan, mixedPairValueArrayAlias) {
-		t.Fatalf("mixed-shape resets took the Histogram path (mutant `==`->`!=` at :85:12)")
+		t.Fatalf("mixed-shape resets took the Histogram path (mutant `==`->`!=` at " +
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`)")
 	}
 }
 
 // TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch kills
-// the CONDITIONALS_NEGATION mutant at :92:12 (`==` -> `!=`), the
+// the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on
+// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`, the
 // FOLD-family (rate/increase/delta/...) sibling of the two dispatches
 // above. Over a MixedRowShape input this case routes to
 // [lowerFurtherWrapMixedOrSubqueryFoldFn], whose own
@@ -152,7 +159,8 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch(t *testing.
 		t.Fatalf("histogram-shape: %v", err)
 	}
 	if _, ok := histPlan.(*chplan.VectorSetOp); ok {
-		t.Fatalf("histogram-shape rate took the Mixed path (mutant `==`->`!=` at :92:12)")
+		t.Fatalf("histogram-shape rate took the Mixed path (mutant `==`->`!=` at " +
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`)")
 	}
 
 	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, rateWindowFn, sub, s, ctx)
@@ -160,16 +168,16 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch(t *testing.
 		t.Fatalf("mixed-shape: %v", err)
 	}
 	if _, ok := mixedPlan.(*chplan.VectorSetOp); !ok {
-		t.Fatalf("mixed-shape rate = %T, want *chplan.VectorSetOp (mutant `==`->`!=` at :92:12)", mixedPlan)
+		t.Fatalf("mixed-shape rate = %T, want *chplan.VectorSetOp (mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`)", mixedPlan)
 	}
 }
 
 // TestLowerFurtherWrapMixedOrSubqueryFoldFn_StepAligned kills both
-// mutants at :139:76 (`ctx.step > 0`, CONDITIONALS_BOUNDARY `>`->`>=` and
-// CONDITIONALS_NEGATION `>`->`<=`) inside
-// lowerFurtherWrapMixedOrSubqueryFoldFn:
-//
-//	return combineMixedAggregateBranches(histFolded, floatFolded, s, ctx.step > 0), nil
+// mutants on the `ctx.step > 0` argument (CONDITIONALS_BOUNDARY `>`->`>=`
+// and CONDITIONALS_NEGATION `>`->`<=`) of
+// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`return combineMixedAggregateBranches(histFolded, floatFolded, s, ctx.step > 0), nil`,
+// inside lowerFurtherWrapMixedOrSubqueryFoldFn:
 //
 // stepAligned threads directly into the returned *chplan.VectorSetOp's own
 // StepAligned field with no other logic in between — see this file's
@@ -196,7 +204,8 @@ func TestLowerFurtherWrapMixedOrSubqueryFoldFn_StepAligned(t *testing.T) {
 		t.Fatalf("plan = %T, want *chplan.VectorSetOp", plan)
 	}
 	if vso.StepAligned {
-		t.Fatalf("instant-mode (step==0) StepAligned = true, want false (mutants at :139:76)")
+		t.Fatalf("instant-mode (step==0) StepAligned = true, want false (mutants on the `ctx.step > 0` argument of " +
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`return combineMixedAggregateBranches(histFolded, floatFolded, s, ctx.step > 0), nil`)")
 	}
 
 	rangeCtx := lowerCtx{start: at, end: at.Add(10 * time.Minute), step: time.Minute}
@@ -214,8 +223,9 @@ func TestLowerFurtherWrapMixedOrSubqueryFoldFn_StepAligned(t *testing.T) {
 }
 
 // TestSplitMixedRelByDiscriminator_PublishesZeroThresholdColumn kills the
-// CONDITIONALS_NEGATION mutant at :177:36 (`!=` -> `==`) inside
-// splitMixedRelByDiscriminator:
+// CONDITIONALS_NEGATION mutant (`!=` -> `==`) at
+// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`if histSchema.ZeroThresholdColumn != ""`,
+// inside splitMixedRelByDiscriminator:
 //
 //	if histSchema.ZeroThresholdColumn != "" {
 //	    histProjs = append(histProjs, ...)
@@ -247,14 +257,16 @@ func TestSplitMixedRelByDiscriminator_PublishesZeroThresholdColumn(t *testing.T)
 		}
 	}
 	if !found {
-		t.Fatalf("expected a %q projection in histBranch; got %#v (mutant `!=`->`==` at :177:36)",
+		t.Fatalf("expected a %q projection in histBranch; got %#v (mutant `!=`->`==` at "+
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`if histSchema.ZeroThresholdColumn != \"\"`)",
 			histSchema.ZeroThresholdColumn, proj.Projections)
 	}
 }
 
 // TestLowerFloatFoldOverSubqueryInput_InstantPinnedNoCrossJoin kills the
-// INVERT_LOGICAL mutant at :224:21 (`&&` -> `||`) inside
-// lowerFloatFoldOverSubqueryInput:
+// INVERT_LOGICAL mutant (`&&` -> `||`) at
+// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`if ctx.rangeMode() && subqueryPinned(sub)`,
+// inside lowerFloatFoldOverSubqueryInput:
 //
 //	if ctx.rangeMode() && subqueryPinned(sub) {
 //	    return wrapRangeWindowAtBroadcast(...) // builds a CrossJoin over a StepGrid
@@ -284,6 +296,7 @@ func TestLowerFloatFoldOverSubqueryInput_InstantPinnedNoCrossJoin(t *testing.T) 
 		return true
 	})
 	if found {
-		t.Fatalf("instant-mode pinned subquery built a CrossJoin (mutant `&&`->`||` at :224:21)")
+		t.Fatalf("instant-mode pinned subquery built a CrossJoin (mutant `&&`->`||` at " +
+			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`if ctx.rangeMode() && subqueryPinned(sub)`)")
 	}
 }

--- a/internal/promql/gremlins_kill_mixed_or_subquery_last_first_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_last_first_test.go
@@ -15,8 +15,9 @@ import (
 )
 
 // TestLowerMixedOrSubqueryLastFirstInput_RangeModePinnedTakesBroadcast
-// kills the INVERT_LOGICAL mutant at :106:21 (`&&` -> `||`) inside
-// lowerMixedOrSubqueryLastFirstInput:
+// kills the INVERT_LOGICAL mutant (`&&` -> `||`) at
+// histogram_native_mixed_or_subquery_last_first.go:`if ctx.rangeMode() && !subqueryPinned(sub)`,
+// inside lowerMixedOrSubqueryLastFirstInput:
 //
 //	if ctx.rangeMode() && !subqueryPinned(sub) {
 //	    return lowerMixedOrSubqueryLastFirstRange(...)
@@ -53,13 +54,15 @@ func TestLowerMixedOrSubqueryLastFirstInput_RangeModePinnedTakesBroadcast(t *tes
 	})
 	if !found {
 		t.Fatalf("expected a CrossJoin (broadcast path) for a range-mode query over an " +
-			"@-pinned mixed-or subquery; mutant `&&`->`||` at :106:21 would route to the " +
+			"@-pinned mixed-or subquery; mutant `&&`->`||` at " +
+			"histogram_native_mixed_or_subquery_last_first.go:`if ctx.rangeMode() && !subqueryPinned(sub)` would route to the " +
 			"true fan-out lowering instead")
 	}
 }
 
 // TestMixedLastFirstAggs_PickDirection kills the CONDITIONALS_NEGATION
-// mutant at :175:14 (`==` -> `!=`) inside mixedLastFirstAggs:
+// mutant (`==` -> `!=`) at
+// histogram_native_mixed_or_subquery_last_first.go:`if windowFn == firstOverTimeWindowFn`, inside mixedLastFirstAggs:
 //
 //	pick := latestArgMax
 //	if windowFn == firstOverTimeWindowFn {
@@ -76,17 +79,20 @@ func TestMixedLastFirstAggs_PickDirection(t *testing.T) {
 
 	last := mixedLastFirstAggs(lastOverTimeWindowFn, histSchema)
 	if last[0].Fn != chplan.FnArgMax {
-		t.Fatalf("last_over_time first agg Fn = %v, want FnArgMax (mutant `==`->`!=` at :175:14)", last[0].Fn)
+		t.Fatalf("last_over_time first agg Fn = %v, want FnArgMax (mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_subquery_last_first.go:`if windowFn == firstOverTimeWindowFn`)", last[0].Fn)
 	}
 	first := mixedLastFirstAggs(firstOverTimeWindowFn, histSchema)
 	if first[0].Fn != chplan.FnArgMin {
-		t.Fatalf("first_over_time first agg Fn = %v, want FnArgMin (mutant `==`->`!=` at :175:14)", first[0].Fn)
+		t.Fatalf("first_over_time first agg Fn = %v, want FnArgMin (mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_subquery_last_first.go:`if windowFn == firstOverTimeWindowFn`)", first[0].Fn)
 	}
 }
 
 // TestMixedLastFirstProjection_PublishesZeroThresholdColumn kills the
-// CONDITIONALS_NEGATION mutant at :206:36 (`!=` -> `==`) inside
-// mixedLastFirstProjection — the last_first sibling of
+// CONDITIONALS_NEGATION mutant (`!=` -> `==`) at
+// histogram_native_mixed_or_subquery_last_first.go:`if histSchema.ZeroThresholdColumn != ""`,
+// inside mixedLastFirstProjection — the last_first sibling of
 // gremlins_kill_mixed_or_subquery_further_setop_test.go's identical
 // splitMixedRelByDiscriminator kill: histSchema always comes from
 // histogramProjectionSchema(s), which unconditionally sets
@@ -112,7 +118,8 @@ func TestMixedLastFirstProjection_PublishesZeroThresholdColumn(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("expected a %q projection; got %#v (mutant `!=`->`==` at :206:36)",
+		t.Fatalf("expected a %q projection; got %#v (mutant `!=`->`==` at "+
+			"histogram_native_mixed_or_subquery_last_first.go:`if histSchema.ZeroThresholdColumn != \"\"`)",
 			histSchema.ZeroThresholdColumn, proj.Projections)
 	}
 }

--- a/internal/promql/gremlins_kill_mixed_or_subquery_resets_changes_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_resets_changes_test.go
@@ -16,10 +16,9 @@ import (
 )
 
 // TestMixedPairCountStage_ProjectionsCapacityIsTight kills the
-// ARITHMETIC_BASE mutant at :158:55 (`+` -> `-`) inside
-// mixedPairCountStage's slice-capacity hint:
-//
-//	projs := make([]chplan.Projection, 0, len(keyAliases)+1)
+// ARITHMETIC_BASE mutant (`+` -> `-`) on mixedPairCountStage's
+// slice-capacity hint,
+// histogram_native_mixed_or_subquery_resets_changes.go:`projs := make([]chplan.Projection, 0, len(keyAliases)+1)`.
 //
 // The function appends exactly one projection per keyAliases entry plus
 // one more for the value column — len(keyAliases)+1 appends total — so
@@ -48,7 +47,8 @@ func TestMixedPairCountStage_ProjectionsCapacityIsTight(t *testing.T) {
 		t.Fatalf("len(Projections) = %d, want %d", got, want)
 	}
 	if got := cap(proj.Projections); got != want {
-		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at :158:55 would force a "+
+		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at "+
+			"histogram_native_mixed_or_subquery_resets_changes.go:`projs := make([]chplan.Projection, 0, len(keyAliases)+1)` would force a "+
 			"reallocation, leaving cap != %d)", got, want, want)
 	}
 }
@@ -84,8 +84,8 @@ func innerPairLambdaParams(t *testing.T, e chplan.Expr) []string {
 }
 
 // TestMixedPairVerdictExpr_WindowFnSelectsBranch kills the
-// CONDITIONALS_NEGATION mutant at :194:14 (`==` -> `!=`) inside
-// mixedPairVerdictExpr:
+// CONDITIONALS_NEGATION mutant (`==` -> `!=`) at
+// histogram_native_mixed_or_subquery_resets_changes.go:mixedPairVerdictExpr:`if windowFn == changesWindowFn`:
 //
 //	prevParam, currParam := paramResetPrevRow, paramResetCurrRow
 //	histVerdict := expHistogramResetVerdictExpr()
@@ -108,18 +108,21 @@ func TestMixedPairVerdictExpr_WindowFnSelectsBranch(t *testing.T) {
 	changesParams := innerPairLambdaParams(t, mixedPairVerdictExpr(changesWindowFn, histSchema))
 
 	if resetsParams[0] != paramResetPrevRow || resetsParams[1] != paramResetCurrRow {
-		t.Fatalf("resets params = %v, want [%q %q] (mutant `==`->`!=` at :194:14)",
+		t.Fatalf("resets params = %v, want [%q %q] (mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_subquery_resets_changes.go:mixedPairVerdictExpr:`if windowFn == changesWindowFn`)",
 			resetsParams, paramResetPrevRow, paramResetCurrRow)
 	}
 	if changesParams[0] != paramChangePrevRow || changesParams[1] != paramChangeCurrRow {
-		t.Fatalf("changes params = %v, want [%q %q] (mutant `==`->`!=` at :194:14)",
+		t.Fatalf("changes params = %v, want [%q %q] (mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_subquery_resets_changes.go:mixedPairVerdictExpr:`if windowFn == changesWindowFn`)",
 			changesParams, paramChangePrevRow, paramChangeCurrRow)
 	}
 }
 
 // TestMixedFloatPairVerdictExpr_WindowFnSelectsShape kills the
-// CONDITIONALS_NEGATION mutant at :252:14 (`==` -> `!=`) inside
-// mixedFloatPairVerdictExpr: resets renders a bare `curr < prev` (a
+// CONDITIONALS_NEGATION mutant (`==` -> `!=`) at
+// histogram_native_mixed_or_subquery_resets_changes.go:mixedFloatPairVerdictExpr:`if windowFn == changesWindowFn`:
+// resets renders a bare `curr < prev` (a
 // top-level OpLt Binary); changes renders the NaN-aware `curr != prev &&
 // !bothNaN` (a top-level OpAnd Binary) — the negation swaps both.
 func TestMixedFloatPairVerdictExpr_WindowFnSelectsShape(t *testing.T) {
@@ -130,17 +133,20 @@ func TestMixedFloatPairVerdictExpr_WindowFnSelectsShape(t *testing.T) {
 
 	resetsExpr := mixedFloatPairVerdictExpr(resetsWindowFn, prev, curr)
 	if bin, ok := resetsExpr.(*chplan.Binary); !ok || bin.Op != chplan.OpLt {
-		t.Fatalf("resets shape = %#v, want top-level OpLt Binary (mutant `==`->`!=` at :252:14)", resetsExpr)
+		t.Fatalf("resets shape = %#v, want top-level OpLt Binary (mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_subquery_resets_changes.go:mixedFloatPairVerdictExpr:`if windowFn == changesWindowFn`)", resetsExpr)
 	}
 
 	changesExpr := mixedFloatPairVerdictExpr(changesWindowFn, prev, curr)
 	if bin, ok := changesExpr.(*chplan.Binary); !ok || bin.Op != chplan.OpAnd {
-		t.Fatalf("changes shape = %#v, want top-level OpAnd Binary (mutant `==`->`!=` at :252:14)", changesExpr)
+		t.Fatalf("changes shape = %#v, want top-level OpAnd Binary (mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_subquery_resets_changes.go:mixedFloatPairVerdictExpr:`if windowFn == changesWindowFn`)", changesExpr)
 	}
 }
 
 // TestLowerMixedOrSubqueryResetsOrChangesInput_RangeModePinnedTakesBroadcast
-// kills the INVERT_LOGICAL mutant at :301:21 (`&&` -> `||`) — the
+// kills the INVERT_LOGICAL mutant (`&&` -> `||`) at
+// histogram_native_mixed_or_subquery_resets_changes.go:`if ctx.rangeMode() && !subqueryPinned(sub)` — the
 // resets/changes sibling of
 // gremlins_kill_mixed_or_subquery_last_first_test.go's identical
 // last_first dispatch kill.
@@ -168,14 +174,16 @@ func TestLowerMixedOrSubqueryResetsOrChangesInput_RangeModePinnedTakesBroadcast(
 	})
 	if !found {
 		t.Fatalf("expected a CrossJoin (broadcast path) for a range-mode query over an " +
-			"@-pinned mixed-or subquery; mutant `&&`->`||` at :301:21 would route to the " +
+			"@-pinned mixed-or subquery; mutant `&&`->`||` at " +
+			"histogram_native_mixed_or_subquery_resets_changes.go:`if ctx.rangeMode() && !subqueryPinned(sub)` would route to the " +
 			"true fan-out lowering instead")
 	}
 }
 
 // TestLowerMixedOrSubqueryResetsOrChangesInput_InstantPinnedNoCrossJoin
-// kills the INVERT_LOGICAL mutant at :314:21 (`&&` -> `||`) inside
-// lowerMixedOrSubqueryResetsOrChangesInput:
+// kills the INVERT_LOGICAL mutant (`&&` -> `||`) at
+// histogram_native_mixed_or_subquery_resets_changes.go:`if ctx.rangeMode() && subqueryPinned(sub)`,
+// inside lowerMixedOrSubqueryResetsOrChangesInput:
 //
 //	if ctx.rangeMode() && subqueryPinned(sub) {
 //	    grid := &chplan.StepGrid{...}
@@ -208,6 +216,7 @@ func TestLowerMixedOrSubqueryResetsOrChangesInput_InstantPinnedNoCrossJoin(t *te
 		return true
 	})
 	if found {
-		t.Fatalf("instant-mode pinned subquery built a CrossJoin (mutant `&&`->`||` at :314:21)")
+		t.Fatalf("instant-mode pinned subquery built a CrossJoin (mutant `&&`->`||` at " +
+			"histogram_native_mixed_or_subquery_resets_changes.go:`if ctx.rangeMode() && subqueryPinned(sub)`)")
 	}
 }

--- a/internal/promql/gremlins_kill_subquery_call_subquery_test.go
+++ b/internal/promql/gremlins_kill_subquery_call_subquery_test.go
@@ -73,10 +73,10 @@ func gremlinsFanoutAggAliases(rbf *chplan.RangeBucketFanout) map[string]bool {
 	return aliases
 }
 
-// TestGremlinsKill_CallSubqueryLastFirst_HistVsMixedRouting kills
-// histogram_native_subquery_call_subquery.go:125:12 (CONDITIONALS_NEGATION
-// on `if shape == chplan.HistogramRowShape` in the last_over_time /
-// first_over_time case). A HistogramRowShape inner must route through
+// TestGremlinsKill_CallSubqueryLastFirst_HistVsMixedRouting kills the
+// CONDITIONALS_NEGATION mutant on the `if shape == chplan.HistogramRowShape`
+// guard of histogram_native_subquery_call_subquery.go:lowerHistogramOrMixedCallSubqueryInput:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`.
+// A HistogramRowShape inner must route through
 // [lowerSelectFnOverCallSubqueryInput] ([nativeHistogramProjection], a
 // *chplan.HistogramProjection — chplan.HistogramRowShape); a MixedRowShape
 // inner must route through [lowerMixedLastFirstOverCallSubqueryInput]
@@ -100,10 +100,10 @@ func TestGremlinsKill_CallSubqueryLastFirst_HistVsMixedRouting(t *testing.T) {
 	}
 }
 
-// TestGremlinsKill_CallSubqueryFold_HistVsMixedRouting kills
-// histogram_native_subquery_call_subquery.go:139:12 (CONDITIONALS_NEGATION
-// on the identical guard in the FOLD-family case). A HistogramRowShape
-// inner routes through [lowerExpHistogramFoldOverCallSubqueryInput]
+// TestGremlinsKill_CallSubqueryFold_HistVsMixedRouting kills the
+// CONDITIONALS_NEGATION mutant on the identical guard in the FOLD-family arm,
+// histogram_native_subquery_call_subquery.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`.
+// A HistogramRowShape inner routes through [lowerExpHistogramFoldOverCallSubqueryInput]
 // ([aggregatedHistogramProjection], chplan.HistogramRowShape); a
 // MixedRowShape inner routes through [lowerMixedFoldOverCallSubqueryInput]
 // ([combineMixedAggregateBranches], which republishes the
@@ -124,9 +124,10 @@ func TestGremlinsKill_CallSubqueryFold_HistVsMixedRouting(t *testing.T) {
 	}
 }
 
-// TestGremlinsKill_CallSubqueryResetsChanges_HistVsMixedRouting kills
-// histogram_native_subquery_call_subquery.go:132:12 (CONDITIONALS_NEGATION
-// on the identical guard in the resets/changes case). Both branches wrap
+// TestGremlinsKill_CallSubqueryResetsChanges_HistVsMixedRouting kills the
+// CONDITIONALS_NEGATION mutant on the identical guard in the resets/changes
+// arm, histogram_native_subquery_call_subquery.go:lowerHistogramOrMixedCallSubqueryInput:`case resetsWindowFn, changesWindowFn:`.
+// Both branches wrap
 // their result in the SAME [expHistogramPairCountProjection] outer node,
 // so chplan.RowShapeOf cannot distinguish them — the two branches differ
 // only in the underlying RangeBucketFanout's own AggFuncs:
@@ -156,10 +157,11 @@ func TestGremlinsKill_CallSubqueryResetsChanges_HistVsMixedRouting(t *testing.T)
 	}
 }
 
-// TestGremlinsKill_CallSubqueryFold_AnchorErrorPropagates kills
-// histogram_native_subquery_call_subquery.go:236:9 (CONDITIONALS_NEGATION
-// on `if err != nil` inside [lowerExpHistogramFoldOverCallSubqueryInput]'s
-// own subqueryAnchor(grid.outerSub, ctx) call — the FOLD-family sibling of
+// TestGremlinsKill_CallSubqueryFold_AnchorErrorPropagates kills the
+// CONDITIONALS_NEGATION mutant at
+// histogram_native_subquery_call_subquery.go:lowerExpHistogramFoldOverCallSubqueryInput:`if err != nil`,
+// which guards that function's own subqueryAnchor(grid.outerSub, ctx) call
+// — the FOLD-family sibling of
 // the identical guard in [lowerSelectFnOverCallSubqueryInput] /
 // [lowerMixedLastFirstOverCallSubqueryInput] /
 // [lowerMixedResetsOrChangesOverCallSubqueryInput]. An outer subquery

--- a/internal/promql/gremlins_kill_subquery_test.go
+++ b/internal/promql/gremlins_kill_subquery_test.go
@@ -3,13 +3,14 @@
 // an input that observably differentiates the original code from the
 // mutated branch, so the test fails when the mutant is applied and the
 // mutant is reported KILLED. See gremlins_kill_test.go's own header for
-// the file:line:col convention.
+// the mutant-citation convention.
 //
 // Two CONDITIONALS_BOUNDARY mutants reported for this file are NOT
 // addressed here (subquery.go:`if step < 0` and subquery.go:`if ns%stepNS != 0 && ns < 0`): both are
-// mathematically equivalent mutants, not coverage gaps. At subquery.go:`if step < 0`
-// (`if step < 0`), `step` is reassigned to the positive
-// `defaultSubqueryStep` constant whenever it was zero (lines 33-36), so
+// mathematically equivalent mutants, not coverage gaps. At
+// subquery.go:`if step < 0`, `step` is reassigned to the positive
+// `defaultSubqueryStep` constant whenever it was zero (the
+// `if step == 0` arm just above it), so
 // `step` can never be exactly 0 by the time the boundary check runs —
 // `<` and `<=` decide identically over every reachable value. At
 // subquery.go:`if ns%stepNS != 0 && ns < 0`, the `<`/`<=`
@@ -33,10 +34,10 @@ import (
 )
 
 // TestLowerOuterRangeFnOverSubquery_PinnedRangeModeWidensByOffsetPlusRange
-// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair at subquery.go:1034:44
-// — the `-rw.Offset` term inside the `@`-pinned + range-mode arm's
+// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair on the `-rw.Offset`
+// term of the `@`-pinned + range-mode arm's
 // `widenSubquerySpine(inner, anchor.End.Add(-rw.Offset-sub.Range), anchor.End)`
-// call. Both mutants flip the Offset term's sign (one by swapping the
+// call, subquery.go:`case rangeMode && pinned:`. Both mutants flip the Offset term's sign (one by swapping the
 // arithmetic operator, one by inverting the unary negation — the
 // observable effect is identical: the inner spine gets widened starting
 // `+rw.Offset` early instead of `-rw.Offset` late).
@@ -44,7 +45,7 @@ import (
 // TestLowerOuterRangeFnOverSubquery_WidensInnerByOffsetPlusRange
 // (subquery_time_offset_test.go) already pins the neighbouring
 // "range mode, not pinned" arm; this test is its `@`-pinned sibling,
-// the one branch that actually reaches line 1034.
+// the one branch that actually reaches that call.
 func TestLowerOuterRangeFnOverSubquery_PinnedRangeModeWidensByOffsetPlusRange(t *testing.T) {
 	t.Parallel()
 
@@ -84,15 +85,16 @@ func TestLowerOuterRangeFnOverSubquery_PinnedRangeModeWidensByOffsetPlusRange(t 
 	wantStart := pinnedTS.Add(-offset).Add(-subRange)
 	if !inner.Start.Equal(wantStart) {
 		t.Errorf("inner.Start = %s, want %s (pinnedTS - offset - subRange) — "+
-			"mutants at subquery.go:1034:44 would yield %s (pinnedTS + offset - subRange)",
+			"mutants on subquery.go:`case rangeMode && pinned:`'s widenSubquerySpine call "+
+			"would yield %s (pinnedTS + offset - subRange)",
 			inner.Start, wantStart, pinnedTS.Add(offset).Add(-subRange))
 	}
 }
 
 // TestLowerAbsentOverTimeOverSubquery_RangeModeWidensByOffsetPlusRange
-// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair at subquery.go:1980:45
-// — the `-a.Offset` term in the range-mode (not pinned) arm of
-// lowerAbsentOverTimeOverSubquery's widenSubquerySpine call.
+// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair on the `-a.Offset`
+// term of lowerAbsentOverTimeOverSubquery's range-mode (not pinned) arm,
+// subquery.go:`widenSubquerySpine(a.Input, ctx.start.Add(-a.Offset-sub.Range), ctx.end)`.
 func TestLowerAbsentOverTimeOverSubquery_RangeModeWidensByOffsetPlusRange(t *testing.T) {
 	t.Parallel()
 
@@ -123,15 +125,15 @@ func TestLowerAbsentOverTimeOverSubquery_RangeModeWidensByOffsetPlusRange(t *tes
 	wantStart := start.Add(-offset).Add(-subRange)
 	if !inner.Start.Equal(wantStart) {
 		t.Errorf("inner.Start = %s, want %s (ctx.start - offset - subRange) — "+
-			"mutants at subquery.go:1980:45 would yield %s (ctx.start + offset - subRange)",
+			"mutants on subquery.go:`widenSubquerySpine(a.Input, ctx.start.Add(-a.Offset-sub.Range), ctx.end)` would yield %s (ctx.start + offset - subRange)",
 			inner.Start, wantStart, start.Add(offset).Add(-subRange))
 	}
 }
 
 // TestLowerAbsentOverTimeOverSubquery_InstantModeWidensByOffsetPlusRange
-// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair at subquery.go:1986:42
-// — the `-a.Offset` term in the default (instant-mode) arm's
-// widenSubquerySpine call.
+// kills the ARITHMETIC_BASE + INVERT_NEGATIVES pair on the `-a.Offset`
+// term of the default (instant-mode) arm's widenSubquerySpine call,
+// subquery.go:`widenSubquerySpine(a.Input, a.End.Add(-a.Offset-sub.Range), a.End)`.
 func TestLowerAbsentOverTimeOverSubquery_InstantModeWidensByOffsetPlusRange(t *testing.T) {
 	t.Parallel()
 
@@ -161,14 +163,15 @@ func TestLowerAbsentOverTimeOverSubquery_InstantModeWidensByOffsetPlusRange(t *t
 	wantStart := evalTS.Add(-offset).Add(-subRange)
 	if !inner.Start.Equal(wantStart) {
 		t.Errorf("inner.Start = %s, want %s (a.End - offset - subRange) — "+
-			"mutants at subquery.go:1986:42 would yield %s (a.End + offset - subRange)",
+			"mutants on subquery.go:`widenSubquerySpine(a.Input, a.End.Add(-a.Offset-sub.Range), a.End)` would yield %s (a.End + offset - subRange)",
 			inner.Start, wantStart, evalTS.Add(offset).Add(-subRange))
 	}
 }
 
 // TestLowerAbsentOverTimeOverSubquery_InstantModeKeepsExistingPin kills the
-// INVERT_LOGICAL mutant at subquery.go:1982:21 — the `&&` in
-// `if a.End.IsZero() && !ctx.end.IsZero()`. That guard only fills a.End
+// INVERT_LOGICAL mutant on the `&&` of
+// subquery.go:lowerAbsentOverTimeOverSubquery:`if a.End.IsZero() && !ctx.end.IsZero()`.
+// That guard only fills a.End
 // from ctx.end when a.End was NOT already set (i.e. the subquery has no
 // `@` pin of its own). Flipping `&&` to `||` makes the guard fire whenever
 // ctx.end is merely non-zero, unconditionally overwriting an existing `@`
@@ -198,7 +201,8 @@ func TestLowerAbsentOverTimeOverSubquery_InstantModeKeepsExistingPin(t *testing.
 		t.Fatalf("no chplan.AbsentOverTime under the lowered %q", query)
 	}
 	if !a.End.Equal(pinnedTS) {
-		t.Errorf("AbsentOverTime.End = %s, want %s (the `@` pin) — mutant `&&`->`||` at subquery.go:1982:21 "+
+		t.Errorf("AbsentOverTime.End = %s, want %s (the `@` pin) — mutant `&&`->`||` at "+
+			"subquery.go:lowerAbsentOverTimeOverSubquery:`if a.End.IsZero() && !ctx.end.IsZero()` "+
 			"would overwrite the pin with the eval timestamp %s", a.End, pinnedTS, evalTS)
 	}
 }
@@ -235,7 +239,8 @@ func TestLowerSubqueryOverCall_UnsafeInstantTransformSkipsIdentityWrap(t *testin
 	if _, isRW := plan.(*chplan.RangeWindow); isRW {
 		t.Fatalf("plan = *chplan.RangeWindow (the Identity wrap); want the per-anchor *chplan.Project " +
 			"fallback (subqueryInstantSafe must be false for abs(rate(...)), so the && must skip the " +
-			"Identity branch — mutant `&&`->`||` at subquery.go:487:34 would take it anyway)")
+			"Identity branch — mutant `&&`->`||` at " +
+			"subquery.go:`if isInstantTransformCall(call) && subqueryInstantSafe(call)` would take it anyway)")
 	}
 	if _, isProj := plan.(*chplan.Project); !isProj {
 		t.Fatalf("plan = %T, want *chplan.Project (subqueryAnchorShape's per-anchor fallback)", plan)
@@ -243,8 +248,8 @@ func TestLowerSubqueryOverCall_UnsafeInstantTransformSkipsIdentityWrap(t *testin
 }
 
 // TestNodeCarriesMetricName_VectorSetOp_OrChecksBothSidesAndUnlessDoesNot
-// kills the CONDITIONALS_NEGATION mutant at subquery.go:1373:11 — the
-// `==` in `if v.Op == chplan.VectorSetOr && !nodeCarriesMetricName(v.Right, s)`.
+// kills the CONDITIONALS_NEGATION mutant on the `==` of
+// subquery.go:`if v.Op == chplan.VectorSetOr && !nodeCarriesMetricName(v.Right, s)`.
 // `or` must check BOTH arms (it unions rows from both); `and`/`unless`
 // must check ONLY the left arm (they only ever emit LHS rows). Flipping
 // `==` to `!=` swaps which operator gets the Right-arm check.
@@ -258,19 +263,23 @@ func TestNodeCarriesMetricName_VectorSetOp_OrChecksBothSidesAndUnlessDoesNot(t *
 	orOp := &chplan.VectorSetOp{Op: chplan.VectorSetOr, Left: named, Right: unnamed}
 	if nodeCarriesMetricName(orOp, s) {
 		t.Fatalf("or: Left carries a name but Right does not; `or` must check BOTH sides and answer " +
-			"false (mutant `==`->`!=` at subquery.go:1373:11 would only check Left here)")
+			"false (mutant `==`->`!=` at " +
+			"subquery.go:`if v.Op == chplan.VectorSetOr && !nodeCarriesMetricName(v.Right, s)` " +
+			"would only check Left here)")
 	}
 
 	andOp := &chplan.VectorSetOp{Op: chplan.VectorSetAnd, Left: named, Right: unnamed}
 	if !nodeCarriesMetricName(andOp, s) {
 		t.Fatalf("and: Left carries a name; `and`/`unless` must ignore Right and answer true " +
-			"(mutant `==`->`!=` at subquery.go:1373:11 would incorrectly also check Right here)")
+			"(mutant `==`->`!=` at " +
+			"subquery.go:`if v.Op == chplan.VectorSetOr && !nodeCarriesMetricName(v.Right, s)` " +
+			"would incorrectly also check Right here)")
 	}
 }
 
 // TestSubqueryInstantSafe_PiExceptionNotRejected kills the
-// CONDITIONALS_NEGATION mutant at subquery.go:1744:49 — the `!=` in
-// `if !isInstantTransformCall(v) && v.Func.Name != "pi"`. pi() is the
+// CONDITIONALS_NEGATION mutant on the `!=` of
+// subquery.go:`if !isInstantTransformCall(v) && v.Func.Name != "pi"`. pi() is the
 // documented parse-time-constant exception: a zero-arg call that is not
 // itself an instant-transform call, but must still be treated as safe.
 // Flipping `!=` to `==` rejects any call subtree containing pi().
@@ -283,7 +292,8 @@ func TestSubqueryInstantSafe_PiExceptionNotRejected(t *testing.T) {
 	}
 	if !subqueryInstantSafe(call) {
 		t.Fatalf("subqueryInstantSafe(clamp_min(demo_cpu, pi())) = false, want true — pi() is the " +
-			"documented exception (mutant `!=`->`==` at subquery.go:1744:49 would reject any call " +
+			"documented exception (mutant `!=`->`==` at " +
+			"subquery.go:`if !isInstantTransformCall(v) && v.Func.Name != \"pi\"` would reject any call " +
 			"tree containing pi())")
 	}
 }
@@ -318,8 +328,8 @@ func TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor(t *testing.T
 }
 
 // TestSubqueryOffsetCtx_NonZeroOffsetShiftsBothBounds kills the
-// CONDITIONALS_NEGATION mutant at subquery.go:804:24 — the `==` in
-// `if sub.OriginalOffset == 0 { return ctx }`. With a non-zero offset and
+// CONDITIONALS_NEGATION mutant on the `==` of
+// subquery.go:`if sub.OriginalOffset == 0`. With a non-zero offset and
 // non-zero start/end bounds, the function must shift both bounds by
 // -offset. Flipping `==` to `!=` returns ctx UNSHIFTED whenever the
 // offset is non-zero — the one case where a shift is actually required.
@@ -338,14 +348,14 @@ func TestSubqueryOffsetCtx_NonZeroOffsetShiftsBothBounds(t *testing.T) {
 			got.start, wantStart, start)
 	}
 	if !got.end.Equal(wantEnd) {
-		t.Errorf("end = %s, want %s (mutant `==`->`!=` at subquery.go:804:24 would leave it at %s)",
+		t.Errorf("end = %s, want %s (mutant `==`->`!=` at subquery.go:`if sub.OriginalOffset == 0` would leave it at %s)",
 			got.end, wantEnd, end)
 	}
 }
 
 // TestProjectCarriesMetricName_ContinuesPastNonMatchingProjections kills
-// the INVERT_LOOPCTRL mutant at subquery.go:1408:4 — the `continue` inside
-// projectCarriesMetricName's loop over p.Projections. The MetricName
+// the INVERT_LOOPCTRL mutant at subquery.go:projectCarriesMetricName:`continue`
+// — the `continue` inside its loop over p.Projections. The MetricName
 // projection is deliberately placed SECOND so the loop must skip past a
 // non-matching first entry to find it. Flipping `continue` to `break`
 // stops at the first non-matching projection and falls through to
@@ -362,16 +372,16 @@ func TestProjectCarriesMetricName_ContinuesPastNonMatchingProjections(t *testing
 	}
 	if !projectCarriesMetricName(p, s) {
 		t.Fatalf("projectCarriesMetricName = false, want true — the MetricName projection is the " +
-			"SECOND entry and carries a real name; mutant `continue`->`break` at subquery.go:1408:4 " +
+			"SECOND entry and carries a real name; mutant `continue`->`break` at " +
+			"subquery.go:projectCarriesMetricName:`continue` " +
 			"would stop at the first (non-matching) entry and answer false")
 	}
 }
 
 // TestLowerSubqueryOverCountValues_MapArgsCapacityIsTight kills the
-// ARITHMETIC_BASE mutant at subquery.go:2546:58 inside
-// lowerSubqueryOverCountValues's `by(...)` capacity hint:
-//
-//	mapArgs := make([]chplan.Expr, 0, (len(agg.Grouping)+1)*2)
+// ARITHMETIC_BASE mutant on lowerSubqueryOverCountValues's `by(...)`
+// capacity hint,
+// subquery.go:`mapArgs := make([]chplan.Expr, 0, (len(agg.Grouping)+1)*2)`.
 //
 // With 2 grouping labels, the original pre-allocates exactly enough room
 // for all 6 appends (2 labels * 2 + the synthetic value-as-label pair),
@@ -412,16 +422,16 @@ func TestLowerSubqueryOverCountValues_MapArgsCapacityIsTight(t *testing.T) {
 		t.Fatalf("len(Args) = %d, want %d", got, wantArgs)
 	}
 	if got := cap(fc.Args); got != wantArgs {
-		t.Fatalf("cap(Args) = %d, want %d (mutant `*`->`/` at subquery.go:2546:58 would yield a "+
+		t.Fatalf("cap(Args) = %d, want %d (mutant `*`->`/` at "+
+			"subquery.go:`mapArgs := make([]chplan.Expr, 0, (len(agg.Grouping)+1)*2)` would yield a "+
 			"different cap via append's reallocation growth path)", got, wantArgs)
 	}
 }
 
 // TestBuildAttributesFromAggregate_ArgsCapacityIsTight kills the
-// ARITHMETIC_BASE mutant at subquery.go:2725:50 inside
-// buildAttributesFromAggregate's `by(...)` capacity hint:
-//
-//	args := make([]chplan.Expr, 0, len(agg.Grouping)*2)
+// ARITHMETIC_BASE mutant on buildAttributesFromAggregate's `by(...)`
+// capacity hint,
+// subquery.go:`args := make([]chplan.Expr, 0, len(agg.Grouping)*2)`.
 //
 // With 3 grouping labels, the original pre-allocates exactly enough room
 // for all 6 appends, so cap stays at 6. The `*` -> `/` mutant starts at
@@ -457,14 +467,16 @@ func TestBuildAttributesFromAggregate_ArgsCapacityIsTight(t *testing.T) {
 		t.Fatalf("len(Args) = %d, want %d", got, wantArgs)
 	}
 	if got := cap(fc.Args); got != wantArgs {
-		t.Fatalf("cap(Args) = %d, want %d (mutant `*`->`/` at subquery.go:2725:50 would yield a "+
+		t.Fatalf("cap(Args) = %d, want %d (mutant `*`->`/` at "+
+			"subquery.go:`args := make([]chplan.Expr, 0, len(agg.Grouping)*2)` would yield a "+
 			"different cap via append's reallocation growth path)", got, wantArgs)
 	}
 }
 
 // TestLowerSubqueryOverCallSubquery_WidensToSumOfBothRanges kills the
-// ARITHMETIC_BASE mutant at subquery.go:2871:28 — the `+` in
-// `widened.Range = sub.Range + innerSub.Range`. The nested-subquery shape
+// ARITHMETIC_BASE mutant on the `+` of
+// subquery.go:lowerSubqueryOverCallSubquery:`widened.Range = sub.Range + innerSub.Range`.
+// The nested-subquery shape
 // `max_over_time(rate(m[1m])[5m:30s])[1h:5m]` must widen the inner
 // subquery's own matrix to cover the OUTER range PLUS the inner range,
 // which surfaces as the widened RangeWindow's OuterRange field. Flipping
@@ -494,6 +506,7 @@ func TestLowerSubqueryOverCallSubquery_WidensToSumOfBothRanges(t *testing.T) {
 	const want = time.Hour + 5*time.Minute
 	if wideInner.OuterRange != want {
 		t.Fatalf("wideInner.OuterRange = %s, want %s (sub.Range + innerSub.Range) — mutant `+`->`-` "+
-			"at subquery.go:lowerSubqueryOverSubquery:`StepAlign: true, // epoch-align inner subquery sample grid (PromQL)` would yield %s", wideInner.OuterRange, want, time.Hour-5*time.Minute)
+			"at subquery.go:lowerSubqueryOverCallSubquery:`widened.Range = sub.Range + innerSub.Range` "+
+			"would yield %s", wideInner.OuterRange, want, time.Hour-5*time.Minute)
 	}
 }

--- a/internal/promql/gremlins_kill_subquery_test.go
+++ b/internal/promql/gremlins_kill_subquery_test.go
@@ -6,13 +6,13 @@
 // the file:line:col convention.
 //
 // Two CONDITIONALS_BOUNDARY mutants reported for this file are NOT
-// addressed here (subquery.go:37:10 and subquery.go:408:26): both are
-// mathematically equivalent mutants, not coverage gaps. At subquery.go:37
+// addressed here (subquery.go:`if step < 0` and subquery.go:`if ns%stepNS != 0 && ns < 0`): both are
+// mathematically equivalent mutants, not coverage gaps. At subquery.go:`if step < 0`
 // (`if step < 0`), `step` is reassigned to the positive
 // `defaultSubqueryStep` constant whenever it was zero (lines 33-36), so
 // `step` can never be exactly 0 by the time the boundary check runs —
 // `<` and `<=` decide identically over every reachable value. At
-// subquery.go:408:26 (`if ns%stepNS != 0 && ns < 0`), the `<`/`<=`
+// subquery.go:`if ns%stepNS != 0 && ns < 0`, the `<`/`<=`
 // boundary sits at ns==0, but ns==0 forces `ns%stepNS == 0` for any
 // nonzero stepNS, which makes the left `&&` operand false and
 // short-circuits the whole expression regardless of the right operand's
@@ -204,7 +204,7 @@ func TestLowerAbsentOverTimeOverSubquery_InstantModeKeepsExistingPin(t *testing.
 }
 
 // TestLowerSubqueryOverCall_UnsafeInstantTransformSkipsIdentityWrap kills
-// the INVERT_LOGICAL mutant at subquery.go:487:34 — the `&&` in
+// the INVERT_LOGICAL mutant at subquery.go:`if isInstantTransformCall(call) && subqueryInstantSafe(call)` — the `&&` in
 // `if isInstantTransformCall(call) && subqueryInstantSafe(call)`. abs() is
 // an instant-transform call, but its argument here is rate(...), which is
 // NOT sample-preserving, so subqueryInstantSafe must be false and the
@@ -289,7 +289,7 @@ func TestSubqueryInstantSafe_PiExceptionNotRejected(t *testing.T) {
 }
 
 // TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor kills the
-// CONDITIONALS_NEGATION mutant at subquery.go:793:83 — the second `==` in
+// CONDITIONALS_NEGATION mutant at subquery.go:lowerSubqueryOverBinary:`if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape` — the second `==` in
 // `if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape`.
 // A plain (non-histogram, non-mixed) `or` composition must lower
 // successfully even with no query eval-time context threaded through
@@ -334,7 +334,7 @@ func TestSubqueryOffsetCtx_NonZeroOffsetShiftsBothBounds(t *testing.T) {
 	wantStart := start.Add(-10 * time.Minute)
 	wantEnd := end.Add(-10 * time.Minute)
 	if !got.start.Equal(wantStart) {
-		t.Errorf("start = %s, want %s (mutant `==`->`!=` at subquery.go:804:24 would leave it at %s)",
+		t.Errorf("start = %s, want %s (mutant `==`->`!=` at subquery.go:`if sub.OriginalOffset == 0` would leave it at %s)",
 			got.start, wantStart, start)
 	}
 	if !got.end.Equal(wantEnd) {
@@ -494,6 +494,6 @@ func TestLowerSubqueryOverCallSubquery_WidensToSumOfBothRanges(t *testing.T) {
 	const want = time.Hour + 5*time.Minute
 	if wideInner.OuterRange != want {
 		t.Fatalf("wideInner.OuterRange = %s, want %s (sub.Range + innerSub.Range) — mutant `+`->`-` "+
-			"at subquery.go:2871:28 would yield %s", wideInner.OuterRange, want, time.Hour-5*time.Minute)
+			"at subquery.go:lowerSubqueryOverSubquery:`StepAlign: true, // epoch-align inner subquery sample grid (PromQL)` would yield %s", wideInner.OuterRange, want, time.Hour-5*time.Minute)
 	}
 }

--- a/internal/promql/gremlins_kill_test.go
+++ b/internal/promql/gremlins_kill_test.go
@@ -5,9 +5,13 @@
 // mutated branch, so the test fails when the mutant is applied and the
 // mutant is reported KILLED.
 //
-// See `.gremlins.yaml` for the mutation operators in play; the mutant
-// IDs in each test's doc comment refer to gremlins's `file:line:col`
-// notation as printed in the workflow logs.
+// See `.gremlins.yaml` for the mutation operators in play. Gremlins prints
+// mutant IDs in `file:line:col` notation in the workflow logs; each test's
+// doc comment cites the same mutant by the CONSTRUCT it lives on instead —
+// the source path, a colon, and the backticked construct, optionally with
+// the enclosing top-level func between them when the construct repeats — so
+// the citation survives edits that only move lines.
+// `.github/scripts/verify-code-citations.mjs` verifies every one of them.
 //
 // Conventions:
 //   - one Test... per source-file cluster of related mutants
@@ -29,8 +33,8 @@ import (
 )
 
 // TestFoldComparisonScalar_LessThanIsStrict kills the `<` → `<=`
-// boundary flip at scalar.go:136 inside foldComparisonScalar's LSS
-// case. PromQL's `<` is strict — `5 < 5` is false (0.0). A
+// boundary flip at scalar.go:`result = lhs < rhs` inside
+// foldComparisonScalar's LSS case. PromQL's `<` is strict — `5 < 5` is false (0.0). A
 // CONDITIONALS_BOUNDARY mutant flipping `<` to `<=` would return 1.0
 // for equal operands, breaking Prom's scalar-scalar comparison
 // semantics.
@@ -52,8 +56,8 @@ func TestFoldComparisonScalar_LessThanIsStrict(t *testing.T) {
 }
 
 // TestFoldComparisonScalar_GreaterThanIsStrict kills the `>` → `>=`
-// boundary flip at scalar.go:140 inside foldComparisonScalar's GTR
-// case. PromQL's `>` is strict — `5 > 5` is false (0.0). A
+// boundary flip at scalar.go:`result = lhs > rhs` inside
+// foldComparisonScalar's GTR case. PromQL's `>` is strict — `5 > 5` is false (0.0). A
 // CONDITIONALS_BOUNDARY mutant flipping `>` to `>=` would return 1.0
 // for equal operands.
 func TestFoldComparisonScalar_GreaterThanIsStrict(t *testing.T) {
@@ -71,7 +75,8 @@ func TestFoldComparisonScalar_GreaterThanIsStrict(t *testing.T) {
 
 // TestFoldComparisonScalar_LessOrEqualIncludesEquality complements the
 // LSS kill above: `<=` includes equality, so `5 <= bool 5` must yield
-// 1.0. This pins the LTE boundary at scalar.go:138 — flipping `<=` to
+// 1.0. This pins the LTE boundary at scalar.go:`result = lhs <= rhs` —
+// flipping `<=` to
 // `<` (a hypothetical sibling mutant in the same family) would return
 // 0 for the equality case. The test is also a regression backstop for
 // the LSS kill in case a future refactor merges the cases.
@@ -111,8 +116,9 @@ func mustParseHoltWintersCall(t *testing.T, q string) *parser.Call {
 }
 
 // TestLowerHoltWinters_SmoothingFactorZeroRejected kills the `<=` → `<`
-// boundary flip at range_fns.go:91 in the smoothing-factor guard. The
-// guard `if sf <= 0 || sf >= 1` rejects the boundary value sf=0; a
+// boundary flip at scalar_domain.go:`if v <= 0 || v >= 1`, the shared
+// factor-domain guard, reached here for the smoothing factor. The
+// guard rejects the boundary value sf=0; a
 // CONDITIONALS_BOUNDARY mutant relaxing `<=` to `<` would let sf=0
 // through into the lowering, where the recurrence is undefined.
 func TestLowerHoltWinters_SmoothingFactorZeroRejected(t *testing.T) {
@@ -122,13 +128,15 @@ func TestLowerHoltWinters_SmoothingFactorZeroRejected(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 	_, err := lowerHoltWinters(call, s, lowerCtx{})
 	if err == nil {
-		t.Fatalf("expected holt_winters(sf=0, ...) to error; got nil (mutant `<=` → `<` at range_fns.go:91 would pass sf=0 through the (0,1) check)")
+		t.Fatalf("expected holt_winters(sf=0, ...) to error; got nil (mutant `<=` → `<` at " +
+			"scalar_domain.go:`if v <= 0 || v >= 1` would pass sf=0 through the (0,1) check)")
 	}
 }
 
 // TestLowerHoltWinters_SmoothingFactorOneRejected kills the `>=` → `>`
-// boundary flip at range_fns.go:91 in the smoothing-factor upper
-// guard. Same shape as the lower-bound test: sf=1 sits exactly on the
+// boundary flip at scalar_domain.go:`if v <= 0 || v >= 1`, the upper
+// half of the same shared factor-domain guard. Same shape as the
+// lower-bound test: sf=1 sits exactly on the
 // `>= 1` boundary; flipping `>=` to `>` would let sf=1 through.
 func TestLowerHoltWinters_SmoothingFactorOneRejected(t *testing.T) {
 	t.Parallel()
@@ -137,13 +145,15 @@ func TestLowerHoltWinters_SmoothingFactorOneRejected(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 	_, err := lowerHoltWinters(call, s, lowerCtx{})
 	if err == nil {
-		t.Fatalf("expected holt_winters(sf=1, ...) to error; got nil (mutant `>=` → `>` at range_fns.go:91 would pass sf=1 through the (0,1) check)")
+		t.Fatalf("expected holt_winters(sf=1, ...) to error; got nil (mutant `>=` → `>` at " +
+			"scalar_domain.go:`if v <= 0 || v >= 1` would pass sf=1 through the (0,1) check)")
 	}
 }
 
 // TestLowerHoltWinters_TrendFactorZeroRejected kills the `<=` → `<`
-// boundary flip at range_fns.go:94 in the trend-factor guard. The
-// guard `if tf <= 0 || tf >= 1` rejects the boundary value tf=0; a
+// boundary flip at scalar_domain.go:`if v <= 0 || v >= 1`, the same
+// shared factor-domain guard reached for the trend factor. The
+// guard rejects the boundary value tf=0; a
 // CONDITIONALS_BOUNDARY mutant relaxing `<=` to `<` would let tf=0
 // through.
 func TestLowerHoltWinters_TrendFactorZeroRejected(t *testing.T) {
@@ -153,12 +163,14 @@ func TestLowerHoltWinters_TrendFactorZeroRejected(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 	_, err := lowerHoltWinters(call, s, lowerCtx{})
 	if err == nil {
-		t.Fatalf("expected holt_winters(tf=0, ...) to error; got nil (mutant `<=` → `<` at range_fns.go:94 would pass tf=0 through the (0,1) check)")
+		t.Fatalf("expected holt_winters(tf=0, ...) to error; got nil (mutant `<=` → `<` at " +
+			"scalar_domain.go:`if v <= 0 || v >= 1` would pass tf=0 through the (0,1) check)")
 	}
 }
 
 // TestLowerHoltWinters_TrendFactorOneRejected kills the `>=` → `>`
-// boundary flip at range_fns.go:94 in the trend-factor upper guard.
+// boundary flip at scalar_domain.go:`if v <= 0 || v >= 1`, reached for
+// the trend factor's upper bound.
 func TestLowerHoltWinters_TrendFactorOneRejected(t *testing.T) {
 	t.Parallel()
 
@@ -166,15 +178,14 @@ func TestLowerHoltWinters_TrendFactorOneRejected(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 	_, err := lowerHoltWinters(call, s, lowerCtx{})
 	if err == nil {
-		t.Fatalf("expected holt_winters(tf=1, ...) to error; got nil (mutant `>=` → `>` at range_fns.go:94 would pass tf=1 through the (0,1) check)")
+		t.Fatalf("expected holt_winters(tf=1, ...) to error; got nil (mutant `>=` → `>` at " +
+			"scalar_domain.go:`if v <= 0 || v >= 1` would pass tf=1 through the (0,1) check)")
 	}
 }
 
 // TestRewriteAnchorToTimeUnix_QualifierGuardsName kills the
-// INVERT_LOGICAL mutant at binary.go:396, where the guard
-//
-//	if v.Name == "anchor_ts" && v.Qualifier == ""
-//
+// INVERT_LOGICAL mutant at
+// binary.go:`if v.Name == "anchor_ts" && v.Qualifier == ""`, whose guard
 // must combine the two conditions with AND. Flipping `&&` to `||`
 // would let a `ColumnRef{Name: "anchor_ts", Qualifier: "leg"}` slip
 // through and get rewritten to the TimestampColumn — but Qualifier
@@ -192,7 +203,8 @@ func TestRewriteAnchorToTimeUnix_QualifierGuardsName(t *testing.T) {
 		t.Fatalf("expected *ColumnRef, got %T", got)
 	}
 	if cr.Name != "anchor_ts" || cr.Qualifier != "leg" {
-		t.Fatalf("expected qualified anchor_ts to pass through unchanged; got %#v (mutant `&&` → `||` at binary.go:396 would rewrite it to %q)",
+		t.Fatalf("expected qualified anchor_ts to pass through unchanged; got %#v (mutant `&&` → `||` at "+
+			"binary.go:`if v.Name == \"anchor_ts\" && v.Qualifier == \"\"` would rewrite it to %q)",
 			cr, s.TimestampColumn)
 	}
 }
@@ -219,8 +231,8 @@ func TestRewriteAnchorToTimeUnix_BareAnchorTsIsRewritten(t *testing.T) {
 }
 
 // TestIsDefaultMatching_AllFourConjunctsRequired kills the conjunctive
-// guard at binary.go:236-238 which combines four independent
-// constraints with `&&`:
+// guard at binary.go:`return vm.Card == parser.CardOneToOne &&`, which
+// combines four independent constraints with `&&`:
 //
 //	vm.Card == parser.CardOneToOne &&
 //	    len(vm.MatchingLabels) == 0 &&
@@ -304,12 +316,9 @@ func TestLowerClamp_MixedBoundsTakeComputedPath(t *testing.T) {
 }
 
 // TestFoldBinaryScalar_DivByZeroNegativeBranches pins the `<` boundary
-// at scalar.go:89 inside foldBinaryScalar's DIV case. The branch
-//
-//	if lhs < 0 { return math.Inf(-1), true }
-//
-// returns -Inf for any strictly-negative LHS divided by zero. The
-// sibling `lhs == 0` branch (line 86) already handles the 0/0 case
+// at scalar.go:foldBinaryScalar:`if lhs < 0` in its DIV case. That
+// branch returns -Inf for any strictly-negative LHS divided by zero. The
+// sibling `if lhs == 0` branch just above it already handles the 0/0 case
 // (NaN), and the fall-through returns +Inf. A boundary mutant would
 // either misclassify the lhs=0 case (already caught earlier in the
 // switch) or shift the negative/positive split — pinning two opposite
@@ -376,10 +385,8 @@ func labelRewriteProject(t *testing.T, plan chplan.Node) *chplan.Project {
 }
 
 // TestLowerLabelJoin_SrcsSliceCapacityIsTight kills the two adjacent
-// arithmetic mutants at label_fns.go:81:39 inside lowerLabelJoin's
-// slice-capacity hint:
-//
-//	srcs := make([]string, 0, len(c.Args)-3)
+// arithmetic mutants on lowerLabelJoin's slice-capacity hint,
+// label_fns.go:`srcs := make([]string, 0, len(c.Args)-3)`.
 //
 // The `-` is gremlins ARITHMETIC_BASE (`-` → `+`) and the literal `3`
 // is INVERT_NEGATIVES (`-3` → `+3`). Both mutants enlarge the initial
@@ -435,7 +442,8 @@ func TestLowerLabelJoin_SrcsSliceCapacityIsTight(t *testing.T) {
 	// `-3` → `+3` mutant: cap == 5+3 == 8 (same observable as above).
 	// Both mutants must yield cap == 8; original yields cap == 2.
 	if got := cap(lj.Srcs); got != wantSrcs {
-		t.Fatalf("cap(Srcs) = %d; want %d (mutants `-` → `+` and `-3` → `+3` at label_fns.go:81:39 would yield cap=%d)",
+		t.Fatalf("cap(Srcs) = %d; want %d (mutants `-` → `+` and `-3` → `+3` at "+
+			"label_fns.go:`srcs := make([]string, 0, len(c.Args)-3)` would yield cap=%d)",
 			got, wantSrcs, len(call.Args)+3)
 	}
 }
@@ -477,16 +485,16 @@ func TestLowerLabelJoin_SrcsSliceCapacityIsTight_FiveSrcs(t *testing.T) {
 		t.Fatalf("len(Srcs) = %d; want %d", got, wantSrcs)
 	}
 	if got := cap(lj.Srcs); got != wantSrcs {
-		t.Fatalf("cap(Srcs) = %d; want %d (mutants at label_fns.go:81:39 would yield cap=%d)",
+		t.Fatalf("cap(Srcs) = %d; want %d (mutants at "+
+			"label_fns.go:`srcs := make([]string, 0, len(c.Args)-3)` would yield cap=%d)",
 			got, wantSrcs, len(call.Args)+3)
 	}
 }
 
 // TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName kills the two
-// adjacent arithmetic mutants at label_fns.go:83:79 inside the
-// per-src error-formatting:
-//
-//	fmt.Sprintf("src_label_%d", i-2)
+// adjacent arithmetic mutants on the per-src error-formatting,
+// label_fns.go:`i-2` (the index expression inside
+// `fmt.Sprintf("src_label_%d", i-2)`).
 //
 // The `-` is gremlins ARITHMETIC_BASE (`-` → `+`) and the literal `2`
 // is INVERT_NEGATIVES (`-2` → `+2`). Both mutants change the parameter
@@ -537,7 +545,8 @@ func TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName(t *testing.T) {
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "src_label_2") {
-		t.Fatalf("error %q does not mention %q (mutants `-` → `+` and `-2` → `+2` at label_fns.go:83:79 would emit %q)",
+		t.Fatalf("error %q does not mention %q (mutants `-` → `+` and `-2` → `+2` at "+
+			"label_fns.go:`i-2` would emit %q)",
 			msg, "src_label_2", "src_label_6")
 	}
 	// Defensive: also ensure the mutant string is NOT present (e.g., if a
@@ -580,7 +589,8 @@ func TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName_FirstSlot(t *testing.
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "src_label_1") {
-		t.Fatalf("error %q does not mention %q (mutants at label_fns.go:83:79 would emit %q)",
+		t.Fatalf("error %q does not mention %q (mutants at "+
+			"label_fns.go:`i-2` would emit %q)",
 			msg, "src_label_1", "src_label_5")
 	}
 	if strings.Contains(msg, "src_label_5") {
@@ -589,10 +599,8 @@ func TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName_FirstSlot(t *testing.
 }
 
 // TestAbsentAttrsMap_ArgsSliceCapacityIsTight kills the ARITHMETIC_BASE
-// mutant at absent.go:absentAttrsMap:`for _, name := range order` inside absentAttrsMap's slice-capacity
-// hint:
-//
-//	args := make([]chplan.Expr, 0, len(pairs)*2)
+// mutant on absentAttrsMap's slice-capacity hint,
+// absent.go:`args := make([]chplan.Expr, 0, len(pairs)*2)`.
 //
 // Each of the len(pairs) iterations below appends exactly 2 elements
 // (one LitString per key, one per value), so len(args) after the loop
@@ -603,7 +611,7 @@ func TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName_FirstSlot(t *testing.
 // level assertions (the emitted Map() args) pass under both branches;
 // only cap() distinguishes them, mirroring
 // TestLowerLabelJoin_SrcsSliceCapacityIsTight's own strategy for the
-// analogous label_fns.go:81:39 pair.
+// analogous label_fns.go:`srcs := make([]string, 0, len(c.Args)-3)` pair.
 func TestAbsentAttrsMap_ArgsSliceCapacityIsTight(t *testing.T) {
 	t.Parallel()
 
@@ -626,16 +634,16 @@ func TestAbsentAttrsMap_ArgsSliceCapacityIsTight(t *testing.T) {
 	// `/` mutant: cap starts at len(pairs)/2 == 1, then grows past it
 	// while appending 6 elements — never lands back on 6.
 	if got := cap(fc.Args); got != wantPairs*2 {
-		t.Fatalf("cap(Args) = %d; want %d (mutant `*` -> `/` at absent.go:absentAttrsMap:`for _, name := range order` would yield a different cap via forced regrowth)",
+		t.Fatalf("cap(Args) = %d; want %d (mutant `*` -> `/` at "+
+			"absent.go:`args := make([]chplan.Expr, 0, len(pairs)*2)` "+
+			"would yield a different cap via forced regrowth)",
 			got, wantPairs*2)
 	}
 }
 
 // TestLowerSortByLabel_KeysSliceCapacityIsTight kills the two adjacent
-// mutants at sort.go:192:48 inside lowerSortByLabel's slice-capacity
-// hint:
-//
-//	keys := make([]chplan.OrderKey, 0, len(c.Args)-1)
+// mutants on lowerSortByLabel's slice-capacity hint,
+// sort.go:`keys := make([]chplan.OrderKey, 0, len(c.Args)-1)`.
 //
 // The `-` is ARITHMETIC_BASE (`-` -> `+`) and the literal `1` is the
 // INVERT_NEGATIVES sibling (`-1` -> `+1`) — both produce the identical
@@ -678,11 +686,8 @@ func TestLowerSortByLabel_KeysSliceCapacityIsTight(t *testing.T) {
 }
 
 // TestLowerClamp_SingleArgHistogramShortcutTakesHistogramPath kills the
-// CONDITIONALS_BOUNDARY mutant at instant_fns.go:202:17, which flips
-//
-//	if len(c.Args) >= 1 {
-//
-// to `> 1`. Every VALID clamp/clamp_max/clamp_min call the parser
+// CONDITIONALS_BOUNDARY mutant at
+// instant_fns.go:`if len(c.Args) >= 1`, which flips it to `> 1`. Every VALID clamp/clamp_max/clamp_min call the parser
 // accepts always carries at least 2 arguments, so a real query can
 // never observe the boundary — the only way to reach it with exactly 1
 // argument is to hand-build the *parser.Call the way this test does,
@@ -710,7 +715,7 @@ func TestLowerClamp_SingleArgHistogramShortcutTakesHistogramPath(t *testing.T) {
 	plan, err := lowerClamp(call, s, lowerCtx{})
 	if err != nil {
 		t.Fatalf("lowerClamp(clamp_max(<1 histogram arg>)): unexpected error %v "+
-			"(mutant `>= 1` -> `> 1` at instant_fns.go:`>= 1` would skip the histogram "+
+			"(mutant `>= 1` -> `> 1` at instant_fns.go:`if len(c.Args) >= 1` would skip the histogram "+
 			"shortcut and fail the switch's arg-count check instead)", err)
 	}
 	if plan == nil {
@@ -719,11 +724,8 @@ func TestLowerClamp_SingleArgHistogramShortcutTakesHistogramPath(t *testing.T) {
 }
 
 // TestLowerClamp_EqualLiteralBoundsTakeComputedPath kills the
-// CONDITIONALS_BOUNDARY mutant at instant_fns.go:271:12, which flips
-//
-//	if maxB < minB {
-//
-// to `<= `. Prom's funcClamp only short-circuits to an empty vector
+// CONDITIONALS_BOUNDARY mutant at instant_fns.go:`if maxB < minB`,
+// which flips it to `<=`. Prom's funcClamp only short-circuits to an empty vector
 // when max is STRICTLY less than min; `clamp(v, 5, 5)` (equal bounds)
 // is a normal, non-degenerate clamp that pins every sample to exactly
 // 5 via greatest(min, least(max, v)). The `<=` mutant would treat the
@@ -760,11 +762,8 @@ func TestLowerClamp_EqualLiteralBoundsTakeComputedPath(t *testing.T) {
 }
 
 // TestLowerInfo_ArgCountRejectsOutOfRange kills the INVERT_LOGICAL
-// mutant at info_fn.go:83:21, which flips
-//
-//	if len(c.Args) < 1 || len(c.Args) > 2 {
-//
-// to `&&`. No integer argument count can be simultaneously < 1 AND >
+// mutant at info_fn.go:`if len(c.Args) < 1 || len(c.Args) > 2`, which
+// flips its `||` to `&&`. No integer argument count can be simultaneously < 1 AND >
 // 2, so the mutant's conjunction is always false — it would accept
 // ANY argument count, including 0, silently skipping the validation
 // that guards `c.Args[0]` from an out-of-range index a few lines
@@ -793,7 +792,8 @@ func TestLowerInfo_ArgCountRejectsOutOfRange(t *testing.T) {
 }
 
 // TestScalarGuardPlan_LoweringErrorPropagates kills the
-// CONDITIONALS_NEGATION mutant at scalar_guard.go:92:9, which flips
+// CONDITIONALS_NEGATION mutant at
+// scalar_guard.go:scalarGuardPlan:`if err != nil`, which flips
 //
 //	if err != nil {
 //		return nil, err
@@ -831,7 +831,7 @@ func TestScalarGuardPlan_LoweringErrorPropagates(t *testing.T) {
 }
 
 // TestHoltWintersFactors_MixedLiteralComputedTakesComputedPath kills
-// the INVERT_LOGICAL mutant at range_fns.go:246:10, which flips
+// the INVERT_LOGICAL mutant at range_fns.go:`if okSf && okTf`, which flips
 //
 //	if okSf && okTf {
 //		return sf, tf, nil, nil, nil
@@ -869,7 +869,8 @@ func TestHoltWintersFactors_MixedLiteralComputedTakesComputedPath(t *testing.T) 
 }
 
 // TestSynthLabelsFromMatchers_NameSkipContinuesPastLaterMatchers kills
-// the INVERT_LOOPCTRL mutant at absent.go:390:4, where
+// the INVERT_LOOPCTRL mutant on the `continue` of
+// absent.go:synthLabelsFromMatchers:`if m.Name == model.MetricNameLabel`:
 //
 //	if m.Name == model.MetricNameLabel {
 //		continue
@@ -895,7 +896,8 @@ func TestSynthLabelsFromMatchers_NameSkipContinuesPastLaterMatchers(t *testing.T
 	want := map[string]string{"job": "a", "instance": "b"}
 	if len(got) != len(want) {
 		t.Fatalf("synthLabelsFromMatchers = %#v; want %d labels (mutant `continue` -> "+
-			"`break` at absent.go:390:4 would abandon the loop at __name__ and drop "+
+			"`break` at absent.go:synthLabelsFromMatchers:`if m.Name == model.MetricNameLabel` "+
+			"would abandon the loop at __name__ and drop "+
 			"every matcher after it, yielding 0)", got, len(want))
 	}
 	for _, sl := range got {
@@ -906,7 +908,8 @@ func TestSynthLabelsFromMatchers_NameSkipContinuesPastLaterMatchers(t *testing.T
 }
 
 // TestAbsentAttrsMap_NameSkipContinuesPastLaterMatchers kills the
-// INVERT_LOOPCTRL mutant at absent.go:440:4 — absentAttrsMap's own
+// INVERT_LOOPCTRL mutant at
+// absent.go:absentAttrsMap:`if m.Name == model.MetricNameLabel` — its own
 // `__name__`-skip, the mirror of synthLabelsFromMatchers' loop just
 // above (see that test's doc comment for why a single-matcher list
 // cannot distinguish `continue` from `break`).
@@ -922,7 +925,8 @@ func TestAbsentAttrsMap_NameSkipContinuesPastLaterMatchers(t *testing.T) {
 	fc, ok := got.(*chplan.FuncCall)
 	if !ok || fc.Fn != chplan.FnMap {
 		t.Fatalf("absentAttrsMap = %#v; want a Map() FuncCall over the surviving pairs "+
-			"(mutant `continue` -> `break` at absent.go:440:4 would abandon the loop at "+
+			"(mutant `continue` -> `break` at "+
+			"absent.go:absentAttrsMap:`if m.Name == model.MetricNameLabel` would abandon the loop at "+
 			"__name__ and drop every matcher after it, yielding the empty-map literal)", got)
 	}
 	// 2 surviving pairs (job, instance) * 2 args each.
@@ -948,8 +952,9 @@ func mixedDiscriminatorMarkerProject(input chplan.Node) *chplan.Project {
 }
 
 // TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop kills
-// the INVERT_LOOPCTRL mutant at duplicate_labelset_guard.go:391:5,
-// inside guardLabelRewriteCollision's per-projection switch:
+// the INVERT_LOOPCTRL mutant on the `continue` of
+// duplicate_labelset_guard.go:`if mixed && mixedPayload[name]`, inside
+// guardLabelRewriteCollision's per-projection switch:
 //
 //	default:
 //		if mixed && mixedPayload[name] {
@@ -994,13 +999,15 @@ func TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop(t *testing.T) 
 	}
 	if !found {
 		t.Fatalf("GroupByAliases = %#v; want %q present (mutant `continue` -> `break` at "+
-			"duplicate_labelset_guard.go:391:5 would abandon the loop at the mixed-payload "+
+			"duplicate_labelset_guard.go:`if mixed && mixedPayload[name]` "+
+			"would abandon the loop at the mixed-payload "+
 			"histogram column and never reach the projection after it)", agg.GroupByAliases, extraStepCol)
 	}
 }
 
 // TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop kills the
-// INVERT_LOOPCTRL mutant at duplicate_labelset_guard.go:400:5:
+// INVERT_LOOPCTRL mutant on the `continue` of
+// duplicate_labelset_guard.go:`if keyOnStep`:
 //
 //	if keyOnStep {
 //		groupBy = append(groupBy, &chplan.ColumnRef{Name: name})
@@ -1042,7 +1049,7 @@ func TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop(t *testing.T) {
 	for name := range wantAliases {
 		if !gotAliases[name] {
 			t.Fatalf("GroupByAliases = %#v; want both %q and %q present (mutant `continue` "+
-				"-> `break` at duplicate_labelset_guard.go:400:5 would abandon the loop after "+
+				"-> `break` at duplicate_labelset_guard.go:`if keyOnStep` would abandon the loop after "+
 				"the first key-on-step projection and never reach the second)",
 				agg.GroupByAliases, colA, colB)
 		}

--- a/internal/promql/gremlins_kill_test.go
+++ b/internal/promql/gremlins_kill_test.go
@@ -589,7 +589,7 @@ func TestLowerLabelJoin_NonLiteralSrcErrorIndexesParamName_FirstSlot(t *testing.
 }
 
 // TestAbsentAttrsMap_ArgsSliceCapacityIsTight kills the ARITHMETIC_BASE
-// mutant at absent.go:473:43 inside absentAttrsMap's slice-capacity
+// mutant at absent.go:absentAttrsMap:`for _, name := range order` inside absentAttrsMap's slice-capacity
 // hint:
 //
 //	args := make([]chplan.Expr, 0, len(pairs)*2)
@@ -626,7 +626,7 @@ func TestAbsentAttrsMap_ArgsSliceCapacityIsTight(t *testing.T) {
 	// `/` mutant: cap starts at len(pairs)/2 == 1, then grows past it
 	// while appending 6 elements — never lands back on 6.
 	if got := cap(fc.Args); got != wantPairs*2 {
-		t.Fatalf("cap(Args) = %d; want %d (mutant `*` -> `/` at absent.go:473:43 would yield a different cap via forced regrowth)",
+		t.Fatalf("cap(Args) = %d; want %d (mutant `*` -> `/` at absent.go:absentAttrsMap:`for _, name := range order` would yield a different cap via forced regrowth)",
 			got, wantPairs*2)
 	}
 }
@@ -672,7 +672,7 @@ func TestLowerSortByLabel_KeysSliceCapacityIsTight(t *testing.T) {
 	// Original: cap == len(c.Args)-1 == 4-1 == 3, exact fit.
 	// Both mutants: cap == 4+1 == 5.
 	if got := cap(ob.Keys); got != wantKeys {
-		t.Fatalf("cap(Keys) = %d; want %d (mutants at sort.go:192:48 would yield cap=%d)",
+		t.Fatalf("cap(Keys) = %d; want %d (mutants at sort.go:`keys := make([]chplan.OrderKey, 0, len(c.Args)-1)` would yield cap=%d)",
 			got, wantKeys, len(call.Args)+1)
 	}
 }
@@ -710,7 +710,7 @@ func TestLowerClamp_SingleArgHistogramShortcutTakesHistogramPath(t *testing.T) {
 	plan, err := lowerClamp(call, s, lowerCtx{})
 	if err != nil {
 		t.Fatalf("lowerClamp(clamp_max(<1 histogram arg>)): unexpected error %v "+
-			"(mutant `>= 1` -> `> 1` at instant_fns.go:202:17 would skip the histogram "+
+			"(mutant `>= 1` -> `> 1` at instant_fns.go:`>= 1` would skip the histogram "+
 			"shortcut and fail the switch's arg-count check instead)", err)
 	}
 	if plan == nil {
@@ -750,7 +750,7 @@ func TestLowerClamp_EqualLiteralBoundsTakeComputedPath(t *testing.T) {
 		if lb, ok := f.Predicate.(*chplan.LitBool); ok && !lb.V {
 			t.Fatalf("clamp(up, 5, 5) lowered to the degenerate-bounds empty Filter %#v; "+
 				"want the computed greatest/least projection (mutant `<` -> `<=` at "+
-				"instant_fns.go:271:12 would treat equal bounds as degenerate)", f)
+				"instant_fns.go:`if maxB < minB` would treat equal bounds as degenerate)", f)
 		}
 	}
 	if _, ok := plan.(*chplan.Project); !ok {
@@ -784,7 +784,7 @@ func TestLowerInfo_ArgCountRejectsOutOfRange(t *testing.T) {
 	_, err := lowerInfo(call, s, lowerCtx{})
 	if err == nil {
 		t.Fatalf("expected info() with 0 arguments to error; got nil " +
-			"(mutant `||` -> `&&` at info_fn.go:83:21 can never be true, so " +
+			"(mutant `||` -> `&&` at info_fn.go:`if len(c.Args) < 1 || len(c.Args) > 2` can never be true, so " +
 			"validation never fires and c.Args[0] would index out of range)")
 	}
 	if !strings.Contains(err.Error(), "got 0") {
@@ -822,7 +822,7 @@ func TestScalarGuardPlan_LoweringErrorPropagates(t *testing.T) {
 	plan, err := scalarGuardPlan(e, s, lowerCtx{})
 	if err == nil {
 		t.Fatalf("expected scalarGuardPlan to propagate lowerScalarArg's error; got nil err, "+
-			"plan=%#v (mutant `!=` -> `==` at scalar_guard.go:92:9 would swallow the error "+
+			"plan=%#v (mutant `!=` -> `==` at scalar_guard.go:scalarGuardPlan:`if err != nil` would swallow the error "+
 			"and build a synthetic vector from a nil value instead)", plan)
 	}
 	if plan != nil {
@@ -858,7 +858,7 @@ func TestHoltWintersFactors_MixedLiteralComputedTakesComputedPath(t *testing.T) 
 	}
 	if sfExpr == nil || tfExpr == nil {
 		t.Fatalf("expected both sfExpr and tfExpr populated on the computed path "+
-			"(sfExpr=%v tfExpr=%v sf=%v tf=%v); mutant `&&` -> `||` at range_fns.go:246:10 "+
+			"(sfExpr=%v tfExpr=%v sf=%v tf=%v); mutant `&&` -> `||` at range_fns.go:`if okSf && okTf` "+
 			"would take the literal-only fast path and leave them nil",
 			sfExpr, tfExpr, sf, tf)
 	}

--- a/internal/promql/histogram_native_range_family_gremlins_test.go
+++ b/internal/promql/histogram_native_range_family_gremlins_test.go
@@ -110,7 +110,7 @@ func TestSelectExpHistogramWindowSamples_ProjectionCapacityIsTight(t *testing.T)
 
 // TestExpHistogramResetMaskStage_ProjectionCapacityIsTight is the sibling
 // of the test above for the ARITHMETIC_BASE mutant at
-// histogram_native_reset.go:156:65 inside expHistogramResetMaskStage's
+// histogram_native_reset.go:`projs := make([]chplan.Projection, 0, len(keyAliases)+len(aggs)+1)` inside expHistogramResetMaskStage's
 // identically-shaped capacity hint. The function appends exactly
 // len(keyAliases) + len(aggs) + 1 (the reset-mask column) projections, so
 // the same exact-capacity argument applies.
@@ -133,14 +133,14 @@ func TestExpHistogramResetMaskStage_ProjectionCapacityIsTight(t *testing.T) {
 		t.Fatalf("len(Projections) = %d, want %d", got, want)
 	}
 	if got := cap(proj.Projections); got != want {
-		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at histogram_native_reset.go:156:65 under-allocates and forces a reallocation, leaving cap != %d)",
+		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at histogram_native_reset.go:`projs := make([]chplan.Projection, 0, len(keyAliases)+len(aggs)+1)` under-allocates and forces a reallocation, leaving cap != %d)",
 			got, want, want)
 	}
 }
 
 // TestCountPresentOverExpHistogram_MetadataFullRangeShortCircuits kills
 // the INVERT_LOGICAL mutant at
-// histogram_native_count_present_over_time.go:65:31, where
+// histogram_native_count_present_over_time.go:`if s.ExpHistogramTable == "" || ctx.metadataFullRange`, where
 //
 //	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
 //
@@ -163,7 +163,7 @@ func TestCountPresentOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.
 
 // TestCountPresentOverExpHistogram_ZeroRangeRejected kills the
 // CONDITIONALS_BOUNDARY mutant at
-// histogram_native_count_present_over_time.go:73:21 (`ms.Range <= 0` ->
+// histogram_native_count_present_over_time.go:`ms.Range <= 0` (`ms.Range <= 0` ->
 // `ms.Range < 0`). A zero-duration matrix selector is built by hand — the
 // PromQL grammar refuses a literal `[0s]` — and must still be rejected.
 func TestCountPresentOverExpHistogram_ZeroRangeRejected(t *testing.T) {
@@ -177,7 +177,7 @@ func TestCountPresentOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 		},
 	}
 	if _, _, _, ok := countPresentOverExpHistogram(call, s, lowerCtx{}); ok {
-		t.Fatalf("expected zero-range matrix selector to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_count_present_over_time.go:73:21)")
+		t.Fatalf("expected zero-range matrix selector to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_count_present_over_time.go:`if !ok || ms.Range <= 0`)")
 	}
 }
 
@@ -197,7 +197,7 @@ func TestRangeFnOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.T) {
 }
 
 // TestRangeFnOverExpHistogram_ZeroRangeRejected kills the
-// CONDITIONALS_BOUNDARY mutant at histogram_native_range_fn.go:170:21
+// CONDITIONALS_BOUNDARY mutant at histogram_native_range_fn.go:`ms.Range <= 0`
 // (`ms.Range <= 0` -> `ms.Range < 0`).
 func TestRangeFnOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	t.Parallel()
@@ -215,7 +215,7 @@ func TestRangeFnOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 }
 
 // TestRangeFnOverExpHistogramSubquery_ZeroRangeRejected kills the
-// CONDITIONALS_BOUNDARY mutant at histogram_native_range_fn.go:223:22
+// CONDITIONALS_BOUNDARY mutant at histogram_native_range_fn.go:`sub.Range <= 0`
 // (`sub.Range <= 0` -> `sub.Range < 0`). Unlike the guard-clause
 // INVERT_LOGICAL mutant on this same function's first line (masked by
 // isExpHistogramValuedShape's own identical guard — see this file's
@@ -243,7 +243,7 @@ func TestRangeFnOverExpHistogramSubquery_ZeroRangeRejected(t *testing.T) {
 }
 
 // TestLowerExpHistogramRangeFnOverSubquery_ZeroStepDefaults kills the
-// CONDITIONALS_NEGATION mutant at histogram_native_range_fn.go:266:10
+// CONDITIONALS_NEGATION mutant at histogram_native_range_fn.go:lowerExpHistogramRangeFnOverSubquery:`if step == 0`
 // (`step == 0` -> `step != 0`) inside lowerExpHistogramRangeFnOverSubquery.
 //
 // A subquery with no explicit step (`[5m:]`) must fall back to
@@ -306,7 +306,7 @@ func TestExpHistogramRangeFnWindowed_PinnedAtNotOverwrittenByQueryEnd(t *testing
 }
 
 // TestLabelCallOverExpHistogramDroppingShape_LabelReplaceExactArity kills
-// two mutants at once, both on histogram_native_dropping_shape.go:213:
+// two mutants at once, both on histogram_native_dropping_shape.go:`len(call.Args) != 5`:
 //   - CONDITIONALS_NEGATION at :204:25 (`s.ExpHistogramTable == ""` ->
 //     `!= ""`): with the negation, ANY non-empty ExpHistogramTable — the
 //     normal, default schema — makes the guard bail, so this test's
@@ -332,7 +332,7 @@ func TestLabelCallOverExpHistogramDroppingShape_LabelReplaceExactArity(t *testin
 }
 
 // TestLabelCallOverExpHistogramDroppingShape_LabelJoinMinArity kills the
-// CONDITIONALS_BOUNDARY mutant at histogram_native_dropping_shape.go:217:21
+// CONDITIONALS_BOUNDARY mutant at histogram_native_dropping_shape.go:`len(call.Args) < 3`
 // (`len(call.Args) < 3` -> `<= 3`). The minimum valid label_join call has
 // exactly 3 args (vector, dst, separator, zero src labels) — the parser
 // itself refuses this degenerate shape, so the Call is built by hand.

--- a/internal/promql/histogram_native_range_family_gremlins_test.go
+++ b/internal/promql/histogram_native_range_family_gremlins_test.go
@@ -8,7 +8,7 @@
 //
 // See gremlins_kill_test.go for the shared convention this file follows:
 // one Test... per mutant (or per tightly-related cluster of mutants), with
-// the gremlins `file:line:col` id named in the doc comment and in the
+// the construct the mutant lives on named in the doc comment and in the
 // failure message.
 package promql
 
@@ -69,10 +69,9 @@ func assertNoCrossJoin(t *testing.T, plan chplan.Node, label string) {
 }
 
 // TestSelectExpHistogramWindowSamples_ProjectionCapacityIsTight kills the
-// ARITHMETIC_BASE mutant at histogram_native_range_fn.go:546:65 inside
-// selectExpHistogramWindowSamples's slice-capacity hint:
-//
-//	projs := make([]chplan.Projection, 0, len(keyAliases)+len(aggs)+1)
+// ARITHMETIC_BASE mutant on selectExpHistogramWindowSamples's
+// slice-capacity hint,
+// histogram_native_range_fn.go:`projs := make([]chplan.Projection, 0, len(keyAliases)+len(aggs)+1)`.
 //
 // The function always appends exactly len(keyAliases) + 1 (the times
 // alias) + len(aggs) projections — one per keyAlias, one for
@@ -103,7 +102,9 @@ func TestSelectExpHistogramWindowSamples_ProjectionCapacityIsTight(t *testing.T)
 		t.Fatalf("len(Projections) = %d, want %d", got, want)
 	}
 	if got := cap(proj.Projections); got != want {
-		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at histogram_native_range_fn.go:546:65 under-allocates and forces a reallocation, leaving cap != %d)",
+		t.Fatalf("cap(Projections) = %d, want %d (mutant `+`->`-` at "+
+			"histogram_native_range_fn.go:`projs := make([]chplan.Projection, 0, len(keyAliases)+len(aggs)+1)` "+
+			"under-allocates and forces a reallocation, leaving cap != %d)",
 			got, want, want)
 	}
 }
@@ -157,7 +158,8 @@ func TestCountPresentOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.
 	s := schema.DefaultOTelMetrics()
 	expr := mustParse(t, `count_over_time(latency_exp_hist[5m])`)
 	if _, _, _, ok := countPresentOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
-		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true (mutant `||`->`&&` at histogram_native_count_present_over_time.go:65:31)")
+		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true (mutant `||`->`&&` at " +
+			"histogram_native_count_present_over_time.go:`s.ExpHistogramTable == \"\" || ctx.metadataFullRange`)")
 	}
 }
 
@@ -182,8 +184,9 @@ func TestCountPresentOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 }
 
 // TestRangeFnOverExpHistogram_MetadataFullRangeShortCircuits kills the
-// INVERT_LOGICAL mutant at histogram_native_range_fn.go:157:31. Like
-// countPresentOverExpHistogram above, rangeFnOverExpHistogram has no
+// INVERT_LOGICAL mutant at
+// histogram_native_range_fn.go:rangeFnOverExpHistogram:`s.ExpHistogramTable == "" || ctx.metadataFullRange`.
+// Like countPresentOverExpHistogram above, rangeFnOverExpHistogram has no
 // downstream call re-checking the same guard, so this is a clean,
 // unmasked differentiator.
 func TestRangeFnOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.T) {
@@ -192,7 +195,8 @@ func TestRangeFnOverExpHistogram_MetadataFullRangeShortCircuits(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 	expr := mustParse(t, `rate(latency_exp_hist[5m])`)
 	if _, ok := rangeFnOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
-		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true (mutant `||`->`&&` at histogram_native_range_fn.go:157:31)")
+		t.Fatalf("expected metadataFullRange to reject recognition; got ok=true (mutant `||`->`&&` at " +
+			"histogram_native_range_fn.go:rangeFnOverExpHistogram:`s.ExpHistogramTable == \"\" || ctx.metadataFullRange`)")
 	}
 }
 
@@ -210,7 +214,7 @@ func TestRangeFnOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 		},
 	}
 	if _, ok := rangeFnOverExpHistogram(call, s, lowerCtx{}); ok {
-		t.Fatalf("expected zero-range matrix selector to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_range_fn.go:170:21)")
+		t.Fatalf("expected zero-range matrix selector to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_range_fn.go:`ms.Range <= 0`)")
 	}
 }
 
@@ -238,7 +242,7 @@ func TestRangeFnOverExpHistogramSubquery_ZeroRangeRejected(t *testing.T) {
 	}
 	ctx := lowerCtx{start: at, end: at}
 	if _, ok := rangeFnOverExpHistogramSubquery(call, s, ctx); ok {
-		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_range_fn.go:223:22)")
+		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutant `<=`->`<` at histogram_native_range_fn.go:`sub.Range <= 0`)")
 	}
 }
 
@@ -263,9 +267,9 @@ func TestLowerExpHistogramRangeFnOverSubquery_ZeroStepDefaults(t *testing.T) {
 }
 
 // TestExpHistogramRangeFnWindowed_PinnedAtNotOverwrittenByQueryEnd kills
-// the INVERT_LOGICAL mutant at histogram_native_range_fn.go:427:25
-// (`anchor.End.IsZero() && !ctx.end.IsZero()` -> `||`) inside
-// expHistogramRangeFnWindowed.
+// the INVERT_LOGICAL mutant (`&&` -> `||`) at
+// histogram_native_range_fn.go:`anchor.End.IsZero() && !ctx.end.IsZero()`,
+// inside expHistogramRangeFnWindowed.
 //
 // The original AND only back-fills anchor.End from ctx.end when the
 // selector carries NO pin of its own. An `@`-pinned selector already has
@@ -301,17 +305,21 @@ func TestExpHistogramRangeFnWindowed_PinnedAtNotOverwrittenByQueryEnd(t *testing
 		t.Fatalf("expected the pinned @ timestamp (2026-01-01) among the emitted parameters, got:\n%s\nSQL:\n%s", got, sql)
 	}
 	if strings.Contains(got, "2030-05-05") {
-		t.Fatalf("emitted parameters leaked the query end (2030-05-05) instead of the pinned @ timestamp (mutant `&&`->`||` at histogram_native_range_fn.go:427:25 overwrites the pin with ctx.end):\n%s", got)
+		t.Fatalf("emitted parameters leaked the query end (2030-05-05) instead of the pinned @ timestamp (mutant `&&`->`||` at histogram_native_range_fn.go:`anchor.End.IsZero() && !ctx.end.IsZero()` overwrites the pin with ctx.end):\n%s", got)
 	}
 }
 
 // TestLabelCallOverExpHistogramDroppingShape_LabelReplaceExactArity kills
-// two mutants at once, both on histogram_native_dropping_shape.go:`len(call.Args) != 5`:
-//   - CONDITIONALS_NEGATION at :204:25 (`s.ExpHistogramTable == ""` ->
-//     `!= ""`): with the negation, ANY non-empty ExpHistogramTable — the
-//     normal, default schema — makes the guard bail, so this test's
-//     ordinary DefaultOTelMetrics() schema alone differentiates.
-//   - CONDITIONALS_NEGATION at :213:21 (`len(call.Args) != 5` -> `== 5`):
+// two mutants at once, both inside
+// histogram_native_dropping_shape.go's labelCallOverExpHistogramDroppingShape:
+//   - CONDITIONALS_NEGATION on
+//     histogram_native_dropping_shape.go:labelCallOverExpHistogramDroppingShape:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//     (`s.ExpHistogramTable == ""` -> `!= ""`): with the negation, ANY
+//     non-empty ExpHistogramTable — the normal, default schema — makes the
+//     guard bail, so this test's ordinary DefaultOTelMetrics() schema alone
+//     differentiates.
+//   - CONDITIONALS_NEGATION on
+//     histogram_native_dropping_shape.go:`len(call.Args) != 5` (-> `== 5`):
 //     with the negation, exactly-5-args (the only valid label_replace
 //     shape) is rejected instead of accepted.
 //
@@ -324,7 +332,9 @@ func TestLabelCallOverExpHistogramDroppingShape_LabelReplaceExactArity(t *testin
 	expr := mustParse(t, `label_replace(latency_exp_hist + 1, "copy", "$1", "service", "(.*)")`)
 	call, ok := labelCallOverExpHistogramDroppingShape(expr, s, lowerCtx{})
 	if !ok {
-		t.Fatalf("expected 5-arg label_replace wrapping a drop-family binop to be recognised under the default schema; got ok=false (mutants at histogram_native_dropping_shape.go:204:25 and :213:21)")
+		t.Fatalf("expected 5-arg label_replace wrapping a drop-family binop to be recognised under the default schema; got ok=false (mutants at " +
+			"histogram_native_dropping_shape.go:labelCallOverExpHistogramDroppingShape:`s.ExpHistogramTable == \"\" || ctx.metadataFullRange` and " +
+			"histogram_native_dropping_shape.go:`len(call.Args) != 5`)")
 	}
 	if call.Func.Name != fnLabelReplace {
 		t.Fatalf("call.Func.Name = %q, want %q", call.Func.Name, fnLabelReplace)
@@ -346,26 +356,27 @@ func TestLabelCallOverExpHistogramDroppingShape_LabelJoinMinArity(t *testing.T) 
 		Args: parser.Expressions{binExpr, &parser.StringLiteral{Val: "copy"}, &parser.StringLiteral{Val: "-"}},
 	}
 	if _, ok := labelCallOverExpHistogramDroppingShape(call, s, lowerCtx{}); !ok {
-		t.Fatalf("expected minimum-arity (3-arg) label_join wrapping a drop-family binop to be recognised; got ok=false (mutant `<`->`<=` at histogram_native_dropping_shape.go:217:21)")
+		t.Fatalf("expected minimum-arity (3-arg) label_join wrapping a drop-family binop to be recognised; got ok=false (mutant `<`->`<=` at histogram_native_dropping_shape.go:`len(call.Args) < 3`)")
 	}
 }
 
 // TestSumOrAvgMixedOrSubqueryOuterFnRecognized_ZeroRangeRejected kills two
-// mutants on histogram_native_mixed_or_subquery_aggregate_range_fn.go's
-// line 124 at once:
-//   - CONDITIONALS_BOUNDARY at :124:22 (`sub.Range <= 0` -> `< 0`).
-//   - INVERT_LOGICAL at :124:27 (the second `||`, between the Range check
-//     and `!subqueryHasEvalAnchor(sub, ctx)`, flipped to `&&`).
+// mutants on
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:`!ok || sub.Range <= 0 || !subqueryHasEvalAnchor(sub, ctx)`
+// at once:
+//   - CONDITIONALS_BOUNDARY on `sub.Range <= 0` (-> `< 0`).
+//   - INVERT_LOGICAL on the second `||`, between the Range check and
+//     `!subqueryHasEvalAnchor(sub, ctx)`, flipped to `&&`.
 //
 // sub.Range = 0 with everything else valid (a real mixed-or inner,
 // eval-anchor-resolvable ctx) makes the ORIGINAL code reject via the
 // Range check alone (short-circuiting subqueryHasEvalAnchor away
 // entirely). subqueryGridCtx tolerates a zero Range via its own
 // sub-step-window clamp, so subqueryHasEvalAnchor(sub, ctx) genuinely
-// returns true here — which is exactly what lets the :124:27 AND-mutant
+// returns true here — which is exactly what lets the second-`||` AND-mutant
 // (needing BOTH operands true) fall through to a false "not rejected"
-// verdict, and what lets the :124:22 boundary-mutant do the same once the
-// Range check alone no longer rejects.
+// verdict, and what lets the `sub.Range <= 0` boundary-mutant do the same
+// once the Range check alone no longer rejects.
 func TestSumOrAvgMixedOrSubqueryOuterFnRecognized_ZeroRangeRejected(t *testing.T) {
 	t.Parallel()
 
@@ -382,14 +393,15 @@ func TestSumOrAvgMixedOrSubqueryOuterFnRecognized_ZeroRangeRejected(t *testing.T
 	}
 	ctx := lowerCtx{start: at, end: at}
 	if _, ok := sumOrAvgMixedOrSubqueryOuterFnRecognized(call, s, ctx); ok {
-		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutants at histogram_native_mixed_or_subquery_aggregate_range_fn.go:124:22 and :124:27)")
+		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutants on " +
+			"histogram_native_mixed_or_subquery_aggregate_range_fn.go:`!ok || sub.Range <= 0 || !subqueryHasEvalAnchor(sub, ctx)`)")
 	}
 }
 
 // TestSumOrAvgMixedOrSubqueryOuterFnRecognized_NonSubqueryArgNoPanic kills
 // the INVERT_LOGICAL mutant at
-// histogram_native_mixed_or_subquery_aggregate_range_fn.go:124:9 — the
-// FIRST `||` on that line (`!ok || sub.Range <= 0 ...`), flipped to `&&`.
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:`!ok || sub.Range <= 0 || !subqueryHasEvalAnchor(sub, ctx)`
+// — the FIRST `||` on that line, flipped to `&&`.
 //
 // When c.Args[0] is not a *parser.SubqueryExpr, the failed type assertion
 // leaves `sub` nil. The original `||` short-circuits on `!ok` and never
@@ -413,8 +425,9 @@ func TestSumOrAvgMixedOrSubqueryOuterFnRecognized_NonSubqueryArgNoPanic(t *testi
 
 // TestLowerSumOrAvgMixedOrSubqueryOuterFn_ZeroStepDefaults kills the
 // CONDITIONALS_NEGATION mutant at
-// histogram_native_mixed_or_subquery_aggregate_range_fn.go:168:10
-// (`step == 0` -> `step != 0`), the sibling of the range_fn.go:266:10
+// histogram_native_mixed_or_subquery_aggregate_range_fn.go:`if step == 0`
+// (`step == 0` -> `step != 0`), the sibling of the
+// histogram_native_range_fn.go:lowerExpHistogramRangeFnOverSubquery:`if step == 0`
 // kill above but inside lowerSumOrAvgMixedOrSubqueryOuterFn. Same
 // divide-by-zero-in-epochFloor signature: the original lowers cleanly,
 // the mutant panics.
@@ -430,10 +443,9 @@ func TestLowerSumOrAvgMixedOrSubqueryOuterFn_ZeroStepDefaults(t *testing.T) {
 }
 
 // TestLowerSumOrAvgMixedOrSubquerySelectFn_InstantPinDoesNotBroadcast
-// kills the INVERT_LOGICAL mutant at
-// histogram_native_mixed_or_subquery_aggregate_range_fn.go:223:21
-// (`ctx.rangeMode() && subqueryPinned(sub)` -> `||`) inside
-// lowerSumOrAvgMixedOrSubquerySelectFn.
+// kills the INVERT_LOGICAL mutant (`&&` -> `||`) on the broadcast guard
+// lowerSumOrAvgMixedOrSubquerySelectFn reaches,
+// histogram_native_subquery_select.go:`if ctx.rangeMode() && subqueryPinned(sub)`.
 //
 // An `@`-pinned mixed-or subquery reached via a plain instant LowerAt
 // (ctx.rangeMode() == false) must take the ordinary single-window branch.
@@ -457,9 +469,10 @@ func TestLowerSumOrAvgMixedOrSubquerySelectFn_InstantPinDoesNotBroadcast(t *test
 // two mutants at once, both `ctx.rangeMode() && subqueryPinned(sub)` ->
 // `||` guards reached from lowerSumOrAvgMixedOrSubqueryFoldFn for the
 // SAME query:
-//   - :335:21 inside lowerHistFoldOverPureSubqueryBranch (the histogram
-//     arm).
-//   - :374:21 inside lowerFloatFoldOverPureSubqueryBranch (the float arm).
+//   - histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerHistFoldOverPureSubqueryBranch:`if ctx.rangeMode() && subqueryPinned(sub)`
+//     (the histogram arm).
+//   - histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerFloatFoldOverPureSubqueryBranch:`if ctx.rangeMode() && subqueryPinned(sub)`
+//     (the float arm).
 //
 // sum_over_time reaches the FOLD family (as opposed to the SELECT family
 // count_over_time exercises above), which runs BOTH arms and recombines
@@ -480,9 +493,8 @@ func TestLowerSumOrAvgMixedOrSubqueryFoldFn_InstantPinDoesNotBroadcast(t *testin
 }
 
 // TestMixedOrSubqueryOuterFn_ArgCountVsNameGuard kills the INVERT_LOGICAL
-// mutant at histogram_native_mixed_or_subquery_range_fn.go:116:22
-// (`len(c.Args) != 1 || !isHistogramSubqueryOuterFnName(c.Func.Name)` ->
-// `&&`).
+// mutant (`||` -> `&&`) at
+// histogram_native_mixed_or_subquery_range_fn.go:`len(c.Args) != 1 || !isHistogramSubqueryOuterFnName(c.Func.Name)`.
 //
 // A 2-arg call to a recognised name (count_over_time takes exactly 1
 // argument) must reject on arity alone. With AND, a recognised name
@@ -506,7 +518,8 @@ func TestMixedOrSubqueryOuterFn_ArgCountVsNameGuard(t *testing.T) {
 	}
 	ctx := lowerCtx{start: at, end: at}
 	if _, _, _, ok := mixedOrSubqueryOuterFn(call, s, ctx); ok {
-		t.Fatalf("expected a 2-arg call to a 1-arg function to be rejected; got ok=true (mutant `||`->`&&` at histogram_native_mixed_or_subquery_range_fn.go:116:22)")
+		t.Fatalf("expected a 2-arg call to a 1-arg function to be rejected; got ok=true (mutant `||`->`&&` at " +
+			"histogram_native_mixed_or_subquery_range_fn.go:`len(c.Args) != 1 || !isHistogramSubqueryOuterFnName(c.Func.Name)`)")
 	}
 }
 
@@ -514,8 +527,10 @@ func TestMixedOrSubqueryOuterFn_ArgCountVsNameGuard(t *testing.T) {
 // histogram_native_mixed_or_subquery_range_fn.go sibling of
 // TestSumOrAvgMixedOrSubqueryOuterFnRecognized_ZeroRangeRejected above,
 // killing:
-//   - CONDITIONALS_BOUNDARY at :120:22 (`sub.Range <= 0` -> `< 0`).
-//   - INVERT_LOGICAL at :120:27 (the second `||` -> `&&`).
+// both on
+// histogram_native_mixed_or_subquery_range_fn.go:`!ok || sub.Range <= 0 || !subqueryHasEvalAnchor(sub, ctx)`:
+//   - CONDITIONALS_BOUNDARY on `sub.Range <= 0` (-> `< 0`).
+//   - INVERT_LOGICAL on the second `||` (-> `&&`).
 func TestMixedOrSubqueryOuterFn_ZeroRangeRejected(t *testing.T) {
 	t.Parallel()
 
@@ -532,16 +547,18 @@ func TestMixedOrSubqueryOuterFn_ZeroRangeRejected(t *testing.T) {
 	}
 	ctx := lowerCtx{start: at, end: at}
 	if _, _, _, ok := mixedOrSubqueryOuterFn(call, s, ctx); ok {
-		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutants at histogram_native_mixed_or_subquery_range_fn.go:120:22 and :120:27)")
+		t.Fatalf("expected zero-range subquery to be rejected; got ok=true (mutants on " +
+			"histogram_native_mixed_or_subquery_range_fn.go:`!ok || sub.Range <= 0 || !subqueryHasEvalAnchor(sub, ctx)`)")
 	}
 }
 
 // TestMixedOrSubqueryOuterFn_NonSubqueryArgNoPanic is the
 // histogram_native_mixed_or_subquery_range_fn.go sibling of
 // TestSumOrAvgMixedOrSubqueryOuterFnRecognized_NonSubqueryArgNoPanic
-// above, killing the INVERT_LOGICAL mutant at :120:9 (the first `||` on
-// that line -> `&&`, causing a nil-pointer panic on `sub.Range` when
-// c.Args[0] is not a subquery).
+// above, killing the INVERT_LOGICAL mutant on the first `||` of
+// histogram_native_mixed_or_subquery_range_fn.go:`!ok || sub.Range <= 0 || !subqueryHasEvalAnchor(sub, ctx)`
+// (-> `&&`, causing a nil-pointer panic on `sub.Range` when c.Args[0] is
+// not a subquery).
 func TestMixedOrSubqueryOuterFn_NonSubqueryArgNoPanic(t *testing.T) {
 	t.Parallel()
 

--- a/internal/promql/histogram_native_ts_of_first_last_over_time.go
+++ b/internal/promql/histogram_native_ts_of_first_last_over_time.go
@@ -44,7 +44,7 @@ import (
 // ...}` appearing to keep it: reference Prometheus's engine strips
 // `__name__` from EVERY range-vector function's output except literally
 // `last_over_time` / `first_over_time` (tsouza/prometheus's
-// promql/engine.go:2114 — `dropName := (e.Func.Name != "last_over_time" &&
+// promql/engine.go — `dropName := (e.Func.Name != "last_over_time" &&
 // e.Func.Name != "first_over_time")` — this cerberus package's own
 // [rangeFnPreservesName] already encodes that exact exception list for the
 // classic float path), so `ts_of_first_over_time` / `ts_of_last_over_time`

--- a/internal/promql/histogram_native_ts_of_first_last_over_time_test.go
+++ b/internal/promql/histogram_native_ts_of_first_last_over_time_test.go
@@ -140,7 +140,7 @@ func TestLower_ExpHistogram_TsOfFirstLastOverTime_AtPin(t *testing.T) {
 // __name__-handling half of cerberus issue #2482's finding: despite
 // reference Prometheus's funcTsOfFirstOverTime / funcTsOfLastOverTime
 // literally assigning `Sample{Metric: el.Metric, ...}`, the engine's
-// separate dropName gate (promql/engine.go:2114) strips it for every
+// separate dropName gate in promql/engine.go strips it for every
 // function except literally "last_over_time"/"first_over_time" — so the
 // projected MetricName here must be the empty-string literal, matching
 // cerberus's own existing (verified) classic float-selector lowering for

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -3199,10 +3199,11 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	// Name-drop collision guard. When the function drops `__name__` and the
 	// selector spans several metrics, two source series that differ only by
 	// name land on one label set — the case reference Prometheus refuses
-	// (engine.go:2295) and cerberus used to answer with a silently merged
-	// series. Widening the window's grouping key with MetricName is what
-	// makes the collision observable at all; the wrap below re-collapses the
-	// widened rows and aborts on any group that held more than one name.
+	// (engine.go's `ContainsSameLabelset` guard) and cerberus used to answer
+	// with a silently merged series. Widening the window's grouping key with
+	// MetricName is what makes the collision observable at all; the wrap below
+	// re-collapses the widened rows and aborts on any group that held more
+	// than one name.
 	// This runs BEFORE the shape switch so the fan-out, native and
 	// `@`-broadcast lowerings all inherit the widened key.
 	guardNameCollision := rangeFnCollidesOnNameDrop(c.Func.Name, vs.LabelMatchers, inner, s)
@@ -3272,7 +3273,7 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	// increase, delta, sum_over_time, ...) produces a derived sample
 	// and Prom drops `__name__` for them. See upstream:
 	//
-	//	prometheus/prometheus@cerberus-parser/promql/engine.go:2114
+	//	prometheus/prometheus@cerberus-parser/promql/engine.go
 	//	`dropName := (e.Func.Name != "last_over_time" && e.Func.Name != "first_over_time")`
 	//
 	// The RangeWindow output schema is (Attributes, [anchor_ts,] Value)
@@ -4124,7 +4125,7 @@ func isIdentityColumnRef(x chplan.Expr, name string) bool {
 // rangeFnPreservesName reports whether a PromQL range function keeps
 // `__name__` on its output. Mirrors upstream:
 //
-//	prometheus/prometheus@cerberus-parser/promql/engine.go:2114
+//	prometheus/prometheus@cerberus-parser/promql/engine.go
 //	`dropName := (e.Func.Name != "last_over_time" && e.Func.Name != "first_over_time")`
 func rangeFnPreservesName(fn string) bool {
 	return fn == "last_over_time" || fn == "first_over_time"
@@ -4231,7 +4232,7 @@ func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name 
 // collapse two distinct series onto one label set by dropping `__name__`,
 // which is the condition reference Prometheus refuses to answer:
 //
-//	prometheus/prometheus@cerberus-parser/promql/engine.go:2295
+//	prometheus/prometheus@cerberus-parser/promql/engine.go
 //	`if !ev.enableDelayedNameRemoval && mat.ContainsSameLabelset() {
 //	     ev.errorf("vector cannot contain metrics with the same labelset") }`
 //

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -1149,7 +1149,7 @@ func lowerOuterRangeFnOverSubquery(
 // empty literal (the `@`-pinned broadcast arm, see the call site).
 //
 // Why there is no matcher shortcut here: reference Prometheus never
-// derives `__name__` from a selector's matchers. promql/engine.go:2114
+// derives `__name__` from a selector's matchers. promql/engine.go
 // computes `dropName := (fn != "last_over_time" && fn != "first_over_time")`
 // for the OUTER call, ORs it per series with the INPUT series' own drop
 // bit, and then reads the name off `selVS.Series[i].Labels()`. For a

--- a/internal/promql/synthetic_tofloat64_test.go
+++ b/internal/promql/synthetic_tofloat64_test.go
@@ -50,8 +50,9 @@ func TestSyntheticScalarVector_WrapsLitFloatInToFloat64(t *testing.T) {
 		// passing &chplan.LitFloat{V:v} to syntheticScalarVector.
 		{"vector_one", `vector(1)`},
 		{"vector_two", `vector(2)`},
-		// `1+1` — lowerBinary scalar-only fold, binary.go:45 callsite
-		// passing &chplan.LitFloat{V:v} to syntheticScalarVector.
+		// `1+1` — lowerBinary scalar-only fold, the
+		// binary.go:`syntheticScalarVector(&chplan.LitFloat{V: v}, nil, s, ctx)`
+		// callsite.
 		{"scalar_fold_add", `1+1`},
 		{"scalar_fold_mul", `2*3`},
 	}

--- a/internal/qlcommon/capture_participation_test.go
+++ b/internal/qlcommon/capture_participation_test.go
@@ -516,8 +516,8 @@ func firstNonEmptyDisagreement(re *regexp.Regexp, inputs []string) string {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// capture_participation.go:181:38 (CONDITIONALS_BOUNDARY, the SECOND `>=` in
-// mutuallyExclusive's `if shared >= len(a.spine) || shared >= len(b.spine)`
+// capture_participation.go:`shared >= len(a.spine) || shared >= len(b.spine)`
+// (CONDITIONALS_BOUNDARY, the SECOND `>=` in mutuallyExclusive's guard
 // -> `>`). The loop above increments `shared` only while it is below BOTH
 // lengths, so shared <= min(len(a.spine), len(b.spine)) on exit and
 // `shared > len(b.spine)` is unsatisfiable: the mutant simply deletes that

--- a/internal/qlcommon/capture_probe_boundary_test.go
+++ b/internal/qlcommon/capture_probe_boundary_test.go
@@ -383,8 +383,9 @@ const negativeCarrierWalks = 64
 
 // TestReadBackPlanSkipsNegativeCarriersWithoutStopping pins that the
 // synthetic negative-sibling requests planCaptureProbes mints — the
-// descending -1, -2, … keys at capture_probe.go:151 — are SKIPPED by the
-// positive-probe walk rather than ending it.
+// descending -1, -2, … keys counted down from
+// capture_probe.go:`nextRequest := -1` — are SKIPPED by the positive-probe
+// walk rather than ending it.
 //
 // probeNames is keyed by carrier and mixes both kinds, so a walk that
 // stopped at the first negative key would drop every positive carrier the
@@ -738,20 +739,24 @@ func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
 // whole package suite re-run to confirm it survives rather than merely
 // lacking a test.
 //
-// capture_probe.go:293:4 (INVERT_LOOPCTRL, `break` after `fork = i` ->
-// `continue`). The loop descends the spine, so `break` leaves `fork` at the
+// capture_probe.go:`fork = i` (INVERT_LOOPCTRL on the `break` immediately
+// after it, -> `continue`). The assignment is what the citation names because
+// the mutated statement is a bare `break`. The loop descends the spine, so `break` leaves `fork` at the
 // DEEPEST syntax.OpAlternate and `continue` leaves it at the SHALLOWEST. With
 // zero or one alternation on the spine the two agree outright. With k >= 2 at
 // depths i1 < … < ik, the original's fork is ik and `shape.spine[:ik]` still
 // contains i1; the mutant's fork is i1 and `shape.spine[i1+1:]` still
 // contains i2. skippable reports true for syntax.OpAlternate
-// (capture_participation.go:126), so whichever way round it lands, one of the
+// (capture_participation.go:`case syntax.OpStar, syntax.OpQuest,
+// syntax.OpAlternate`), so whichever way round it lands, one of the
 // two spine scans below rejects the carrier and the function returns
 // (nil, false). Both loops are side-effect-free and run before anything else.
 //
-// capture_probe.go:310:13 (CONDITIONALS_BOUNDARY, `for parent >= 0 && …` ->
-// `parent > 0`). Index 0 is the virtual whole-pattern group, minted with
-// parent -1 at regex_source_scan.go:57, so the two forms differ only at
+// capture_probe.go:`for parent >= 0 && len(groups[parent].alternations) == 0`
+// (CONDITIONALS_BOUNDARY, `parent >= 0` -> `parent > 0`). Index 0 is the virtual whole-pattern group, minted with
+// parent -1 at
+// regex_source_scan.go:`open: -1, bodyStart: 0, bodyEnd: len(src), parent: -1`,
+// so the two forms differ only at
 // parent == 0 with no alternations on that group: the original steps to -1
 // and returns at the `parent < 0` check, while the mutant leaves the loop
 // holding 0. It then reaches branchContaining(groups[0], …), which returns
@@ -760,8 +765,8 @@ func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
 // pattern into an empty map, `known` is false, and the next guard returns
 // (nil, false) — the answer the original returned one branch earlier.
 //
-// capture_probe.go:319:12 (INVERT_LOGICAL, `if !known ||
-// !branchShape.unconditional` -> `&&`). When `known` is false branchShape is
+// capture_probe.go:`if !known || !branchShape.unconditional` (INVERT_LOGICAL,
+// `||` -> `&&`). When `known` is false branchShape is
 // the zero captureShape, so `!branchShape.unconditional` is true and the
 // conjunction is true as well: the mutant declines exactly where the original
 // does. The only state that separates them is known && !unconditional, and it
@@ -774,8 +779,8 @@ func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
 // differs), so the carrier is never inside the factored prefix, and removing
 // a prefix cannot introduce a skippable ancestor.
 //
-// capture_probe.go:336:33 (CONDITIONALS_BOUNDARY, `return siblings,
-// len(siblings) > 0` -> `>= 0`). Reaching this line requires
+// capture_probe.go:`return siblings, len(siblings) > 0`
+// (CONDITIONALS_BOUNDARY, `> 0` -> `>= 0`). Reaching this line requires
 // groups[parent].alternations to be non-empty, so appending bodyEnd to it
 // yields at least two spans. They are consecutive disjoint ranges over the
 // parent's body, so at most one of them equals `branch` and is skipped, and
@@ -783,20 +788,20 @@ func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
 // parse / matchesEmpty check above. len(siblings) is therefore never 0 here
 // and the two comparisons agree.
 //
-// capture_probe.go:376:28 (CONDITIONALS_BOUNDARY, the sort's
-// `ordered[i].start < ordered[j].start` -> `<=`). The line is guarded by
+// capture_probe.go:`return ordered[i].start < ordered[j].start`
+// (CONDITIONALS_BOUNDARY, the sort's `<` -> `<=`). The line is guarded by
 // `if ordered[i].start != ordered[j].start`, and on unequal operands `<` and
 // `<=` are the same function.
 //
-// capture_probe.go:378:25 (CONDITIONALS_BOUNDARY, `ordered[i].end >
-// ordered[j].end` -> `>=`). Reached only when the two starts are equal.
+// capture_probe.go:`return ordered[i].end > ordered[j].end`
+// (CONDITIONALS_BOUNDARY, `>` -> `>=`). Reached only when the two starts are equal.
 // `ordered` is filled through the `named map[sourceSpan]string` seen-check
 // above, so its elements are pairwise distinct spans; equal starts therefore
 // force unequal ends, where `>` and `>=` agree. sort.SliceStable never calls
 // less(i, i).
 //
-// capture_probe.go:496:13 (CONDITIONALS_BOUNDARY, branchContaining's
-// `if offset < bar` -> `<=`). `offset` is always a group's `open`, the byte
+// capture_probe.go:`if offset < bar` (CONDITIONALS_BOUNDARY,
+// branchContaining's `<` -> `<=`). `offset` is always a group's `open`, the byte
 // index of a '(', and `bar` is the byte index of a '|'. One byte cannot be
 // both, so offset == bar is unreachable and the two comparisons agree on
 // every offset a caller can supply.

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -358,8 +358,8 @@ func TestEmptyCapturesReplacement(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// label_replace.go:770:10 (CONDITIONALS_BOUNDARY, extractRef's
-// `for end < len(rest)` -> `<=`). The extra iteration the mutant admits runs
+// label_replace.go:`for end < len(rest)` (CONDITIONALS_BOUNDARY, extractRef's
+// loop condition, `<` -> `<=`). The extra iteration the mutant admits runs
 // at end == len(rest), where `rest[end:]` is the empty string — a legal
 // slice — and utf8.DecodeRuneInString("") returns (utf8.RuneError, 0).
 // utf8.RuneError is U+FFFD, category So: unicode.IsLetter and unicode.IsDigit

--- a/internal/qlcommon/regex_source_scan_test.go
+++ b/internal/qlcommon/regex_source_scan_test.go
@@ -191,18 +191,21 @@ func TestPlanCaptureProbesDeclines(t *testing.T) {
 // Four surviving mutants in regex_source_scan.go, all of them in a `switch`
 // that is the ENTIRE body of its enclosing `for`.
 //
-// regex_source_scan.go:77:5 (INVERT_LOOPCTRL, scanSourceGroups' `\Q` arm) and
-// regex_source_scan.go:155:5 (INVERT_LOOPCTRL, skipCharClass' POSIX-name arm)
-// are the same shape. `break` inside a `switch` leaves the SWITCH, not the
+// The `continue` after regex_source_scan.go:`i = endOfQuotedRun(src, i)`
+// (INVERT_LOOPCTRL, scanSourceGroups' `\Q` arm) and the one after
+// regex_source_scan.go:`j += 2 + end + 2` (INVERT_LOOPCTRL, skipCharClass'
+// POSIX-name arm) are the same shape. Each citation names the statement above
+// the mutated `continue`, which is a bare keyword no construct can single
+// out. `break` inside a `switch` leaves the SWITCH, not the
 // loop. In both functions the switch is the whole loop body and the `for` has
 // an empty post statement, so the byte after the switch is the loop's closing
 // brace: `break` re-evaluates the loop condition exactly as `continue` does,
 // and it skips the `i += 2` / `j++` that follows in the same case arm for the
 // same reason. The two forms have identical control flow on every input.
 //
-// regex_source_scan.go:142:11 (CONDITIONALS_BOUNDARY, skipCharClass'
-// `if j+1 >= len(src)` -> `>`) and regex_source_scan.go:142:8
-// (ARITHMETIC_BASE, the same line's `j+1` -> `j-1`). The guard sits inside
+// regex_source_scan.go:`if j+1 >= len(src)` carries two mutants —
+// CONDITIONALS_BOUNDARY (skipCharClass' `>=` -> `>`) and ARITHMETIC_BASE (the
+// same line's `j+1` -> `j-1`). The guard sits inside
 // `for j < len(src)`, so j+1 <= len(src) and j-1 <= len(src)-2: neither
 // `j+1 > len(src)` nor `j-1 >= len(src)` can hold, and both mutants delete
 // the guard rather than move it. The deleted case is a trailing `\` at

--- a/internal/traceql/ast/lexer_mutation_test.go
+++ b/internal/traceql/ast/lexer_mutation_test.go
@@ -138,8 +138,8 @@ func TestParentScopedAttribute(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// lexer.go:`if sb.Len() > longestScopePrefix` (CONDITIONALS_BOUNDARY, `if sb.Len() > longestScopePrefix`
-// -> `>=`). tryScopeAttribute only ever ACTS on the two keywords that map to
+// lexer.go:`sb.Len() > longestScopePrefix` (CONDITIONALS_BOUNDARY, `>` ->
+// `>=`). tryScopeAttribute only ever ACTS on the two keywords that map to
 // tokSpanDot / tokResourceDot — "span." (5 bytes) and "resource." (9) — and
 // the '.' arm two branches above fires before this length check, so sb holds
 // at most 4 and 8 bytes respectively when the check runs. Both forms build
@@ -150,8 +150,8 @@ func TestParentScopedAttribute(t *testing.T) {
 // exhaustive check of keywordTokens confirms no key mapping to tokSpanDot or
 // tokResourceDot exceeds longestScopePrefix.
 //
-// lexer.go:554:23 (INVERT_LOGICAL, `if r == scanner.EOF ||
-// unicode.IsSpace(r)` -> `&&`). This arm is subsumed by the character test on
+// lexer.go:`r == scanner.EOF || unicode.IsSpace(r)` (INVERT_LOGICAL, `||` ->
+// `&&`). This arm is subsumed by the character test on
 // the next branch: `!unicode.IsNumber(r) && !isDurationRune(r) && r != '.'`
 // breaks for every rune the EOF/space arm catches, because no rune is at once
 // a space and a digit, one of isDurationRune's nine letters, or '.'. Under

--- a/internal/traceql/ast/lexer_mutation_test.go
+++ b/internal/traceql/ast/lexer_mutation_test.go
@@ -138,7 +138,7 @@ func TestParentScopedAttribute(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// lexer.go:523:15 (CONDITIONALS_BOUNDARY, `if sb.Len() > longestScopePrefix`
+// lexer.go:`if sb.Len() > longestScopePrefix` (CONDITIONALS_BOUNDARY, `if sb.Len() > longestScopePrefix`
 // -> `>=`). tryScopeAttribute only ever ACTS on the two keywords that map to
 // tokSpanDot / tokResourceDot — "span." (5 bytes) and "resource." (9) — and
 // the '.' arm two branches above fires before this length check, so sb holds

--- a/internal/traceql/ast/parse_lenient_test.go
+++ b/internal/traceql/ast/parse_lenient_test.go
@@ -146,7 +146,7 @@ func TestReplaceIncompleteMatchersScansPastAnUnrepairableComparison(t *testing.T
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// parse.go:197:17 (INVERT_LOGICAL, `if expr == nil ||
+// parse.go:`if expr == nil || len(expr.Pipeline.Elements) == 0` (INVERT_LOGICAL, `if expr == nil ||
 // len(expr.Pipeline.Elements) == 0` -> `&&`). Both operands are always false
 // together, so neither form ever enters the branch. parseTokens returns a nil
 // expr only alongside a non-nil error, which ParseIdentifier has already

--- a/internal/traceql/ast/parse_lenient_test.go
+++ b/internal/traceql/ast/parse_lenient_test.go
@@ -146,8 +146,8 @@ func TestReplaceIncompleteMatchersScansPastAnUnrepairableComparison(t *testing.T
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// parse.go:`if expr == nil || len(expr.Pipeline.Elements) == 0` (INVERT_LOGICAL, `if expr == nil ||
-// len(expr.Pipeline.Elements) == 0` -> `&&`). Both operands are always false
+// parse.go:`expr == nil || len(expr.Pipeline.Elements) == 0`
+// (INVERT_LOGICAL, `||` -> `&&`). Both operands are always false
 // together, so neither form ever enters the branch. parseTokens returns a nil
 // expr only alongside a non-nil error, which ParseIdentifier has already
 // returned on; on the success path parseRoot returns the result of

--- a/internal/traceql/ast/references.go
+++ b/internal/traceql/ast/references.go
@@ -8,7 +8,7 @@ package ast
 // The scope is the WHOLE query — every pipeline stage plus the metrics
 // first stage — and that is a deliberate mirror of upstream rather than a
 // convenience. Upstream's `RootExpr.extractConditions`
-// (pkg/traceql/ast_conditions.go:3) folds every stage of the query into a
+// (in pkg/traceql/ast_conditions.go) folds every stage of the query into a
 // single FetchSpansRequest, so its storage layer materialises an
 // intrinsic on every candidate span the moment any part of the query
 // mentions it. There is no per-spanset-side narrowing to model:

--- a/internal/traceql/ast/rewrite_mutation_test.go
+++ b/internal/traceql/ast/rewrite_mutation_test.go
@@ -174,7 +174,7 @@ func TestStaticTypeAllowedMatchesExactly(t *testing.T) {
 // EARLIER `continue` (the op.LHS extraction) or at the outer-operator match,
 // so a `break` here reaches the same `return nil, false`.
 //
-// rewrite.go:123:52 (INVERT_LOGICAL, `if !staticTypeAllowed(valL.Type,
+// rewrite.go:`if !staticTypeAllowed(valL.Type, rule.restrict) || !staticTypeAllowed(valR.Type, rule.restrict)` (INVERT_LOGICAL, `if !staticTypeAllowed(valL.Type,
 // rule.restrict) || !staticTypeAllowed(valR.Type, rule.restrict)` -> `&&`).
 // Both rules that carry a `restrict` list carry the same one — the string
 // family, {TypeString, TypeStringArray} — and that family is exactly the set

--- a/internal/traceql/ast/rewrite_mutation_test.go
+++ b/internal/traceql/ast/rewrite_mutation_test.go
@@ -164,8 +164,8 @@ func TestStaticTypeAllowedMatchesExactly(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// rewrite.go:115:4 (INVERT_LOOPCTRL, the `continue` under `if !ok || attrL !=
-// attrR`). Reaching that branch means attrLiteralOperands accepted op.LHS
+// rewrite.go:`!ok || attrL != attrR` (INVERT_LOOPCTRL, the `continue` under
+// that guard). Reaching that branch means attrLiteralOperands accepted op.LHS
 // against the CURRENT rule, so op.LHS's operator is that rule's `scalar` or
 // `array`. arrayFoldRules pairs the only two rules that share an outer
 // operator as {OpEqual, OpIn} with {OpRegex, OpRegexMatchAny} under `||`, and
@@ -174,8 +174,8 @@ func TestStaticTypeAllowedMatchesExactly(t *testing.T) {
 // EARLIER `continue` (the op.LHS extraction) or at the outer-operator match,
 // so a `break` here reaches the same `return nil, false`.
 //
-// rewrite.go:`if !staticTypeAllowed(valL.Type, rule.restrict) || !staticTypeAllowed(valR.Type, rule.restrict)` (INVERT_LOGICAL, `if !staticTypeAllowed(valL.Type,
-// rule.restrict) || !staticTypeAllowed(valR.Type, rule.restrict)` -> `&&`).
+// rewrite.go:`!staticTypeAllowed(valL.Type, rule.restrict) || !staticTypeAllowed(valR.Type, rule.restrict)`
+// (INVERT_LOGICAL, `||` -> `&&`).
 // Both rules that carry a `restrict` list carry the same one — the string
 // family, {TypeString, TypeStringArray} — and that family is exactly the set
 // staticMerge will merge a string with. So the two operands are either both

--- a/internal/traceql/ast/static_mutation_test.go
+++ b/internal/traceql/ast/static_mutation_test.go
@@ -214,8 +214,8 @@ func TestStaticEncodeToString(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// static.go:221:23 (INVERT_LOGICAL, `if s.Type == TypeNil || o.Type ==
-// TypeNil` -> `&&`). The guard is a fast path for a result the rest of the
+// static.go:`s.Type == TypeNil || o.Type == TypeNil` (INVERT_LOGICAL, `||`
+// -> `&&`). The guard is a fast path for a result the rest of the
 // function already produces. With both operands nil the `&&` is true and both
 // forms return false. With exactly one nil operand the mutant falls through:
 // isNumeric is false for TypeNil, so the numeric arm is skipped; TypeNil is

--- a/internal/traceql/lower_mutation_survivors_test.go
+++ b/internal/traceql/lower_mutation_survivors_test.go
@@ -11,25 +11,26 @@ import (
 
 // Mutation-coverage tests for the five `CONDITIONALS_NEGATION` survivors
 // tracked by #1524: gremlins-phase4-traceql-lower run 30695961440 recorded
-// nine LIVED mutants on lower.go, two of which (lower.go:651 / :655, inside
-// the now-deleted spansetArmExposesSpanID) no longer exist — #1413 removed
-// that function when it folded span-identity tracking into mapSetOp's own
+// nine LIVED mutants on lower.go, two of which (inside the now-deleted
+// spansetArmExposesSpanID) no longer exist — #1413 removed that function
+// when it folded span-identity tracking into mapSetOp's own
 // alignUnionArms call. The remaining five all still exist, unchanged in
-// substance, just renumbered by intervening edits:
+// substance:
 //
-//	lower.go:612  isNarrowSpanProjection  Replacements guard
-//	lower.go:620  isNarrowSpanProjection  Projections-length guard
-//	lower.go:1333 lowerInOperation        absentAttributePredicate guard
-//	lower.go:1417 attributeHasNoBacking   instrumentation-scope guard
-//	lower.go:1670 coerceBoolFieldAccess   op guard
+//	isNarrowSpanProjection  lower.go:`len(p.Replacements) != 0`
+//	isNarrowSpanProjection  lower.go:`len(p.Projections) != len(want)`
+//	lowerInOperation        lower.go:`absentAttributePredicate(attr, s, b.Op == traceql.OpNotIn); absent`
+//	attributeHasNoBacking   lower.go:`attr.Scope == traceql.AttributeScopeInstrumentation && s.ScopeAttributesColumn == ""`
+//	coerceBoolFieldAccess   lower.go:`op != chplan.OpEq && op != chplan.OpNe`
 //
 // Each test below calls the mutated function/call-site directly and asserts
 // the CONCRETE result on both sides of the guard, so a CONDITIONALS_NEGATION
 // mutant (which wraps the whole guard condition in `!(...)`) flips at least
 // one assertion's expected outcome.
 
-// TestIsNarrowSpanProjection_ReplacementsGuard pins the `len(p.Replacements)
-// != 0` guard (lower.go:613). The mutant flips it to `== 0`, which:
+// TestIsNarrowSpanProjection_ReplacementsGuard pins the
+// lower.go:`len(p.Replacements) != 0` guard. The mutant flips it to
+// `== 0`, which:
 //   - on the canonical envelope (Replacements empty) short-circuits false
 //     instead of falling through to the (matching) shape check;
 //   - on a Project WITH Replacements set skips the short-circuit and falls
@@ -51,7 +52,7 @@ func TestIsNarrowSpanProjection_ReplacementsGuard(t *testing.T) {
 }
 
 // TestIsNarrowSpanProjection_ProjectionCountGuard pins the
-// `len(p.Projections) != len(want)` guard (lower.go:620). The mutant flips it
+// lower.go:`len(p.Projections) != len(want)` guard. The mutant flips it
 // to `==`, which:
 //   - on the exact-length canonical envelope short-circuits false instead of
 //     running the per-column check that confirms it;
@@ -74,8 +75,8 @@ func TestIsNarrowSpanProjection_ProjectionCountGuard(t *testing.T) {
 }
 
 // TestIsNarrowSpanProjection_PerColumnGuard pins the per-column rejection
-// guard `!ok || projection.Alias != "" || column.Name != want[i]`
-// (lower.go:625). This guard was previously NOT_COVERED — nothing exercised
+// guard lower.go:`!ok || projection.Alias != "" || column.Name != want[i]`.
+// This guard was previously NOT_COVERED — nothing exercised
 // isNarrowSpanProjection's loop body at all — so the two length guards above
 // were the only ones gremlins could even attempt to kill. Reaching the loop
 // (as the two tests above now do) makes this three-way OR live too; each arm
@@ -107,9 +108,9 @@ func TestIsNarrowSpanProjection_PerColumnGuard(t *testing.T) {
 	}
 }
 
-// TestLowerInOperation_AbsentAttributeGuard pins the `; absent {` guard at
-// lower.go:1333 (`if pred, absent := absentAttributePredicate(...); absent`).
-// The mutant flips it to `; !absent {`, which:
+// TestLowerInOperation_AbsentAttributeGuard pins the `; absent` guard
+// lower.go:`absentAttributePredicate(attr, s, b.Op == traceql.OpNotIn); absent`.
+// The mutant flips it to `; !absent`, which:
 //   - on a backed attribute (absent == false) wrongly fires the early
 //     return, yielding the (nil, nil) zero value instead of an *InList;
 //   - on an unbacked attribute (absent == true) wrongly SKIPS the early
@@ -150,9 +151,9 @@ func TestLowerInOperation_AbsentAttributeGuard(t *testing.T) {
 	}
 }
 
-// TestAttributeHasNoBacking_InstrumentationScopeGuard pins the
-// `attr.Scope == AttributeScopeInstrumentation && s.ScopeAttributesColumn ==
-// ""` predicate (lower.go:1417). The mutant negates the whole expression,
+// TestAttributeHasNoBacking_InstrumentationScopeGuard pins the predicate
+// lower.go:`attr.Scope == traceql.AttributeScopeInstrumentation && s.ScopeAttributesColumn == ""`.
+// The mutant negates the whole expression,
 // which flips every one of the three cases below.
 func TestAttributeHasNoBacking_InstrumentationScopeGuard(t *testing.T) {
 	t.Parallel()
@@ -178,9 +179,9 @@ func TestAttributeHasNoBacking_InstrumentationScopeGuard(t *testing.T) {
 	}
 }
 
-// TestCoerceBoolFieldAccess_OpGuard pins the `op != chplan.OpEq && op !=
-// chplan.OpNe` guard (lower.go:1670). The mutant flips it to `op == OpEq ||
-// op == OpNe`, which:
+// TestCoerceBoolFieldAccess_OpGuard pins the guard
+// lower.go:`op != chplan.OpEq && op != chplan.OpNe`. The mutant flips it
+// to `op == OpEq || op == OpNe`, which:
 //   - on OpEq wrongly fires the early return, leaving the LitBool operand
 //     un-coerced instead of rewritten to its OTel-CH string encoding;
 //   - on a non-equality op (OpAnd) wrongly SKIPS the early return and

--- a/internal/traceql/search_limit.go
+++ b/internal/traceql/search_limit.go
@@ -284,8 +284,10 @@ func pushLeafPredicate(n chplan.Node, pred chplan.Expr) chplan.Node {
 		return v
 	case *chplan.SearchTraceLimit:
 		// Already fully windowed: stampSearchTraceLimit creates this node and
-		// folds the window onto its plain-search leaves at lower.go:56, before
-		// stampSearchWindow runs at :62. Recursing here would double-fold the
+		// folds the window onto its plain-search leaves at
+		// lower.go:`plan = stampSearchTraceLimit(plan, searchTraceLimit(ctx), start, end, s)`,
+		// before lower.go:`plan = stampSearchWindow(plan, searchTraceLimit(ctx), start, end, s)`
+		// runs. Recursing here would double-fold the
 		// predicate (TestSearchWindow_PlainNotDoubleFolded). This is an explicit
 		// "already handled", not a silent drop — every OTHER node still recurses.
 		return n

--- a/internal/traceql/search_limit_mutation_test.go
+++ b/internal/traceql/search_limit_mutation_test.go
@@ -86,12 +86,12 @@ func TestWithSearchTraceLimit_ZeroStoresNothing(t *testing.T) {
 	}
 }
 
-// TestSearchTraceLimit_NegativeStoredValueGuarded pins the `ok && n > 0`
-// conjunction in searchTraceLimit (search_limit.go:41). A negative int stored
-// directly under the key (bypassing WithSearchTraceLimit's own guard) must read
-// back as 0: `ok` is true but `n > 0` is false, so the AND is false. The
-// INVERT_LOGICAL mutant `ok || n > 0` would be true (ok alone) and return the
-// negative value verbatim.
+// TestSearchTraceLimit_NegativeStoredValueGuarded pins the
+// search_limit.go:`ok && n >= 1` conjunction in searchTraceLimit. A negative
+// int stored directly under the key (bypassing WithSearchTraceLimit's own
+// guard) must read back as 0: `ok` is true but `n >= 1` is false, so the AND
+// is false. The INVERT_LOGICAL mutant `ok || n >= 1` would be true (ok alone)
+// and return the negative value verbatim.
 func TestSearchTraceLimit_NegativeStoredValueGuarded(t *testing.T) {
 	t.Parallel()
 	const storedNegative = -5
@@ -105,8 +105,8 @@ func TestSearchTraceLimit_NegativeStoredValueGuarded(t *testing.T) {
 	}
 }
 
-// TestSearchTraceLimit_MinimumPositiveRoundTrips pins the exact `n >= 1` boundary
-// in searchTraceLimit (search_limit.go:41). A limit of 1 — the smallest positive
+// TestSearchTraceLimit_MinimumPositiveRoundTrips pins the exact boundary of
+// search_limit.go:`ok && n >= 1` in searchTraceLimit. A limit of 1 — the smallest positive
 // value — must read back as 1, not fall through to 0. The CONDITIONALS_BOUNDARY
 // mutant `n > 1` would reject the boundary value and return 0.
 func TestSearchTraceLimit_MinimumPositiveRoundTrips(t *testing.T) {
@@ -119,8 +119,8 @@ func TestSearchTraceLimit_MinimumPositiveRoundTrips(t *testing.T) {
 }
 
 // TestStampRecursiveScanWindow_EndOnlyStillStamps pins the
-// `startNano == 0 && endNano == 0` guard in stampRecursiveScanWindow
-// (search_limit.go:181). An end-only window (start zero, end set) has exactly one
+// search_limit.go:`startNano == 0 && endNano == 0` guard in
+// stampRecursiveScanWindow. An end-only window (start zero, end set) has exactly one
 // operand true, so the AND is false and the walk proceeds to stamp the window
 // onto the StructuralJoin. The INVERT_LOGICAL mutant `||` would be true and
 // short-circuit the stamp, leaving the recursive step scan windowless (full-
@@ -158,8 +158,9 @@ func rootFilterOverScan(op chplan.BinaryOp, left, right chplan.Expr) *chplan.Fil
 	}
 }
 
-// TestIsRootSpanFilter_NonEqOpRejected pins the `!ok || b.Op != OpEq` disjunction
-// in isRootSpanFilter (search_limit.go:399). The predicate here IS a *Binary
+// TestIsRootSpanFilter_NonEqOpRejected pins the
+// search_limit.go:`!ok || b.Op != chplan.OpEq` disjunction in
+// isRootSpanFilter. The predicate here IS a *Binary
 // (`!ok` false) but its op is `<`, not `=` (`b.Op != OpEq` true), so the OR is
 // true and the shape is rejected. The INVERT_LOGICAL mutant `&&` would be false
 // (one operand false) and fall through to accept a NON-equality predicate as a
@@ -182,8 +183,9 @@ func TestIsRootSpanFilter_NonEqOpRejected(t *testing.T) {
 	}
 }
 
-// TestIsRootSpanFilter_WrongColumnRejected pins the FIRST `&&` on
-// search_limit.go:407 (`ok && col.Name == parentSpanIDCol`). The predicate is a
+// TestIsRootSpanFilter_WrongColumnRejected pins the FIRST `&&` of
+// search_limit.go:`ok && col.Name == parentSpanIDCol && lit.V == rootParentSpanID`.
+// The predicate is a
 // well-formed `<col> = ""` over the WRONG column: `ok` true, the column check
 // false, the empty-string check true. The AND chain is false (rejected). The
 // INVERT_LOGICAL mutant `ok || col.Name == parentSpanIDCol && lit.V == ""`
@@ -199,8 +201,9 @@ func TestIsRootSpanFilter_WrongColumnRejected(t *testing.T) {
 	}
 }
 
-// TestIsRootSpanFilter_NonEmptyLiteralRejected pins the SECOND `&&` on
-// search_limit.go:407 (`... && lit.V == ""`). The predicate is `<parentCol> =
+// TestIsRootSpanFilter_NonEmptyLiteralRejected pins the SECOND `&&` of
+// search_limit.go:`ok && col.Name == parentSpanIDCol && lit.V == rootParentSpanID`
+// (`rootParentSpanID` is `""`). The predicate is `<parentCol> =
 // "srv"`: `ok` true, column matches, but the literal is NON-empty. The AND chain
 // is false (rejected). The INVERT_LOGICAL mutant `(ok && col.Name == …) ||
 // lit.V == ""` is true on the left conjunction alone and would ACCEPT a

--- a/internal/traceql/search_limit_mutation_test.go
+++ b/internal/traceql/search_limit_mutation_test.go
@@ -67,7 +67,7 @@ func TestStampSearchTraceLimitWrapsPlainSource(t *testing.T) {
 }
 
 // TestWithSearchTraceLimit_ZeroStoresNothing pins the exact `n <= 0` boundary in
-// WithSearchTraceLimit (search_limit.go:32). At n == 0 the `<=` guard returns the
+// WithSearchTraceLimit (search_limit.go:`n <= 0`). At n == 0 the `<=` guard returns the
 // context UNCHANGED, so the key is never stored. The CONDITIONALS_BOUNDARY mutant
 // `n < 0` would fall through at n == 0 and store the int 0 under the key.
 // searchTraceLimit masks that (its own `n > 0` check reads it back as 0 either

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -416,8 +416,8 @@ FROM numbers(600)`
 
 	// Classic-histogram companion rows for `http_server_request_duration`.
 	//
-	// Since PR #645 (`HistogramCompanionColumn`,
-	// internal/schema/otel.go:373), the PromQL lowering routes any
+	// Since PR #645 ([schema.Metrics.HistogramCompanionColumn] in
+	// internal/schema/otel.go), the PromQL lowering routes any
 	// `<base>_count` / `<base>_sum` reference to `otel_metrics_histogram`
 	// under the bare `<base>` MetricName, projecting `Count` / `Sum` as
 	// the value. That's the correct production behaviour — the OTel-CH
@@ -466,7 +466,8 @@ FROM numbers(600)`
 	// seed_now: [seed_now - 300 s, seed_now + 285 s], with 40 rows at
 	// 15 s cadence across 3 services. The rolling re-seeder re-runs
 	// this INSERT every 30 s, so every Loki `/query` instant request
-	// (5 m staleness lookback, see internal/api/loki/handler.go:235)
+	// (5 m staleness lookback, see
+	// internal/api/loki/handler.go:`h.langForRequest(ts.Add(-qlcommon.InstantLookback), ts)`)
 	// finds ≥1 row inside the lookback regardless of suite drift.
 	//
 	// `service_name="api"` rows (number % 3 = 0, ~14 of the 40) are

--- a/test/integration/promql/matrix.go
+++ b/test/integration/promql/matrix.go
@@ -139,7 +139,7 @@ func cat2Histogram() []exoticCase {
 		{name: "cat2/hq_p90", promql: "histogram_quantile(0.9, sum by(le)(rate(" + h + "[5m])))"},
 		{name: "cat2/hq_p95", promql: "histogram_quantile(0.95, sum by(le)(rate(" + h + "[5m])))"},
 		{name: "cat2/hq_by_path", promql: "histogram_quantile(0.9, sum by(le, path)(rate(" + h + "[5m])))"},
-		// phi out of domain (Prometheus quantile.go:114-119): phi < 0 ->
+		// phi out of domain (Prometheus quantile.go): phi < 0 ->
 		// -Inf, phi > 1 -> +Inf. Pinned by Wave-0 fix (b); phi == 0 / 1
 		// stay in domain and fall through to the normal bucket search.
 		{name: "cat2/hq_phi_neg", promql: "histogram_quantile(-0.1, sum by(le)(rate(" + h + "[5m])))"},

--- a/test/perf/orderby_chdb_test.go
+++ b/test/perf/orderby_chdb_test.go
@@ -2,11 +2,13 @@
 
 // Deliverable 1 (task #70): quantify the metrics-table ORDER BY decision.
 //
-// Production renders the OTel-CH metrics tables with
+// The OTel-CH default renders the metrics tables with
 //
 //	ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
 //
-// (ServiceName FIRST — see internal/chsql/tableshape.go:136). A
+// (ServiceName FIRST; cerberus now patches that in the cerberus-ddl fork,
+// so internal/chsql/tableshape.go:`metrics.MetricNameColumn,` leads the
+// metrics sort key). A
 // metric-name-first PromQL instant query with NO service.name matcher —
 // the common Grafana / Drilldown-Metrics case — cannot PK-range-prune on
 // the leading ServiceName key, so ClickHouse falls back to a generic

--- a/test/regression/image_build_registry_retry_test.go
+++ b/test/regression/image_build_registry_retry_test.go
@@ -294,8 +294,17 @@ func TestBuildRetryWrapperRetriesOnlyTransientRegistryFailures(t *testing.T) {
 			"https://registry-1.docker.io/v2/library/golang/manifests/1.26: 429 Too Many Requests"
 		hubRateLimitProse = "toomanyrequests: You have reached your unauthenticated pull rate limit."
 
-		resetConnection     = `#4 ERROR: failed to do request: Head "https://registry-1.docker.io/v2/": read: connection reset by peer`
-		compileError        = "internal/api/prom/handler.go:12:2: undefined: notAThing"
+		resetConnection = `#4 ERROR: failed to do request: Head "https://registry-1.docker.io/v2/": read: connection reset by peer`
+		// The build failure is spelled as BuildKit's step-exit line rather than
+		// the compiler diagnostic it wraps. A raw `<file>.go:<line>:<col>:`
+		// diagnostic is indistinguishable, to any reader and to
+		// verify-code-citations, from a source citation naming a line — the form
+		// that gate exists to reject (#2953) — and this string is fixture data
+		// with no construct to name. Both spellings are classified identically:
+		// neither matches a transient or a rate-limit pattern in
+		// .github/scripts/lib/registry.mjs, so the case still asserts that a
+		// genuine build failure is not retried and keeps its exit status.
+		compileError        = `#8 ERROR: process "/bin/sh -c go build ./cmd/cerberus" did not complete successfully: exit code: 2`
 		compileExitStatus   = 2
 		neverSucceeds       = buildRetryAttempts + 1
 		succeedsImmediately = 1


### PR DESCRIPTION
## What this is

A citation in a mutation-adjudication note now names the **construct** the mutant lives on, and a
gate resolves it. The line number is gone from the convention, and every citation in the tree is
converted, so the gate's first green is not vacuous.

```go
// NOT KILLABLE — the arms are semantically identical.
//   range_window.go:`numAnchors-1`
//   range_window.go:emitRangeWindow:`ns%stepNS != 0`
```

## What I measured, and how

Scanning every `<path>.go:<line>` token in every tracked Go file — comments **and** string
literals — and resolving each against the file it names, at `bf5fafb05`:

| | count |
| --- | --- |
| **total line-number citations**, over 2157 tracked Go files | **470** |
| — naming a file **outside** this repository (upstream Prometheus / Loki / Tempo / Grafana) | 46 |
| — resolving in-repo | 424 |
| &nbsp;&nbsp;…to a **line past the end of the file** | **2** |
| &nbsp;&nbsp;…to a **comment or a blank line** — provably drifted | **133** |
| &nbsp;&nbsp;…to a code line whose text is **not unique in that file** (`}`, `return nil`, `if err != nil {`) | **88** |
| &nbsp;&nbsp;…to a unique code line | 201 |

So **223 of the 424 in-repo citations — 53% — provably or near-provably did not name what they
claimed**, and only 201 landed somewhere a reader could have trusted.

The issue measured 335 resolvable citations and 112 provably drifted. My number is higher because
the issue's scan covered `//` comments in `internal/**/*_test.go` only; it missed **85 citations
inside `t.Fatalf` string literals** — the message a reader sees when the test actually fails, which
is exactly when the citation matters — and **37 in non-test source files**. The provable-drift class
is 133 rather than 112 for the same reason, and the issue's own note that its figure was a lower
bound is borne out: the 88 non-unique-line citations are the class it said it could not count.

Reproduce on the parent commit with `node .github/scripts/verify-code-citations.mjs`, which reports
all 470.

## Which remedy, and why the others lose

The issue sketched two remedies and did not choose. A third was proposed in review: keep the line
number but add the construct — `lower.go:613 (len(p.Replacements) != 0)` — so a gate can resolve the
line and assert it contains the named token.

I measured the cost of keeping the line number before deciding. Replaying the **200 first-parent
commits** on `main` before this branch against the citation set they would have carried:

| | commits | citations |
| --- | --- | --- |
| would have invalidated a citation by **moving lines above it** — construct untouched | **65 (33%)** | **573** |
| actually **modified a cited line** — the construct changed | **2 (1%)** | **2** |

That is a **287:1 false-alarm ratio**. A gate that verifies a line number goes red on one merged
commit in three, demanding a mechanical renumber of up to 43 comments in a single PR, for a signal
that carries no information. Gates with that profile get weakened, bypassed, or worked around — the
exact failure four separate fixes this milestone existed to stop.

So:

- **Sketch 1 (reject comment/blank citations)** loses because it admits in its own text that it
  misses the drifted-onto-a-different-code-line class, and because it still verifies a line number
  and inherits the churn above.
- **Sketch 3 (line + construct)** loses on the same churn: it detects drift instead of removing it,
  and 573 of every 575 alarms would be noise.
- **Sketch 2 (name the construct)** is right about the anchor and wrong that it "needs no gate" — an
  unenforced convention is the exact rot this milestone is fighting, and nothing would check that a
  named function or construct still exists.

This change is sketch 2 **with** the gate sketch 3 wanted, which is what makes it verifiable:
naming the construct *removes* the drift class rather than detecting it, and the only edit that can
invalidate a citation is one that changes the construct — precisely when a human must re-read the
adjudication. Both of the issue's provable classes become unrepresentable: a construct is searched
only among **code** lines, so a citation cannot resolve to a comment or a blank line, and there is
no line to drift onto a different code line.

## The gate

`.github/scripts/verify-code-citations.mjs`, two steps of the required `forbid-skip` job.

Grammar — two shapes, both fully verified:

```
range_window.go:`numAnchors-1`                  construct, unique among the file's code lines
range_window.go:emitRangeWindow:`numAnchors-1`  construct, unique among that func's code lines
```

It resolves the path relative to the citing file's directory, else to the repository root; requires
the construct (whitespace collapsed) to appear on **exactly one code line** of that file or of the
named top-level func; and searches code lines only — blank lines and whole-line `//` comments are
never searched, which is what makes the provable-drift class unrepresentable rather than merely
detected.

**Fail closed.** Every one of these is an error, never a skip: `foo.go:613`, `foo.go:613:22`,
`foo.go:108-109`, `foo.go:97:23/29/38`; a path that does not resolve in this repository; a construct
matching no code line or more than one; an unterminated or empty construct; a func scope that is not
a top-level func of the cited file; and a `PATHSPECS` that matches no Go file at all. Scope is a git
pathspec over every tracked Go file — **no path boundary, no allow-list, no tolerance file, and
nothing that can silently shrink** the way the `HARNESS_PATHS` hand-list did in #2948.

**What it deliberately does not model.** `.go:` followed by anything other than a digit or a
construct carries no address and therefore cannot suffer this drift: ordinary prose ("see
`range_window.go`: the anchor grid…"), a bare function reference (`lower.go:wrapRangeLatestPerSeries`),
and `test/rejection-parity`'s `path.go:func#hash` **site identifiers** — a data format, not a
citation, whose own test builds deliberately fabricated ones (`internal/promql/a.go:fnA#0000aaaa`)
that no resolver should ever be asked to resolve.

## Proof the gate can fail

`.github/scripts/verify-code-citations.test.mjs` — 21 `node --test` cases driving the real CLI over
a throwaway git repository. Every rejection is paired with its **nearest-miss acceptance**, so a
regression that widens the gate into uselessness and one that narrows it into noise both surface:

- accepts a construct resolving to exactly one code line / **rejects one matching nothing** /
  **rejects one matching more than one**
- accepts a construct scoped to a func / **rejects a scope that is not a top-level func** /
  **rejects a construct sitting outside the named func, after its closing brace**
- accepts a construct written with different whitespace, or split across a wrapped comment block
- accepts a path written relative to the repo root / **rejects one that escapes the repo root** /
  **rejects one naming a file outside this repository**
- **rejects a bare line number**, **a `line:col`**, and **a line range** — the three drifting shapes
- **rejects a construct that lives only in a comment of the cited file** — the issue's provable class
- **rejects an unterminated construct** rather than reading past it, and **rejects an empty one**
- unescapes a construct written inside a Go string literal (a `t.Fatalf` message spelling `\"`)
- leaves prose and the rejection-parity `path.go:func#hash` site-id format alone
- **fails when the pathspec matches no Go file at all** — a gate that finds nothing must not be green
- reports every violation in one run rather than stopping at the first

And a live demonstration on a real corrected citation — revert one, watch it go red, restore it:

```console
$ sed -i '20s|lower.go:`len(p.Replacements) != 0`|lower.go:613|' \
    internal/traceql/lower_mutation_survivors_test.go
$ PATHSPECS='internal/traceql/*.go' node .github/scripts/verify-code-citations.mjs
internal/traceql/lower_mutation_survivors_test.go:20: line-number citation `lower.go:613 …`
  — a line number cannot be verified and drifts on every insertion above it.
    Name the construct: `lower.go:`<construct>``.
::error::1 source citation(s) do not resolve. …
exit=1

# and the other direction — the construct itself changes, which is the ONLY
# edit that should invalidate a citation:
$ sed -i '20s|len(p.Replacements) != 0|len(p.Replacements) != 1|' \
    internal/traceql/lower_mutation_survivors_test.go
internal/traceql/lower_mutation_survivors_test.go:20: construct `len(p.Replacements) != 1`
  matches no code line in internal/traceql/lower.go. The construct moved or changed —
  re-read the note before repointing it.
exit=1

$ git checkout internal/traceql/lower_mutation_survivors_test.go
$ node .github/scripts/verify-code-citations.mjs
::notice::verify-code-citations: every construct citation across 2157 Go file(s) resolves
exit=0
```

That first case is the exact citation the issue reported as landing on a blank line
(`internal/traceql/lower_mutation_survivors_test.go` → `lower.go:613`).


## Fail-open cross-check

A gate that silently skips citations reads the same as one that verifies them, so I checked the
gate's coverage against an **independent scanner** written from the issue's description rather than
from the gate's own grammar, over all 2157 tracked Go files:

```console
independent scanner: line-number citations still in the tree = 0
construct citations now in the tree = 498
```

That cross-check also caught a real defect before it shipped: the gate was reporting a citation at
the line its comment **block** started on rather than the citation's own line, which would have sent
a reviewer to the wrong line inside a twenty-line note.

## The corrections

All 470 are converted; `node .github/scripts/verify-code-citations.mjs` is green over 2157 Go
files, and an independent scanner confirms zero `file.go:<digit>` tokens remain anywhere in the
tree. The tree now carries 498 construct citations — more than 470 because a **multi-site**
citation (`scan_resource_bound.go:97:23/29/38`, `nary_vector_set_op.go:75/76/77`,
`range_window.go:211+214`) named several mutants at once and became one citation per construct.

`gofmt -l -e` and `go vet` are clean over every changed package, and no line exceeds the `lll`
limit of 280.

**The mechanical pass was not sufficient, and that is worth stating plainly.** I first converted
the 94 citations whose construct could be derived from the line they already named, guarded so
that a note whose prose named a construct the cited line lacked was never auto-converted. Reviewing
those afterwards found that some still named the **wrong** construct: they resolve, so the gate is
green on them, but a green gate is not evidence that the construct is the one the note is about —
the line they were derived from had already drifted. Every one of the 94 was therefore re-read
against the note's prose and repointed where it disagreed. This is the honest limit of automating
this conversion, and the reason the remaining 376 were derived by reading each note rather than by
a rule.

**Upstream references lose their line numbers.** A line number in Prometheus, Loki, Tempo or Grafana
is unverifiable from this repository and rots exactly the same way — the repository pins those forks
by branch, so the numbers were never a reliable jump. Those 46 citations keep the file name and name
the construct in prose instead. This is the issue's own sketch 2 applied where verification is
impossible, and sketch 2's weakness does not bite there because there is nothing a gate could have
checked either way.

## Citations I could not resolve confidently

**None were left unconverted.** Two classes needed more than a repoint, and both are named here
because a reviewer should re-read them rather than trust the substitution:

**Ten citations named a construct that no longer exists where the note put it.** These are not line
drift — the code was refactored after the note was written. Each was traced to the commit that wrote
the note (`git show <sha>:<path>`) to confirm what the citation originally meant, then repointed at
the construct that now carries the behaviour, with only the clauses that had become false removed:

- `internal/chplan/gremlins_rewrite_mutants_test.go` cited `rule.go:251/463/507`. That file was
  `internal/optimizer/rule.go` when the note was written; #1121 moved it to
  `internal/chplan/rewrite_children.go`, and a later refactor folded two of the three guards into
  `rewriteOptionalPair`. Two of the constructs no longer exist at all.
- `internal/promql/histogram_native_range_family_gremlins_test.go` — a broadcast guard refactored
  out of `lowerSumOrAvgMixedOrSubquerySelectFn` into `histogram_native_subquery_select.go`.
- `internal/promql/gremlins_kill_test.go` — the four holt-winters factor guards merged into one
  shared `holtWintersFactorDomain` check in `scalar_domain.go`.
- Six in `internal/chsql`, all the same shape: a `len(…) > 0` guard deleted once the builder call it
  guarded became a no-op on an empty slice, plus `prewhere.go`'s insertion-sort tiebreaker (already
  gone at `0ad92a02e`, so that citation had rotted at least that long ago).

**Two citations resolved to the wrong file entirely.** `internal/chsql/lwr_fanout_bound.go` and
`internal/chsql/histogram_quantile_fanout_nonfinite_bound_chdb_test.go` cited
`histogram_quantile.go:NNNN` for symbols that live in `internal/promql/histogram_quantile.go`;
directory-relative resolution silently landed them on `internal/chsql/histogram_quantile.go`, a
different file. Both are now written repo-root-relative. Nothing would have caught this before —
the citation resolved, to the wrong file.

**Sixteen sites cite an adjacent unique line rather than the mutated operator**, because the
construct repeats inside one function and no substring of it is unique (four identical
`if err != nil` lines in one func; `if i > 0` appearing 29 times in `builder.go`). Those use the
enclosing `case` label, the `for` header, or the bare func form, and name the mutated operand in
prose. The gate verifies the address resolves; it cannot verify the reader lands on the right
operator, so these are the sites most likely to rot semantically next. That limit is stated in the
script's own header rather than left for a reader to discover.

## Filed

- **#2957** — `test: mutation-note prose claims drift from the code they adjudicate`. The half this
  change cannot reach: a citation can resolve perfectly while the sentence around it asserts
  something the code stopped doing. Two verified instances (a perf benchmark whose "ServiceName
  FIRST" premise is now inverted, and an equivalence note whose argument count arithmetic no longer
  matches its own assertions). Filed as one issue rather than two, because they are one root cause.
- **#2958** — `test: two files adjudicate the same exemplars capacity mutant in opposite directions`.
  One documents `len(groupAliases)*2+6` as unkillable in a `NOT KILLABLE` footer; the other claims to
  kill it while conceding in its own comment that "the test gives gremlins a path to call it dead
  anyway". Under the repo's surviving-mutant policy that is neither remedy 1 nor remedy 2.

Both carry milestone **M1: Restore CI truth and the evidence substrate** and are attached as real
sub-issues of epic #2891.

One reported finding was **refuted** rather than filed: a suspected `scan.UnionTables[0]` index
panic in `internal/chsql/emit_node.go`. `filterScanQuery` calls `validateScanShape(scan)` before
reaching it, and that validator rejects both-empty, so an empty `Table` really is proof that
`UnionTables` is non-empty. The comment asserting this is correct.

## Known limits, stated rather than discovered later

- **A construct that repeats inside one function** and has no unique substring cannot be cited
  precisely; 16 sites cite an adjacent unique line and name the operand in prose (above).
- **A bare line reference with no `.go:` opener** (`:119:31` as a continuation, or the prose "line
  118") is outside the grammar and is not gated: `:\d+:\d+` alone matches 1386 innocent tokens
  across the tree (times, ratios, version strings), so a rule for it would be noise rather than a
  gate. All such references that existed were converted by hand during this change. The shape is
  largely self-closing — a continuation address only makes sense after a `file.go:NNN` citation, and
  those are now rejected.
- **The gate verifies that a citation resolves, not that it is the right construct.** That is the
  limit the mechanical pass ran into (above), and no gate can close it; it is reviewer territory,
  the same division CLAUDE.md's invariant 10 already draws for `chsql`.

Closes #2953
