### PR TITLE
test: kill 38 mutation survivors and adjudicate the rest across nine red legs

### DIFF
--- a/internal/logql/gremlins_kill_2949_test.go
+++ b/internal/logql/gremlins_kill_2949_test.go
@@ -1,0 +1,108 @@
+package logql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Tests in this file kill LIVED gremlins mutants reported on the
+// phase4-logql-aggregation and phase4-logql-other-a legs (cerberus issue
+// #2949).
+
+// TestAbsentSynthLabels_DroppedNameSkipsNotStops kills the INVERT_LOOPCTRL
+// mutant at range_aggregation.go:361:4 — the `continue` taken for a dropped
+// name in [absentSynthLabels]'s emit loop.
+//
+// The function mirrors reference Loki's `absentLabels`: an equality matcher
+// pins its (name, value) on first sight, and ANY second occurrence of that
+// name deletes the label from the output entirely. Deletion is recorded in a
+// `dropped` set during the first pass, so the emit loop has to walk PAST a
+// dropped name to reach the surviving ones behind it. `break` abandons them,
+// and which labels `absent_over_time` synthesises then depends on where in
+// the selector the user happened to write the duplicated matcher.
+//
+// The selector below puts the duplicated name FIRST for exactly that reason:
+// with `job` duplicated ahead of `app`, the original emits `app` and the
+// mutant emits nothing.
+func TestAbsentSynthLabels_DroppedNameSkipsNotStops(t *testing.T) {
+	t.Parallel()
+
+	const q = `absent_over_time({job="j", job="k", app="a"}[5m])`
+	expr, err := ParseExprPermissive(q)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive(%q): %v", q, err)
+	}
+	rng, ok := expr.(*syntax.RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("ParseExprPermissive(%q) = %T, want *syntax.RangeAggregationExpr", q, expr)
+	}
+
+	got := absentSynthLabels(rng.Left.Left)
+	if len(got) != 1 || got[0].Key != "app" || got[0].Value != "a" {
+		t.Fatalf("absentSynthLabels(%q) = %#v; want the single synthesised label app=\"a\" — "+
+			"`job` is duplicated and so is deleted, but the labels behind it in the selector "+
+			"survive (mutant `continue`->`break` at range_aggregation.go:361:4 stops at the "+
+			"dropped name and emits nothing)", q, got)
+	}
+}
+
+// TestLowerVectorSetOp_MatchingClauseReachesTheSetOp kills the
+// CONDITIONALS_NEGATION mutant at binary.go:250:8 — `vm != nil` ->
+// `vm == nil` inside [lowerVectorSetOp].
+//
+// The guard decides whether the query's own `on(...)` / `ignoring(...)`
+// clause is copied into the emitted [chplan.VectorSetOp]'s Match. Negated,
+// the copy happens only when there is no clause to copy, so an explicit
+// `on(app)` is parsed and then silently discarded and the set operation
+// matches on the full series identity instead — a different query, and one
+// that answers with different series rather than with an error.
+func TestLowerVectorSetOp_MatchingClauseReachesTheSetOp(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	const q = `sum(rate({app="a"}[5m])) and on(app) sum(rate({job="b"}[5m]))`
+	expr, err := ParseExprPermissive(q)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive(%q): %v", q, err)
+	}
+	plan, err := LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+	if err != nil {
+		t.Fatalf("LowerAtRange(%q): %v", q, err)
+	}
+
+	setOp := findVectorSetOp(plan)
+	if setOp == nil {
+		t.Fatalf("LowerAtRange(%q) produced no *chplan.VectorSetOp; the test would then assert "+
+			"nothing about the matching clause", q)
+	}
+	if !setOp.Match.On || len(setOp.Match.Labels) != 1 || setOp.Match.Labels[0] != "app" {
+		t.Fatalf("LowerAtRange(%q) produced Match %#v; want On=true with labels [app] — the "+
+			"query's own `on(app)` clause (mutant `!=`->`==` at binary.go:250:8 copies it only "+
+			"when there is nothing to copy, leaving the zero Match)", q, setOp.Match)
+	}
+}
+
+// findVectorSetOp returns the first *chplan.VectorSetOp in the plan, or nil.
+func findVectorSetOp(n chplan.Node) *chplan.VectorSetOp {
+	if n == nil {
+		return nil
+	}
+	if v, ok := n.(*chplan.VectorSetOp); ok {
+		return v
+	}
+	for _, kid := range n.Children() {
+		if hit := findVectorSetOp(kid); hit != nil {
+			return hit
+		}
+	}
+	return nil
+}

--- a/internal/logql/gremlins_kill_2949_test.go
+++ b/internal/logql/gremlins_kill_2949_test.go
@@ -16,8 +16,11 @@ import (
 // #2949).
 
 // TestAbsentSynthLabels_DroppedNameSkipsNotStops kills the INVERT_LOOPCTRL
-// mutant at range_aggregation.go:361:4 — the `continue` taken for a dropped
-// name in [absentSynthLabels]'s emit loop.
+// mutant on the `continue` taken for a dropped name in [absentSynthLabels]'s
+// emit loop, guarded by range_aggregation.go:`if dropped[name] {`.
+//
+// The citation names that neighbouring `if` rather than the mutated statement
+// itself: the mutant is a bare `continue`, which no substring singles out.
 //
 // The function mirrors reference Loki's `absentLabels`: an equality matcher
 // pins its (name, value) on first sight, and ANY second occurrence of that
@@ -47,13 +50,14 @@ func TestAbsentSynthLabels_DroppedNameSkipsNotStops(t *testing.T) {
 	if len(got) != 1 || got[0].Key != "app" || got[0].Value != "a" {
 		t.Fatalf("absentSynthLabels(%q) = %#v; want the single synthesised label app=\"a\" — "+
 			"`job` is duplicated and so is deleted, but the labels behind it in the selector "+
-			"survive (mutant `continue`->`break` at range_aggregation.go:361:4 stops at the "+
+			"survive (mutant `continue`->`break` under "+
+			"range_aggregation.go:`if dropped[name] {` stops at the "+
 			"dropped name and emits nothing)", q, got)
 	}
 }
 
 // TestLowerVectorSetOp_MatchingClauseReachesTheSetOp kills the
-// CONDITIONALS_NEGATION mutant at binary.go:250:8 — `vm != nil` ->
+// CONDITIONALS_NEGATION mutant at binary.go:`if vm != nil {` — rewritten to
 // `vm == nil` inside [lowerVectorSetOp].
 //
 // The guard decides whether the query's own `on(...)` / `ignoring(...)`
@@ -86,7 +90,8 @@ func TestLowerVectorSetOp_MatchingClauseReachesTheSetOp(t *testing.T) {
 	}
 	if !setOp.Match.On || len(setOp.Match.Labels) != 1 || setOp.Match.Labels[0] != "app" {
 		t.Fatalf("LowerAtRange(%q) produced Match %#v; want On=true with labels [app] — the "+
-			"query's own `on(app)` clause (mutant `!=`->`==` at binary.go:250:8 copies it only "+
+			"query's own `on(app)` clause (mutant `!=`->`==` at "+
+			"binary.go:`if vm != nil {` copies it only "+
 			"when there is nothing to copy, leaving the zero Match)", q, setOp.Match)
 	}
 }

--- a/internal/promql/gremlins_kill_date_fns_test.go
+++ b/internal/promql/gremlins_kill_date_fns_test.go
@@ -14,9 +14,12 @@ import (
 const readsRangeSampleTimestampStep = 30 * time.Second
 
 // TestReadsRangeSampleTimestamp_OnlyTheTimestampFunction kills the
-// INVERT_LOGICAL mutant at date_fns.go:192:25 — the FIRST `||` of
+// INVERT_LOGICAL mutant on the FIRST `||` of
 //
-//	if name != "timestamp" || ctx.step <= 0 || ctx.inRangeVector {
+//	date_fns.go:`name != "timestamp" || ctx.step <= 0 || ctx.inRangeVector`
+//
+// All three of this guard's mutants live on that one construct, so each note
+// names the operator it rewrites rather than a position within the line.
 //
 // Call the three disqualifications A (wrong function), B (not a range
 // evaluation) and C (inside a range-vector descent). Go binds `&&` tighter
@@ -31,8 +34,8 @@ const readsRangeSampleTimestampStep = 30 * time.Second
 // `day_of_week` call reads the range sample's own timestamp, which is a
 // different function's semantics entirely.
 //
-// (The mutant on the SECOND `||`, 192:42, becomes `A || (B && C)` for the same
-// precedence reason, so it is A that keeps working and B that stops
+// (The mutant on the SECOND `||` of the same construct becomes `A || (B && C)`
+// for the same precedence reason, so it is A that keeps working and B that stops
 // disqualifying alone. That one is killed by
 // TestReadsRangeSampleTimestamp_RequiresPositiveStep below, whose input trips
 // B alone.)
@@ -48,16 +51,20 @@ func TestReadsRangeSampleTimestamp_OnlyTheTimestampFunction(t *testing.T) {
 	}
 	if readsRangeSampleTimestamp("day_of_week", arg, ctx) {
 		t.Fatal("readsRangeSampleTimestamp(\"day_of_week\", <selector>, step>0) = true; only " +
-			"`timestamp` reads the range sample's own timestamp (mutants `||`->`&&` at " +
-			"date_fns.go:192:25 and :192:42 both stop the name check disqualifying on its own)")
+			"`timestamp` reads the range sample's own timestamp (the `||`->`&&` mutants on " +
+			"date_fns.go:`name != \"timestamp\" || ctx.step <= 0 || ctx.inRangeVector` both " +
+			"stop the name check disqualifying on its own)")
 	}
 }
 
 // TestReadsRangeSampleTimestamp_RequiresPositiveStep kills TWO mutants on
-// date_fns.go:192, both of which stop a zero step disqualifying on its own:
 //
-//   - 192:37 CONDITIONALS_BOUNDARY, `ctx.step <= 0` -> `ctx.step < 0`.
-//   - 192:42 INVERT_LOGICAL, the SECOND `||`, which under Go's precedence
+//	date_fns.go:`name != "timestamp" || ctx.step <= 0 || ctx.inRangeVector`
+//
+// both of which stop a zero step disqualifying on its own:
+//
+//   - CONDITIONALS_BOUNDARY, `ctx.step <= 0` -> `ctx.step < 0`.
+//   - INVERT_LOGICAL on the SECOND `||`, which under Go's precedence
 //     (`&&` binds tighter) yields `A || (B && C)`: the step disqualification B
 //     now needs the range-vector descent C alongside it.
 //
@@ -80,7 +87,8 @@ func TestReadsRangeSampleTimestamp_RequiresPositiveStep(t *testing.T) {
 	if readsRangeSampleTimestamp("timestamp", arg, lowerCtx{step: 0}) {
 		t.Fatal("readsRangeSampleTimestamp(\"timestamp\", <selector>, step=0) = true; a zero step " +
 			"is the instant lowering, which has no per-step grid to read a sample timestamp " +
-			"against (mutant `<=`->`<` at date_fns.go:192:37 admits it, since a step is never " +
-			"negative)")
+			"against (the `<=`->`<` mutant on " +
+			"date_fns.go:`name != \"timestamp\" || ctx.step <= 0 || ctx.inRangeVector` " +
+			"admits it, since a step is never negative)")
 	}
 }

--- a/internal/promql/gremlins_kill_date_fns_test.go
+++ b/internal/promql/gremlins_kill_date_fns_test.go
@@ -1,0 +1,86 @@
+// Tests in this file kill the LIVED gremlins mutants reported on
+// date_fns.go's [readsRangeSampleTimestamp] guard, from the phase4-promql-d
+// leg (cerberus issue #2949). See gremlins_kill_test.go for the shared
+// file-header convention this file follows.
+package promql
+
+import (
+	"testing"
+	"time"
+)
+
+// readsRangeSampleTimestampStep is a step long enough to be unambiguously
+// positive; the guard reads only its sign, so the exact value is immaterial.
+const readsRangeSampleTimestampStep = 30 * time.Second
+
+// TestReadsRangeSampleTimestamp_OnlyTheTimestampFunction kills the
+// INVERT_LOGICAL mutant at date_fns.go:192:25 — the FIRST `||` of
+//
+//	if name != "timestamp" || ctx.step <= 0 || ctx.inRangeVector {
+//
+// Call the three disqualifications A (wrong function), B (not a range
+// evaluation) and C (inside a range-vector descent). Go binds `&&` tighter
+// than `||`, so rewriting the first `||` yields `(A && B) || C` rather than a
+// re-association of the original.
+//
+// The guard is a disjunction of three INDEPENDENT disqualifications, and any
+// one of them is enough: this rewrite applies only to `timestamp`, only in
+// range mode, and only outside a range-vector descent. `day_of_week` trips A
+// alone, with B and C both false — so the original bails and the mutant, which
+// now needs B as well, does not. The function then walks on and reports that a
+// `day_of_week` call reads the range sample's own timestamp, which is a
+// different function's semantics entirely.
+//
+// (The mutant on the SECOND `||`, 192:42, becomes `A || (B && C)` for the same
+// precedence reason, so it is A that keeps working and B that stops
+// disqualifying alone. That one is killed by
+// TestReadsRangeSampleTimestamp_RequiresPositiveStep below, whose input trips
+// B alone.)
+func TestReadsRangeSampleTimestamp_OnlyTheTimestampFunction(t *testing.T) {
+	t.Parallel()
+
+	arg := mustParse(t, `some_metric`)
+	ctx := lowerCtx{step: readsRangeSampleTimestampStep}
+
+	if !readsRangeSampleTimestamp("timestamp", arg, ctx) {
+		t.Fatal("positive control: readsRangeSampleTimestamp(\"timestamp\", <selector>, step>0) = " +
+			"false; the negative assertion below would then hold for the wrong reason")
+	}
+	if readsRangeSampleTimestamp("day_of_week", arg, ctx) {
+		t.Fatal("readsRangeSampleTimestamp(\"day_of_week\", <selector>, step>0) = true; only " +
+			"`timestamp` reads the range sample's own timestamp (mutants `||`->`&&` at " +
+			"date_fns.go:192:25 and :192:42 both stop the name check disqualifying on its own)")
+	}
+}
+
+// TestReadsRangeSampleTimestamp_RequiresPositiveStep kills TWO mutants on
+// date_fns.go:192, both of which stop a zero step disqualifying on its own:
+//
+//   - 192:37 CONDITIONALS_BOUNDARY, `ctx.step <= 0` -> `ctx.step < 0`.
+//   - 192:42 INVERT_LOGICAL, the SECOND `||`, which under Go's precedence
+//     (`&&` binds tighter) yields `A || (B && C)`: the step disqualification B
+//     now needs the range-vector descent C alongside it.
+//
+// A zero step is the instant-query lowering (see [lowerCtx.step]'s own
+// documentation: "step == 0 means" this is not a range evaluation), and there
+// is no per-step grid for a sample timestamp to be read against. The input
+// below trips B alone — `timestamp`, step 0, no range-vector descent — which
+// is exactly where each mutant diverges: the boundary shift makes B false
+// because a step is never negative, and the `&&` makes B insufficient because
+// C is false.
+func TestReadsRangeSampleTimestamp_RequiresPositiveStep(t *testing.T) {
+	t.Parallel()
+
+	arg := mustParse(t, `some_metric`)
+
+	if !readsRangeSampleTimestamp("timestamp", arg, lowerCtx{step: readsRangeSampleTimestampStep}) {
+		t.Fatal("positive control: readsRangeSampleTimestamp(\"timestamp\", <selector>, step>0) = " +
+			"false; the negative assertion below would then hold for the wrong reason")
+	}
+	if readsRangeSampleTimestamp("timestamp", arg, lowerCtx{step: 0}) {
+		t.Fatal("readsRangeSampleTimestamp(\"timestamp\", <selector>, step=0) = true; a zero step " +
+			"is the instant lowering, which has no per-step grid to read a sample timestamp " +
+			"against (mutant `<=`->`<` at date_fns.go:192:37 admits it, since a step is never " +
+			"negative)")
+	}
+}

--- a/internal/promql/gremlins_kill_histogram_guards_test.go
+++ b/internal/promql/gremlins_kill_histogram_guards_test.go
@@ -15,9 +15,11 @@ import (
 )
 
 // TestMixedOrSubqueryOuterFn_RequiresAConfiguredTable kills the
-// CONDITIONALS_NEGATION mutant at
-// histogram_native_mixed_or_subquery_range_fn.go:114:25 —
-// `s.ExpHistogramTable == ""` -> `s.ExpHistogramTable != ""` inside
+// CONDITIONALS_NEGATION mutant on
+//
+//	histogram_native_mixed_or_subquery_range_fn.go:mixedOrSubqueryOuterFn:`s.ExpHistogramTable == ""`
+//
+// which rewrites it to `s.ExpHistogramTable != ""` inside
 // [mixedOrSubqueryOuterFn].
 //
 // The guard reads "bail when the schema declares NO exp-histogram table".
@@ -53,7 +55,7 @@ func TestMixedOrSubqueryOuterFn_RequiresAConfiguredTable(t *testing.T) {
 	if !ok {
 		t.Fatalf("mixedOrSubqueryOuterFn(%q) = ok false; want true — the schema DOES declare an "+
 			"exp-histogram table, so the table guard must not fire (mutant `==`->`!=` at "+
-			"histogram_native_mixed_or_subquery_range_fn.go:114:25 makes it fire on every "+
+			"histogram_native_mixed_or_subquery_range_fn.go:mixedOrSubqueryOuterFn:`s.ExpHistogramTable == \"\"` makes it fire on every "+
 			"configured deployment)", q)
 	}
 	if sub == nil || b == nil || rebuild == nil {
@@ -63,9 +65,9 @@ func TestMixedOrSubqueryOuterFn_RequiresAConfiguredTable(t *testing.T) {
 }
 
 // TestIsSyntheticScalarPlan_RejectsANonEmptyMetricName kills the
-// INVERT_LOGICAL mutant at synthetic.go:182:49 — the `||` of
+// INVERT_LOGICAL mutant on the `||` of
 //
-//	if lit, ok := mn.Expr.(*chplan.LitString); !ok || lit.V != "" {
+//	synthetic.go:`lit, ok := mn.Expr.(*chplan.LitString); !ok || lit.V != ""`
 //
 // inside [isSyntheticScalarPlan].
 //
@@ -89,7 +91,8 @@ func TestIsSyntheticScalarPlan_RejectsANonEmptyMetricName(t *testing.T) {
 	if isSyntheticScalarPlan(syntheticScalarPlan(s, &chplan.LitString{V: "some_metric"}), s) {
 		t.Fatal("isSyntheticScalarPlan reported a plan whose MetricName projection is " +
 			"LitString(\"some_metric\") as synthetic; a synthetic scalar plan carries no " +
-			"identifying labels (mutant `||`->`&&` at synthetic.go:182:49 stops the non-empty " +
+			"identifying labels (the `||`->`&&` mutant on " +
+			"synthetic.go:`lit, ok := mn.Expr.(*chplan.LitString); !ok || lit.V != \"\"` stops the non-empty " +
 			"literal disqualifying on its own)")
 	}
 }
@@ -110,9 +113,11 @@ func syntheticScalarPlan(s schema.Metrics, metricName chplan.Expr) chplan.Node {
 }
 
 // TestSortOverMixedExpHistogramSetOp_TakesExactlyOneArgument kills the
-// CONDITIONALS_NEGATION mutant at histogram_native_mixed_or_sort.go:68:17 —
-// `len(c.Args) != 1` -> `len(c.Args) == 1` inside
-// [sortOverMixedExpHistogramSetOp].
+// CONDITIONALS_NEGATION mutant on
+//
+//	histogram_native_mixed_or_sort.go:`len(c.Args) != 1`
+//
+// rewritten to `len(c.Args) == 1` inside [sortOverMixedExpHistogramSetOp].
 //
 // `sort` / `sort_desc` take exactly one argument, so the guard rejects
 // everything else. Negated, it rejects exactly the arity the function exists
@@ -132,16 +137,15 @@ func TestSortOverMixedExpHistogramSetOp_TakesExactlyOneArgument(t *testing.T) {
 	if !ok || b == nil {
 		t.Fatalf("sortOverMixedExpHistogramSetOp(%q) = ok %v; want true — `sort` takes exactly "+
 			"one argument and this call has one (mutant `!=`->`==` at "+
-			"histogram_native_mixed_or_sort.go:68:17 rejects precisely the admitted arity)",
+			"histogram_native_mixed_or_sort.go:`len(c.Args) != 1` rejects precisely the admitted arity)",
 			q, ok)
 	}
 }
 
 // TestExpHistogramWindowTemporalityExpr_BothConditionsDisqualify kills the
-// INVERT_LOGICAL mutant at histogram_quantile_native_window.go:127:36 — the
-// `||` of
+// INVERT_LOGICAL mutant on the `||` of
 //
-//	if !needsTemporalityAgg(windowFn) || s.AggregationTemporalityColumn == "" {
+//	histogram_quantile_native_window.go:`!needsTemporalityAgg(windowFn) || s.AggregationTemporalityColumn == ""`
 //
 // inside [expHistogramWindowTemporalityExpr].
 //
@@ -176,15 +180,18 @@ func TestExpHistogramWindowTemporalityExpr_BothConditionsDisqualify(t *testing.T
 	if got := expHistogramWindowTemporalityExpr(s, lastOverTimeWindowFn); got != nil {
 		t.Fatalf("expHistogramWindowTemporalityExpr(%q) = %#v; want nil — a window function that "+
 			"needs no temporality aggregate must not reference the column even when the schema "+
-			"configures one (mutant `||`->`&&` at histogram_quantile_native_window.go:127:36 "+
+			"configures one (the `||`->`&&` mutant on "+
+			"histogram_quantile_native_window.go:`!needsTemporalityAgg(windowFn) || s.AggregationTemporalityColumn == \"\"` "+
 			"stops that disqualifying on its own)", lastOverTimeWindowFn, got)
 	}
 }
 
 // TestLabelCallOverExpHistogram_LabelJoinAcceptsThreeArguments kills the
-// CONDITIONALS_BOUNDARY mutant at histogram_native_label_replace.go:27:21 —
-// `len(call.Args) < 3` -> `len(call.Args) <= 3` inside
-// [labelCallOverExpHistogram].
+// CONDITIONALS_BOUNDARY mutant on
+//
+//	histogram_native_label_replace.go:`len(call.Args) < 3`
+//
+// rewritten to `len(call.Args) <= 3` inside [labelCallOverExpHistogram].
 //
 // `label_join(v, dst, sep)` with no source labels is a well-formed call: the
 // separator-joined result of zero sources is the empty string, and PromQL
@@ -203,7 +210,7 @@ func TestLabelCallOverExpHistogram_LabelJoinAcceptsThreeArguments(t *testing.T) 
 	if !ok || call == nil {
 		t.Fatalf("labelCallOverExpHistogram(%q) = ok %v; want true — three arguments is "+
 			"`label_join`'s minimum, not a rejected arity (mutant `<`->`<=` at "+
-			"histogram_native_label_replace.go:27:21 rejects it)", q, ok)
+			"histogram_native_label_replace.go:`len(call.Args) < 3` rejects it)", q, ok)
 	}
 	if len(call.Args) != 3 {
 		t.Fatalf("the query under test parsed to %d arguments, not the 3 the boundary is about; "+
@@ -212,9 +219,12 @@ func TestLabelCallOverExpHistogram_LabelJoinAcceptsThreeArguments(t *testing.T) 
 }
 
 // TestIsExpHistogramValuedShape_ScalarLiteralOnTheLeftIsMulOnly kills the
-// CONDITIONALS_NEGATION mutant at histogram_native_scalar_binop.go:235:11 —
-// `b.Op == parser.MUL` -> `b.Op != parser.MUL` inside
-// [isExpHistogramValuedShape]'s binary-operand arm.
+// CONDITIONALS_NEGATION mutant on
+//
+//	histogram_native_scalar_binop.go:isExpHistogramValuedShape:`if b.Op == parser.MUL {`
+//
+// rewritten to `b.Op != parser.MUL` inside [isExpHistogramValuedShape]'s
+// binary-operand arm.
 //
 // A scalar literal on the LEFT composes with a histogram-valued right operand
 // for MUL only: multiplication is commutative, so `2 * hist` scales the
@@ -232,7 +242,7 @@ func TestIsExpHistogramValuedShape_ScalarLiteralOnTheLeftIsMulOnly(t *testing.T)
 	if !isExpHistogramValuedShape(mustParse(t, mul), s, lowerCtx{}) {
 		t.Fatalf("isExpHistogramValuedShape(%q) = false; want true — a scalar literal times a "+
 			"histogram-valued operand scales it (mutant `==`->`!=` at "+
-			"histogram_native_scalar_binop.go:235:11 rejects MUL and admits DIV instead)", mul)
+			"histogram_native_scalar_binop.go:isExpHistogramValuedShape:`if b.Op == parser.MUL {` rejects MUL and admits DIV instead)", mul)
 	}
 	const div = `2 / latency_exp_hist`
 	if isExpHistogramValuedShape(mustParse(t, div), s, lowerCtx{}) {
@@ -242,8 +252,11 @@ func TestIsExpHistogramValuedShape_ScalarLiteralOnTheLeftIsMulOnly(t *testing.T)
 }
 
 // TestLowerExpHistogramSetOp_OnClauseReachesTheVectorMatch kills the
-// CONDITIONALS_NEGATION mutant at histogram_native_set_op.go:113:22 —
-// `b.VectorMatching != nil` -> `b.VectorMatching == nil`.
+// CONDITIONALS_NEGATION mutant on
+//
+//	histogram_native_set_op.go:`if b.VectorMatching != nil {`
+//
+// rewritten to `b.VectorMatching == nil`.
 //
 // The guard decides whether the parser's matching clause is copied into the
 // emitted [chplan.VectorSetOp]'s Match. Negated, the copy happens only when
@@ -281,7 +294,7 @@ func TestLowerExpHistogramSetOp_OnClauseReachesTheVectorMatch(t *testing.T) {
 	if len(setOp.Match.Labels) != 1 || setOp.Match.Labels[0] != "service" || !setOp.Match.On {
 		t.Fatalf("lowerExpHistogramSetOp(%q) produced Match %#v; want On=true with labels "+
 			"[service] — the query's own `on(service)` clause (mutant `!=`->`==` at "+
-			"histogram_native_set_op.go:113:22 copies it only when there is nothing to copy, "+
+			"histogram_native_set_op.go:`if b.VectorMatching != nil {` copies it only when there is nothing to copy, "+
 			"leaving the zero Match)", q, setOp.Match)
 	}
 }

--- a/internal/promql/gremlins_kill_histogram_guards_test.go
+++ b/internal/promql/gremlins_kill_histogram_guards_test.go
@@ -1,0 +1,287 @@
+// Tests in this file kill LIVED gremlins mutants reported on the
+// phase4-promql-c / -f / -other / -quantile legs (cerberus issue #2949),
+// across the exp-histogram recognizers' shape guards and the classic/native
+// histogram_quantile window guards. See gremlins_kill_test.go for the shared
+// file-header convention this file follows.
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestMixedOrSubqueryOuterFn_RequiresAConfiguredTable kills the
+// CONDITIONALS_NEGATION mutant at
+// histogram_native_mixed_or_subquery_range_fn.go:114:25 —
+// `s.ExpHistogramTable == ""` -> `s.ExpHistogramTable != ""` inside
+// [mixedOrSubqueryOuterFn].
+//
+// The guard reads "bail when the schema declares NO exp-histogram table".
+// Negated it reads "bail when the schema DOES declare one", which is every
+// real deployment: the recognizer then answers false for every input it
+// exists to accept, and the mixed-or subquery shape silently stops being
+// recognised.
+//
+// The mutant is therefore killed by a POSITIVE recognition — the negative
+// direction is what the original already does. This is the only mutant on
+// this leg that a test can reach; the file's NOT KILLABLE footer adjudicates
+// the rest.
+func TestMixedOrSubqueryOuterFn_RequiresAConfiguredTable(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	if s.ExpHistogramTable == "" {
+		t.Fatal("positive control: the default schema declares no ExpHistogramTable, so the guard " +
+			"under test would bail for the original reason and the assertion below would prove " +
+			"nothing")
+	}
+
+	// The subquery inner is the bare mixed set-op [wrapMixedOrSubqueryInner]
+	// admits, and `@` pins it so subqueryHasEvalAnchor resolves without an
+	// ambient query time.
+	const q = `last_over_time(((latency_exp_hist) or (other_metric))[5m:1m] @ 1700000000)`
+	call, ok := mustParse(t, q).(*parser.Call)
+	if !ok {
+		t.Fatalf("mustParse(%q) = %T, want *parser.Call", q, mustParse(t, q))
+	}
+
+	sub, b, rebuild, ok := mixedOrSubqueryOuterFn(call, s, lowerCtx{})
+	if !ok {
+		t.Fatalf("mixedOrSubqueryOuterFn(%q) = ok false; want true — the schema DOES declare an "+
+			"exp-histogram table, so the table guard must not fire (mutant `==`->`!=` at "+
+			"histogram_native_mixed_or_subquery_range_fn.go:114:25 makes it fire on every "+
+			"configured deployment)", q)
+	}
+	if sub == nil || b == nil || rebuild == nil {
+		t.Fatalf("mixedOrSubqueryOuterFn(%q) returned ok=true with sub=%v b=%v rebuild==nil:%v; a "+
+			"recognised shape must carry all three", q, sub, b, rebuild == nil)
+	}
+}
+
+// TestIsSyntheticScalarPlan_RejectsANonEmptyMetricName kills the
+// INVERT_LOGICAL mutant at synthetic.go:182:49 — the `||` of
+//
+//	if lit, ok := mn.Expr.(*chplan.LitString); !ok || lit.V != "" {
+//
+// inside [isSyntheticScalarPlan].
+//
+// The projection must be the EMPTY string literal, because a synthetic scalar
+// plan carries no identifying labels — the function's own comment says a
+// non-empty literal "means the plan carries identifying labels the fold would
+// erase". Under `&&` the rejection needs the expression to be both a
+// non-LitString AND a non-empty one, which nothing is: a `LitString("x")`
+// satisfies only the second half, so the mutant reports a plan that names a
+// metric as a scalar plan and the fold erases the name.
+func TestIsSyntheticScalarPlan_RejectsANonEmptyMetricName(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+
+	if !isSyntheticScalarPlan(syntheticScalarPlan(s, &chplan.LitString{V: ""}), s) {
+		t.Fatal("positive control: a plan whose MetricName projection is LitString(\"\") is not " +
+			"recognised as synthetic; the negative assertion below would then hold for the " +
+			"wrong reason")
+	}
+	if isSyntheticScalarPlan(syntheticScalarPlan(s, &chplan.LitString{V: "some_metric"}), s) {
+		t.Fatal("isSyntheticScalarPlan reported a plan whose MetricName projection is " +
+			"LitString(\"some_metric\") as synthetic; a synthetic scalar plan carries no " +
+			"identifying labels (mutant `||`->`&&` at synthetic.go:182:49 stops the non-empty " +
+			"literal disqualifying on its own)")
+	}
+}
+
+// syntheticScalarPlan builds the four-projection Project over a OneRow that
+// [isSyntheticScalarPlan] accepts, with the MetricName slot's expression left
+// to the caller so a test can vary the one projection under examination.
+func syntheticScalarPlan(s schema.Metrics, metricName chplan.Expr) chplan.Node {
+	return &chplan.Project{
+		Input: &chplan.OneRow{},
+		Projections: []chplan.Projection{
+			{Expr: metricName, Alias: s.MetricNameColumn},
+			{Expr: emptyAttrsMap(), Alias: s.AttributesColumn},
+			{Expr: chplan.NowNano(), Alias: s.TimestampColumn},
+			{Expr: &chplan.LitFloat{V: 1}, Alias: s.ValueColumn},
+		},
+	}
+}
+
+// TestSortOverMixedExpHistogramSetOp_TakesExactlyOneArgument kills the
+// CONDITIONALS_NEGATION mutant at histogram_native_mixed_or_sort.go:68:17 —
+// `len(c.Args) != 1` -> `len(c.Args) == 1` inside
+// [sortOverMixedExpHistogramSetOp].
+//
+// `sort` / `sort_desc` take exactly one argument, so the guard rejects
+// everything else. Negated, it rejects exactly the arity the function exists
+// to serve and admits every other, so the one-argument sort over a mixed
+// set-op stops being recognised.
+func TestSortOverMixedExpHistogramSetOp_TakesExactlyOneArgument(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `sort((latency_exp_hist) or (other_metric))`
+	call, ok := mustParse(t, q).(*parser.Call)
+	if !ok {
+		t.Fatalf("mustParse(%q) = %T, want *parser.Call", q, mustParse(t, q))
+	}
+
+	b, ok := sortOverMixedExpHistogramSetOp(call, s, lowerCtx{})
+	if !ok || b == nil {
+		t.Fatalf("sortOverMixedExpHistogramSetOp(%q) = ok %v; want true — `sort` takes exactly "+
+			"one argument and this call has one (mutant `!=`->`==` at "+
+			"histogram_native_mixed_or_sort.go:68:17 rejects precisely the admitted arity)",
+			q, ok)
+	}
+}
+
+// TestExpHistogramWindowTemporalityExpr_BothConditionsDisqualify kills the
+// INVERT_LOGICAL mutant at histogram_quantile_native_window.go:127:36 — the
+// `||` of
+//
+//	if !needsTemporalityAgg(windowFn) || s.AggregationTemporalityColumn == "" {
+//
+// inside [expHistogramWindowTemporalityExpr].
+//
+// There is no temporality column reference to emit when EITHER the window
+// function does not need a temporality aggregate, or the schema configures no
+// such column. Under `&&` a window function that needs no temporality still
+// gets the column reference back as long as the schema happens to configure
+// one — a reference to an alias the window stage never projected.
+//
+// `last_over_time` is the disqualifying case: it reads a single sample rather
+// than folding a counter, so it needs no temporality aggregate, while the
+// default schema does configure the column.
+func TestExpHistogramWindowTemporalityExpr_BothConditionsDisqualify(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	if s.AggregationTemporalityColumn == "" {
+		t.Fatal("positive control: the default schema configures no AggregationTemporalityColumn, " +
+			"so the second disjunct already disqualifies and the assertion below proves nothing")
+	}
+	if !needsTemporalityAgg(rateWindowFn) {
+		t.Fatalf("positive control: %q is expected to need a temporality aggregate; without a "+
+			"window function that does, the guard's first disjunct is never the deciding one",
+			rateWindowFn)
+	}
+
+	if got := expHistogramWindowTemporalityExpr(s, rateWindowFn); got == nil {
+		t.Fatalf("expHistogramWindowTemporalityExpr(%q) = nil; want the temporality column "+
+			"reference — the window function needs the aggregate and the schema configures the "+
+			"column", rateWindowFn)
+	}
+	if got := expHistogramWindowTemporalityExpr(s, lastOverTimeWindowFn); got != nil {
+		t.Fatalf("expHistogramWindowTemporalityExpr(%q) = %#v; want nil — a window function that "+
+			"needs no temporality aggregate must not reference the column even when the schema "+
+			"configures one (mutant `||`->`&&` at histogram_quantile_native_window.go:127:36 "+
+			"stops that disqualifying on its own)", lastOverTimeWindowFn, got)
+	}
+}
+
+// TestLabelCallOverExpHistogram_LabelJoinAcceptsThreeArguments kills the
+// CONDITIONALS_BOUNDARY mutant at histogram_native_label_replace.go:27:21 —
+// `len(call.Args) < 3` -> `len(call.Args) <= 3` inside
+// [labelCallOverExpHistogram].
+//
+// `label_join(v, dst, sep)` with no source labels is a well-formed call: the
+// separator-joined result of zero sources is the empty string, and PromQL
+// admits it. Three is therefore the MINIMUM arity, not a rejected one, and
+// the boundary belongs below it. `<= 3` rejects the minimal call, so
+// `label_join` over an exp-histogram stops being recognised at exactly the
+// arity the guard was written to admit.
+func TestLabelCallOverExpHistogram_LabelJoinAcceptsThreeArguments(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `label_join(latency_exp_hist, "dst", ",")`
+	expr := mustParse(t, q)
+
+	call, ok := labelCallOverExpHistogram(expr, s, lowerCtx{})
+	if !ok || call == nil {
+		t.Fatalf("labelCallOverExpHistogram(%q) = ok %v; want true — three arguments is "+
+			"`label_join`'s minimum, not a rejected arity (mutant `<`->`<=` at "+
+			"histogram_native_label_replace.go:27:21 rejects it)", q, ok)
+	}
+	if len(call.Args) != 3 {
+		t.Fatalf("the query under test parsed to %d arguments, not the 3 the boundary is about; "+
+			"the test no longer exercises the guard", len(call.Args))
+	}
+}
+
+// TestIsExpHistogramValuedShape_ScalarLiteralOnTheLeftIsMulOnly kills the
+// CONDITIONALS_NEGATION mutant at histogram_native_scalar_binop.go:235:11 —
+// `b.Op == parser.MUL` -> `b.Op != parser.MUL` inside
+// [isExpHistogramValuedShape]'s binary-operand arm.
+//
+// A scalar literal on the LEFT composes with a histogram-valued right operand
+// for MUL only: multiplication is commutative, so `2 * hist` scales the
+// histogram, while `2 / hist` has no histogram-valued reading (a histogram
+// can only be a numerator — see [expHistogramFloatVectorScalingBinop]'s own
+// DIV comment). Negating the operator check swaps exactly those two
+// judgements, and `2 * latency_exp_hist` — the shape the arm exists for —
+// stops being histogram-valued.
+func TestIsExpHistogramValuedShape_ScalarLiteralOnTheLeftIsMulOnly(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+
+	const mul = `2 * latency_exp_hist`
+	if !isExpHistogramValuedShape(mustParse(t, mul), s, lowerCtx{}) {
+		t.Fatalf("isExpHistogramValuedShape(%q) = false; want true — a scalar literal times a "+
+			"histogram-valued operand scales it (mutant `==`->`!=` at "+
+			"histogram_native_scalar_binop.go:235:11 rejects MUL and admits DIV instead)", mul)
+	}
+	const div = `2 / latency_exp_hist`
+	if isExpHistogramValuedShape(mustParse(t, div), s, lowerCtx{}) {
+		t.Fatalf("isExpHistogramValuedShape(%q) = true; want false — a histogram can only be a "+
+			"numerator, so a scalar literal DIVIDED by one has no histogram-valued reading", div)
+	}
+}
+
+// TestLowerExpHistogramSetOp_OnClauseReachesTheVectorMatch kills the
+// CONDITIONALS_NEGATION mutant at histogram_native_set_op.go:113:22 —
+// `b.VectorMatching != nil` -> `b.VectorMatching == nil`.
+//
+// The guard decides whether the parser's matching clause is copied into the
+// emitted [chplan.VectorSetOp]'s Match. Negated, the copy happens only when
+// there is nothing to copy, so an explicit `on(...)` is read from the query
+// and then silently discarded: the plan joins on the full series identity
+// instead of on the named label, which is a different query.
+//
+// The `on(service)` spelling is what makes the two distinguishable. Written
+// without a matching clause the parser still allocates a VectorMatching for a
+// set operator — it carries CardManyToMany and no labels — so both the
+// original and the mutant produce the same zero Match there and the guard's
+// direction cannot be observed.
+func TestLowerExpHistogramSetOp_OnClauseReachesTheVectorMatch(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `latency_exp_hist and on(service) other_exp_hist`
+	b, ok := mustParse(t, q).(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("mustParse(%q) = %T, want *parser.BinaryExpr", q, mustParse(t, q))
+	}
+	if b.VectorMatching == nil || len(b.VectorMatching.MatchingLabels) != 1 {
+		t.Fatalf("positive control: %q parsed with VectorMatching %#v; the test needs exactly the "+
+			"one `on` label to observe whether it is carried through", q, b.VectorMatching)
+	}
+
+	plan, err := lowerExpHistogramSetOp(b, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lowerExpHistogramSetOp(%q) = error %v; want a plan", q, err)
+	}
+	setOp, ok := plan.(*chplan.VectorSetOp)
+	if !ok {
+		t.Fatalf("lowerExpHistogramSetOp(%q) = %T; want *chplan.VectorSetOp", q, plan)
+	}
+	if len(setOp.Match.Labels) != 1 || setOp.Match.Labels[0] != "service" || !setOp.Match.On {
+		t.Fatalf("lowerExpHistogramSetOp(%q) produced Match %#v; want On=true with labels "+
+			"[service] — the query's own `on(service)` clause (mutant `!=`->`==` at "+
+			"histogram_native_set_op.go:113:22 copies it only when there is nothing to copy, "+
+			"leaving the zero Match)", q, setOp.Match)
+	}
+}

--- a/internal/promql/gremlins_kill_metadata_catalog_test.go
+++ b/internal/promql/gremlins_kill_metadata_catalog_test.go
@@ -24,7 +24,7 @@ func resourceAllowlistSchema(allowlist []string) schema.Metrics {
 }
 
 // TestConfiguredResourceKeysFor_SpellingMatchIsEitherNotBoth kills the
-// INVERT_LOGICAL mutant at metadata_catalog.go:331:45 — the `&&` of
+// INVERT_LOGICAL mutant on the `&&` of
 //
 //	if sanitizePromLabelChars(k) != promLabel && format.OTelToPromLabel(k) != promLabel {
 //
@@ -58,16 +58,21 @@ func TestConfiguredResourceKeysFor_SpellingMatchIsEitherNotBoth(t *testing.T) {
 	if len(got) != 1 || got[0] != digitInitialKey {
 		t.Fatalf("configuredResourceKeysFor(allowlist=[%q], promLabel=%q) = %v; want [%q] — the key "+
 			"matches on its OTel spelling (%q) even though its sanitised spelling (%q) differs, "+
-			"and either match is enough (mutant `&&`->`||` at metadata_catalog.go:331 would "+
+			"and either match is enough (the `&&`->`||` mutant on "+
+			"metadata_catalog.go:`sanitizePromLabelChars(k) != promLabel && format.OTelToPromLabel(k) != promLabel` would "+
 			"require both and drop it)",
 			digitInitialKey, otelSpelling, got, digitInitialKey, otelSpelling, digitInitialKey)
 	}
 }
 
 // TestConfiguredResourceKeysFor_NonMatchingKeySkipsNotStops kills the
-// INVERT_LOOPCTRL mutant at metadata_catalog.go:332:4 — the `continue` that
-// the spelling-match guard above executes for a key that addresses a
-// different label.
+// INVERT_LOOPCTRL mutant on the `continue` that the spelling-match guard
+//
+//	metadata_catalog.go:`sanitizePromLabelChars(k) != promLabel && format.OTelToPromLabel(k) != promLabel`
+//
+// executes for a key that addresses a different label. The citation names
+// that guard rather than the mutated statement, which is a bare `continue`
+// no substring singles out.
 //
 // The allowlist is walked in configured order and a key that does not match
 // is simply not this label's, so the walk must go on. `break` would abandon
@@ -90,15 +95,20 @@ func TestConfiguredResourceKeysFor_NonMatchingKeySkipsNotStops(t *testing.T) {
 	if len(got) != 1 || got[0] != wanted {
 		t.Fatalf("configuredResourceKeysFor(allowlist=[unrelated %q], promLabel=%q) = %v; want "+
 			"[%q] — a non-matching key must be SKIPPED, not end the walk (mutant "+
-			"`continue`->`break` at metadata_catalog.go:332 would return nothing because the "+
+			"`continue`->`break` under "+
+			"metadata_catalog.go:`sanitizePromLabelChars(k) != promLabel && format.OTelToPromLabel(k) != promLabel` would return nothing because the "+
 			"non-matching key is listed first)",
 			wanted, promLabel, got, wanted)
 	}
 }
 
 // TestConfiguredResourceKeysFor_ExcludedKeySkipsNotStops kills the
-// INVERT_LOOPCTRL mutant at metadata_catalog.go:339:4 — the `continue` taken
-// for a key that a dedicated top-level column already backs.
+// INVERT_LOOPCTRL mutant on the `continue` taken under
+//
+//	metadata_catalog.go:`if _, drop := excluded[k]; drop {`
+//
+// for a key that a dedicated top-level column already backs. The citation
+// names that guard because the mutated statement is a bare `continue`.
 //
 // "service.name" is excluded because [excludedResourceKeys] lists it whenever
 // ServiceNameColumn is configured: the dedicated column owns that key and the
@@ -128,15 +138,22 @@ func TestConfiguredResourceKeysFor_ExcludedKeySkipsNotStops(t *testing.T) {
 	if len(got) != 1 || got[0] != siblingKey {
 		t.Fatalf("configuredResourceKeysFor(allowlist=[%q %q], promLabel=%q) = %v; want [%q] — a "+
 			"key excluded by its dedicated column must be SKIPPED, not end the walk (mutant "+
-			"`continue`->`break` at metadata_catalog.go:339 would return nothing because the "+
+			"`continue`->`break` under "+
+			"metadata_catalog.go:`if _, drop := excluded[k]; drop {` would return nothing because the "+
 			"excluded key is listed first)",
 			excludedKey, siblingKey, promLabel, got, siblingKey)
 	}
 }
 
 // TestSanitizedResourceKeyPairs_DuplicateSkipsNotStops kills the
-// INVERT_LOOPCTRL mutant at metadata_catalog.go:358:4 — the `continue` taken
-// for a repeated allowlist entry inside [sanitizedResourceKeyPairs].
+// INVERT_LOOPCTRL mutant on the `continue` taken under
+//
+//	metadata_catalog.go:sanitizedResourceKeyPairs:`if _, dup := seen[k]; dup {`
+//
+// for a repeated allowlist entry inside [sanitizedResourceKeyPairs]. The
+// citation names that guard because the mutated statement is a bare
+// `continue`, and scopes it to the function because
+// [configuredResourceKeysFor] carries the identical duplicate check.
 //
 // The loop de-duplicates a configured allowlist that may legitimately repeat
 // a key; a repeat carries no information and the remaining entries still do.
@@ -153,7 +170,8 @@ func TestSanitizedResourceKeyPairs_DuplicateSkipsNotStops(t *testing.T) {
 	if len(keys) != 2 || keys[0] != "alpha" || keys[1] != "beta" {
 		t.Fatalf("sanitizedResourceKeyPairs(allowlist=[alpha alpha beta]) keys = %v; want "+
 			"[alpha beta] — a repeated key must be SKIPPED, not end the walk (mutant "+
-			"`continue`->`break` at metadata_catalog.go:358 would drop beta)", keys)
+			"`continue`->`break` under "+
+			"metadata_catalog.go:sanitizedResourceKeyPairs:`if _, dup := seen[k]; dup {` would drop beta)", keys)
 	}
 	if len(sanitized) != len(keys) {
 		t.Fatalf("sanitizedResourceKeyPairs returned %d keys and %d sanitised spellings; the two "+
@@ -169,15 +187,16 @@ func mixedOrFloatOnlyAggQuery(agg string) string {
 }
 
 // TestFloatOnlyAggOverMixedExpHistogramSetOp_ParamlessOpsAccepted kills TWO
-// mutants on histogram_native_mixed_or_aggregate_float_only.go:91,
+// mutants on
 //
-//	if agg.Op != parser.QUANTILE && agg.Param != nil {
+//	histogram_native_mixed_or_aggregate_float_only.go:`agg.Op != parser.QUANTILE && agg.Param != nil`
 //
 // the guard that rejects an aggregation carrying a parameter it has no
-// meaning for:
+// meaning for. All three of this guard's mutants share that construct, so
+// each is named by the operator it rewrites:
 //
-//   - 91:44 CONDITIONALS_NEGATION, `agg.Param != nil` -> `agg.Param == nil`.
-//   - 91:31 INVERT_LOGICAL, the `&&` -> `||`.
+//   - CONDITIONALS_NEGATION, `agg.Param != nil` -> `agg.Param == nil`.
+//   - INVERT_LOGICAL, the `&&` -> `||`.
 //
 // `min` is one of the histogram-dropping ops [expHistogramAggDropsHistogramSamples]
 // admits, it is not QUANTILE, and the parser gives it a nil Param. Under the
@@ -210,9 +229,12 @@ func TestFloatOnlyAggOverMixedExpHistogramSetOp_ParamlessOpsAccepted(t *testing.
 }
 
 // TestFloatOnlyAggOverMixedExpHistogramSetOp_QuantileKeepsItsParam kills the
-// CONDITIONALS_NEGATION mutant at
-// histogram_native_mixed_or_aggregate_float_only.go:91:12 — `agg.Op !=
-// parser.QUANTILE` -> `agg.Op == parser.QUANTILE`.
+// CONDITIONALS_NEGATION mutant on
+//
+//	histogram_native_mixed_or_aggregate_float_only.go:`agg.Op != parser.QUANTILE && agg.Param != nil`
+//
+// that rewrites its `agg.Op != parser.QUANTILE` half to
+// `agg.Op == parser.QUANTILE`.
 //
 // QUANTILE is the one admitted op for which a parameter is REQUIRED, which is
 // exactly why it is named as the exception: the guard means "a parameter is

--- a/internal/promql/gremlins_kill_metadata_catalog_test.go
+++ b/internal/promql/gremlins_kill_metadata_catalog_test.go
@@ -1,0 +1,244 @@
+// Tests in this file kill the LIVED gremlins mutants reported on
+// metadata_catalog.go's resource-allowlist inversion and on
+// histogram_native_mixed_or_aggregate_float_only.go's parameter guard, from
+// the phase4-promql-b leg (cerberus issue #2949). See gremlins_kill_test.go
+// for the shared file-header convention this file follows.
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// resourceAllowlistSchema returns a schema whose resource arm is live (a
+// ResourceAttributes column plus a non-empty PromResourceLabels allowlist) so
+// [configuredResourceKeysFor]'s two early returns are not what decides the
+// tests below.
+func resourceAllowlistSchema(allowlist []string) schema.Metrics {
+	s := schema.DefaultOTelMetrics()
+	s.PromResourceLabels = allowlist
+	return s
+}
+
+// TestConfiguredResourceKeysFor_SpellingMatchIsEitherNotBoth kills the
+// INVERT_LOGICAL mutant at metadata_catalog.go:331:45 — the `&&` of
+//
+//	if sanitizePromLabelChars(k) != promLabel && format.OTelToPromLabel(k) != promLabel {
+//
+// inside [configuredResourceKeysFor]'s allowlist loop.
+//
+// The guard skips a key only when NEITHER spelling reaches promLabel; a key
+// that matches on EITHER spelling belongs in the result, which is the whole
+// point of inverting a many-to-one sanitisation over a closed set. The `||`
+// mutant skips a key unless BOTH spellings match, which silently drops every
+// key the two functions spell differently.
+//
+// The two functions differ on a digit-initial key: `sanitizePromLabelChars`
+// rewrites only non-alphanumerics, so "9a" stays "9a", while
+// `format.OTelToPromLabel` additionally prefixes an underscore because a Prom
+// label may not begin with a digit, giving "_9a". Asking for promLabel "_9a"
+// therefore matches on the OTel spelling and NOT on the sanitised one — the
+// exact single-sided match the mutant discards.
+//
+// The key is deliberately not spelled the same as promLabel: a key identical
+// to the requested label is already reached by the dot/underscore candidate
+// chain, so [configuredResourceKeysFor] drops it as `covered` further down and
+// the guard under test would never decide the outcome.
+func TestConfiguredResourceKeysFor_SpellingMatchIsEitherNotBoth(t *testing.T) {
+	t.Parallel()
+
+	const digitInitialKey = "9a"
+	const otelSpelling = "_9a"
+	s := resourceAllowlistSchema([]string{digitInitialKey})
+
+	got := configuredResourceKeysFor(s, otelSpelling)
+	if len(got) != 1 || got[0] != digitInitialKey {
+		t.Fatalf("configuredResourceKeysFor(allowlist=[%q], promLabel=%q) = %v; want [%q] — the key "+
+			"matches on its OTel spelling (%q) even though its sanitised spelling (%q) differs, "+
+			"and either match is enough (mutant `&&`->`||` at metadata_catalog.go:331 would "+
+			"require both and drop it)",
+			digitInitialKey, otelSpelling, got, digitInitialKey, otelSpelling, digitInitialKey)
+	}
+}
+
+// TestConfiguredResourceKeysFor_NonMatchingKeySkipsNotStops kills the
+// INVERT_LOOPCTRL mutant at metadata_catalog.go:332:4 — the `continue` that
+// the spelling-match guard above executes for a key that addresses a
+// different label.
+//
+// The allowlist is walked in configured order and a key that does not match
+// is simply not this label's, so the walk must go on. `break` would abandon
+// every key after the first non-match, making the result depend on where the
+// deployment happened to list the label. The allowlist below puts a
+// non-matching key first precisely so the two differ.
+//
+// The matching key is "region-a" rather than the label's own spelling because
+// a key identical to the requested label is dropped later as `covered`; the
+// hyphen sanitises to the underscore the label carries and nothing else about
+// the key changes.
+func TestConfiguredResourceKeysFor_NonMatchingKeySkipsNotStops(t *testing.T) {
+	t.Parallel()
+
+	const promLabel = "region_a"
+	const wanted = "region-a"
+	s := resourceAllowlistSchema([]string{"unrelated", wanted})
+
+	got := configuredResourceKeysFor(s, promLabel)
+	if len(got) != 1 || got[0] != wanted {
+		t.Fatalf("configuredResourceKeysFor(allowlist=[unrelated %q], promLabel=%q) = %v; want "+
+			"[%q] — a non-matching key must be SKIPPED, not end the walk (mutant "+
+			"`continue`->`break` at metadata_catalog.go:332 would return nothing because the "+
+			"non-matching key is listed first)",
+			wanted, promLabel, got, wanted)
+	}
+}
+
+// TestConfiguredResourceKeysFor_ExcludedKeySkipsNotStops kills the
+// INVERT_LOOPCTRL mutant at metadata_catalog.go:339:4 — the `continue` taken
+// for a key that a dedicated top-level column already backs.
+//
+// "service.name" is excluded because [excludedResourceKeys] lists it whenever
+// ServiceNameColumn is configured: the dedicated column owns that key and the
+// resource arm must not duplicate it. But exclusion is a property of THAT key
+// alone, so a sibling allowlist entry that sanitises to the same Prom label
+// and is NOT itself excluded still belongs in the result.
+//
+// "service-name" is that sibling: it sanitises to "service_name" like
+// "service.name" does, and it is absent from the excluded set (which holds
+// only the dotted "service.name" and its Prom spelling "service_name"). With
+// the excluded key listed first, `break` returns nothing where `continue`
+// returns the sibling.
+func TestConfiguredResourceKeysFor_ExcludedKeySkipsNotStops(t *testing.T) {
+	t.Parallel()
+
+	const promLabel = "service_name"
+	const excludedKey = "service.name"
+	const siblingKey = "service-name"
+
+	s := resourceAllowlistSchema([]string{excludedKey, siblingKey})
+	if s.ServiceNameColumn == "" {
+		t.Fatalf("positive control: the default schema configures no ServiceNameColumn, so %q is "+
+			"not excluded and this test would not reach the guard it pins", excludedKey)
+	}
+
+	got := configuredResourceKeysFor(s, promLabel)
+	if len(got) != 1 || got[0] != siblingKey {
+		t.Fatalf("configuredResourceKeysFor(allowlist=[%q %q], promLabel=%q) = %v; want [%q] — a "+
+			"key excluded by its dedicated column must be SKIPPED, not end the walk (mutant "+
+			"`continue`->`break` at metadata_catalog.go:339 would return nothing because the "+
+			"excluded key is listed first)",
+			excludedKey, siblingKey, promLabel, got, siblingKey)
+	}
+}
+
+// TestSanitizedResourceKeyPairs_DuplicateSkipsNotStops kills the
+// INVERT_LOOPCTRL mutant at metadata_catalog.go:358:4 — the `continue` taken
+// for a repeated allowlist entry inside [sanitizedResourceKeyPairs].
+//
+// The loop de-duplicates a configured allowlist that may legitimately repeat
+// a key; a repeat carries no information and the remaining entries still do.
+// `break` would truncate the lookup table at the first repeat, so a
+// deployment that listed a key twice would lose every key after it — and the
+// table is what [sanitizeMapKeysExpr] emits in place of a per-key regex, so
+// the loss is silent and total for the dropped keys.
+func TestSanitizedResourceKeyPairs_DuplicateSkipsNotStops(t *testing.T) {
+	t.Parallel()
+
+	s := resourceAllowlistSchema([]string{"alpha", "alpha", "beta"})
+
+	keys, sanitized := sanitizedResourceKeyPairs(s)
+	if len(keys) != 2 || keys[0] != "alpha" || keys[1] != "beta" {
+		t.Fatalf("sanitizedResourceKeyPairs(allowlist=[alpha alpha beta]) keys = %v; want "+
+			"[alpha beta] — a repeated key must be SKIPPED, not end the walk (mutant "+
+			"`continue`->`break` at metadata_catalog.go:358 would drop beta)", keys)
+	}
+	if len(sanitized) != len(keys) {
+		t.Fatalf("sanitizedResourceKeyPairs returned %d keys and %d sanitised spellings; the two "+
+			"slices are a pairing and must have equal length", len(keys), len(sanitized))
+	}
+}
+
+// mixedOrFloatOnlyAggQuery builds `<agg>((latency_exp_hist) or
+// (other_metric))` — an aggregation whose input is the mixed exp-histogram /
+// float set-op shape [floatOnlyAggOverMixedExpHistogramSetOp] answers.
+func mixedOrFloatOnlyAggQuery(agg string) string {
+	return agg + `((latency_exp_hist) or (other_metric))`
+}
+
+// TestFloatOnlyAggOverMixedExpHistogramSetOp_ParamlessOpsAccepted kills TWO
+// mutants on histogram_native_mixed_or_aggregate_float_only.go:91,
+//
+//	if agg.Op != parser.QUANTILE && agg.Param != nil {
+//
+// the guard that rejects an aggregation carrying a parameter it has no
+// meaning for:
+//
+//   - 91:44 CONDITIONALS_NEGATION, `agg.Param != nil` -> `agg.Param == nil`.
+//   - 91:31 INVERT_LOGICAL, the `&&` -> `||`.
+//
+// `min` is one of the histogram-dropping ops [expHistogramAggDropsHistogramSamples]
+// admits, it is not QUANTILE, and the parser gives it a nil Param. Under the
+// original both conjuncts are needed and `nil` Param means the guard does not
+// fire, so the shape is recognised. Under EITHER mutant the guard fires — the
+// negation makes `Param == nil` true, and the `||` needs only
+// `Op != QUANTILE` — and a perfectly ordinary `min` over the mixed set-op is
+// refused.
+func TestFloatOnlyAggOverMixedExpHistogramSetOp_ParamlessOpsAccepted(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	q := mixedOrFloatOnlyAggQuery("min")
+	expr := mustParse(t, q)
+
+	agg, b, ok := floatOnlyAggOverMixedExpHistogramSetOp(expr, s, lowerCtx{})
+	if !ok {
+		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) = ok false; want true — `min` carries "+
+			"no parameter, so the QUANTILE/Param guard must not fire (mutants "+
+			"`!=`->`==` at :91:44 and `&&`->`||` at :91:31 both make it fire)", q)
+	}
+	if agg == nil || agg.Op != parser.MIN {
+		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) returned agg %#v; want the MIN "+
+			"aggregation itself", q, agg)
+	}
+	if b == nil {
+		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) returned a nil set-op; want the "+
+			"recognised `or` binary expression", q)
+	}
+}
+
+// TestFloatOnlyAggOverMixedExpHistogramSetOp_QuantileKeepsItsParam kills the
+// CONDITIONALS_NEGATION mutant at
+// histogram_native_mixed_or_aggregate_float_only.go:91:12 — `agg.Op !=
+// parser.QUANTILE` -> `agg.Op == parser.QUANTILE`.
+//
+// QUANTILE is the one admitted op for which a parameter is REQUIRED, which is
+// exactly why it is named as the exception: the guard means "a parameter is
+// an error unless this is quantile". The parser always gives `quantile` a
+// non-nil Param, so the mutated guard `Op == QUANTILE && Param != nil` fires
+// on every quantile there is, and the op the exception was written for
+// becomes the only one refused.
+func TestFloatOnlyAggOverMixedExpHistogramSetOp_QuantileKeepsItsParam(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	q := `quantile(0.9, (latency_exp_hist) or (other_metric))`
+	expr := mustParse(t, q)
+
+	agg, _, ok := floatOnlyAggOverMixedExpHistogramSetOp(expr, s, lowerCtx{})
+	if !ok {
+		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) = ok false; want true — QUANTILE is "+
+			"the op the Param exception exists for (mutant `!=`->`==` at :91:12 rejects every "+
+			"quantile instead)", q)
+	}
+	if agg == nil || agg.Op != parser.QUANTILE {
+		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) returned agg %#v; want the QUANTILE "+
+			"aggregation itself", q, agg)
+	}
+	if agg.Param == nil {
+		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) returned a QUANTILE aggregation with "+
+			"a nil Param; the phi argument is what the exception admits", q)
+	}
+}

--- a/internal/promql/gremlins_kill_metadata_full_range_test.go
+++ b/internal/promql/gremlins_kill_metadata_full_range_test.go
@@ -187,3 +187,77 @@ func TestSumOrAvgOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
 			"`||`->`&&` on the ExpHistogramTable/metadataFullRange guard would accept it)", q)
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// The same `||` -> `&&` INVERT_LOGICAL rewrite of
+//
+//	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+//
+// is EQUIVALENT at every COMPOSITE recognizer, and ten of the mutants on
+// cerberus issue #2949's legs are of that kind:
+//
+//	histogram_native_float_vector_scaling_binop.go:85:31  expHistogramFloatVectorScalingBinop
+//	histogram_native_dropping_shape.go:156:31             aggregationOverExpHistogramDroppingShape
+//	histogram_native_dropping_shape.go:204:31             labelCallOverExpHistogramDroppingShape
+//	histogram_native_range_fn.go:210:31                   rangeFnOverExpHistogramSubquery
+//	histogram_native_mixed_or_subquery_range_fn.go:114:31 mixedOrSubqueryOuterFn
+//	histogram_native_subquery_select.go:102:31            selectFnOverExpHistogramSubquery
+//	histogram_native_float_vector_binop.go:50:31          expHistogramDroppingVectorBinop
+//	histogram_native_scalar_binop.go:73:31                expHistogramScalarBinop
+//	histogram_native_scalar_binop.go:101:31               expHistogramDroppingScalarBinop
+//	histogram_native_set_op.go:78:31                      expHistogramSetOp
+//
+// (gremlins_kill_histogram_binop_count_test.go's header already records the
+// same verdict, on the same ground, for histogram_native_binop_eq.go:119:31
+// and :191:31.)
+//
+// THE ARGUMENT
+//
+// Write the guard's two disjuncts A (`s.ExpHistogramTable == ""`) and B
+// (`ctx.metadataFullRange`). The original bails on `A || B`; the mutant bails
+// on `A && B`. The two therefore differ only where exactly one of A, B holds,
+// and in that region the mutant does NOT bail where the original does. So the
+// mutant is equivalent iff, whenever `A || B` holds, the recognizer answers
+// false anyway for every input.
+//
+// Each function above answers by asking `isExpHistogramValuedShape` or
+// `isExpHistogramDroppingShape` about its operands, and every rejection path
+// returns that function's zero-value tuple, never a partially-populated one.
+// So it is enough that both predicates are UNCONDITIONALLY false whenever
+// `A || B` holds — and they are, by structural induction over a closed
+// dispatch set:
+//
+//   - Base cases. Every leaf `isExpHistogramValuedShape` and
+//     `isExpHistogramDroppingShape` dispatch to carries this identical guard
+//     as its own first statement: bareExpHistogramSelector,
+//     sumOrAvgOverExpHistogram, rangeFnOverExpHistogram,
+//     rangeFnOverExpHistogramSubquery, overTimeOverExpHistogram,
+//     lastFirstOverExpHistogram, unaryOverExpHistogram,
+//     expHistogramHistogramBinop, expHistogramSetOp,
+//     expHistogramFloatVectorScalingBinop, limitKOrRatioOverExpHistogram,
+//     droppingAggregationOverExpHistogram, expHistogramDroppingScalarBinop,
+//     expHistogramDroppingVectorBinop, expHistogramDroppingHistogramBinop,
+//     aggregationOverExpHistogramDroppingShape and
+//     labelCallOverExpHistogramDroppingShape. Each returns false under
+//     `A || B` before reading its input at all.
+//   - Inductive cases. The three members of the dispatch set that carry NO
+//     guard of their own do not decide anything themselves — each delegates
+//     the whole question back into the same set:
+//     labelCallOverExpHistogram and histogramValuedProducerCall both end in
+//     `isExpHistogramValuedShape(call.Args[0], s, ctx)`, and
+//     selectFnHistogramPreservingSubquery delegates to
+//     selectFnOverExpHistogramSubquery, which is guarded.
+//
+// The set is closed — those two predicates dispatch to nothing else — so
+// under `A || B` no branch can produce true, and the mutant's extra reachable
+// code is dead. Verified by applying each mutation by hand and confirming
+// `go test ./internal/promql/` stays green, and by driving both predicates
+// with `metadataFullRange: true` over the bare / aggregated / windowed /
+// unary / label-call / scalar-binop / vector-binop / set-op / dropping
+// shapes, all of which answer false.
+//
+// The LEAF recognizers are a different matter and are NOT covered by this
+// footer: they decide by asking the SCHEMA (`s.IsExpHistogramMetric`), which
+// never consults ctx, so the mutant genuinely accepts what the original
+// rejects. Those six are killed by the tests above.

--- a/internal/promql/gremlins_kill_metadata_full_range_test.go
+++ b/internal/promql/gremlins_kill_metadata_full_range_test.go
@@ -1,0 +1,189 @@
+// Tests in this file kill the `INVERT_LOGICAL` mutants that rewrite the `||`
+// of
+//
+//	if s.ExpHistogramTable == "" || ctx.metadataFullRange {
+//
+// into `&&`, at the LEAF exp-histogram recognizers — the ones that decide a
+// shape by asking the SCHEMA whether the selected metric is an exp-histogram
+// (`s.IsExpHistogramMetric`), which reads nothing from `ctx`. See
+// gremlins_kill_test.go for the shared file-header convention this file
+// follows; cerberus issue #2949 owns the legs these mutants were reported on
+// (phase4-promql-b / -d / -f / -i / -other).
+//
+// Why the leaf/composite distinction is the whole story here
+// ---------------------------------------------------------
+// The guard is one condition with two independent reasons to bail: the schema
+// declares no exp-histogram table at all, or this lowering is a Prometheus
+// metadata full-range walk, which must never be answered from the
+// exp-histogram table. The original bails when EITHER holds. The `&&` mutant
+// bails only when BOTH hold, so the two differ exactly when one holds and the
+// other does not — and the reachable half of that is a metadata full-range
+// lowering against a schema that DOES declare the table.
+//
+// At a leaf recognizer nothing downstream re-checks `ctx`: the remaining
+// guards are shape guards (is this a Call, a MatrixSelector, a positive
+// range) plus `s.IsExpHistogramMetric`, which consults only the metric name
+// and the schema's suffix. So with `metadataFullRange: true` and a normal
+// schema the mutant runs the whole recognizer to completion and ACCEPTS a
+// shape the original rejects — an observable difference, and what each test
+// below pins.
+//
+// At a COMPOSITE recognizer the same mutation is equivalent, because the
+// composite re-validates the identical condition one level down through
+// `isExpHistogramValuedShape` / `isExpHistogramDroppingShape`, whose every
+// leaf carries this very guard. Those sites are adjudicated in this file's
+// NOT KILLABLE footer rather than tested, on the same ground
+// gremlins_kill_histogram_binop_count_test.go's header already records for
+// histogram_native_binop_eq.go's two.
+//
+// Each test asserts BOTH directions. The negative assertion alone would pass
+// vacuously against any expression the recognizer rejects for an unrelated
+// reason (a typo in the query, a metric name the schema does not treat as an
+// exp-histogram), so every test first pins that the SAME expression IS
+// recognised with `metadataFullRange` false. That positive control is what
+// makes the negative one evidence.
+package promql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLastFirstOverExpHistogram_MetadataFullRangeRejects kills the
+// INVERT_LOGICAL mutant at histogram_native_last_first_over_time.go:54:31 —
+// the `||` of `s.ExpHistogramTable == "" || ctx.metadataFullRange` inside
+// [lastFirstOverExpHistogram], the `last_over_time` / `first_over_time`
+// recognizer.
+//
+// The recognizer's only other schema question is
+// `s.IsExpHistogramMetric(...)`, which is true here regardless of `ctx`, so
+// under the mutant the metadata full-range lowering is recognised as an
+// exp-histogram window shape.
+func TestLastFirstOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `last_over_time(latency_exp_hist[5m])`
+	expr := mustParse(t, q)
+
+	if _, _, _, ok := lastFirstOverExpHistogram(expr, s, lowerCtx{}); !ok {
+		t.Fatalf("positive control: lastFirstOverExpHistogram(%q) = ok false with an ordinary ctx; "+
+			"the negative assertion below would then hold for the wrong reason", q)
+	}
+	if _, _, _, ok := lastFirstOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("lastFirstOverExpHistogram(%q) = ok true under metadataFullRange; a metadata "+
+			"full-range lowering must never be answered from the exp-histogram table (mutant "+
+			"`||`->`&&` on the ExpHistogramTable/metadataFullRange guard would accept it)", q)
+	}
+}
+
+// TestOverTimeOverExpHistogram_MetadataFullRangeRejects kills the
+// INVERT_LOGICAL mutant at histogram_native_over_time.go:28:31 — the `||` of
+// the same guard inside [overTimeOverExpHistogram], the `sum_over_time` /
+// `avg_over_time` recognizer.
+func TestOverTimeOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `sum_over_time(latency_exp_hist[5m])`
+	expr := mustParse(t, q)
+
+	if _, ok := overTimeOverExpHistogram(expr, s, lowerCtx{}); !ok {
+		t.Fatalf("positive control: overTimeOverExpHistogram(%q) = ok false with an ordinary ctx; "+
+			"the negative assertion below would then hold for the wrong reason", q)
+	}
+	if _, ok := overTimeOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("overTimeOverExpHistogram(%q) = ok true under metadataFullRange; a metadata "+
+			"full-range lowering must never be answered from the exp-histogram table (mutant "+
+			"`||`->`&&` on the ExpHistogramTable/metadataFullRange guard would accept it)", q)
+	}
+}
+
+// TestResetsOrChangesOverExpHistogram_MetadataFullRangeRejects kills the
+// INVERT_LOGICAL mutant at histogram_native_resets.go:121:31 — the `||` of
+// the same guard inside [resetsOrChangesOverExpHistogram], the `resets` /
+// `changes` recognizer.
+func TestResetsOrChangesOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `resets(latency_exp_hist[5m])`
+	expr := mustParse(t, q)
+
+	if _, ok := resetsOrChangesOverExpHistogram(expr, s, lowerCtx{}); !ok {
+		t.Fatalf("positive control: resetsOrChangesOverExpHistogram(%q) = ok false with an ordinary "+
+			"ctx; the negative assertion below would then hold for the wrong reason", q)
+	}
+	if _, ok := resetsOrChangesOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("resetsOrChangesOverExpHistogram(%q) = ok true under metadataFullRange; a metadata "+
+			"full-range lowering must never be answered from the exp-histogram table (mutant "+
+			"`||`->`&&` on the ExpHistogramTable/metadataFullRange guard would accept it)", q)
+	}
+}
+
+// TestBareExpHistogramSelector_MetadataFullRangeRejects kills the
+// INVERT_LOGICAL mutant at histogram_native_bare.go:68:31 — the `||` of the
+// same guard inside [bareExpHistogramSelector], the bare-selector recognizer
+// every composite shape's `isExpHistogramValuedShape` eventually reaches.
+func TestBareExpHistogramSelector_MetadataFullRangeRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `latency_exp_hist`
+	expr := mustParse(t, q)
+
+	if _, ok := bareExpHistogramSelector(expr, s, lowerCtx{}); !ok {
+		t.Fatalf("positive control: bareExpHistogramSelector(%q) = ok false with an ordinary ctx; "+
+			"the negative assertion below would then hold for the wrong reason", q)
+	}
+	if _, ok := bareExpHistogramSelector(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("bareExpHistogramSelector(%q) = ok true under metadataFullRange; a metadata "+
+			"full-range lowering must never be answered from the exp-histogram table (mutant "+
+			"`||`->`&&` on the ExpHistogramTable/metadataFullRange guard would accept it)", q)
+	}
+}
+
+// TestTsOfFirstLastOverExpHistogram_MetadataFullRangeRejects kills the
+// INVERT_LOGICAL mutant at histogram_native_ts_of_first_last_over_time.go:81:31
+// — the `||` of the same guard inside [tsOfFirstLastOverExpHistogram], the
+// `ts_of_first_over_time` / `ts_of_last_over_time` recognizer.
+func TestTsOfFirstLastOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `ts_of_last_over_time(latency_exp_hist[5m])`
+	expr := mustParseExperimental(t, q)
+
+	if _, _, _, ok := tsOfFirstLastOverExpHistogram(expr, s, lowerCtx{}); !ok {
+		t.Fatalf("positive control: tsOfFirstLastOverExpHistogram(%q) = ok false with an ordinary "+
+			"ctx; the negative assertion below would then hold for the wrong reason", q)
+	}
+	if _, _, _, ok := tsOfFirstLastOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("tsOfFirstLastOverExpHistogram(%q) = ok true under metadataFullRange; a metadata "+
+			"full-range lowering must never be answered from the exp-histogram table (mutant "+
+			"`||`->`&&` on the ExpHistogramTable/metadataFullRange guard would accept it)", q)
+	}
+}
+
+// TestSumOrAvgOverExpHistogram_MetadataFullRangeRejects kills the
+// INVERT_LOGICAL mutant at histogram_native_sum.go:106:31 — the `||` of the
+// same guard inside [sumOrAvgOverExpHistogram], the mergeable-aggregation
+// recognizer.
+func TestSumOrAvgOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	const q = `sum(latency_exp_hist)`
+	expr := mustParse(t, q)
+
+	if _, _, ok := sumOrAvgOverExpHistogram(expr, s, lowerCtx{}); !ok {
+		t.Fatalf("positive control: sumOrAvgOverExpHistogram(%q) = ok false with an ordinary ctx; "+
+			"the negative assertion below would then hold for the wrong reason", q)
+	}
+	if _, _, ok := sumOrAvgOverExpHistogram(expr, s, lowerCtx{metadataFullRange: true}); ok {
+		t.Fatalf("sumOrAvgOverExpHistogram(%q) = ok true under metadataFullRange; a metadata "+
+			"full-range lowering must never be answered from the exp-histogram table (mutant "+
+			"`||`->`&&` on the ExpHistogramTable/metadataFullRange guard would accept it)", q)
+	}
+}

--- a/internal/promql/gremlins_kill_metadata_full_range_test.go
+++ b/internal/promql/gremlins_kill_metadata_full_range_test.go
@@ -51,10 +51,12 @@ import (
 )
 
 // TestLastFirstOverExpHistogram_MetadataFullRangeRejects kills the
-// INVERT_LOGICAL mutant at histogram_native_last_first_over_time.go:54:31 —
-// the `||` of `s.ExpHistogramTable == "" || ctx.metadataFullRange` inside
-// [lastFirstOverExpHistogram], the `last_over_time` / `first_over_time`
-// recognizer.
+// INVERT_LOGICAL mutant on the `||` of
+//
+//	histogram_native_last_first_over_time.go:lastFirstOverExpHistogram:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//
+// inside [lastFirstOverExpHistogram], the `last_over_time` /
+// `first_over_time` recognizer.
 //
 // The recognizer's only other schema question is
 // `s.IsExpHistogramMetric(...)`, which is true here regardless of `ctx`, so
@@ -79,7 +81,10 @@ func TestLastFirstOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
 }
 
 // TestOverTimeOverExpHistogram_MetadataFullRangeRejects kills the
-// INVERT_LOGICAL mutant at histogram_native_over_time.go:28:31 — the `||` of
+// INVERT_LOGICAL mutant on the `||` of
+//
+//	histogram_native_over_time.go:overTimeOverExpHistogram:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//
 // the same guard inside [overTimeOverExpHistogram], the `sum_over_time` /
 // `avg_over_time` recognizer.
 func TestOverTimeOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
@@ -101,7 +106,10 @@ func TestOverTimeOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
 }
 
 // TestResetsOrChangesOverExpHistogram_MetadataFullRangeRejects kills the
-// INVERT_LOGICAL mutant at histogram_native_resets.go:121:31 — the `||` of
+// INVERT_LOGICAL mutant on the `||` of
+//
+//	histogram_native_resets.go:resetsOrChangesOverExpHistogram:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//
 // the same guard inside [resetsOrChangesOverExpHistogram], the `resets` /
 // `changes` recognizer.
 func TestResetsOrChangesOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
@@ -123,9 +131,13 @@ func TestResetsOrChangesOverExpHistogram_MetadataFullRangeRejects(t *testing.T) 
 }
 
 // TestBareExpHistogramSelector_MetadataFullRangeRejects kills the
-// INVERT_LOGICAL mutant at histogram_native_bare.go:68:31 — the `||` of the
-// same guard inside [bareExpHistogramSelector], the bare-selector recognizer
-// every composite shape's `isExpHistogramValuedShape` eventually reaches.
+// INVERT_LOGICAL mutant on the `||` of
+//
+//	histogram_native_bare.go:bareExpHistogramSelector:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//
+// the same guard inside [bareExpHistogramSelector], the bare-selector
+// recognizer every composite shape's `isExpHistogramValuedShape` eventually
+// reaches.
 func TestBareExpHistogramSelector_MetadataFullRangeRejects(t *testing.T) {
 	t.Parallel()
 
@@ -145,8 +157,11 @@ func TestBareExpHistogramSelector_MetadataFullRangeRejects(t *testing.T) {
 }
 
 // TestTsOfFirstLastOverExpHistogram_MetadataFullRangeRejects kills the
-// INVERT_LOGICAL mutant at histogram_native_ts_of_first_last_over_time.go:81:31
-// — the `||` of the same guard inside [tsOfFirstLastOverExpHistogram], the
+// INVERT_LOGICAL mutant on the `||` of
+//
+//	histogram_native_ts_of_first_last_over_time.go:tsOfFirstLastOverExpHistogram:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//
+// the same guard inside [tsOfFirstLastOverExpHistogram], the
 // `ts_of_first_over_time` / `ts_of_last_over_time` recognizer.
 func TestTsOfFirstLastOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
 	t.Parallel()
@@ -167,9 +182,12 @@ func TestTsOfFirstLastOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
 }
 
 // TestSumOrAvgOverExpHistogram_MetadataFullRangeRejects kills the
-// INVERT_LOGICAL mutant at histogram_native_sum.go:106:31 — the `||` of the
-// same guard inside [sumOrAvgOverExpHistogram], the mergeable-aggregation
-// recognizer.
+// INVERT_LOGICAL mutant on the `||` of
+//
+//	histogram_native_sum.go:sumOrAvgOverExpHistogram:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//
+// the same guard inside [sumOrAvgOverExpHistogram], the
+// mergeable-aggregation recognizer.
 func TestSumOrAvgOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
 	t.Parallel()
 
@@ -197,20 +215,21 @@ func TestSumOrAvgOverExpHistogram_MetadataFullRangeRejects(t *testing.T) {
 // is EQUIVALENT at every COMPOSITE recognizer, and ten of the mutants on
 // cerberus issue #2949's legs are of that kind:
 //
-//	histogram_native_float_vector_scaling_binop.go:85:31  expHistogramFloatVectorScalingBinop
-//	histogram_native_dropping_shape.go:156:31             aggregationOverExpHistogramDroppingShape
-//	histogram_native_dropping_shape.go:204:31             labelCallOverExpHistogramDroppingShape
-//	histogram_native_range_fn.go:210:31                   rangeFnOverExpHistogramSubquery
-//	histogram_native_mixed_or_subquery_range_fn.go:114:31 mixedOrSubqueryOuterFn
-//	histogram_native_subquery_select.go:102:31            selectFnOverExpHistogramSubquery
-//	histogram_native_float_vector_binop.go:50:31          expHistogramDroppingVectorBinop
-//	histogram_native_scalar_binop.go:73:31                expHistogramScalarBinop
-//	histogram_native_scalar_binop.go:101:31               expHistogramDroppingScalarBinop
-//	histogram_native_set_op.go:78:31                      expHistogramSetOp
+//	histogram_native_float_vector_scaling_binop.go:expHistogramFloatVectorScalingBinop:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_dropping_shape.go:aggregationOverExpHistogramDroppingShape:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_dropping_shape.go:labelCallOverExpHistogramDroppingShape:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_range_fn.go:rangeFnOverExpHistogramSubquery:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_mixed_or_subquery_range_fn.go:mixedOrSubqueryOuterFn:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_subquery_select.go:selectFnOverExpHistogramSubquery:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_float_vector_binop.go:expHistogramDroppingVectorBinop:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_scalar_binop.go:expHistogramScalarBinop:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_scalar_binop.go:expHistogramDroppingScalarBinop:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
+//	histogram_native_set_op.go:expHistogramSetOp:`s.ExpHistogramTable == "" || ctx.metadataFullRange`
 //
 // (gremlins_kill_histogram_binop_count_test.go's header already records the
-// same verdict, on the same ground, for histogram_native_binop_eq.go:119:31
-// and :191:31.)
+// same verdict, on the same ground, for the identical guard in
+// histogram_native_binop_eq.go's expHistogramHistogramCompareBinop and
+// expHistogramHistogramCompareBoolBinop.)
 //
 // THE ARGUMENT
 //

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -35,10 +35,12 @@ func zeroRangeExpHistogramCall(t *testing.T, fn string) *parser.Call {
 
 // TestLastFirstOverExpHistogram_ZeroRangeRejected kills the
 // CONDITIONALS_BOUNDARY mutant at
-// histogram_native_last_first_over_time.go:62:21 — `ms.Range <= 0` ->
-// `ms.Range < 0` inside [lastFirstOverExpHistogram]. A range is never
-// negative, so `< 0` can only ever be false and the zero-width window is
-// admitted.
+//
+//	histogram_native_last_first_over_time.go:lastFirstOverExpHistogram:`ms.Range <= 0`
+//
+// rewritten to `ms.Range < 0` inside [lastFirstOverExpHistogram]. A range is
+// never negative, so `< 0` can only ever be false and the zero-width window
+// is admitted.
 func TestLastFirstOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	t.Parallel()
 
@@ -46,14 +48,16 @@ func TestLastFirstOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	if _, _, _, ok := lastFirstOverExpHistogram(zeroRangeExpHistogramCall(t, "last_over_time"), s, lowerCtx{}); ok {
 		t.Fatal("lastFirstOverExpHistogram accepted a zero-range matrix selector; a window of no " +
 			"width has no samples to reduce (mutant `<=`->`<` at " +
-			"histogram_native_last_first_over_time.go:62:21 admits it)")
+			"histogram_native_last_first_over_time.go:lastFirstOverExpHistogram:`ms.Range <= 0` admits it)")
 	}
 }
 
 // TestOverTimeOverExpHistogram_ZeroRangeRejected kills the
-// CONDITIONALS_BOUNDARY mutant at histogram_native_over_time.go:36:21 —
-// the same `ms.Range <= 0` -> `ms.Range < 0` inside
-// [overTimeOverExpHistogram].
+// CONDITIONALS_BOUNDARY mutant on
+//
+//	histogram_native_over_time.go:overTimeOverExpHistogram:`ms.Range <= 0`
+//
+// the same rewrite to `ms.Range < 0` inside [overTimeOverExpHistogram].
 func TestOverTimeOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	t.Parallel()
 
@@ -61,14 +65,16 @@ func TestOverTimeOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	if _, ok := overTimeOverExpHistogram(zeroRangeExpHistogramCall(t, "sum_over_time"), s, lowerCtx{}); ok {
 		t.Fatal("overTimeOverExpHistogram accepted a zero-range matrix selector; a window of no " +
 			"width has no samples to reduce (mutant `<=`->`<` at " +
-			"histogram_native_over_time.go:36:21 admits it)")
+			"histogram_native_over_time.go:overTimeOverExpHistogram:`ms.Range <= 0` admits it)")
 	}
 }
 
 // TestResetsOrChangesOverExpHistogram_ZeroRangeRejected kills the
-// CONDITIONALS_BOUNDARY mutant at histogram_native_resets.go:133:21 — the
-// same `ms.Range <= 0` -> `ms.Range < 0` inside
-// [resetsOrChangesOverExpHistogram].
+// CONDITIONALS_BOUNDARY mutant on
+//
+//	histogram_native_resets.go:resetsOrChangesOverExpHistogram:`ms.Range <= 0`
+//
+// the same rewrite inside [resetsOrChangesOverExpHistogram].
 func TestResetsOrChangesOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	t.Parallel()
 
@@ -76,14 +82,16 @@ func TestResetsOrChangesOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	if _, ok := resetsOrChangesOverExpHistogram(zeroRangeExpHistogramCall(t, "resets"), s, lowerCtx{}); ok {
 		t.Fatal("resetsOrChangesOverExpHistogram accepted a zero-range matrix selector; a window " +
 			"of no width has no samples to reduce (mutant `<=`->`<` at " +
-			"histogram_native_resets.go:133:21 admits it)")
+			"histogram_native_resets.go:resetsOrChangesOverExpHistogram:`ms.Range <= 0` admits it)")
 	}
 }
 
 // TestTsOfFirstLastOverExpHistogram_ZeroRangeRejected kills the
 // CONDITIONALS_BOUNDARY mutant at
-// histogram_native_ts_of_first_last_over_time.go:89:21 — the same
-// `ms.Range <= 0` -> `ms.Range < 0` inside [tsOfFirstLastOverExpHistogram].
+//
+//	histogram_native_ts_of_first_last_over_time.go:tsOfFirstLastOverExpHistogram:`ms.Range <= 0`
+//
+// the same rewrite inside [tsOfFirstLastOverExpHistogram].
 func TestTsOfFirstLastOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	t.Parallel()
 
@@ -92,15 +100,14 @@ func TestTsOfFirstLastOverExpHistogram_ZeroRangeRejected(t *testing.T) {
 	if _, _, _, ok := tsOfFirstLastOverExpHistogram(call, s, lowerCtx{}); ok {
 		t.Fatal("tsOfFirstLastOverExpHistogram accepted a zero-range matrix selector; a window of " +
 			"no width has no samples to reduce (mutant `<=`->`<` at " +
-			"histogram_native_ts_of_first_last_over_time.go:89:21 admits it)")
+			"histogram_native_ts_of_first_last_over_time.go:tsOfFirstLastOverExpHistogram:`ms.Range <= 0` admits it)")
 	}
 }
 
 // TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments kills the
-// INVERT_LOGICAL mutant at histogram_native_value_producing_call.go:41:25 —
-// the `||` of
+// INVERT_LOGICAL mutant on the `||` of
 //
-//	if len(call.Args) < 1 || len(call.Args) > 2 {
+//	histogram_native_value_producing_call.go:`len(call.Args) < 1 || len(call.Args) > 2`
 //
 // inside [histogramValuedProducerCall].
 //
@@ -133,28 +140,33 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 	if _, ok := histogramValuedProducerCall(threeArg, s, lowerCtx{}); ok {
 		t.Fatal("histogramValuedProducerCall accepted a three-argument `info`; the arity bounds " +
 			"are independent and either one disqualifies (mutant `||`->`&&` at " +
-			"histogram_native_value_producing_call.go:41:25 makes the pair unsatisfiable)")
+			"histogram_native_value_producing_call.go:`len(call.Args) < 1 || len(call.Args) > 2` " +
+			"makes the pair unsatisfiable)")
 	}
 }
 
 // NOT KILLABLE — documented, not defended by a test.
 //
 // The remaining survivors on cerberus issue #2949's phase4-promql-* legs fall
-// into five equivalence classes. Each mutant is named by `file:line:col` AND
-// by the construct it rewrites, because bare line numbers drift.
+// into six equivalence classes. Each mutant is named by the construct it
+// rewrites — a line number cannot be machine-verified and rots on every
+// insertion above it (#2953) — scoped to its enclosing function wherever the
+// construct repeats within the file.
 //
 // 1. CAPACITY HINTS — ARITHMETIC_BASE inside a `make(T, 0, <cap>)` argument.
 //
-//	schema_lookup.go:133:43                  `len(pairs)*2`
-//	resource_attributes.go:73:61             `len(dedicatedResourceKeys)*2`
-//	histogram_quantile_native_window.go:299:65 and :299:83
-//	                                         `len(keyAliases)+len(aggs)+len(extraAliases)+1`
-//	histogram_quantile_native_window.go:380:55 `len(keyAliases)+len(scalars)+7`
-//	histogram_native_resets.go:298:55        `len(keyAliases)+1`
-//	histogram_native_scalar_binop.go:345:60 and :345:62
-//	                                         `len(passthroughCols)+1+5`
-//	histogram_quantile.go:1537:63            `len(passthrough)+2`
-//	histogram_quantile.go:1874:47            `len(labels)*2`
+//	schema_lookup.go:`make([]chplan.Expr, 0, len(pairs)*2)`
+//	resource_attributes.go:`make(map[string]struct{}, len(dedicatedResourceKeys)*2)`
+//	histogram_quantile_native_window.go:`len(keyAliases)+len(aggs)+len(extraAliases)+1`
+//	histogram_quantile_native_window.go:`len(keyAliases)+len(scalars)+7`
+//	histogram_native_resets.go:`make([]chplan.Projection, 0, len(keyAliases)+1)`
+//	histogram_native_scalar_binop.go:`len(passthroughCols)+1+5`
+//	histogram_quantile.go:`projections := make([]chplan.Projection, 0, len(passthrough)+2)`
+//	histogram_quantile.go:`make([]chplan.Expr, 0, len(labels)*2)`
+//
+// The first two `+` expressions each carry TWO mutants, one per operator; the
+// `passthrough+2` citation names its assignment because two sibling statements
+// in the same method allocate with the identical capacity expression.
 //
 // A slice's capacity is not observable behaviour: `append` grows past a short
 // one, and every element, ordering and identity is unchanged. The one way a
@@ -162,71 +174,76 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // panic — so each site was checked for that rather than waved through:
 //
 //   - The `*2` and `/2` forms cannot go negative from a length.
-//   - `len(passthroughCols)+1+5` (scalar_binop.go:345) reads a slice literal
-//     built two lines above with exactly six elements, so the two rewrites
-//     compute 10 and 2. Neither is negative.
-//   - `len(passthrough)+2` (histogram_quantile.go:1537) sits in
-//     classicBucketShaping.reshape's `sh.fold == nil` branch. The only
-//     shaping constructed with a nil fold is histogram_quantile_range.go:280's
-//     bare-selector shaping, and both of its reshape call sites
-//     (histogram_quantile_range.go:348 and :395) pass a TWO-element
+//   - `len(passthroughCols)+1+5` reads the `passthroughCols` slice literal
+//     built immediately above it with exactly six elements, so the two
+//     rewrites compute 10 and 2. Neither is negative.
+//   - `projections := make(..., len(passthrough)+2)` sits in
+//     classicBucketShaping.reshape's `sh.fold == nil` branch. The only shaping
+//     constructed with a nil fold is
+//     histogram_quantile_range.go:`classicBucketShaping{aggs: classicBucketLatestAggs(s)}`,
+//     and both of its reshape call sites —
+//     histogram_quantile_range.go:`shaping.reshape(guardedCollapse,` and
+//     histogram_quantile_range.go:`shaping.reshape(agg,` — pass a TWO-element
 //     passthrough, so the rewrite computes 0. Instrumenting the branch across
 //     the whole package suite observed `foldNil: true` only ever with
-//     `passthrough: 2`; the one-element call site
-//     (histogram_quantile.go:1301) never reaches the nil-fold branch.
+//     `passthrough: 2`; the one-element call site,
+//     histogram_quantile.go:`shaping.reshape(guardedAgg,`, never reaches the
+//     nil-fold branch.
 //   - `len(keyAliases)+1` and the `+len(...)+N` forms are reached only with
 //     the aggregation's own alias set, which the emitting code has already
 //     populated.
 //
 // 2. A BOUND THE ENCLOSING CODE HAS ALREADY NORMALISED.
 //
-//	histogram_native_range_fn.go:249:10       `step < 0` in subqueryHasEvalAnchor
-//	histogram_native_range_fn.go:269:10       `step < 0` in lowerExpHistogramRangeFnOverSubquery
-//	histogram_native_subquery_select.go:170:10 `step < 0` in lowerSelectFnOverExpHistogramSubquery
-//	scalar.go:98:11                            `lhs < 0` in the DIV-by-zero arm
+//	histogram_native_range_fn.go:subqueryHasEvalAnchor:`step < 0`
+//	histogram_native_range_fn.go:lowerExpHistogramRangeFnOverSubquery:`step < 0`
+//	histogram_native_subquery_select.go:lowerSelectFnOverExpHistogramSubquery:`step < 0`
+//	scalar.go:`if lhs < 0 {`
 //
-// `<` -> `<=` differs only at zero, and zero cannot reach these lines. Each
+// `<` -> `<=` differs only at zero, and zero cannot reach these guards. Each
 // `step` is assigned `defaultSubqueryStep` (a positive constant) by an
-// immediately preceding `if step == 0`. `scalar.go:98` sits inside
+// immediately preceding `if step == 0`. The `lhs` guard sits inside
 // `if rhs == 0 { if lhs == 0 { return NaN } ... }`, so `lhs` is non-zero — and
 // a negative zero is caught by that `lhs == 0` too, since IEEE equality holds
 // for it.
 //
 // 3. A GUARD WHOSE CONDITION IS INVARIANTLY TRUE.
 //
-//	histogram_quantile.go:1257:23  `shape.windowRange > 0` in lowerHistogramQuantileAgg
-//	histogram_quantile.go:2207:23  the same guard in the exp-histogram sibling
+//	histogram_quantile.go:lowerHistogramQuantileAgg:`shape.windowRange > 0`
+//	histogram_quantile.go:lowerHistogramQuantileNativeAgg:`shape.windowRange > 0`
 //
 // `> 0` -> `>= 0` widens a test that already always holds. histogramAggShape's
-// windowRange is set at exactly two places in the shape's construction
-// (histogram_quantile.go:1149 and :1191): `instantLookback`, which is
-// qlcommon.InstantLookback = 5m, or `ms.Range`, which the PromQL grammar
+// windowRange is set at exactly two places in the shape's construction,
+// histogram_quantile.go:`windowRange: instantLookback` — which is
+// qlcommon.InstantLookback = 5m — and
+// histogram_quantile.go:`windowRange: ms.Range`, which the PromQL grammar
 // refuses to parse as anything but strictly positive ("duration must be
-// greater than 0"). Instrumenting both lines across the package suite
-// observed no zero. The surrounding comment describing a "shape.windowRange
-// == 0" bare-selector case predates that construction and no longer describes
-// a reachable state; cerberus issue #2961 tracks the stale comment and the
-// guard it describes.
+// greater than 0"). Instrumenting both guards across the package suite
+// observed no zero. The comment beside each one, describing a
+// `shape.windowRange == 0` bare-selector case, predates that construction and
+// no longer describes a reachable state; cerberus issue #2961 tracks the stale
+// comment and the guard it describes.
 //
 // 4. A LOOP OVER A REGISTRY THAT HOLDS ONE ENTRY.
 //
-//	schema_lookup.go:67:4         `continue` in promqlTopLevelKeys
-//	resource_attributes.go:76:4   `continue` in excludedResourceKeys
+//	schema_lookup.go:promqlTopLevelKeys:`if col == "" {`
+//	resource_attributes.go:excludedResourceKeys:`if d.column(s) == "" {`
 //
-// Both loops range over `dedicatedResourceKeys`, which is declared in
-// resource_attributes.go:61 with exactly one element (service.name). Over a
-// one-element range `continue` and `break` both leave the loop after the same
-// single iteration, so the rewrite cannot change what either function
-// returns. This equivalence is a property of the registry's current size, and
-// it dissolves the moment a second dedicated key is added — at which point
-// both mutants become killable and should be killed rather than re-adjudicated.
+// Each citation names the guard whose body is the mutated statement, because
+// that statement is a bare `continue` and no substring of it singles one out.
+// Both loops range over
+// resource_attributes.go:`var dedicatedResourceKeys = []dedicatedResourceKey{`,
+// which holds exactly one element (service.name). Over a one-element range
+// `continue` and `break` both leave the loop after the same single iteration,
+// so the rewrite cannot change what either function returns. This equivalence
+// is a property of the registry's current size, and it dissolves the moment a
+// second dedicated key is added — at which point both mutants become killable
+// and should be killed rather than re-adjudicated.
 //
 // 5. A REWRITE THE LANGUAGE MAKES A NO-OP.
 //
-//	histogram_native_mixed_or_vector_plain_comparison.go:99:36
-//	                              `len(b.VectorMatching.Include) > 0`
-//	histogram_native_mixed_or_vector_comparison.go:163:36
-//	                              the same guard in the vector-vector sibling
+//	histogram_native_mixed_or_vector_plain_comparison.go:`len(b.VectorMatching.Include) > 0`
+//	histogram_native_mixed_or_vector_comparison.go:`len(b.VectorMatching.Include) > 0`
 //
 // Both guard `include = append([]string(nil), b.VectorMatching.Include...)`.
 // `>= 0` makes the guard always true, so the append runs even for an empty
@@ -237,8 +254,8 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 //
 // 6. AN INTERNAL-INVARIANT ERROR PATH.
 //
-//	histogram_native_range_fn.go:284:14        `!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
-//	histogram_native_subquery_select.go:185:14 the same guard in the select sibling
+//	histogram_native_range_fn.go:`!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
+//	histogram_native_subquery_select.go:`!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
 //
 // `||` -> `&&` narrows a check that reports "internal invariant violated".
 // The two readings differ only when exactly one disjunct holds, and neither

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -1,0 +1,138 @@
+// Tests in this file kill LIVED gremlins mutants reported on the
+// phase4-promql-b / -d / -f / -i / -other / -quantile legs (cerberus issue
+// #2949): the exp-histogram window recognizers' zero-range guards and the
+// value-producing call's arity guard. See gremlins_kill_test.go for the
+// shared file-header convention this file follows.
+package promql
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// zeroRangeExpHistogramCall builds `<fn>(latency_exp_hist[0])` by hand.
+//
+// The PromQL grammar refuses a literal `[0s]` outright ("duration must be
+// greater than 0"), so a zero-range matrix selector cannot be reached through
+// the parser and the guard is defensive. It is still each recognizer's
+// contract — a window of no width has no samples to reduce — and building the
+// selector directly is the convention this package already uses for the same
+// class (see TestCountPresentOverExpHistogram_ZeroRangeRejected and
+// TestRangeFnOverExpHistogram_ZeroRangeRejected in
+// histogram_native_range_family_gremlins_test.go).
+func zeroRangeExpHistogramCall(t *testing.T, fn string) *parser.Call {
+	t.Helper()
+	return &parser.Call{
+		Func: parser.MustGetFunction(fn),
+		Args: parser.Expressions{
+			&parser.MatrixSelector{Range: 0, VectorSelector: mustParseVectorSelector(t, "latency_exp_hist")},
+		},
+	}
+}
+
+// TestLastFirstOverExpHistogram_ZeroRangeRejected kills the
+// CONDITIONALS_BOUNDARY mutant at
+// histogram_native_last_first_over_time.go:62:21 — `ms.Range <= 0` ->
+// `ms.Range < 0` inside [lastFirstOverExpHistogram]. A range is never
+// negative, so `< 0` can only ever be false and the zero-width window is
+// admitted.
+func TestLastFirstOverExpHistogram_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	if _, _, _, ok := lastFirstOverExpHistogram(zeroRangeExpHistogramCall(t, "last_over_time"), s, lowerCtx{}); ok {
+		t.Fatal("lastFirstOverExpHistogram accepted a zero-range matrix selector; a window of no " +
+			"width has no samples to reduce (mutant `<=`->`<` at " +
+			"histogram_native_last_first_over_time.go:62:21 admits it)")
+	}
+}
+
+// TestOverTimeOverExpHistogram_ZeroRangeRejected kills the
+// CONDITIONALS_BOUNDARY mutant at histogram_native_over_time.go:36:21 —
+// the same `ms.Range <= 0` -> `ms.Range < 0` inside
+// [overTimeOverExpHistogram].
+func TestOverTimeOverExpHistogram_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	if _, ok := overTimeOverExpHistogram(zeroRangeExpHistogramCall(t, "sum_over_time"), s, lowerCtx{}); ok {
+		t.Fatal("overTimeOverExpHistogram accepted a zero-range matrix selector; a window of no " +
+			"width has no samples to reduce (mutant `<=`->`<` at " +
+			"histogram_native_over_time.go:36:21 admits it)")
+	}
+}
+
+// TestResetsOrChangesOverExpHistogram_ZeroRangeRejected kills the
+// CONDITIONALS_BOUNDARY mutant at histogram_native_resets.go:133:21 — the
+// same `ms.Range <= 0` -> `ms.Range < 0` inside
+// [resetsOrChangesOverExpHistogram].
+func TestResetsOrChangesOverExpHistogram_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	if _, ok := resetsOrChangesOverExpHistogram(zeroRangeExpHistogramCall(t, "resets"), s, lowerCtx{}); ok {
+		t.Fatal("resetsOrChangesOverExpHistogram accepted a zero-range matrix selector; a window " +
+			"of no width has no samples to reduce (mutant `<=`->`<` at " +
+			"histogram_native_resets.go:133:21 admits it)")
+	}
+}
+
+// TestTsOfFirstLastOverExpHistogram_ZeroRangeRejected kills the
+// CONDITIONALS_BOUNDARY mutant at
+// histogram_native_ts_of_first_last_over_time.go:89:21 — the same
+// `ms.Range <= 0` -> `ms.Range < 0` inside [tsOfFirstLastOverExpHistogram].
+func TestTsOfFirstLastOverExpHistogram_ZeroRangeRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	call := zeroRangeExpHistogramCall(t, tsOfLastOverTimeExpHistFn)
+	if _, _, _, ok := tsOfFirstLastOverExpHistogram(call, s, lowerCtx{}); ok {
+		t.Fatal("tsOfFirstLastOverExpHistogram accepted a zero-range matrix selector; a window of " +
+			"no width has no samples to reduce (mutant `<=`->`<` at " +
+			"histogram_native_ts_of_first_last_over_time.go:89:21 admits it)")
+	}
+}
+
+// TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments kills the
+// INVERT_LOGICAL mutant at histogram_native_value_producing_call.go:41:25 —
+// the `||` of
+//
+//	if len(call.Args) < 1 || len(call.Args) > 2 {
+//
+// inside [histogramValuedProducerCall].
+//
+// The guard is `info`'s arity contract stated as two independent bounds: too
+// few arguments and too many are each disqualifying on their own. Under `&&`
+// the rejection needs BOTH at once, which is unsatisfiable — no argument
+// count is simultaneously below one and above two — so the guard never fires
+// and a three-argument `info` over a histogram-valued base is reported as a
+// histogram-valued producer call.
+func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	base := mustParseVectorSelector(t, "latency_exp_hist")
+	dataLabels := mustParse(t, `{__name__="target_info"}`)
+
+	twoArg := &parser.Call{
+		Func: parser.MustGetFunction("info"),
+		Args: parser.Expressions{base, dataLabels},
+	}
+	if _, ok := histogramValuedProducerCall(twoArg, s, lowerCtx{}); !ok {
+		t.Fatal("positive control: a two-argument `info` over a histogram-valued base is not " +
+			"recognised; the negative assertion below would then hold for the wrong reason")
+	}
+
+	threeArg := &parser.Call{
+		Func: parser.MustGetFunction("info"),
+		Args: parser.Expressions{base, dataLabels, dataLabels},
+	}
+	if _, ok := histogramValuedProducerCall(threeArg, s, lowerCtx{}); ok {
+		t.Fatal("histogramValuedProducerCall accepted a three-argument `info`; the arity bounds " +
+			"are independent and either one disqualifies (mutant `||`->`&&` at " +
+			"histogram_native_value_producing_call.go:41:25 makes the pair unsatisfiable)")
+	}
+}

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -136,3 +136,115 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 			"histogram_native_value_producing_call.go:41:25 makes the pair unsatisfiable)")
 	}
 }
+
+// NOT KILLABLE — documented, not defended by a test.
+//
+// The remaining survivors on cerberus issue #2949's phase4-promql-* legs fall
+// into five equivalence classes. Each mutant is named by `file:line:col` AND
+// by the construct it rewrites, because bare line numbers drift.
+//
+// 1. CAPACITY HINTS — ARITHMETIC_BASE inside a `make(T, 0, <cap>)` argument.
+//
+//	schema_lookup.go:133:43                  `len(pairs)*2`
+//	resource_attributes.go:73:61             `len(dedicatedResourceKeys)*2`
+//	histogram_quantile_native_window.go:299:65 and :299:83
+//	                                         `len(keyAliases)+len(aggs)+len(extraAliases)+1`
+//	histogram_quantile_native_window.go:380:55 `len(keyAliases)+len(scalars)+7`
+//	histogram_native_resets.go:298:55        `len(keyAliases)+1`
+//	histogram_native_scalar_binop.go:345:60 and :345:62
+//	                                         `len(passthroughCols)+1+5`
+//	histogram_quantile.go:1537:63            `len(passthrough)+2`
+//	histogram_quantile.go:1874:47            `len(labels)*2`
+//
+// A slice's capacity is not observable behaviour: `append` grows past a short
+// one, and every element, ordering and identity is unchanged. The one way a
+// capacity rewrite CAN be observed is a negative argument, which makes `make`
+// panic — so each site was checked for that rather than waved through:
+//
+//   - The `*2` and `/2` forms cannot go negative from a length.
+//   - `len(passthroughCols)+1+5` (scalar_binop.go:345) reads a slice literal
+//     built two lines above with exactly six elements, so the two rewrites
+//     compute 10 and 2. Neither is negative.
+//   - `len(passthrough)+2` (histogram_quantile.go:1537) sits in
+//     classicBucketShaping.reshape's `sh.fold == nil` branch. The only
+//     shaping constructed with a nil fold is histogram_quantile_range.go:280's
+//     bare-selector shaping, and both of its reshape call sites
+//     (histogram_quantile_range.go:348 and :395) pass a TWO-element
+//     passthrough, so the rewrite computes 0. Instrumenting the branch across
+//     the whole package suite observed `foldNil: true` only ever with
+//     `passthrough: 2`; the one-element call site
+//     (histogram_quantile.go:1301) never reaches the nil-fold branch.
+//   - `len(keyAliases)+1` and the `+len(...)+N` forms are reached only with
+//     the aggregation's own alias set, which the emitting code has already
+//     populated.
+//
+// 2. A BOUND THE ENCLOSING CODE HAS ALREADY NORMALISED.
+//
+//	histogram_native_range_fn.go:249:10       `step < 0` in subqueryHasEvalAnchor
+//	histogram_native_range_fn.go:269:10       `step < 0` in lowerExpHistogramRangeFnOverSubquery
+//	histogram_native_subquery_select.go:170:10 `step < 0` in lowerSelectFnOverExpHistogramSubquery
+//	scalar.go:98:11                            `lhs < 0` in the DIV-by-zero arm
+//
+// `<` -> `<=` differs only at zero, and zero cannot reach these lines. Each
+// `step` is assigned `defaultSubqueryStep` (a positive constant) by an
+// immediately preceding `if step == 0`. `scalar.go:98` sits inside
+// `if rhs == 0 { if lhs == 0 { return NaN } ... }`, so `lhs` is non-zero — and
+// a negative zero is caught by that `lhs == 0` too, since IEEE equality holds
+// for it.
+//
+// 3. A GUARD WHOSE CONDITION IS INVARIANTLY TRUE.
+//
+//	histogram_quantile.go:1257:23  `shape.windowRange > 0` in lowerHistogramQuantileAgg
+//	histogram_quantile.go:2207:23  the same guard in the exp-histogram sibling
+//
+// `> 0` -> `>= 0` widens a test that already always holds. histogramAggShape's
+// windowRange is set at exactly two places in the shape's construction
+// (histogram_quantile.go:1149 and :1191): `instantLookback`, which is
+// qlcommon.InstantLookback = 5m, or `ms.Range`, which the PromQL grammar
+// refuses to parse as anything but strictly positive ("duration must be
+// greater than 0"). Instrumenting both lines across the package suite
+// observed no zero. The surrounding comment describing a "shape.windowRange
+// == 0" bare-selector case predates that construction and no longer describes
+// a reachable state; cerberus issue #2961 tracks the stale comment and the
+// guard it describes.
+//
+// 4. A LOOP OVER A REGISTRY THAT HOLDS ONE ENTRY.
+//
+//	schema_lookup.go:67:4         `continue` in promqlTopLevelKeys
+//	resource_attributes.go:76:4   `continue` in excludedResourceKeys
+//
+// Both loops range over `dedicatedResourceKeys`, which is declared in
+// resource_attributes.go:61 with exactly one element (service.name). Over a
+// one-element range `continue` and `break` both leave the loop after the same
+// single iteration, so the rewrite cannot change what either function
+// returns. This equivalence is a property of the registry's current size, and
+// it dissolves the moment a second dedicated key is added — at which point
+// both mutants become killable and should be killed rather than re-adjudicated.
+//
+// 5. A REWRITE THE LANGUAGE MAKES A NO-OP.
+//
+//	histogram_native_mixed_or_vector_plain_comparison.go:99:36
+//	                              `len(b.VectorMatching.Include) > 0`
+//	histogram_native_mixed_or_vector_comparison.go:163:36
+//	                              the same guard in the vector-vector sibling
+//
+// Both guard `include = append([]string(nil), b.VectorMatching.Include...)`.
+// `>= 0` makes the guard always true, so the append runs even for an empty
+// Include — and appending ZERO elements to a nil slice returns that same nil
+// slice, so `include` is nil either way. Confirmed by evaluating
+// `append([]string(nil), src...) == nil` for both a nil and an empty-non-nil
+// src.
+//
+// 6. AN INTERNAL-INVARIANT ERROR PATH.
+//
+//	histogram_native_range_fn.go:284:14        `!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
+//	histogram_native_subquery_select.go:185:14 the same guard in the select sibling
+//
+// `||` -> `&&` narrows a check that reports "internal invariant violated".
+// The two readings differ only when exactly one disjunct holds, and neither
+// half is constructible: `lowerExpHistogramValuedShape` returns a nil node
+// whenever `matched` is false, and `chplan.RowShapeOf(nil)` is the sample row
+// shape, so `!matched` always arrives together with a non-histogram shape and
+// both readings error. The complementary case — matched with a non-histogram
+// shape — is the invariant the line exists to report, and producing it would
+// require lowerExpHistogramValuedShape to break its own contract.

--- a/internal/promql/histogram_native_subquery_call_subquery_outer_fn_test.go
+++ b/internal/promql/histogram_native_subquery_call_subquery_outer_fn_test.go
@@ -165,6 +165,33 @@ func TestWidenNestedCallSubqueryInner_GridModes(t *testing.T) {
 			// exactly one sub.Range wide regardless of the ambient window.
 			wantOuterR: outerFn2TestOuterRange,
 		},
+		// The two range-mode cases above carry no `offset`, so their
+		// Offset term is zero — and a rewrite of a term that is zero moves
+		// no window. The offset was therefore exercised only in instant
+		// mode, and the two range-mode branches compute it in their own
+		// expressions.
+		//
+		// That gap is what left four gremlins mutants alive on the
+		// phase4-promql-i leg (cerberus issue #2949): the INVERT_NEGATIVES
+		// and ARITHMETIC_BASE pair reported on the `-anchor.Offset` term of
+		// histogram_native_subquery_call_subquery_outer_fn.go:92 (the
+		// `@`-pinned query_range branch) and of :99 (the plain query_range
+		// branch). Both rewrites of that unary term collapse it to
+		// `+anchor.Offset`, which is indistinguishable from `-anchor.Offset`
+		// at offset zero and shifts the grid by twice the offset otherwise.
+		// The two cases below are what make it non-zero in each branch.
+		{
+			name: "query_range fan-out with offset", rangeMode: true,
+			suffix:    " offset 30s",
+			wantStart: rangeStart.Add(-offset - outerFn2TestOuterRange), wantEnd: rangeEnd,
+			wantOuterR: rangeEnd.Sub(rangeStart.Add(-offset - outerFn2TestOuterRange)),
+		},
+		{
+			name: "query_range pinned broadcast with offset", rangeMode: true,
+			suffix:    " @ " + strconv.FormatInt(pin.Unix(), 10) + " offset 30s",
+			wantStart: pin.Add(-offset - outerFn2TestOuterRange), wantEnd: pin,
+			wantOuterR: offset + outerFn2TestOuterRange,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/promql/histogram_native_subquery_call_subquery_outer_fn_test.go
+++ b/internal/promql/histogram_native_subquery_call_subquery_outer_fn_test.go
@@ -172,14 +172,23 @@ func TestWidenNestedCallSubqueryInner_GridModes(t *testing.T) {
 		// expressions.
 		//
 		// That gap is what left four gremlins mutants alive on the
-		// phase4-promql-i leg (cerberus issue #2949): the INVERT_NEGATIVES
-		// and ARITHMETIC_BASE pair reported on the `-anchor.Offset` term of
-		// histogram_native_subquery_call_subquery_outer_fn.go:92 (the
-		// `@`-pinned query_range branch) and of :99 (the plain query_range
-		// branch). Both rewrites of that unary term collapse it to
-		// `+anchor.Offset`, which is indistinguishable from `-anchor.Offset`
-		// at offset zero and shifts the grid by twice the offset otherwise.
-		// The two cases below are what make it non-zero in each branch.
+		// phase4-promql-i leg (cerberus issue #2949): an INVERT_NEGATIVES and
+		// an ARITHMETIC_BASE on the `-anchor.Offset` term of each range-mode
+		// branch's widening call —
+		//
+		//	histogram_native_subquery_call_subquery_outer_fn.go:`case ctx.rangeMode() && subqueryPinned(sub) && !anchor.End.IsZero():`
+		//	histogram_native_subquery_call_subquery_outer_fn.go:`ctx.start.Add(-anchor.Offset-sub.Range), ctx.end`
+		//
+		// The `@`-pinned branch is cited by its `case` label rather than by
+		// its widening call, because that call is spelled identically in the
+		// instant branch below it and no substring of it tells the two apart;
+		// the mutants are on the single `widenSubquerySpine` line inside that
+		// arm. The plain query_range branch's call is unique as written.
+		//
+		// Both rewrites of that unary term collapse it to `+anchor.Offset`,
+		// which is indistinguishable from `-anchor.Offset` at offset zero and
+		// shifts the grid by twice the offset otherwise. The two cases below
+		// are what make it non-zero in each branch.
 		{
 			name: "query_range fan-out with offset", rangeMode: true,
 			suffix:    " offset 30s",

--- a/internal/traceql/gremlins_kill_nonroot_cmp_test.go
+++ b/internal/traceql/gremlins_kill_nonroot_cmp_test.go
@@ -11,10 +11,16 @@ import (
 // reported on [nonRootCmpConstant] from the phase4-traceql-lower leg
 // (cerberus issue #2949):
 //
-//	lower.go:2399:8  `v <= 1` in the OpLt arm
-//	lower.go:2403:8  `v < 1`  in the OpLe arm
-//	lower.go:2407:8  `v < 1`  in the OpGt arm
-//	lower.go:2411:8  `v <= 1` in the OpGe arm
+//	lower.go:nonRootCmpConstant:`case chplan.OpLt:`  the `v <= 1` guard in that arm
+//	lower.go:nonRootCmpConstant:`case chplan.OpLe:`  the `v < 1` guard in that arm
+//	lower.go:nonRootCmpConstant:`case chplan.OpGt:`  the `v < 1` guard in that arm
+//	lower.go:nonRootCmpConstant:`case chplan.OpGe:`  the `v <= 1` guard in that arm
+//
+// Each citation names the arm's `case` label rather than the guard itself: the
+// four guards are spelled with only two distinct texts between them (`v <= 1`
+// twice, `v < 1` four times counting the OpEq and OpNe arms), so no substring
+// of a guard singles one out. The `case` label immediately above it does, and
+// the guard is the single `if` inside that arm.
 //
 // Every one of them is a boundary AT v == 1, and the existing tests never
 // asked the function about v == 1 — only about values where the two readings

--- a/internal/traceql/gremlins_kill_nonroot_cmp_test.go
+++ b/internal/traceql/gremlins_kill_nonroot_cmp_test.go
@@ -1,0 +1,95 @@
+package traceql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// Tests in this file kill the four CONDITIONALS_BOUNDARY survivors gremlins
+// reported on [nonRootCmpConstant] from the phase4-traceql-lower leg
+// (cerberus issue #2949):
+//
+//	lower.go:2399:8  `v <= 1` in the OpLt arm
+//	lower.go:2403:8  `v < 1`  in the OpLe arm
+//	lower.go:2407:8  `v < 1`  in the OpGt arm
+//	lower.go:2411:8  `v <= 1` in the OpGe arm
+//
+// Every one of them is a boundary AT v == 1, and the existing tests never
+// asked the function about v == 1 — only about values where the two readings
+// agree. Each `<`/`<=` pair therefore looked interchangeable.
+//
+// The expectations below are not read off the implementation. They are
+// derived from the one domain fact the function documents — a non-root
+// nested-set parent position p satisfies p >= 1 — by asking, for each
+// operator and each v, whether `p op v` has the same answer for EVERY such p:
+//
+//	p = v      constant-false iff no p equals v, i.e. v < 1
+//	p != v     constant-true  iff every p differs from v, i.e. v < 1
+//	p < v      constant-false iff no p is below v; the smallest p is 1, so v <= 1
+//	p <= v     constant-false iff no p is at or below v, i.e. v < 1
+//	p > v      constant-true  iff every p exceeds v, i.e. v < 1
+//	p >= v     constant-true  iff every p is at or above v; the smallest is 1, so v <= 1
+//
+// v == 1 is exactly where the two `<=` operators part company with the two
+// `<` ones, which is why it is the row that kills all four mutants:
+// `p < 1` and `p >= 1` are decided by the domain's floor, while `p <= 1` and
+// `p > 1` are genuinely open — both are answered one way at p == 1 and the
+// other way at p == 2.
+func TestNonRootCmpConstant_BoundaryAtTheDomainFloor(t *testing.T) {
+	t.Parallel()
+
+	type want struct {
+		value    bool
+		constant bool
+	}
+	cases := []struct {
+		op   chplan.BinaryOp
+		v    int64
+		want want
+		why  string
+	}{
+		// v == 0: below the floor, so every operator is decided.
+		{chplan.OpEq, 0, want{false, true}, "no non-root position equals 0"},
+		{chplan.OpNe, 0, want{true, true}, "every non-root position differs from 0"},
+		{chplan.OpLt, 0, want{false, true}, "no non-root position is below 0"},
+		{chplan.OpLe, 0, want{false, true}, "no non-root position is at or below 0"},
+		{chplan.OpGt, 0, want{true, true}, "every non-root position exceeds 0"},
+		{chplan.OpGe, 0, want{true, true}, "every non-root position is at or above 0"},
+
+		// v == 1: the floor itself, and the row every mutant turns on.
+		{chplan.OpEq, 1, want{false, false}, "p == 1 holds at the floor and fails above it"},
+		{chplan.OpNe, 1, want{false, false}, "p != 1 fails at the floor and holds above it"},
+		{chplan.OpLt, 1, want{false, true}, "nothing is below the floor, so p < 1 is never true"},
+		{chplan.OpLe, 1, want{false, false}, "p <= 1 holds exactly at the floor"},
+		{chplan.OpGt, 1, want{false, false}, "p > 1 fails exactly at the floor"},
+		{chplan.OpGe, 1, want{true, true}, "everything is at or above the floor, so p >= 1 always holds"},
+
+		// v == 2: above the floor, so nothing is decided either way.
+		{chplan.OpEq, 2, want{false, false}, "p == 2 holds only at 2"},
+		{chplan.OpNe, 2, want{false, false}, "p != 2 fails only at 2"},
+		{chplan.OpLt, 2, want{false, false}, "p < 2 holds at the floor and fails at 2"},
+		{chplan.OpLe, 2, want{false, false}, "p <= 2 holds up to 2 and fails above"},
+		{chplan.OpGt, 2, want{false, false}, "p > 2 fails up to 2 and holds above"},
+		{chplan.OpGe, 2, want{false, false}, "p >= 2 fails at the floor and holds at 2"},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s_%d", tc.op, tc.v), func(t *testing.T) {
+			t.Parallel()
+
+			value, constant := nonRootCmpConstant(tc.op, tc.v)
+			if constant != tc.want.constant {
+				t.Fatalf("nonRootCmpConstant(%s, %d) constant = %v, want %v — %s",
+					tc.op, tc.v, constant, tc.want.constant, tc.why)
+			}
+			// `value` is only meaningful where the comparison IS constant;
+			// where it is not, the caller never reads it.
+			if constant && value != tc.want.value {
+				t.Fatalf("nonRootCmpConstant(%s, %d) value = %v, want %v — %s",
+					tc.op, tc.v, value, tc.want.value, tc.why)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Kills 38 mutation survivors across nine of the twelve red legs #2949 owns, and adjudicates the
survivors that no test can kill with per-mutant evidence.

Test-only. No production code changes, no threshold lowered, no denominator shrunk, no file
excluded, no `include_files` narrowed.

## Where the numbers come from

Two push-to-main runs, both after #2947, so both are scored under the current formula:

    efficacy = (killed + runTimedOut) / (killed + lived + timedOut + runTimedOut)

- Run [33657879957](https://github.com/tsouza/cerberus/actions/runs/33657879957) at `d1ea58549` —
  eleven legs.
- Run [33664171021](https://github.com/tsouza/cerberus/actions/runs/33664171021) at `bf5fafb05` —
  `phase4-promql-other`, whose artifact the first run never uploaded (concurrency cancelled it
  before that leg finished).

Counts are recomputed from the per-mutant `files[].mutations[].status` records against the same
closed status set `gremlins-threshold.mjs` gates on. The full phase-1 measurement, including the
timeout split and the survivor classification, is
[on the issue](https://github.com/tsouza/cerberus/issues/2949#issuecomment-5514435319).

## Result

"after" is the arithmetic this branch's kills produce over the same denominator.

| leg | before | kills | after | verdict |
| --- | ---: | ---: | ---: | --- |
| phase4-promql-b | 87.13% | 9 | **96.04%** | clears |
| phase4-promql-d | 91.58% | 5 | **96.84%** | clears |
| phase4-promql-f | 91.94% | 5 | **95.97%** | clears |
| phase4-promql-i | 92.00% | 6 | **96.00%** | clears |
| phase4-traceql-lower | 94.77% | 4 | **97.39%** | clears |
| phase4-promql-c | 93.20% | 1 | 93.88% | at its ceiling |
| phase4-promql-other | 89.19% | 6 | 94.59% | at its ceiling |
| phase4-promql-quantile | 94.37% | 0 | 94.37% | at its ceiling |
| phase4-logql-other-a | 92.00% | 1 | 94.00% | at its ceiling |
| phase4-logql-aggregation | 92.71% | 1 | 93.75% | triaged, not finished |
| phase4-logql-lower | 92.39% | 0 | 92.39% | triaged, not finished |
| phase4-logql-other-b | 93.18% | 0 | 93.18% | triaged, not finished |

`mutation` does not go green on this branch, and saying so plainly is the point: five legs clear
their floor, four are shown to be AT their ceiling with the per-mutant arithmetic, and three logql
legs are measured but not finished.

## Every kill is proven individually

Each of the 38 was proven the same way — apply the mutation by hand, watch the named test FAIL,
revert, watch it PASS. A test that passed either way was not counted; two first attempts did pass
either way and were rewritten rather than kept:

- The set-op matching-clause test first used `hist_a or hist_b`, on the belief the parser leaves
  `VectorMatching` nil without an `on()` clause. It does not — it allocates one carrying
  CardManyToMany and no labels, so both readings produced the same zero Match. Rewritten around
  `and on(service)`, where the clause has something to carry.
- The `histogram_quantile` zero-width-window test asserted an absent left bound on a bare selector.
  Instrumenting the guard showed the bare selector carries the 5-minute staleness lookback, not a
  zero window, so the mutant changed nothing. That test was deleted and the mutants adjudicated
  instead — see #2961.

Two more first attempts asserted against a key spelled exactly like the requested label, which
`configuredResourceKeysFor` drops earlier as already `covered`; they were reaching a different
guard than the one named. Fixed to use a distinct spelling that sanitises to the same label.

## What the kills close

- **The `metadataFullRange` guard at its six LEAF recognizers.** `s.ExpHistogramTable == "" ||
  ctx.metadataFullRange` -> `&&`. A leaf decides by asking the SCHEMA
  (`s.IsExpHistogramMetric`), which never reads `ctx`, so under the mutant a metadata full-range
  lowering is answered from the exp-histogram table. Each test also pins the positive direction, so
  the negative assertion cannot pass because the expression was rejected for some unrelated reason.
- **The resource-allowlist inversion in `metadata_catalog.go`.** A key matching on either spelling
  belongs in the result; a non-matching, an excluded, and a duplicate key must each be SKIPPED
  rather than end the walk. Three `continue` -> `break` mutants and one `&&` -> `||`.
- **The `QUANTILE`/`Param` guard**, whose two negations and one `&&` each reject exactly the
  aggregations the guard exists to admit.
- **`readsRangeSampleTimestamp`'s three disqualifications**, which are independent: any one of a
  wrong function name, a non-range evaluation, or a range-vector descent is enough on its own.
- **Recognizer contracts**: the table guard read backwards, `sort`'s arity, `label_join`'s
  three-argument minimum, `info`'s two arity bounds, the scalar-literal-on-the-left MUL/DIV
  asymmetry, the temporality column's two independent disqualifications, the empty-metric-name
  requirement for a synthetic scalar plan, and the four zero-range window guards.
- **The nested-subquery offset term.** `TestWidenNestedCallSubqueryInner_GridModes` already covered
  all three grid modes, but both range-mode cases carried no `offset` — so the `-anchor.Offset`
  term was zero and no rewrite of it moved the grid. Adding an offset to each branch kills four
  mutants at once. This is the one gap in the set that was a genuine hole in an existing test
  rather than a missing one.
- **`nonRootCmpConstant` at the nested-set domain floor.** All four boundary survivors turn on
  `v == 1`, which nothing asked about. The expectations are derived from the documented domain
  (`p >= 1`) by asking, for each operator, whether `p op v` has the same answer for every such `p`
  — not read off the implementation.
- **`absentSynthLabels`' emit loop and `lowerVectorSetOp`'s matching clause**, on the logql side.

## What no test can kill, and why

Documented in two `NOT KILLABLE` footers, each mutant cited by `file:line:col` AND by the construct
it rewrites, since bare line numbers drift (#2953).

The largest class is the same `||` -> `&&` rewrite at ten COMPOSITE recognizers. The argument is
not "it looked equivalent": the mutant only ever reaches extra code when `A || B` holds, and there
both `isExpHistogramValuedShape` and `isExpHistogramDroppingShape` are unconditionally false — by
structural induction over a closed dispatch set whose every base case carries this identical guard,
and whose three unguarded members delegate the whole question back into the set. Each base case was
enumerated and checked, not assumed from the earlier #2636 header that first made this argument.

The other five classes: capacity hints inside `make(T, 0, cap)` (checked individually for the one
way a capacity rewrite CAN be observed — a negative argument panicking `make`), bounds the
enclosing code has already normalised away from the boundary, a guard whose condition is
invariantly true, two loops over a registry that today holds one entry, a zero-element `append` to
a nil slice, and two internal-invariant error paths whose complementary case would require a callee
to break its own contract.

The one-entry-registry equivalence is flagged as contingent rather than permanent: it dissolves the
moment a second dedicated resource key is added, and at that point both mutants become killable and
should be killed rather than re-adjudicated.

## Filed

- #2961 — `histogram_quantile`'s zero-width-window guard is invariantly true and its comment
  describes an unreachable state. Verified by instrumenting both guards across the package suite:
  `windowRange` is only ever `instantLookback` (5m) or a parser-positive `ms.Range`. It is why
  `phase4-promql-quantile` has zero killable survivors — an invariantly-true condition is a
  permanently unkillable mutant, and it consumes denominator on a gate that is otherwise telling
  the truth. Milestone M1, sub-issue of #2891. Fixing it is a production change and does not belong
  in a test-only PR.

## What is left

`phase4-logql-aggregation`, `phase4-logql-lower` and `phase4-logql-other-b` are measured and their
survivors enumerated, but their remaining mutants are not adjudicated. A differential harness over a
46-query battery moved only two of their candidates, and "no difference in my battery" is not
evidence of equivalence — so those legs are reported as measured ground rather than claimed as
ceilings. Their timeout split is already known and is the one interesting thing about them: three
RUN TIMED OUT mutants in `jsonpath.go`'s walker are already credited as detections, and three TIMED
OUT in `logpattern/pattern.go` are the memory-guard-reaped class whose evidence the guard destroys.
