### PR TITLE
test: correct two adjudication notes whose prose drifted from the code they adjudicate

### DIFF
--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1369,6 +1369,52 @@ other than a digit or a construct carries no address and is left alone,
 which is what keeps `test/rejection-parity`'s `path.go:func#hash` site
 identifiers — a data format, not a citation — out of the gate's way.
 
+### How a note states a number
+
+A citation that resolves is only half of a re-checkable note. The other
+half is the sentence wrapped around it, and a note can carry a perfectly
+resolving citation while the prose asserts something the code stopped
+doing — the citation still reads as evidence (cerberus issue #2957).
+
+Prose is not machine-checkable in general, so the rule is not to check
+the sentence but to keep it from carrying load:
+
+- **A count the source can compute is never written down.** Derive it in
+  the test and name the derivation. `wantLen :=
+  multiIfArgCount(len(canonicalLevelGroups))` is re-checkable; "the 15
+  subsequent appends" is a second, unverified statement of the same fact,
+  free to disagree with the first. This is the technique
+  `.github/scripts/doc-counts.mjs` applies to documentation prose, applied
+  by hand where a gate cannot reach.
+- **A property the note claims is asserted, not narrated.** "Any
+  arithmetic mutation produces a different capacity" is the whole
+  equivalence argument; enumerate the mutations and assert it. A `NOT
+  KILLABLE` footer that ends in a testable claim usually means the claim
+  was testable all along.
+- **A fact the code already fixes is read, not restated.** Where the
+  production value is derivable in-repo — a rendered DDL, a registry, a
+  schema default — read it. `test/perf/orderby_chdb_test.go` takes the
+  metrics sort key it benchmarks out of the DDL `internal/schema/ddl`
+  renders, so the harness cannot come to disagree with the schema it
+  claims to measure.
+- **A measurement stays prose, with its context.** "8-17x fewer granules
+  on this grid", "95% efficacy floor" — these describe a run, not a
+  structure, and no derivation replaces them. Say what was measured and
+  on what, so a reader can re-measure rather than trust.
+
+No gate enforces this, and one was weighed and rejected on measurement
+rather than taste. Across the 340 adjudication blocks on `main`, the
+integers that restate a source-countable fact are outnumbered roughly
+three to one by digits that are simply operands of a quoted expression
+(`i == 1`, `Step=0`), and the same class of claim is written as a
+spelled-out numeral ("four conjuncts", "three join keys") more often
+than as a digit at all. A checker keyed on digits is therefore blind to
+most of what it would need to model, which is the one thing a gate here
+may not be: a set that silently shrinks is worse than no set. Reviewer
+attention plus the four rules above is the control, and the first rule
+is what makes the other three cheap — a number that lives in an
+assertion cannot rot without a test going red.
+
 ### Non-terminating mutants and a leg's irreducible ceiling
 
 A hand-written scanner — a lexer, a regex source walk, a replacement

--- a/internal/logql/detected_level_test.go
+++ b/internal/logql/detected_level_test.go
@@ -426,11 +426,13 @@ func isMatchOp(op chplan.BinaryOp) bool {
 	return false
 }
 
-// canonicalLevelGroups mirrors the (variants, canonical) table inside
-// [normaliseLevelExpr] so the assertions below can pin the documented
-// 7-level order without re-importing the unexported `group` struct.
-// Order matches the source — upstream Loki's `normalizeLogLevel` switch
-// (trace / debug / info / warn / error / critical / fatal).
+// canonicalLevelGroups is an INDEPENDENT restatement of the
+// variant-to-canonical table [levelNormalizationGroups] holds. It is written
+// out again on purpose rather than read from the source: assertions that
+// derived their expectations from the very table under test would mirror a
+// wrong edit to it instead of failing on one. Order matches upstream Loki's
+// `normalizeLogLevel` switch — trace / debug / info / warn / error /
+// critical / fatal.
 var canonicalLevelGroups = []struct {
 	variants  []string
 	canonical string
@@ -444,35 +446,36 @@ var canonicalLevelGroups = []struct {
 	{[]string{"fatal"}, "fatal"},
 }
 
-// TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape kills the two
-// adjacent ARITHMETIC_BASE mutants reported by the gremlins phase-4
-// run on the slice-capacity hint
-// detected_level.go:`(len(levelNormalizationGroups)+1)*2+1` — the `*`
-// and the trailing `+` of that expression. `*` flipping to `/` (or
-// `%`) and `+` flipping to `-` (or `*`) change the pre-allocated
-// capacity but `append` silently grows past it, so a semantic-only
-// test cannot observe the difference. This test pins:
+// TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape kills the
+// ARITHMETIC_BASE mutants gremlins reports on the slice-capacity hint
+// detected_level.go:`(len(levelNormalizationGroups)+1)*2+1`. Substituting an
+// operator there changes the PRE-ALLOCATED capacity, but `append` grows past
+// a too-small hint and simply under-fills a too-large one, so a semantic-only
+// test cannot observe the difference: the SQL the emitter prints from the
+// resulting FuncCall is byte-identical however the slice was allocated.
 //
-//  1. `len(Args) == 2*len(canonicalLevelGroups)+1` (the load-bearing
-//     count: 7 (cond, literal) pairs plus the trailing default
-//     branch) — documents the arithmetic so a structural mutation
-//     elsewhere shows up immediately.
-//  2. `cap(Args) == 2*len(canonicalLevelGroups)+1` (the direct kill:
-//     `make([]T, 0, N)` returns a slice with `cap == N` before any
-//     append, and the 15 subsequent appends never exceed that
-//     capacity — so the final `cap` equals the hint). Any
-//     ARITHMETIC_BASE mutation on that `*` or `+` shifts the
-//     allocated capacity, triggers an `append`-driven re-allocation
-//     with Go's runtime growth strategy, and produces a final `cap`
-//     that is NOT 15 (the original mutants would yield e.g. 4, 8,
-//     16, or 26 depending on the operator). Asserting `cap == 15`
-//     exactly catches each shift.
+// Both facts this test pins are COMPUTED from `canonicalLevelGroups` into
+// `wantLen`, never written down as an integer, so neither can be restated
+// wrongly here:
 //
-// The cap assertion is the only direct kill for a slice-capacity
+//  1. `len(fn.Args)` — the load-bearing count: one leading (empty, unknown)
+//     pair, one (cond, literal) pair per canonical group, and the trailing
+//     default branch. A structural mutation that drops or duplicates a slot
+//     shows up immediately.
+//  2. `cap(fn.Args)` — the direct kill. `make([]T, 0, N)` hands back a slice
+//     whose cap is exactly N, and the appends that follow fill it exactly, so
+//     the finished slice still reports the hint. Any ARITHMETIC_BASE mutation
+//     shifts the hint off that count, and `append`'s growth schedule never
+//     lands back on it.
+//
+// That last sentence is the claim an equivalence note has no way to prove on
+// its own, so it is not left as prose: `TestNormaliseLevelExpr_CapHintMutantsAreKilled`
+// replays every operator substitution and asserts the resulting capacity
+// differs from the unmutated one.
+//
+// The cap assertion is the only direct kill available for a slice-capacity
 // arithmetic mutant — append's growth strategy hides the change from
-// length-only tests, and the SQL the emitter prints from the
-// resulting FuncCall is byte-identical regardless of how the
-// underlying slice was allocated.
+// length-only tests.
 func TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape(t *testing.T) {
 	t.Parallel()
 
@@ -490,32 +493,203 @@ func TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape(t *testing.T) {
 	// The leading (empty → "unknown") pair — reference Loki stamps
 	// `detected_level="unknown"` when no level is detectable
 	// (pkg/distributor/field_detection.go, constants.LogLevelUnknown)
-	// — precedes the 7 canonical groups, then the lowercased default.
-	wantLen := 2*(len(canonicalLevelGroups)+1) + 1
+	// — precedes the canonical groups, then the lowercased default.
+	wantLen := multiIfArgCount(len(canonicalLevelGroups))
 	if got := len(fn.Args); got != wantLen {
-		t.Fatalf("len(multiIf.Args) = %d; want %d (1 (empty, unknown) pair + 7 (cond, literal) pairs + 1 default)", got, wantLen)
+		t.Fatalf("len(multiIf.Args) = %d; want %d (one (empty, unknown) pair, "+
+			"one (cond, literal) pair per canonical group, one default)", got, wantLen)
 	}
 
 	// Kill: any arithmetic mutation on the capacity hint either
-	// over-allocates (appends fit, final cap = the mutated hint) or
-	// under-allocates (append re-grows via the runtime's schedule) —
-	// both produce a final cap different from the exact arg count.
-	// Asserting cap == wantLen pins the arithmetic.
+	// over-allocates (the appends fit, and the final cap is the mutated
+	// hint) or under-allocates (append re-grows via the runtime's
+	// schedule) — both produce a final cap different from the exact arg
+	// count. Asserting cap == wantLen pins the arithmetic;
+	// `TestNormaliseLevelExpr_CapHintMutantsAreKilled` proves it
+	// discriminates every operator substitution.
 	if got, want := cap(fn.Args), wantLen; got != want {
 		t.Fatalf("cap(multiIf.Args) = %d; want %d (mutant `*` → `/`/`%%` or `+` → `-`/`*` in detected_level.go:`(len(levelNormalizationGroups)+1)*2+1` would shift the capacity hint and re-allocate via append's growth schedule)", got, want)
 	}
 }
 
+// capHintOps are the binary arithmetic operators gremlins' ARITHMETIC_BASE
+// operator substitutes into an expression. Applying each of them to each
+// operator position of the capacity hint enumerates that hint's whole mutant
+// set.
+var capHintOps = []string{"+", "-", "*", "/", "%"}
+
+// applyCapHintOp evaluates `a op b` for the operators ARITHMETIC_BASE can
+// produce. Every b it is called with below is non-zero, so `/` and `%` are
+// total here.
+func applyCapHintOp(t *testing.T, a int, op string, b int) int {
+	t.Helper()
+
+	switch op {
+	case "+":
+		return a + b
+	case "-":
+		return a - b
+	case "*":
+		return a * b
+	case "/":
+		return a / b
+	case "%":
+		return a % b
+	}
+	t.Fatalf("unknown arithmetic operator %q", op)
+	return 0
+}
+
+// capHint evaluates the SHAPE of detected_level.go's capacity hint
+// `(len(levelNormalizationGroups)+1)*2+1` with each of its three operator
+// positions supplied explicitly: `(n innerOp 1) mulOp 2 tailOp 1`. Passing the
+// operators in is what lets the caller enumerate the mutants of the hint
+// without writing any of their values down.
+func capHint(t *testing.T, n int, innerOp, mulOp, tailOp string) int {
+	t.Helper()
+
+	return applyCapHintOp(t,
+		applyCapHintOp(t,
+			applyCapHintOp(t, n, innerOp, 1),
+			mulOp, 2),
+		tailOp, 1)
+}
+
+// multiIfArgCount derives the number of arguments normaliseLevelExpr's multiIf
+// carries for `groups` canonical level groups: one leading (empty, unknown)
+// pair, one (cond, literal) pair per group, and the trailing default branch.
+// Both tests below take their expected count from here rather than writing an
+// integer down, so the two cannot state it differently.
+func multiIfArgCount(groups int) int { return 2*(groups+1) + 1 }
+
+// capAfterBuild replays [normaliseLevelExpr]'s exact append sequence against a
+// slice pre-allocated with `hint`, and reports the length and the capacity the
+// finished slice carries.
+//
+// The element type has to be the real one. Go rounds a growing slice's
+// capacity up to an allocator size class measured in BYTES, so a slice whose
+// elements are a different width grows to different capacities and the
+// simulation would answer a question nobody asked.
+func capAfterBuild(hint, groups int) (length, capacity int) {
+	args := make([]chplan.Expr, 0, hint)
+	args = append(args, nil, nil) // leading (empty, unknown) pair
+	for i := 0; i < groups; i++ {
+		args = append(args, nil, nil) // (cond, canonical literal)
+	}
+	args = append(args, nil) // trailing default branch
+	return len(args), cap(args)
+}
+
+// TestNormaliseLevelExpr_CapHintMutantsAreKilled proves that the `cap`
+// assertion in [TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape] actually
+// discriminates. For every ARITHMETIC_BASE operator substitution gremlins can
+// make in detected_level.go:`(len(levelNormalizationGroups)+1)*2+1`, the
+// capacity the finished slice ends up with must differ from the capacity the
+// unmutated hint produces — otherwise that assertion passes on the mutant and
+// the equivalence note above is claiming a kill it does not deliver.
+//
+// This is the claim the note used to make in prose, with the mutants'
+// capacities written out by hand. Written out, they were free to drift from
+// the arithmetic they described, and they did. Computed here they cannot: if a
+// future edit to the append sequence, to the group table, or to the hint let
+// some mutant land back on the true capacity, this test goes red and names it.
+func TestNormaliseLevelExpr_CapHintMutantsAreKilled(t *testing.T) {
+	t.Parallel()
+
+	// The operators the unmutated hint uses, in the three positions
+	// `(n + 1) * 2 + 1`.
+	const (
+		origInnerOp = "+"
+		origMulOp   = "*"
+		origTailOp  = "+"
+	)
+	positions := []struct{ name, orig string }{
+		{"the inner `+1`", origInnerOp},
+		{"the `*2`", origMulOp},
+		{"the trailing `+1`", origTailOp},
+	}
+
+	n := len(canonicalLevelGroups)
+	trueHint := capHint(t, n, origInnerOp, origMulOp, origTailOp)
+	trueLen, trueCap := capAfterBuild(trueHint, n)
+
+	// The premise of the whole equivalence argument: the appends FILL the
+	// pre-allocation exactly — neither growing past it nor leaving slack. Only
+	// then does the finished cap read back the hint, and only then does
+	// asserting cap pin the hint's arithmetic. Checking capacity alone would
+	// miss the under-filling half: a slice that never grows keeps the cap it
+	// was made with however few elements are appended to it.
+	if trueLen != trueHint || trueCap != trueHint {
+		t.Fatalf("the unmutated hint %d does not exactly fit the append sequence "+
+			"(finished len %d, cap %d): the appends no longer fill the "+
+			"pre-allocation exactly, so cap() has stopped reading back the hint "+
+			"and asserting it has stopped being a capacity kill",
+			trueHint, trueLen, trueCap)
+	}
+
+	// …and the sequence replayed here has to be the one the sibling test pins
+	// on the real multiIf, or this whole test measures a slice nobody builds.
+	if want := multiIfArgCount(n); trueLen != want {
+		t.Fatalf("the replayed append sequence produces %d args, but the multiIf "+
+			"under test carries %d — the simulation has drifted from the builder "+
+			"it stands in for", trueLen, want)
+	}
+
+	mutants, checked, negative := 0, 0, 0
+	for i, pos := range positions {
+		for _, op := range capHintOps {
+			if op == pos.orig {
+				continue
+			}
+			mutants++
+
+			ops := []string{origInnerOp, origMulOp, origTailOp}
+			ops[i] = op
+			hint := capHint(t, n, ops[0], ops[1], ops[2])
+
+			if hint < 0 {
+				// `make` panics on a negative capacity, so this mutant dies in
+				// any test that reaches normaliseLevelExpr at all.
+				negative++
+				continue
+			}
+			checked++
+
+			if _, got := capAfterBuild(hint, n); got == trueCap {
+				t.Errorf("mutating %s to %q gives capacity hint %d, and the finished "+
+					"slice still ends at cap %d — identical to the unmutated build, so "+
+					"the `cap(fn.Args) == wantLen` assertion does NOT kill this mutant",
+					pos.name, op, hint, got)
+			}
+		}
+	}
+
+	// Anti-vacuity: a loop that enumerated nothing would report a clean run
+	// while proving nothing at all.
+	if want := len(positions) * (len(capHintOps) - 1); mutants != want {
+		t.Fatalf("enumerated %d hint mutants, want %d (one per operator substitution "+
+			"in each of the %d positions) — the enumeration is not covering the "+
+			"mutant set it claims to", mutants, want, len(positions))
+	}
+	if checked == 0 {
+		t.Fatalf("every one of the %d hint mutants was skipped as a negative capacity, "+
+			"so the discriminating comparison never ran", mutants)
+	}
+	t.Logf("hint mutants: %d enumerated, %d distinguished by capacity, %d killed by a "+
+		"negative make() capacity", mutants, checked, negative)
+}
+
 // TestNormaliseLevelExpr_CanonicalLevelOrder pins the exact (cond,
-// literal) pair structure of the multiIf chain. The 14 paired slots
-// follow the canonical 7-level enumeration trace / debug / info /
-// warn / error / critical / fatal — in that order — and the 15th
-// (default) slot is the lowercased pass-through. A regression that
-// drops a group, reorders the groups, or swaps an OR-chain for an
-// unrelated condition will fail here. Combined with the cap test
-// above this also serves as a structural backstop: it forces the
-// `args` slice to actually be built end-to-end, so a capacity
-// mutation can't quietly survive by also short-circuiting the loop.
+// literal) pair structure of the multiIf chain. After the leading
+// (empty, unknown) pair comes one (cond, literal) pair per canonical
+// group, in the enumeration order trace / debug / info / warn / error /
+// critical / fatal, and the final slot is the lowercased pass-through
+// default. A regression that drops a group, reorders the groups, or
+// swaps an OR-chain for an unrelated condition will fail here.
+// Combined with the cap test above this also serves as a structural
+// backstop: it forces the `args` slice to actually be built
+// end-to-end, so a capacity mutation can't quietly survive by also
+// short-circuiting the loop.
 func TestNormaliseLevelExpr_CanonicalLevelOrder(t *testing.T) {
 	t.Parallel()
 
@@ -576,11 +750,11 @@ func TestNormaliseLevelExpr_CanonicalLevelOrder(t *testing.T) {
 
 	// The trailing default branch is the lowercased pass-through —
 	// `lower(<source>)`, where <source> is the detected_level
-	// precedence cascade. A mutation on `+1` that drops the default
-	// slot would shorten Args to 14 and trip the len check above; this
-	// assertion pins the SHAPE of the default branch so a refactor that
-	// swaps it for something else (e.g. an empty string fall-through)
-	// still trips a test.
+	// precedence cascade. A mutation on the hint's trailing `+1` that
+	// dropped the default slot would shorten Args by one and trip the
+	// len check above; this assertion pins the SHAPE of the default
+	// branch so a refactor that swaps it for something else (e.g. an
+	// empty string fall-through) still trips a test.
 	defaultIdx := 2 * (len(canonicalLevelGroups) + 1)
 	defaultCall, ok := fn.Args[defaultIdx].(*chplan.FuncCall)
 	if !ok {

--- a/test/perf/orderby_chdb_test.go
+++ b/test/perf/orderby_chdb_test.go
@@ -1,42 +1,65 @@
 //go:build chdb
 
-// Deliverable 1 (task #70): quantify the metrics-table ORDER BY decision.
+// Metrics-table ORDER BY: the standing execution proof that leading the
+// metrics sort key with MetricName still buys the granule-prune win (#791).
 //
-// The OTel-CH default renders the metrics tables with
+// Cerberus does not ship the stock OTel-CH metrics layout. The
+// tsouza/opentelemetry-collector-contrib:cerberus-ddl fork carries one
+// deliberate divergence (docs/upstream-forks.md): the five metrics tables lead
+// their sort key with MetricName, where upstream leads with ServiceName. The
+// reason is granule pruning. A metric-name-first PromQL instant query with NO
+// service.name matcher — the common Grafana / Drilldown-Metrics case — cannot
+// PK-range-prune against a leading ServiceName key, so ClickHouse falls back to
+// a generic exclusion search that touches granules from every ServiceName
+// block.
 //
-//	ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+// That divergence is a permanent maintenance cost, so the win it buys has to
+// stay MEASURED rather than remembered. Three layers pin different halves of
+// it, and only this one executes ClickHouse:
 //
-// (ServiceName FIRST; cerberus now patches that in the cerberus-ddl fork,
-// so internal/chsql/tableshape.go:`metrics.MetricNameColumn,` leads the
-// metrics sort key). A
-// metric-name-first PromQL instant query with NO service.name matcher —
-// the common Grafana / Drilldown-Metrics case — cannot PK-range-prune on
-// the leading ServiceName key, so ClickHouse falls back to a generic
-// exclusion search that touches granules from every ServiceName block.
+//   - internal/schema/ddl renders the CREATE TABLE from the fork's own
+//     templates — the layout production is actually created with.
+//   - internal/chsql/tableshape_orderby_test.go:`TestMetricsTableShapeLeadsWithMetricName`
+//     pins cerberus's granule-pruning MODEL of that key. Always-on, pure
+//     function, no libchdb.so.
+//   - this harness runs both keys over byte-identical data and measures the
+//     pruning difference the other two layers only assert.
 //
-// This bench seeds two parallel MergeTree tables with byte-identical data
-// and contrasting sort keys:
+// So the question it answers is live, not settled: ClickHouse index behaviour
+// is what makes the leading column matter, and if a future version pruned a
+// ServiceName-first key just as well, the fork patch would be paying
+// maintenance for nothing. The ratio this harness reports is the evidence that
+// keeps the divergence justified.
 //
-//	svcfirst : (ServiceName, MetricName, Attributes, ts)  — production
-//	metric   : (MetricName, Attributes, ServiceName, ts)  — proposed fork patch
+// The production sort key is READ OUT of the rendered DDL by
+// `productionMetricsSortKey` rather than written down here, so this file cannot
+// come to disagree with the schema it claims to measure. The comparison key is
+// that same key with ServiceName hoisted to the front — the stock upstream
+// layout — built by `serviceNameFirst`. If the fork patch were ever dropped the
+// two keys would coincide, and `TestOrderByDecision_ChDB` fails on that rather
+// than quietly measuring one table against itself.
 //
-// then runs EXPLAIN indexes=1 (parts/granules pruned) + wall-clock timing
-// for two query shapes:
+// Two parallel MergeTree tables are seeded with byte-identical data under the
+// two keys, then EXPLAIN indexes=1 (parts / granules pruned) and wall-clock
+// timing run over two query shapes:
 //
 //	metric-only : WHERE MetricName = ?                    (no service filter)
 //	svc+metric  : WHERE ServiceName = ? AND MetricName = ?
 //
-// The numbers feed the RC1 accept-OTel-default vs patch-cerberus-ddl-fork
-// decision. Build-tagged `chdb`, same lane as the rest of the chDB execs.
+// Build-tagged `chdb`, same lane as the rest of the chDB execs.
 package perf
 
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	_ "github.com/chdb-io/chdb-go/chdb/driver" // registers "chdb" sql driver
+
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
 )
 
 // Data shape — representative of a mid-size OTel deployment:
@@ -178,13 +201,29 @@ func TestOrderByDecision_ChDB(t *testing.T) {
 
 	total := nServices * nMetrics * nAttr * nTime
 
+	m := schema.DefaultOTelMetrics()
+	prodKey := productionMetricsSortKey(t)
+	upstreamKey := serviceNameFirst(t, prodKey, m.ServiceNameColumn)
+
+	// The whole comparison is meaningful only while cerberus actually diverges
+	// from upstream. If the rendered DDL ever leads with ServiceName, the two
+	// keys below are the same key and the ratio assertion would compare a table
+	// against itself and pass on 1x. Fail on that here instead.
+	if prodKey[0] == m.ServiceNameColumn {
+		t.Fatalf("the rendered metrics DDL leads its sort key with %q (full key %v): "+
+			"the cerberus-ddl fork's MetricName-first patch is absent from the DDL "+
+			"this build renders, so the granule-prune win this harness exists to "+
+			"keep measured has been lost at the schema layer",
+			m.ServiceNameColumn, prodKey)
+	}
+
 	tables := []struct {
 		name    string
 		orderBy string
 		label   string
 	}{
-		{"m_svcfirst", "(ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))", "ServiceName-first (PRODUCTION)"},
-		{"m_metricfirst", "(MetricName, Attributes, ServiceName, toUnixTimestamp64Nano(TimeUnix))", "MetricName-first (PROPOSED)"},
+		{"m_production", sortKeyClause(prodKey), productionKeyLabel},
+		{"m_svcfirst", sortKeyClause(upstreamKey), upstreamKeyLabel},
 	}
 
 	for _, tb := range tables {
@@ -235,11 +274,11 @@ func TestOrderByDecision_ChDB(t *testing.T) {
 		}
 	}
 
-	t.Logf("%-12s | %-32s | %-12s | %-16s | %-10s | %s",
-		"shape", "ORDER BY", "PK keys", "parts", "granules", "best wall")
-	t.Log("-------------+----------------------------------+--------------+------------------+------------+----------")
+	t.Logf("%-12s | %-38s | %-12s | %-16s | %-10s | %s",
+		"shape", "sort key", "PK keys", "parts", "granules", "best wall")
+	t.Log("-------------+----------------------------------------+--------------+------------------+------------+----------")
 	for _, r := range results {
-		t.Logf("%-12s | %-32s | %-12s | %-16s | %-10s | %v",
+		t.Logf("%-12s | %-38s | %-12s | %-16s | %-10s | %v",
 			r.shape, r.variant, r.st.keys,
 			stripPrefix(r.st.parts, "Parts: "),
 			stripPrefix(r.st.granules, "Granules: "),
@@ -261,42 +300,161 @@ func TestOrderByDecision_ChDB(t *testing.T) {
 
 	// --- ASSERTION: granule-prune ratio floor (guards #791) ---------------
 	//
-	// The landed cerberus-ddl fork patch leads the metrics ORDER BY with
-	// MetricName so the common metric-name-first query (NO service.name
-	// matcher — the Grafana / Drilldown-Metrics default) binary-searches
-	// the PK instead of falling to a generic-exclusion scan that touches
-	// granules from every ServiceName block. The measured win on this grid
-	// is 8–17× fewer granules read on the metric-only shape.
+	// On the metric-only shape (NO service.name matcher — the Grafana /
+	// Drilldown-Metrics default) the production key binary-searches the PK,
+	// while the stock upstream key falls to a generic-exclusion scan that
+	// touches granules from every ServiceName block.
 	//
-	// We assert a generous ratio FLOOR (≥4×), not an absolute granule
+	// The floor is a RATIO between the two keys, not an absolute granule
 	// count: the absolute number is index_granularity-dependent and would
-	// drift if CH changed the default or the grid scaled, but the *ratio*
-	// between the two sort keys on byte-identical data is the structural
+	// drift if ClickHouse changed the default or the grid scaled, but the
+	// ratio between two sort keys over byte-identical data is the structural
 	// property the fork patch buys. The fixed-grid OPTIMIZE … FINAL
-	// single-part setup above makes both granule counts deterministic. A
-	// regression that re-led the sort key with ServiceName (the OTel
-	// upstream default) collapses the ratio toward 1× and trips this floor.
-	svcFirstGranules := selectedGranulesFor(t, results, "metric-only", "ServiceName-first (PRODUCTION)")
-	metricFirstGranules := selectedGranulesFor(t, results, "metric-only", "MetricName-first (PROPOSED)")
+	// single-part setup above makes both counts deterministic.
+	//
+	// Because the production key is derived from the rendered DDL, this is a
+	// real regression guard rather than a statement about a hard-coded key:
+	// drop the fork patch and the leading-column check above fails, and change
+	// ClickHouse's index behaviour so the leading column stops mattering and
+	// the ratio collapses into this floor.
+	prodGranules := selectedGranulesFor(t, results, "metric-only", productionKeyLabel)
+	upstreamGranules := selectedGranulesFor(t, results, "metric-only", upstreamKeyLabel)
 
-	t.Logf("metric-only granule prune: svcfirst=%d  metricfirst=%d  ratio=%.1fx",
-		svcFirstGranules, metricFirstGranules, float64(svcFirstGranules)/float64(maxInt1(metricFirstGranules)))
+	t.Logf("metric-only granule prune: production=%d  upstream-default=%d  ratio=%.1fx",
+		prodGranules, upstreamGranules, float64(upstreamGranules)/float64(maxInt1(prodGranules)))
 
-	if metricFirstGranules <= 0 {
-		t.Fatalf("metric-first metric-only query read %d granules — EXPLAIN parse is "+
-			"degenerate (expected ≥1 selected granule); cannot evaluate the prune ratio",
-			metricFirstGranules)
+	if prodGranules <= 0 {
+		t.Fatalf("the production-key metric-only query read %d granules — the EXPLAIN "+
+			"parse is degenerate (expected ≥1 selected granule); the prune ratio "+
+			"cannot be evaluated", prodGranules)
 	}
-	const minRatio = 4 // generous floor vs the measured 8–17×
-	if metricFirstGranules*minRatio > svcFirstGranules {
-		t.Fatalf("metrics ORDER BY granule-prune regression: the metric-name-first key "+
-			"read %d granules and the service-name-first key read %d — only %.1f× fewer, "+
-			"below the %d× floor. The cerberus-ddl fork's MetricName-first ORDER BY win "+
-			"(measured 8–17× on this grid) has regressed; the leading sort key is no "+
-			"longer letting a no-service.name query PK-range-prune.",
-			metricFirstGranules, svcFirstGranules,
-			float64(svcFirstGranules)/float64(metricFirstGranules), minRatio)
+	// A floor well under the ratio this grid actually produces: the assertion
+	// is meant to catch the win COLLAPSING, not to pin a measurement that
+	// legitimately moves with ClickHouse's index implementation.
+	const minRatio = 4
+	if prodGranules*minRatio > upstreamGranules {
+		t.Fatalf("metrics ORDER BY granule-prune regression: the production key %v "+
+			"read %d granules and the stock upstream key %v read %d — only %.1f× "+
+			"fewer, below the %d× floor. Leading the metrics sort key with %q has "+
+			"stopped letting a no-service.name query PK-range-prune, which is the "+
+			"entire justification for the cerberus-ddl fork's divergence.",
+			prodKey, prodGranules, upstreamKey, upstreamGranules,
+			float64(upstreamGranules)/float64(prodGranules), minRatio, prodKey[0])
 	}
+}
+
+// The two sort-key variants under test, named once so the label a result row
+// carries and the label the assertions look it up by cannot drift apart.
+const (
+	productionKeyLabel = "production (from the rendered DDL)"
+	upstreamKeyLabel   = "stock OTel default (ServiceName-first)"
+)
+
+// orderByPrefix opens the ORDER BY line of a rendered CREATE TABLE statement.
+const orderByPrefix = "ORDER BY "
+
+// productionMetricsSortKey returns the ORDER BY elements the OTel-CH metrics
+// tables are actually created with, read out of the DDL internal/schema/ddl
+// renders from the cerberus-ddl fork's own templates.
+//
+// Reading the key rather than restating it is the point. A hand-written copy is
+// a claim that can quietly stop describing production — and when it does, the
+// harness goes on measuring a layout nobody runs while still reporting a
+// healthy ratio.
+func productionMetricsSortKey(t *testing.T) []string {
+	t.Helper()
+
+	m := schema.DefaultOTelMetrics()
+	stmts, err := ddl.RenderAll(ddl.Config{}, []ddl.Signal{ddl.Metrics})
+	if err != nil {
+		t.Fatalf("render the metrics DDL: %v", err)
+	}
+	for _, stmt := range stmts {
+		if !strings.Contains(stmt, m.GaugeTable) {
+			continue
+		}
+		for _, line := range strings.Split(stmt, "\n") {
+			line = trimSpace(line)
+			if !hasPrefix(line, orderByPrefix) {
+				continue
+			}
+			return splitSortKey(t, stripPrefix(line, orderByPrefix))
+		}
+	}
+	t.Fatalf("no %s line in the rendered DDL for %q — the metrics table template "+
+		"changed shape and the production sort key can no longer be read from it",
+		orderByPrefix, m.GaugeTable)
+	return nil
+}
+
+// splitSortKey turns the `(a, b, f(c))` expression list of an ORDER BY clause
+// into its top-level elements. A comma inside a function call is not a
+// separator, so the scan tracks parenthesis depth.
+func splitSortKey(t *testing.T, clause string) []string {
+	t.Helper()
+
+	clause = trimSpace(clause)
+	if !hasPrefix(clause, "(") || !strings.HasSuffix(clause, ")") {
+		t.Fatalf("ORDER BY clause %q is not a parenthesised expression list", clause)
+	}
+	inner := clause[1 : len(clause)-1]
+
+	var out []string
+	depth, start := 0, 0
+	for i := 0; i < len(inner); i++ {
+		switch inner[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, trimSpace(inner[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, trimSpace(inner[start:]))
+
+	for _, c := range out {
+		if c == "" {
+			t.Fatalf("ORDER BY clause %q has an empty element: %v", clause, out)
+		}
+	}
+	return out
+}
+
+// serviceNameFirst returns key with its ServiceName element hoisted to the
+// front — the stock upstream metrics layout, expressed as a PERMUTATION of
+// whatever cerberus actually ships rather than as a second hand-written key.
+// Deriving the comparison this way keeps the two tables byte-comparable: they
+// differ in the position of one column and in nothing else.
+func serviceNameFirst(t *testing.T, key []string, serviceNameCol string) []string {
+	t.Helper()
+
+	idx := -1
+	for i, c := range key {
+		if c == serviceNameCol {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatalf("the metrics sort key %v has no %q element, so the stock upstream "+
+			"comparison key cannot be built from it", key, serviceNameCol)
+	}
+
+	out := make([]string, 0, len(key))
+	out = append(out, key[idx])
+	out = append(out, key[:idx]...)
+	out = append(out, key[idx+1:]...)
+	return out
+}
+
+// sortKeyClause renders sort-key elements back into the parenthesised
+// expression list a CREATE TABLE ORDER BY takes.
+func sortKeyClause(key []string) string {
+	return "(" + strings.Join(key, ", ") + ")"
 }
 
 // selectedGranulesFor pulls the count of SELECTED granules (the
@@ -349,7 +507,11 @@ func maxInt1(n int) int {
 	return n
 }
 
-// --- tiny string helpers (avoid importing strings for two calls) ---
+// --- EXPLAIN-line string helpers, shared across package perf ---
+//
+// Kept as package-local helpers rather than folded into `strings` calls at
+// every site: the chDB EXPLAIN harnesses in this package all trim and
+// prefix-match the same way, and several of them predate any `strings` import.
 
 func trimSpace(s string) string {
 	i, j := 0, len(s)


### PR DESCRIPTION
## What drifted

#2953 closed the machine-checkable half of note rot — a citation names a construct and
`verify-code-citations` resolves it. Nothing checks the **prose claim** wrapped around that
citation, so a note can carry a perfectly resolving citation while the sentence around it
asserts something the code stopped doing, and it still reads as evidence.

### 1. `test/perf/orderby_chdb_test.go`

**Before:** the header said production renders the metrics tables
`ORDER BY (ServiceName, MetricName, Attributes, …)` and framed the benchmark as input to an
"accept the OTel default vs patch the cerberus-ddl fork" decision. The table it labelled
`ServiceName-first (PRODUCTION)` was the stock upstream layout; the one labelled `PROPOSED`
was production. The assertion block claimed "a regression that re-led the sort key with
ServiceName collapses the ratio and trips this floor" — which it could not do, because both
sort keys were hard-coded string literals that no schema change touches.

**After:** the production key is READ out of the DDL `internal/schema/ddl` renders from the
cerberus-ddl fork's own templates (`productionMetricsSortKey`), and the comparison key is that
same key with ServiceName hoisted to the front (`serviceNameFirst`) — the stock upstream layout
expressed as a permutation rather than a second hard-coded string. The header now says what the
benchmark is for, and the assertion is the regression guard it claimed to be.

**What the benchmark is now for.** Its original motivation expired, but its subject did not.
The fork divergence is a permanent maintenance cost (`docs/upstream-forks.md`), and three layers
pin different halves of it: `internal/schema/ddl` renders the key, `TestMetricsTableShapeLeadsWithMetricName`
pins cerberus's granule-pruning *model* of it, and only this harness measures whether the win is
still real. That is a live question — ClickHouse index behaviour is what makes the leading column
matter, and if a future version pruned a ServiceName-first key just as well, the fork patch would
be paying maintenance for nothing. So the framing inverts rather than the benchmark disappearing:
it is the standing evidence that keeps the divergence justified.

### 2. `internal/logql/detected_level_test.go`

**Before:** the note reasoned from `2*len(canonicalLevelGroups)+1` while the test computes
`2*(len(canonicalLevelGroups)+1) + 1`. The parenthesisation differs and the code grew a leading
(empty, unknown) pair the prose never picked up, so the real value is **17**, not the **15** the
whole narrative was built on — "the 15 subsequent appends", "a final cap that is NOT 15",
"Asserting `cap == 15`", and in the sibling test "the 14 paired slots", "the 15th (default) slot",
"would shorten Args to 14". The assertions were correct; the adjudication reasoning was not.

**After:** both counts derive from `multiIfArgCount`, shared by the two tests so they cannot state
it differently, and no hand-typed count survives in either note or in their failure messages. The
note's least checkable sentence — that every ARITHMETIC_BASE mutation of the capacity hint yields
a capacity the `cap` assertion distinguishes — is no longer prose:
`TestNormaliseLevelExpr_CapHintMutantsAreKilled` enumerates all twelve operator substitutions and
asserts it, replaying the builder's append sequence over the real `chplan.Expr` element type
because Go rounds slice growth to byte-sized allocator classes.

A third drifted claim in the same file is corrected on the way past: `canonicalLevelGroups`
justified itself as avoiding "re-importing the unexported `group` struct", but the test is
`package logql` and the struct is `levelNormalizationGroup`. The duplication is right — an
independent restatement, so a wrong edit to the source table fails instead of being mirrored —
and the comment now says that.

## Root cause: (a) was weighed and refuted; (b) is adopted

**(a) derive numeric claims in adjudication notes, the `doc-counts.mjs` way — does not
generalise.** Four measurements, taken on this branch's base:

| measurement | result |
|---|---|
| Backticked expression naming an own-package identifier must resolve to a code line | 834 violations / 1475 spans (**57%**) — backticks in Go comments mark regexes, URLs, PromQL, CLI flags |
| Narrowed to adjudication notes + a strict Go-arithmetic grammar | 14 violations, **12 of them legitimate** deliberate counterfactuals (`make([]Frag, 0, -1)` is the *result* of a mutant, so by definition absent from the code) |
| …and what that rule sees of instance 2 | the two backticked expressions only — blind to `cap == 15`, "the 15 subsequent appends", "the 14 paired slots", which carried most of the rot |
| Bare integers inside the 340 adjudication blocks | 462 instances; **91** restate a source-countable fact, **325** are operands of a quoted expression (`i == 1`, `Step=0`) |

The decisive one is the shape of the class rather than its noise: the same claim is written as a
**spelled-out numeral** ("four conjuncts", "three join keys", "nine accepted runes") **339 times**
in those blocks — more often than as a digit. A digit-keyed checker is therefore structurally blind
to the majority of what it must model, which is precisely what a gate here may not be. And keyed
per note, `doc-counts.mjs`'s technique becomes a hand-maintained registry: it works because it is
six bespoke claim-to-derivation pairs over a four-file doc surface, whereas adjudication notes are
340 blocks across 65 files with new ones landing on most mutation PRs. That is the `HARNESS_PATHS`
hand-list from #2948 — a set that silently stops covering things.

**(b) shrink how much prose carries load — adopted, and it needs no new gate, because the Go test
suite already is one.** A count that lives in an assertion cannot rot without a test going red.
Both corrections apply it concretely: instance 1 moves "production sorts this way" from a sentence
into a value read from the rendered DDL; instance 2 moves the arg count into `multiIfArgCount` and
the mutant-discrimination claim into a test. The residue (b) cannot reach is the 17 of 59
source-countable sites with no code nearby stating the number, 12 of them in `NOT KILLABLE` blocks
that by construction have no test — and for those the answer is the convention, not a checker.

So `docs/test-strategy.md` gains **"How a note states a number"** beside the existing citation
convention: a count the source can compute is never written down; a property the note claims is
asserted rather than narrated; a fact the code already fixes is read rather than restated; a
measurement stays prose, with its context. It records the refutation above so the next person does
not re-derive it.

## Proof every assertion can fail

No new `.mjs` gate, so the proofs are against the assertions this PR adds or repairs. Each mutation
was applied by hand and reverted.

| mutation | result |
|---|---|
| `(len(levelNormalizationGroups)+1)*2+1` → `…/2+1` (a real ARITHMETIC_BASE mutant) | RED — `cap(multiIf.Args) = 20; want 17` |
| `applyCapHintOp` makes `-` behave as `+`, so a mutant lands back on the true cap | RED — names both mutants the `cap` assertion would stop killing |
| drop the default append from the replayed sequence | RED — `finished len 16, cap 17` … the appends no longer fill the pre-allocation exactly |
| `multiIfArgCount` returns a wrong derivation | RED in both tests — including "the simulation has drifted from the builder it stands in for" |
| rendered DDL leads with ServiceName (fork patch reverted) | RED — "the cerberus-ddl fork's MetricName-first patch is absent from the DDL this build renders" |
| `minRatio` raised above the measured ratio | RED — production 3 granules vs upstream 51, 17.0× |

The third row is worth calling out: the premise guard was written comparing `cap` and **did not
fire**, because a slice that never grows keeps the capacity it was made with however few elements
are appended. That is this issue's own bug class reappearing in the fix — a sentence claiming
"the appends fill it exactly" backed by an assertion that only checks one half. The guard now
checks length and capacity, and the proof above is the corrected one.

Live run on chDB, unmutated: production key reads **3/74** granules by binary search, stock
upstream key reads **51/74** by generic exclusion search — 17.0×.

## Filed

#2964 — `line 92:20` style addresses written as prose evade `verify-code-citations`, which bans
only the `file.go:613` spelling. Two verified rotted instances: `histogram_quantile_test.go` cites
lines 217 and 318, now `Mul(` and a whole-line comment; `equal_invariants_test.go` cites "line 92"
with no file at all, while the construct sits at `internal/chplan/topk.go:141`. Distinct class from
this issue — a prose *address* is as checkable as the backticked form, unlike a prose *claim* —
and attached as a sub-issue of epic #2891 under M1.

## Verification

`verify-code-citations` (2159 files, all resolve), `forbid-sql-raw`, `doc-counts`,
`markdownlint-cli2` on the changed doc, `go vet` on the touched packages, and narrow
`go test -run` on both suites including the chDB-tagged one.

Closes #2957
