### PR TITLE
fix(ci): bound the memory guard's overshoot by notice latency, not a fitted byte multiple

### DIFF
--- a/.github/scripts/mutant-memory-guard.test.mjs
+++ b/.github/scripts/mutant-memory-guard.test.mjs
@@ -9,26 +9,82 @@ import { byteSize, goDurationSeconds, residentBytes } from './mutant-memory-guar
 
 const guard = '.github/scripts/mutant-memory-guard.mjs';
 
-// A child that allocates past the ceiling the tests set, retaining every buffer
-// so the growth is LIVE — the shape of the mutant this guard exists for
-// (`i += size` -> `i = size` pins a scanner index and appends per iteration).
+// The ceiling every test in this file sets, in the two forms it is needed in.
+// One source, because a self-limit or an assertion that drifted from the
+// ceiling the guard was actually given would be silently comparing two
+// different runs.
+const ceilingMiB = 256;
+const ceilingSpec = `${ceilingMiB}MiB`;
+const ceilingBytes = ceilingMiB * 1024 ** 2;
+
+// The runaway child grows at a rate THIS TEST SETS: one allocationStepBytes
+// buffer per allocationStepIntervalMs tick, every one retained so the growth is
+// LIVE — the shape of the mutant this guard exists for (`i += size` ->
+// `i = size` pins a scanner index and appends per iteration).
 //
+// The rate is set here rather than left to a tight allocation loop because the
+// overshoot assertion below reads back as a LATENCY, and a tight loop runs at
+// whatever rate the machine happens to have left over. That made the assertion
+// measure runner load as much as it measured the guard: a full 30-leg mutation
+// matrix on the same runner was enough to fail it with no defect in the guard
+// (#2955). A timer-driven child stretches under load in the same direction as
+// the guard's own timer, so the ratio between them — which is what the bound is
+// about — survives a busy machine.
+const allocationStepBytes = 8 * 1024 ** 2;
+const allocationStepIntervalMs = 50;
+
 // It stops at 4x the ceiling under test rather than running away for real. That
 // self-limit is not decoration: this suite runs on a shared CI runner, and a
 // child that allocated without bound would take the runner down whenever the
 // guard is BROKEN — turning a test failure into the very outage the guard
 // exists to prevent, with no assertion to read afterwards. A working guard kills
-// it at the 256MiB ceiling long before the self-limit; a broken one lets the
-// child stop on its own and leaves the ledger empty, which is what the
-// assertions below read.
-const runawayChildCeilingBytes = 4 * 256 * 1024 * 1024;
+// it at the ceiling long before the self-limit; a broken one lets the child stop
+// on its own and leaves the ledger empty, which is what the assertions below
+// read.
+const runawayChildCeilingBytes = 4 * ceilingBytes;
 const runawayChild = `
 const held = [];
-while (held.length * 8 * 1024 * 1024 < ${runawayChildCeilingBytes}) {
-  held.push(Buffer.alloc(8 * 1024 * 1024, 1));
-}
-setTimeout(() => process.exit(0), 30_000);
+const step = () => {
+  held.push(Buffer.alloc(${allocationStepBytes}, 1));
+  if (held.length * ${allocationStepBytes} >= ${runawayChildCeilingBytes}) {
+    setTimeout(() => process.exit(0), 30_000);
+    return;
+  }
+  setTimeout(step, ${allocationStepIntervalMs});
+};
+step();
 `;
+
+// maxNoticeLatencyMs is the property the overshoot assertion pins: the guard
+// must kill within this long of the child's RSS crossing the ceiling. The guard
+// samples /proc every 50ms, so this grants it two sampling intervals of
+// lateness.
+//
+// Two intervals is headroom measured rather than guessed. Against this child a
+// healthy guard notices in ~1ms, on an idle machine and under 4x CPU
+// oversubscription alike: child and guard are both timer-driven, so load
+// stretches them together and the GAP between them — the only thing this bound
+// is about — does not move. Two orders of magnitude of headroom, and a guard
+// whose sampling interval is widened to 250ms still records ~160ms of lateness
+// and fails.
+//
+// It is deliberately NOT derived from the guard's own sampling interval. A bound
+// that moved with the number it is auditing could not fail when that number is
+// widened, which is the single defect this assertion exists to catch.
+const maxNoticeLatencyMs = 100;
+const maxOvershootBytes = (maxNoticeLatencyMs / allocationStepIntervalMs) * allocationStepBytes;
+
+// How long the runaway subtests wait for the guard to record a breach. At the
+// rate set above the child takes ~1.7s to cross the ceiling, so this is generous
+// by more than an order of magnitude: it detects a wedged guard, and a slow
+// runner cannot walk it into a failure the way a bound on the MEASUREMENT can.
+const breachRecordedTimeoutMs = 60_000;
+
+// How long the guard must still be running after a breach for the hold to be
+// real. Load can only ever make it MORE likely to still be there, so this bound
+// cannot fail on a busy runner; only a guard that exited instead of holding
+// trips it.
+const holdObservedMs = 1500;
 
 function workspace(t) {
   const root = mkdtempSync(join(tmpdir(), 'mutant-memory-guard-'));
@@ -45,7 +101,7 @@ function child(root, source) {
 function guardEnv(root, overrides = {}) {
   return {
     ...process.env,
-    MUTANT_MEMORY_MAX: '256MiB',
+    MUTANT_MEMORY_MAX: ceilingSpec,
     MUTANT_MEMORY_HOLD: '2s',
     MUTANT_MEMORY_LEDGER: join(root, 'ledger.jsonl'),
     ...overrides,
@@ -140,29 +196,37 @@ test('a runaway child is killed, recorded, and then HELD rather than exited', as
   t.after(() => proc.kill('SIGKILL'));
 
   const exited = new Promise((resolve) => proc.on('exit', (code, signal) => resolve({ code, signal })));
-  const deadline = Date.now() + 60_000;
+  const deadline = Date.now() + breachRecordedTimeoutMs;
   while (ledgerLines(root).length === 0 && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
 
   const [breach] = ledgerLines(root);
   assert.ok(breach !== undefined, 'the runaway child was never recorded as a breach');
-  assert.equal(breach.limit_bytes, 256 * 1024 ** 2);
+  assert.equal(breach.limit_bytes, ceilingBytes);
   assert.ok(
     breach.resident_bytes > breach.limit_bytes,
     `a breach must record the RSS that crossed the line, got ${breach.resident_bytes}`,
   );
-  // The sampling interval bounds the overshoot; a guard that only noticed the
-  // runaway after it had taken the machine would pass the line above and still
-  // be useless.
+  // A guard that only noticed the runaway after it had taken the machine would
+  // pass the line above and still be useless, so the recorded overshoot is read
+  // back as the guard's NOTICE LATENCY. That conversion is exact because the
+  // child's rate is set by this test: every allocationStepIntervalMs of lateness
+  // costs exactly allocationStepBytes, so `resident_bytes - limit_bytes` over
+  // that rate IS the milliseconds the guard took, and the bound is a statement
+  // about the guard rather than about how much CPU the runner had spare.
+  const overshootBytes = breach.resident_bytes - breach.limit_bytes;
   assert.ok(
-    breach.resident_bytes < 2 * breach.limit_bytes,
-    `overshoot past the ceiling must stay small, got ${breach.resident_bytes} over ${breach.limit_bytes}`,
+    overshootBytes <= maxOvershootBytes,
+    `the guard must notice a crossing within ${maxNoticeLatencyMs}ms, which at this child's ` +
+      `${allocationStepBytes}B/${allocationStepIntervalMs}ms rate is ${maxOvershootBytes} bytes of ` +
+      `overshoot; it recorded ${overshootBytes} bytes past the ${breach.limit_bytes} ceiling ` +
+      `(~${Math.round((overshootBytes / allocationStepBytes) * allocationStepIntervalMs)}ms late)`,
   );
 
   const raced = await Promise.race([
     exited,
-    new Promise((resolve) => setTimeout(() => resolve('still-holding'), 1500)),
+    new Promise((resolve) => setTimeout(() => resolve('still-holding'), holdObservedMs)),
   ]);
   assert.equal(raced, 'still-holding', `the guard exited after a breach instead of holding: ${JSON.stringify(raced)}`);
 });


### PR DESCRIPTION
## What was wrong

`forbid-skip` is a required check, and one of its steps — "Assert the per-mutant memory guard
records rather than kills" — carried an assertion a busy runner could fail on its own:

```js
assert.ok(breach.resident_bytes < 2 * breach.limit_bytes, …);
```

The runaway child allocated in a tight `while` loop, so its growth rate was whatever CPU the
machine had spare, while the guard samples RSS on a 50ms timer. The recorded `resident_bytes` was
therefore *allocation rate x sampling latency*, and the test controlled neither factor. On PR #2951
a runner executing the full 30-leg mutation matrix measured 583,888,896 bytes against a
268,435,456-byte ceiling — 2.17x against a 2x bound — on a branch that touches nothing in
`.github/`.

## What the bound is expressed against now

The child grows at a rate **this test sets**: one `allocationStepBytes` (8MiB) buffer per
`allocationStepIntervalMs` (50ms) tick, every one retained so the growth is still LIVE — the same
shape as the mutant the guard exists for. With the rate fixed, the recorded overshoot converts
exactly into the guard's **notice latency**: 8MiB past the ceiling *is* 50ms of lateness, whatever
the runner is doing.

The assertion is that latency:

```js
const overshootBytes = breach.resident_bytes - breach.limit_bytes;
assert.ok(overshootBytes <= maxOvershootBytes, …);   // maxNoticeLatencyMs = 100ms
```

`maxNoticeLatencyMs` is 100ms — two of the guard's 50ms sampling intervals. It is deliberately
**not** derived from the guard's own `residentSampleIntervalMs`: a bound that moved with the number
it audits could not fail when that number is widened, which is the single defect it exists to
catch. The guard file itself is unchanged by this PR.

## Why it is load-proof

Child and guard are now both timer-driven, so a loaded machine stretches them **together** and the
gap between them — the only thing the bound reads — does not move. Measured on this host with the
shipped test, 8 rounds each:

| condition | overshoot | notice latency | margin to the 16MiB budget |
| --- | --- | --- | --- |
| idle | 0.0–0.1MiB | ~0–1ms | 630–2730x |
| 3x CPU oversubscription (24 busy loops on 8 cores) | 0.1MiB | ~0–1ms | 468–964x |
| 4x CPU oversubscription (32 busy loops on 8 cores) | 0.0–0.1MiB | ~0–1ms | 136–410x |

The old tight-loop child left roughly 1.1x of margin, which is why a busy runner walked it into a
red required check.

## Evidence the assertion still fails when the guard notices late

The first green after loosening a bound is vacuous, so the bound was falsified against the shipped
test by editing `residentSampleIntervalMs` in `mutant-memory-guard.mjs` and reverting afterwards:

| `residentSampleIntervalMs` | result | recorded |
| --- | --- | --- |
| 50ms (shipped) | 14/14 green, 3 consecutive runs | ~0.1MiB, ~1ms late |
| 200ms | **red** | 27,238,400 bytes past the ceiling, ~162ms late |
| 250ms | **red**, 3/3 runs | 27,246,592 bytes past the ceiling, ~162ms late |
| 500ms | **red** | 52,420,608 / 69,238,784 bytes, ~312–413ms late |
| 1000ms | **red** | 79,417,344 bytes, ~473ms late |
| 5000ms | **red** | 522,498,048 bytes, ~3114ms late |

At 250ms the run reports 13 passing and exactly one failure — the runaway subtest — with the
message `the guard must notice a crossing within 100ms, which at this child's 8388608B/50ms rate is
16777216 bytes of overshoot; it recorded 27246592 bytes past the 268435456 ceiling (~162ms late)`.

Detection near the boundary depends on where the crossing lands in the broken sample grid, as it
must for any latency bound with headroom; from 200ms upward — a 4x widening — the subtest goes red.

The subtest is not removed and the bound is not the last failure's measurement widened: 2x of the
ceiling was 268MiB of allowed overshoot, and the bound is now 16MiB, an **order of magnitude
tighter** than the one it replaces.

## Also in this change

- `breachRecordedTimeoutMs` and `holdObservedMs` name the file's two remaining bare timing literals
  (CLAUDE.md invariant 13). Both are one-directional — load can only make them more likely to pass
  — so their values are unchanged; only the names and the reasoning are new.
- The 256MiB ceiling had three independent spellings (the env value, the child's self-limit, the
  `limit_bytes` assertion). It now has one source, so the child's self-limit cannot drift from the
  ceiling the guard is actually given.

I scanned the other `.github/scripts/*.test.mjs` files for assertions of the same fitted-threshold
shape. The two candidates that surfaced — `update-golden-guard.test.mjs:630` and `:650` — are both
`MAX_WAIT_MS: '1'` cases asserting that the guard **times out**, so a slow runner makes them more
likely to pass, never less. They are deterministic in the direction that matters and were left
alone.

## Verification

- `node --test .github/scripts/mutant-memory-guard.test.mjs` — 14/14, three consecutive runs, each
  under `systemd-run --scope --user -p MemoryMax=2G -p MemorySwapMax=0`.
- `node --test .github/scripts/mutation-matrix.test.mjs` — 45/45 (it asserts on this file's path).
- `CHECK=all node .github/scripts/forbid-skip.mjs` — clean; `scripts/test-forbid-skip.sh` 25/25.

Closes #2955
