### PR TITLE
test(mutation): give a mutant one verdict, and gate the contradiction

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -394,6 +394,54 @@ what actually runs.
     real CLI over a throwaway git repository and pairs every rejection with the
     nearest-miss acceptance, so neither widening the gate into uselessness nor
     narrowing it into noise passes.
+- **`forbid-contradicted-mutants.mjs`** — `ci.yml`, the `forbid-skip` job step
+  "Reject a mutant adjudicated both killed and equivalent". A mutant gets ONE
+  verdict. `docs/test-strategy.md` § "Surviving-mutant policy" offers a
+  surviving mutant two remedies — prove it equivalent and document it, or add a
+  genuinely distinguishing test — and they are opposite conclusions about the
+  same thing, so recording both means one is false. The gate reads every kill
+  claim (`// TestX kills …`, a sentence-initial `Kills …`, or `killed by
+  TestX`) and every equivalence verdict (a `NOT KILLABLE` footer, or a
+  file-header ledger that says `equivalent` / `unkillable` in so many words),
+  resolves the construct each cites through `verify-code-citations.mjs`'s own
+  resolver, and fails when one construct carries both. Two mutants on `main`
+  did, and the mutation lane recorded each of them LIVED (#2958).
+  - The unit is a comment PARAGRAPH, not a comment block: one footer in this
+    tree names three mutators across nine citations, and attributing a whole
+    run's vocabulary to every citation in it would smear the evidence.
+  - One construct is not one mutant, so two refinements apply. By POSITION,
+    `best < 0 || r < best` hosts an independent CONDITIONALS_BOUNDARY per
+    operand — verdicts conflict only when their constructs OVERLAP by
+    containment, and disjoint siblings on a shared line are different mutants.
+    By MUTATOR, `err != nil && srcErr == nil` carries CONDITIONALS_NEGATION
+    mutants a test kills and an INVERT_LOGICAL mutant a footer proves
+    equivalent — two notes naming disjoint mutators describe different mutants.
+    Naming nothing is no evidence, and the pair is still reported.
+  - One mutator striking one construct TWICE (`*2` and `+6` in
+    `len(groupAliases)*2+6`) is deliberately not discriminated: keying on the
+    `` `X` -> `Y` `` rewrite a note spells was tried and rejected, because two
+    notes about the same mutant routinely spell it differently and the rule
+    traded a narrow false positive for silently missed contradictions. The
+    remedy is to narrow both citations to the operand each is about.
+  - The mutator vocabulary is read from `.gremlins.yaml` rather than
+    hard-coded; an empty one is a hard error, since it would silently widen the
+    gate rather than break it. A citation that does not resolve to exactly one
+    code line is left to `verify-code-citations.mjs`, which owns that failure
+    and runs immediately before this gate.
+  - Env: `REPO_ROOT` (default `process.cwd()`), `PATHSPECS` (default
+    `*_test.go`).
+  - Exit: `0` when no mutant carries two verdicts, `1` otherwise — including a
+    pathspec that matched no file (a green over zero files is not evidence) and
+    an unreadable mutator vocabulary.
+  - Pins: `forbid-contradicted-mutants.test.mjs` (`node --test`), 19 cases
+    driving the real CLI over a throwaway git repository and pairing every
+    rejection with its nearest-miss acceptance — the sibling-mutants-on-one-line
+    and different-mutators shapes that must stay green, each beside the
+    one-token variant that must fail; a footer paragraph that never says
+    "equivalent" and must still count; a ledger outside any footer that must
+    count; the disclaiming test that defers to a footer; a `kill-switch` that
+    is not a claim; and the empty vocabulary and empty scan that must both be
+    errors.
 - **`generated-baseline-structural-guard.mjs`** — `ci.yml`, the `forbid-skip`
   job step "Structural sanity check over generated baseline shapes (#1568)".
   A fast, dependency-free structural pre-filter (unique key, sorted order,

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -406,9 +406,20 @@ what actually runs.
   resolves the construct each cites through `verify-code-citations.mjs`'s own
   resolver, and fails when one construct carries both. Two mutants on `main`
   did, and the mutation lane recorded each of them LIVED (#2958).
-  - The unit is a comment PARAGRAPH, not a comment block: one footer in this
-    tree names three mutators across nine citations, and attributing a whole
-    run's vocabulary to every citation in it would smear the evidence.
+  - The VERDICT is per comment PARAGRAPH, not per block: one footer in this
+    tree names three mutators across nine citations, and letting a whole run
+    cast a verdict would make a disclaimer ("this test does NOT kill …") or a
+    neighbouring note read as one.
+  - Which MUTATOR a verdict is about is a property of the whole note, though,
+    because a good footer states the rewrite once and then enumerates the sites
+    it applies to. So a citation paragraph that names no mutator inherits its
+    comment run's — and only when the run names exactly one, since an ambiguous
+    preamble lends nothing. This widens the evidence, never the verdict.
+    Measured over the tree: 10 equivalence paragraphs need it, all under a run
+    naming exactly one mutator, with none naming more; no kill paragraph
+    qualifies, so the rule is symmetric at zero cost. A paragraph that still
+    names nothing matches ANY mutator, which is the fail-closed reading — no
+    evidence is not a defence.
   - One construct is not one mutant, so two refinements apply. By POSITION,
     `best < 0 || r < best` hosts an independent CONDITIONALS_BOUNDARY per
     operand — verdicts conflict only when their constructs OVERLAP by
@@ -417,6 +428,9 @@ what actually runs.
     mutants a test kills and an INVERT_LOGICAL mutant a footer proves
     equivalent — two notes naming disjoint mutators describe different mutants.
     Naming nothing is no evidence, and the pair is still reported.
+    A real pair in `internal/promql` is exactly this shape: a
+    CONDITIONALS_NEGATION kill and an INVERT_LOGICAL equivalence on one guard,
+    both true.
   - One mutator striking one construct TWICE (`*2` and `+6` in
     `len(groupAliases)*2+6`) is deliberately not discriminated: keying on the
     `` `X` -> `Y` `` rewrite a note spells was tried and rejected, because two
@@ -433,15 +447,16 @@ what actually runs.
   - Exit: `0` when no mutant carries two verdicts, `1` otherwise — including a
     pathspec that matched no file (a green over zero files is not evidence) and
     an unreadable mutator vocabulary.
-  - Pins: `forbid-contradicted-mutants.test.mjs` (`node --test`), 19 cases
+  - Pins: `forbid-contradicted-mutants.test.mjs` (`node --test`), 22 cases
     driving the real CLI over a throwaway git repository and pairing every
     rejection with its nearest-miss acceptance — the sibling-mutants-on-one-line
     and different-mutators shapes that must stay green, each beside the
     one-token variant that must fail; a footer paragraph that never says
     "equivalent" and must still count; a ledger outside any footer that must
     count; the disclaiming test that defers to a footer; a `kill-switch` that
-    is not a claim; and the empty vocabulary and empty scan that must both be
-    errors.
+    is not a claim; a citation list that inherits its note's single mutator
+    beside the ambiguous note that must lend nothing; and the empty vocabulary
+    and empty scan that must both be errors.
 - **`generated-baseline-structural-guard.mjs`** — `ci.yml`, the `forbid-skip`
   job step "Structural sanity check over generated baseline shapes (#1568)".
   A fast, dependency-free structural pre-filter (unique key, sorted order,

--- a/.github/scripts/forbid-contradicted-mutants.mjs
+++ b/.github/scripts/forbid-contradicted-mutants.mjs
@@ -1,0 +1,393 @@
+// forbid-contradicted-mutants.mjs — one mutant, one adjudication. A mutant
+// documented as EQUIVALENT may not also be claimed as KILLED.
+//
+// WHY THIS EXISTS (#2958). `docs/test-strategy.md` § "Surviving-mutant policy"
+// gives a surviving mutant exactly two remedies: prove it equivalent and
+// document it (remedy 1, preferred), or add a test that genuinely
+// distinguishes original from mutant (remedy 2). The two are mutually
+// exclusive verdicts on one mutant. When both are recorded, one of them is
+// false — and the false one is almost always the kill, because a `kills`
+// header costs nothing to write and nothing checks it.
+//
+// Two such pairs were on `main` in a single file, both adjudicating mutants
+// that the mutation lane records as LIVED:
+//
+//   - exemplars.go:`len(groupAliases)*2+6` — a slice CAPACITY hint. The
+//     "kill" conceded in its own prose that it gave the tool "a path to call
+//     it dead anyway". The whole internal/chsql package passes with the
+//     mutation applied.
+//   - exemplars.go:`if maxPerSeries > 0` — the "kill" asserted the `>= 0`
+//     mutant "would emit `LIMIT 0 BY ...`". It does not: Limit(0) leaves
+//     QueryBuilder's hasLimit false, so the mutant is byte-identical.
+//
+// A PROSE gate cannot find these. The first conceded in words and the second
+// did not — its prose was confident and simply wrong — so any grep for
+// hedging phrasings ("plausibly equivalent", "gives gremlins a path") finds
+// one and misses the other. Every such phrasing on `main` occurs exactly
+// once, in that one comment. The signature is STRUCTURAL: the same mutant
+// carrying two opposite verdicts. That is what this gate checks.
+//
+// WHAT MAKES IT PRECISE is #2953's construct citations. Both verdicts already
+// name the mutant they adjudicate as `<file>.go:`<construct>``, which
+// verify-code-citations.mjs resolves to exactly one code line. Resolving both
+// sides through that same resolver turns "do these two notes mean the same
+// mutant" from a judgement call into a set intersection.
+//
+// THE UNIT OF ADJUDICATION IS A PARAGRAPH, not a comment block. A footer
+// routinely adjudicates several mutants in one unbroken `//` run — one names
+// three mutators across nine citations — so attributing a run's whole
+// vocabulary to every citation in it would smear the evidence and defeat the
+// discriminations below exactly where notes are densest.
+//
+// ONE CONSTRUCT IS NOT ONE MUTANT, and three refinements follow.
+//
+//   POSITION. `best < 0 || r < best` hosts an independent
+//   CONDITIONALS_BOUNDARY per operand, one killed and one proven equivalent,
+//   so a shared LINE is not a contradiction. Verdicts conflict only when their
+//   constructs OVERLAP by containment — `maxPerSeries > 0` inside
+//   `if maxPerSeries > 0` is one mutant at two widths, while `best < 0` and
+//   `r < best` are disjoint siblings.
+//
+//   MUTATOR. `err != nil && srcErr == nil` carries CONDITIONALS_NEGATION
+//   mutants a test kills AND an INVERT_LOGICAL mutant a footer proves
+//   equivalent. Two notes naming disjoint mutators describe different mutants.
+//
+// In both cases naming nothing is no evidence rather than a defence: the pair
+// is still reported. Fail closed, not open.
+//
+// ONE MUTATOR CAN ALSO STRIKE ONE CONSTRUCT TWICE, and the gate deliberately
+// does NOT try to tell those apart from prose. `len(groupAliases)*2+6` carries
+// the ARITHMETIC_BASE at `*2` (equivalent) and the one at `+6` (killed — it
+// panics on a negative capacity), so a kill of the second alongside a
+// verdict on the first is reported even though both are true. Discriminating
+// on the `` `X` -> `Y` `` rewrite a note spells was tried and rejected: two
+// notes about the SAME mutant routinely spell it differently — one writes
+// `` `*2` -> `/2` ``, the other quotes the whole `make(...)` line — so the
+// rule bought a narrow false-positive fix at the price of silently MISSING
+// real contradictions, which is the one failure this gate must not have.
+//
+// The remedy is the same one the POSITION refinement asks for, and it is a
+// real improvement to the note rather than a suppression: narrow BOTH
+// citations to the operand each is about, so `len(groupAliases)*2` and `2+6`
+// name one mutant apiece. A citation covering the whole expression adjudicates
+// neither.
+//
+// The mutator vocabulary is READ FROM `.gremlins.yaml` rather than hard-coded,
+// so enabling or retiring a mutator cannot leave a stale list here silently
+// mis-adjudicating. An unreadable or empty mutants block is a hard error — a
+// vocabulary that quietly became empty would make every mutator set empty, and
+// an empty set names nothing, which would silently WIDEN the gate.
+//
+// DIVISION OF LABOUR: a citation that does not resolve to exactly one line is
+// not re-reported here — it is already a hard error in
+// verify-code-citations.mjs, which runs immediately before this gate in the
+// same job. Duplicating that failure would print every citation defect twice.
+// There is no tolerance file and no allow-list.
+//
+// ENV CONTRACT
+//   REPO_ROOT   — repository root. Default `process.cwd()`.
+//   PATHSPECS   — whitespace-separated git pathspecs to scan.
+//                 Default `*_test.go` (every tracked Go test file).
+//
+// Exit: 0 when no mutant carries two verdicts, 1 otherwise — including when
+// the pathspec matched no file at all, or the vocabulary could not be read.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import {
+  units,
+  parseCitations,
+  resolveCited,
+  matchLines,
+  funcRanges,
+  normalise,
+  unescape,
+} from './verify-code-citations.mjs';
+import { error, log, notice, lsFiles } from './lib/gh.mjs';
+
+// A kill claim, in the three shapes the tree uses: the canonical
+// `// TestX kills …` header from `docs/test-strategy.md`, a sentence-initial
+// `Kills …`, and `killed by TestX`. Keying only on the canonical header reads
+// 224 of the tree's 269 kill-claim paragraphs and misses 45, including every
+// `Kills INVERT_LOGICAL (…)` written as a second sentence.
+//
+// Two exclusions are deliberate. A NEGATED mention ("It does NOT kill the
+// CONDITIONALS_BOUNDARY mutant …") is a disclaimer, and the correct pattern,
+// so unanchored `kill`/`kills` is not a claim. And `Kills` requires the
+// capital and the plural, which is what keeps the tree's `kill-switch`,
+// `ch-pod-kill` and "tests that kill the LIVED mutants" out.
+export const KILL_CLAIM = /\bTest[A-Za-z0-9_]+\s+kills\b|\bKills\b|\bkilled by\s+Test[A-Za-z0-9_]+/;
+
+// An equivalence verdict. The `NOT KILLABLE` footer is the form
+// `docs/test-strategy.md` prescribes, but it is not the only one in the tree:
+// several packages keep a file-header ledger instead ("EQUIVALENCE verdicts
+// (no killing test possible …)", "Genuinely equivalent", "provably
+// EQUIVALENT"). Reading only the prescribed opener left ten verdicts
+// invisible — among them a capacity-hint ARITHMETIC_BASE in internal/logql,
+// the very class this gate exists for. A verdict is therefore recognised by
+// what it SAYS, not by the heading it happens to sit under.
+export const EQUIV_VERDICT = /\bNOT KILLABLE\b|\bequivalent\b|\bunkillable\b/i;
+
+// footerRegion — the 1-based lines under a `NOT KILLABLE` opener, which runs
+// to the end of its comment run. Everything under that heading is a verdict by
+// declaration, whether or not the individual paragraph restates the word: the
+// exemplars footer argues one mutant is byte-identical without ever writing
+// "equivalent", and losing it would lose half of what this gate was built for.
+// The opener is anchored at a line start, which is what separates a footer
+// from a REFERENCE to one — "see the NOT KILLABLE note at the foot of this
+// file" is a disclaimer, and the correct pattern.
+export function footerRegion(lines) {
+  const inFooter = new Set();
+  let runStart = null;
+  const close = (end) => {
+    if (runStart === null) return;
+    for (let n = runStart; n <= end; n += 1) {
+      const body = lines[n - 1].trim().replace(/^\/\/\s?/, '');
+      if (!/^NOT KILLABLE\b/.test(body)) continue;
+      for (let k = n; k <= end; k += 1) inFooter.add(k);
+      break;
+    }
+    runStart = null;
+  };
+  lines.forEach((line, i) => {
+    if (line.trim().startsWith('//')) {
+      if (runStart === null) runStart = i + 1;
+      return;
+    }
+    close(i);
+  });
+  close(lines.length);
+  return inFooter;
+}
+
+// paragraphs — the 1-based line ranges of every comment PARAGRAPH: a maximal
+// run of `//` lines carrying text, bounded by a bare `//` or by a non-comment
+// line. This is the unit a single adjudication is written in.
+export function paragraphs(lines) {
+  const out = [];
+  let start = null;
+  const flush = (end) => {
+    if (start !== null) out.push({ start, end });
+    start = null;
+  };
+  lines.forEach((line, i) => {
+    const t = line.trim();
+    const isText = t.startsWith('//') && t.replace(/^\/\/\s?/, '').trim() !== '';
+    if (isText) {
+      if (start === null) start = i + 1;
+      return;
+    }
+    flush(i);
+  });
+  flush(lines.length);
+  return out;
+}
+
+// mutatorVocabulary — the enabled gremlins mutators, as the UPPER_SNAKE names
+// adjudication prose spells them. `.gremlins.yaml` lists them kebab-cased under
+// `mutants:`, which is `mt.String()` with `_` -> `-`, so the mapping back is
+// exact rather than a guess.
+export function mutatorVocabulary(root) {
+  let text;
+  try {
+    text = readFileSync(resolve(root, '.gremlins.yaml'), 'utf8');
+  } catch (cause) {
+    throw new Error(`cannot read .gremlins.yaml: ${cause.message}`);
+  }
+  const block = /^mutants:\s*$/m.exec(text);
+  if (!block) {
+    throw new Error('.gremlins.yaml has no `mutants:` block — the vocabulary would be empty');
+  }
+  const names = new Set();
+  for (const line of text.slice(block.index + block[0].length).split('\n')) {
+    if (/^\S/.test(line)) break; // dedent ends the block
+    const m = /^\s{2}([a-z][a-z0-9-]*):\s*$/.exec(line);
+    if (m) names.add(m[1].toUpperCase().replaceAll('-', '_'));
+  }
+  if (names.size === 0) {
+    throw new Error('.gremlins.yaml `mutants:` block named none — refusing to scan with an empty vocabulary');
+  }
+  return names;
+}
+
+// namedMutators — the vocabulary members a paragraph names, which is what it
+// says about WHICH mutant on the cited construct it adjudicates.
+export function namedMutators(text, vocabulary) {
+  const out = new Set();
+  for (const name of vocabulary) if (text.includes(name)) out.add(name);
+  return out;
+}
+
+// maskTo — the file's lines with every line outside [start, end] blanked.
+// Blanking rather than slicing preserves each surviving line's index, so
+// `units()` reports true source line numbers.
+function maskTo(lines, { start, end }) {
+  return lines.map((line, i) => (i + 1 >= start && i + 1 <= end ? line : ''));
+}
+
+// citationsIn — every construct citation of one paragraph, resolved to the
+// single code line it names. A citation that resolves to zero or many lines is
+// skipped; see the division-of-labour note in the file header.
+function citationsIn({ root, file, lines, range, load }) {
+  const out = [];
+  for (const unit of units(maskTo(lines, range))) {
+    if (!unit.lines.length) continue;
+    for (const c of parseCitations(unit)) {
+      if (c.kind !== 'construct' || c.unterminated || !c.construct) continue;
+      const rel = resolveCited({ root, from: file, path: c.path });
+      if (rel === null) continue;
+      const target = load(rel);
+      let ranges = null;
+      if (c.scope !== null) {
+        const found = funcRanges(target).get(c.scope);
+        if (!found) continue;
+        ranges = found;
+      }
+      const hits = matchLines({ lines: target, construct: c.construct, ranges });
+      if (hits.length !== 1) continue;
+      out.push({
+        cited: `${rel}#${hits[0]}`,
+        construct: normalise(unescape(c.construct)),
+        where: `${file}:${c.line}`,
+      });
+    }
+  }
+  return out;
+}
+
+// collectFile — the kill claims and equivalence verdicts one file records, one
+// paragraph at a time. A paragraph that claims a kill is never also read as an
+// equivalence verdict: a kill claim that explains why a NEARBY mutant is
+// equivalent is pointing at someone else's verdict, not casting one.
+export function collectFile({ root, file, load, vocabulary }) {
+  const lines = readFileSync(resolve(root, file), 'utf8').split('\n');
+  const footer = footerRegion(lines);
+  const kills = [];
+  const equivalents = [];
+  for (const range of paragraphs(lines)) {
+    const text = lines
+      .slice(range.start - 1, range.end)
+      .map((l) => l.trim().replace(/^\/\/\s?/, ''))
+      .join(' ');
+    const isKill = KILL_CLAIM.test(text);
+    const underFooter = footer.has(range.start);
+    const isEquiv = !isKill && (underFooter || EQUIV_VERDICT.test(text));
+    if (!isKill && !isEquiv) continue;
+    const mutators = namedMutators(text, vocabulary);
+    for (const c of citationsIn({ root, file, lines, range, load })) {
+      (isKill ? kills : equivalents).push({ ...c, mutators });
+    }
+  }
+  return { kills, equivalents };
+}
+
+// overlaps — whether two constructs describe the same expression. Containment
+// either way means one note simply quoted more surrounding text than the
+// other; disjoint constructs on a shared line are sibling mutants.
+export function overlaps(a, b) {
+  return a.includes(b) || b.includes(a);
+}
+
+// disjoint — both sides named something, and they named different things.
+function disjoint(a, b) {
+  if (a.size === 0 || b.size === 0) return false;
+  for (const x of a) if (b.has(x)) return false;
+  return true;
+}
+
+// sameMutant — whether a kill claim and an equivalence verdict can be about one
+// mutant. Naming a DIFFERENT mutator is positive evidence of different mutants;
+// naming none is no evidence at all, so the pair is still reported.
+export function sameMutant(kill, equiv) {
+  if (!overlaps(kill.construct, equiv.construct)) return false;
+  if (disjoint(kill.mutators, equiv.mutators)) return false;
+  return true;
+}
+
+// scan — every contradiction across the pathspec set.
+export function scan({ root = process.cwd(), pathspecs = ['*_test.go'] } = {}) {
+  const files = lsFiles(pathspecs, { cwd: root });
+  // A scan that matched nothing is not a clean scan, it is no scan — the same
+  // fail-closed rule verify-code-citations.mjs applies to its own pathspec. A
+  // typo in PATHSPECS, or a rename that empties it, would otherwise report a
+  // confident green over zero files.
+  if (files.length === 0) {
+    throw new Error(`no file matched ${JSON.stringify(pathspecs)} — refusing to report a vacuous pass`);
+  }
+
+  const cache = new Map();
+  const load = (rel) => {
+    if (!cache.has(rel)) cache.set(rel, readFileSync(resolve(root, rel), 'utf8').split('\n'));
+    return cache.get(rel);
+  };
+
+  const vocabulary = mutatorVocabulary(root);
+  const kills = [];
+  const equivalents = [];
+  for (const file of files) {
+    const got = collectFile({ root, file, load, vocabulary });
+    kills.push(...got.kills);
+    equivalents.push(...got.equivalents);
+  }
+
+  // One contradiction is one finding, however many equivalence paragraphs
+  // restate the verdict — a footer and the disclaiming test that points at it
+  // both count as verdicts, and reporting the same kill claim twice would read
+  // as two defects.
+  const violations = [];
+  const seen = new Set();
+  for (const k of kills) {
+    for (const e of equivalents) {
+      if (k.cited !== e.cited) continue;
+      if (!sameMutant(k, e)) continue;
+      const key = `${k.where}|${k.cited}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      violations.push(
+        `${k.where}: claims to KILL \`${k.construct}\`, which ${e.where} documents as equivalent ` +
+          `(\`${e.construct}\`). One of the two verdicts is false. Apply the mutation by hand and ` +
+          `run the claimed killer: if it passes, the kill claim is the one to retire; if it fails, ` +
+          `the equivalence note is. If they are genuinely different mutants on one construct, say ` +
+          `which: name the mutator on both sides, or narrow each citation to the operand it is ` +
+          `about.`,
+      );
+    }
+  }
+  return { files: files.length, kills: kills.length, equivalents: equivalents.length, violations };
+}
+
+function main() {
+  const root = process.env.REPO_ROOT || process.cwd();
+  const pathspecs = (process.env.PATHSPECS || '*_test.go').split(/\s+/).filter(Boolean);
+
+  let result;
+  try {
+    result = scan({ root, pathspecs });
+  } catch (err) {
+    error(`forbid-contradicted-mutants: ${err.message}`);
+    process.exit(1);
+  }
+  const { files, kills, equivalents, violations } = result;
+
+  if (violations.length > 0) {
+    for (const v of violations) error(v);
+    error(
+      `forbid-contradicted-mutants: ${violations.length} mutant(s) carry two opposite verdicts. ` +
+        `docs/test-strategy.md § "Surviving-mutant policy" allows exactly one per mutant.`,
+    );
+    process.exit(1);
+  }
+  log(
+    `forbid-contradicted-mutants: ${files} file(s), ${kills} kill claim(s) and ` +
+      `${equivalents} equivalence verdict(s); no mutant carries both.`,
+  );
+  notice(
+    `forbid-contradicted-mutants: ${kills} kill claim(s) and ${equivalents} equivalence ` +
+      `verdict(s) agree across ${files} file(s)`,
+  );
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/.github/scripts/forbid-contradicted-mutants.mjs
+++ b/.github/scripts/forbid-contradicted-mutants.mjs
@@ -52,8 +52,34 @@
 //   mutants a test kills AND an INVERT_LOGICAL mutant a footer proves
 //   equivalent. Two notes naming disjoint mutators describe different mutants.
 //
-// In both cases naming nothing is no evidence rather than a defence: the pair
-// is still reported. Fail closed, not open.
+// A paragraph that names NO mutator is treated as matching ANY of them. That
+// is the fail-closed reading — no evidence is not a defence — and it is worth
+// stating plainly, because it means the discrimination above is only as good
+// as the notes' own precision, and a note that names nothing gets reported.
+//
+// WHICH MUTATOR A NOTE IS ABOUT IS A PROPERTY OF THE NOTE, NOT OF ONE
+// PARAGRAPH. A well-written footer states the rewrite once and then
+// enumerates the sites it applies to:
+//
+//     // The same `||` -> `&&` INVERT_LOGICAL rewrite of … is EQUIVALENT at
+//     // every COMPOSITE recognizer, and ten of the mutants are of that kind:
+//     //
+//     //     histogram_native_scalar_binop.go:expHistogramScalarBinop:`…`
+//     //     …
+//
+// Reading the citation list in isolation says "equivalent, mutator unknown",
+// which then cannot be told apart from a genuine CONDITIONALS_NEGATION kill on
+// the same guard — and that is a real pair in internal/promql, both verdicts
+// true. So a citation paragraph that names no mutator INHERITS its comment
+// run's, and only when the run names exactly one: an ambiguous preamble lends
+// nothing. This widens the evidence, never the verdict — whether a paragraph
+// is a kill claim or an equivalence verdict stays strictly per paragraph, so a
+// disclaimer or a neighbouring note still cannot cast one.
+//
+// Measured over the tree: 10 equivalence paragraphs carry citations without
+// naming a mutator, and all 10 sit under a run naming exactly one, with no run
+// naming more. On the kill side no paragraph qualifies at all, so the rule is
+// symmetric at zero cost rather than a special case for footers.
 //
 // ONE MUTATOR CAN ALSO STRIKE ONE CONSTRUCT TWICE, and the gate deliberately
 // does NOT try to tell those apart from prose. `len(groupAliases)*2+6` carries
@@ -141,26 +167,33 @@ export const EQUIV_VERDICT = /\bNOT KILLABLE\b|\bequivalent\b|\bunkillable\b/i;
 // file" is a disclaimer, and the correct pattern.
 export function footerRegion(lines) {
   const inFooter = new Set();
-  let runStart = null;
-  const close = (end) => {
-    if (runStart === null) return;
-    for (let n = runStart; n <= end; n += 1) {
+  for (const { start, end } of commentRuns(lines)) {
+    for (let n = start; n <= end; n += 1) {
       const body = lines[n - 1].trim().replace(/^\/\/\s?/, '');
       if (!/^NOT KILLABLE\b/.test(body)) continue;
       for (let k = n; k <= end; k += 1) inFooter.add(k);
       break;
     }
-    runStart = null;
-  };
+  }
+  return inFooter;
+}
+
+// commentRuns — the 1-based line bounds of every maximal run of `//` lines,
+// bare separators included. A run is the whole note; `paragraphs()` splits it
+// into the units a single verdict is written in.
+export function commentRuns(lines) {
+  const out = [];
+  let start = null;
   lines.forEach((line, i) => {
     if (line.trim().startsWith('//')) {
-      if (runStart === null) runStart = i + 1;
+      if (start === null) start = i + 1;
       return;
     }
-    close(i);
+    if (start !== null) out.push({ start, end: i });
+    start = null;
   });
-  close(lines.length);
-  return inFooter;
+  if (start !== null) out.push({ start, end: lines.length });
+  return out;
 }
 
 // paragraphs — the 1-based line ranges of every comment PARAGRAPH: a maximal
@@ -184,6 +217,15 @@ export function paragraphs(lines) {
   });
   flush(lines.length);
   return out;
+}
+
+// paragraphText — one comment range as a single line of prose, with the `//`
+// markers stripped, so a sentence that wraps reads as one string.
+export function paragraphText(lines, { start, end }) {
+  return lines
+    .slice(start - 1, end)
+    .map((l) => l.trim().replace(/^\/\/\s?/, ''))
+    .join(' ');
 }
 
 // mutatorVocabulary — the enabled gremlins mutators, as the UPPER_SNAKE names
@@ -265,18 +307,27 @@ function citationsIn({ root, file, lines, range, load }) {
 export function collectFile({ root, file, load, vocabulary }) {
   const lines = readFileSync(resolve(root, file), 'utf8').split('\n');
   const footer = footerRegion(lines);
+  // The mutator vocabulary of each enclosing note, for the inheritance rule
+  // described in the file header. Only an unambiguous run (exactly one
+  // mutator) lends it to a paragraph that names none.
+  const runMutators = commentRuns(lines).map((run) => ({
+    ...run,
+    mutators: namedMutators(paragraphText(lines, run), vocabulary),
+  }));
+  const inherited = (range) => {
+    const run = runMutators.find((r) => range.start >= r.start && range.end <= r.end);
+    return run && run.mutators.size === 1 ? run.mutators : new Set();
+  };
   const kills = [];
   const equivalents = [];
   for (const range of paragraphs(lines)) {
-    const text = lines
-      .slice(range.start - 1, range.end)
-      .map((l) => l.trim().replace(/^\/\/\s?/, ''))
-      .join(' ');
+    const text = paragraphText(lines, range);
     const isKill = KILL_CLAIM.test(text);
     const underFooter = footer.has(range.start);
     const isEquiv = !isKill && (underFooter || EQUIV_VERDICT.test(text));
     if (!isKill && !isEquiv) continue;
-    const mutators = namedMutators(text, vocabulary);
+    const own = namedMutators(text, vocabulary);
+    const mutators = own.size > 0 ? own : inherited(range);
     for (const c of citationsIn({ root, file, lines, range, load })) {
       (isKill ? kills : equivalents).push({ ...c, mutators });
     }

--- a/.github/scripts/forbid-contradicted-mutants.test.mjs
+++ b/.github/scripts/forbid-contradicted-mutants.test.mjs
@@ -536,3 +536,102 @@ test('a footer paragraph that never says "equivalent" is still a verdict', () =>
   const { status, output } = run(f.dir);
   assert.equal(status, 1, output);
 });
+
+test('a citation paragraph inherits the mutator its note states once up front', () => {
+  // The real internal/promql shape: a footer states the rewrite once and then
+  // enumerates the ten sites it applies to. Reading the citation list alone
+  // says "equivalent, mutator unknown", which cannot be told apart from a
+  // genuine CONDITIONALS_NEGATION kill on the same guard — and both verdicts
+  // there are true.
+  const f = fixture();
+  f.write(
+    'kill_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestNegation kills the CONDITIONALS_NEGATION on',
+      '// target.go:`best < 0 || r < best` (`best < 0` -> `best != 0`).',
+      'func TestNegation(t *testing.T) {}',
+      '',
+    ].join('\n'),
+  );
+  f.write(
+    'footer_test.go',
+    [
+      'package fixture',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// The same `||` -> `&&` INVERT_LOGICAL rewrite is EQUIVALENT at every',
+      '// recognizer, and these are of that kind:',
+      '//',
+      '//\ttarget.go:`best < 0 || r < best`',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 0, output);
+});
+
+test('an AMBIGUOUS note lends nothing, so the pair is still reported', () => {
+  // The nearest miss of the case above, and the reason the rule requires the
+  // run to name exactly one mutator. A note discussing two mutators cannot say
+  // which of them its citation list is about, so inheriting either would be a
+  // guess — and a guess that suppresses a real contradiction.
+  const f = fixture();
+  f.write(
+    'kill_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestNegation kills the CONDITIONALS_NEGATION on',
+      '// target.go:`best < 0 || r < best`.',
+      'func TestNegation(t *testing.T) {}',
+      '',
+    ].join('\n'),
+  );
+  f.write(
+    'footer_test.go',
+    [
+      'package fixture',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// Both the INVERT_LOGICAL and the CONDITIONALS_NEGATION rewrites are',
+      '// discussed in this note, which is what makes it ambiguous:',
+      '//',
+      '//\ttarget.go:`best < 0 || r < best`',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /claims to KILL/);
+});
+
+test('inheritance widens the evidence, never the verdict', () => {
+  // A run whose preamble is an equivalence note still may not turn a kill
+  // paragraph inside it into a verdict, or vice versa. Classification is per
+  // paragraph; only the mutator vocabulary is inherited. Here the kill claim
+  // and the verdict sit in ONE run, name the same mutator, and must conflict.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// The ARITHMETIC_BASE rewrite below is equivalent:',
+      '//',
+      '//\ttarget.go:`len(groupAliases)*2+6`',
+      '//',
+      '// TestCapacity kills that same mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /claims to KILL/);
+});

--- a/.github/scripts/forbid-contradicted-mutants.test.mjs
+++ b/.github/scripts/forbid-contradicted-mutants.test.mjs
@@ -1,0 +1,538 @@
+// Suite for forbid-contradicted-mutants.mjs. Every case drives the real CLI
+// over a throwaway git repository, because the gate's scope comes from
+// `git ls-files` and a unit test that bypassed that would not be testing what
+// CI runs.
+//
+// The suite's job is to prove the gate CAN FAIL, one modelled shape at a time —
+// a gate whose first green nobody has seen go red reports something other than
+// what a reader takes it to mean. Each rejection case is paired with its
+// nearest-miss acceptance case, because the two failure modes of this gate pull
+// in opposite directions: too wide and it rejects the legitimate pattern of a
+// killed mutant sitting beside a proven-equivalent sibling on ONE line; too
+// narrow and it accepts the contradiction it exists to catch.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CLI = join(HERE, 'forbid-contradicted-mutants.mjs');
+
+// The cited file every fixture shares. `cap` models the capacity hint of
+// cerberus issue #2958; the `||` line models two independent boundary mutants
+// sharing one line, one killed and one equivalent.
+const TARGET = [
+  'package fixture',
+  '',
+  'func alpha(groupAliases []string) []int {',
+  '\tfrags := make([]int, 0, len(groupAliases)*2+6)',
+  '\treturn frags',
+  '}',
+  '',
+  'func beta(cols []int) int {',
+  '\tbest := -1',
+  '\tfor _, r := range cols {',
+  '\t\tif best < 0 || r < best {',
+  '\t\t\tbest = r',
+  '\t\t}',
+  '\t}',
+  '\treturn best',
+  '}',
+  '',
+].join('\n');
+
+const GREMLINS_YAML = [
+  'silent: false',
+  'mutants:',
+  '  arithmetic-base:',
+  '    enabled: true',
+  '  conditionals-boundary:',
+  '    enabled: true',
+  '  conditionals-negation:',
+  '    enabled: true',
+  '  invert-logical:',
+  '    enabled: true',
+  '',
+].join('\n');
+
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'forbid-contradicted-mutants-'));
+  const git = (args) => {
+    const res = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    assert.equal(res.status, 0, `git ${args.join(' ')} failed: ${res.stderr}`);
+  };
+  git(['init', '--quiet']);
+  writeFileSync(join(dir, 'target.go'), TARGET);
+  // The gate reads its mutator vocabulary from `.gremlins.yaml` rather than a
+  // hard-coded list, so every fixture repo needs one.
+  writeFileSync(join(dir, '.gremlins.yaml'), GREMLINS_YAML);
+  git(['add', 'target.go', '.gremlins.yaml']);
+  git(['-c', 'user.email=a@a', '-c', 'user.name=a', 'commit', '--quiet', '-m', 'seed']);
+  return {
+    dir,
+    write(path, source) {
+      mkdirSync(join(dir, dirname(path)), { recursive: true });
+      writeFileSync(join(dir, path), source);
+    },
+  };
+}
+
+function run(cwd, env = {}) {
+  const result = spawnSync(process.execPath, [CLI], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return { status: result.status, output: `${result.stdout}${result.stderr}` };
+}
+
+const FOOTER_CAP = [
+  '// NOT KILLABLE — documented, not defended by a test.',
+  '//',
+  '// target.go:`len(groupAliases)*2+6` (ARITHMETIC_BASE) is a capacity hint,',
+  '// unobservable from any exported surface.',
+].join('\n');
+
+test('rejects a kill claim on a mutant a NOT KILLABLE footer calls equivalent', () => {
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity kills the ARITHMETIC_BASE mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+      FOOTER_CAP,
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /claims to KILL `len\(groupAliases\)\*2\+6`/);
+  assert.match(output, /1 mutant\(s\) carry two opposite verdicts/);
+});
+
+test('rejects the contradiction across two separate files', () => {
+  const f = fixture();
+  f.write(
+    'kill_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity kills the ARITHMETIC_BASE mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+    ].join('\n'),
+  );
+  f.write('footer_test.go', ['package fixture', '', FOOTER_CAP, ''].join('\n'));
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /kill_test\.go:4: claims to KILL/);
+  assert.match(output, /footer_test\.go:\d+ documents as equivalent/);
+});
+
+test('rejects it when the two verdicts quote the construct at different widths', () => {
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestBoundary kills the boundary flip at target.go:`best < 0`.',
+      'func TestBoundary(t *testing.T) {}',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// target.go:`if best < 0` (CONDITIONALS_BOUNDARY) is equivalent.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /claims to KILL `best < 0`/);
+});
+
+test('accepts a killed mutant beside an equivalent SIBLING on the same line', () => {
+  // The legitimate shape this gate must not break: `best < 0 || r < best`
+  // carries two independent CONDITIONALS_BOUNDARY mutants. One is killed, the
+  // other is proven equivalent. Disjoint constructs on a shared line are
+  // different mutants, not a contradiction.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestBoundary kills the `<` boundary flip on target.go:`best < 0`.',
+      'func TestBoundary(t *testing.T) {}',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// target.go:`r < best` (CONDITIONALS_BOUNDARY) is equivalent because',
+      '// the boundary is unreachable.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 0, output);
+  assert.match(output, /no mutant carries both/);
+});
+
+test('accepts a test that DISCLAIMS the kill and defers to the footer', () => {
+  // The correct remedy-1 pattern: a contract test that pins behaviour while
+  // explicitly not claiming the kill. Its prose names the footer, so a gate
+  // keyed on the phrase rather than on the footer opener would misread it as a
+  // second verdict.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestShape pins the slice contents. It does NOT kill the',
+      '// ARITHMETIC_BASE mutant at target.go:`len(groupAliases)*2+6`; see the',
+      '// NOT KILLABLE note at the foot of this file for why it is equivalent.',
+      'func TestShape(t *testing.T) {}',
+      '',
+      FOOTER_CAP,
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 0, output);
+});
+
+test('accepts a kill claim on a mutant no footer contradicts', () => {
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity kills the ARITHMETIC_BASE mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 0, output);
+  assert.match(output, /1 kill claim\(s\)/);
+});
+
+test('finds a footer that opens a paragraph mid-comment-run', () => {
+  // prewhere_mutation_test.go carries an unrelated note and a NOT KILLABLE
+  // footer in one unbroken `//` run. A gate that only recognised a footer at
+  // the START of a comment block would read this file as having no verdict.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity kills the ARITHMETIC_BASE mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+      '// CI-TIMING NOISE, not a test gap.',
+      '//',
+      '// Some unrelated prose about a flaky run.',
+      '//',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// target.go:`len(groupAliases)*2+6` (ARITHMETIC_BASE) is a capacity hint.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /claims to KILL/);
+});
+
+test('PATHSPECS narrows the scanned set', () => {
+  const f = fixture();
+  f.write(
+    'skipped/adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity kills the ARITHMETIC_BASE mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+      FOOTER_CAP,
+      '',
+    ].join('\n'),
+  );
+  f.write('other/clean_test.go', ['package fixture', '', 'func TestClean(t *testing.T) {}', ''].join('\n'));
+  // In scope by default -> caught. Narrowed to a DIFFERENT, matching pathspec
+  // -> clean. The second pathspec must match something, or the pass would come
+  // from the vacuous-scan guard rather than from the narrowing.
+  assert.equal(run(f.dir).status, 1);
+  assert.equal(run(f.dir, { PATHSPECS: 'other/*_test.go' }).status, 0);
+});
+
+test('fails closed when the pathspec matches no file', () => {
+  // A green over zero files is not evidence. This is the same rule
+  // verify-code-citations.mjs applies to its own scope.
+  const f = fixture();
+  f.write('adjudication_test.go', ['package fixture', '', FOOTER_CAP, ''].join('\n'));
+  const { status, output } = run(f.dir, { PATHSPECS: 'nothing_here/*_test.go' });
+  assert.notEqual(status, 0, output);
+  assert.match(output, /vacuous/);
+});
+
+test('accepts two verdicts on one construct when they name DIFFERENT mutators', () => {
+  // The legitimate shape found while building this gate:
+  // `err != nil && srcErr == nil` carries CONDITIONALS_NEGATION mutants a test
+  // kills AND an INVERT_LOGICAL mutant a footer proves equivalent. One
+  // expression, different mutants, two compatible verdicts.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestNegation kills both CONDITIONALS_NEGATION mutants of',
+      '// target.go:`best < 0 || r < best`.',
+      'func TestNegation(t *testing.T) {}',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// target.go:`best < 0 || r < best` (INVERT_LOGICAL, `||` -> `&&`) is',
+      '// equivalent.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 0, output);
+});
+
+test('still rejects when the two verdicts name the SAME mutator', () => {
+  // The nearest miss of the case above: change only the footer's mutator so the
+  // two sets intersect, and the same fixture must now fail. Without this pair,
+  // the acceptance above could be passing because the gate stopped working.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestNegation kills both CONDITIONALS_NEGATION mutants of',
+      '// target.go:`best < 0 || r < best`.',
+      'func TestNegation(t *testing.T) {}',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// target.go:`best < 0 || r < best` (CONDITIONALS_NEGATION) is',
+      '// equivalent.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /claims to KILL/);
+});
+
+test('reports the pair when only ONE side names a mutator', () => {
+  // Fail closed: naming different mutators is evidence of different mutants,
+  // but naming none is no evidence, so the pair must still surface. This is the
+  // shape the second real false kill had — "the boundary flip", unnamed.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestBoundary kills the boundary flip at target.go:`best < 0`.',
+      'func TestBoundary(t *testing.T) {}',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// target.go:`best < 0` (CONDITIONALS_BOUNDARY) is equivalent.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+});
+
+test('reads a sentence-initial `Kills` claim, not just the canonical header', () => {
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity pins the slice contents.',
+      '//',
+      '// Kills the ARITHMETIC_BASE mutant of',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+      FOOTER_CAP,
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+});
+
+test('does not read a kill-switch or a pod-kill as a claim', () => {
+  // `kill` lowercase and singular appears all over the tree in unrelated prose.
+  // Reading it as a claim would make every such comment a candidate verdict.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestSwitch pins the absolute kill-switch, and models the ch-pod-kill',
+      '// failure. Tests that kill the LIVED mutants live elsewhere.',
+      '// It touches target.go:`len(groupAliases)*2+6` only incidentally.',
+      'func TestSwitch(t *testing.T) {}',
+      '',
+      FOOTER_CAP,
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 0, output);
+});
+
+test('fails closed when the mutator vocabulary cannot be read', () => {
+  // An empty vocabulary would make every named-mutator set empty, and an empty
+  // set names nothing — which would silently WIDEN the gate rather than break
+  // it. That has to be an error, not a default.
+  const f = fixture();
+  f.write('.gremlins.yaml', 'silent: false\n');
+  f.write(
+    'adjudication_test.go',
+    ['package fixture', '', FOOTER_CAP, ''].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.notEqual(status, 0, output);
+  assert.match(output, /mutants:/);
+});
+
+test('reads an equivalence verdict written outside a NOT KILLABLE footer', () => {
+  // Several packages keep a file-header ledger instead of the prescribed
+  // footer ("EQUIVALENCE verdicts (no killing test possible …)", "Genuinely
+  // equivalent"). Reading only the footer opener left ten such verdicts
+  // invisible, one of them a capacity-hint ARITHMETIC_BASE — this gate's own
+  // bug class, in another package.
+  const f = fixture();
+  f.write(
+    'ledger_test.go',
+    [
+      'package fixture',
+      '',
+      '// EQUIVALENCE verdicts (no killing test possible — documented here so',
+      '// the next reader does not re-derive them):',
+      '//',
+      '//   - target.go:`len(groupAliases)*2+6` ARITHMETIC_BASE. The `*2` is a',
+      '//     slice CAPACITY pre-allocation hint. Genuinely equivalent.',
+      '',
+    ].join('\n'),
+  );
+  f.write(
+    'kill_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity kills the ARITHMETIC_BASE mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /ledger_test\.go:\d+ documents as equivalent/);
+});
+
+test('attributes mutators per PARAGRAPH, not per comment run', () => {
+  // A footer routinely adjudicates several mutants in one unbroken `//` run.
+  // Collecting the run's whole vocabulary and stamping it on every citation
+  // would let an unrelated neighbouring paragraph lend its mutator name to
+  // this one, and the different-mutators defence would stop discriminating.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestNegation kills both CONDITIONALS_NEGATION mutants of',
+      '// target.go:`best < 0 || r < best`.',
+      'func TestNegation(t *testing.T) {}',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// target.go:`best < 0 || r < best` (INVERT_LOGICAL) is equivalent.',
+      '//',
+      '// Separately, an unrelated CONDITIONALS_NEGATION elsewhere in the file',
+      '// is also equivalent, for reasons of its own.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 0, output);
+});
+
+test('reports one contradiction once, however many verdicts restate it', () => {
+  // A footer and the disclaiming test that points at it are both verdicts.
+  // Reporting the same kill claim against each would read as two defects.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity kills the ARITHMETIC_BASE mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+      '// TestShape pins the contents. The mutant at',
+      '// target.go:`len(groupAliases)*2+6` is equivalent; see the footer.',
+      'func TestShape(t *testing.T) {}',
+      '',
+      FOOTER_CAP,
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+  assert.match(output, /1 mutant\(s\) carry two opposite verdicts/);
+});
+
+test('a footer paragraph that never says "equivalent" is still a verdict', () => {
+  // The real exemplars footer argues one mutant is byte-identical without ever
+  // writing the word. Requiring the word inside every footer paragraph would
+  // have lost half of what this gate was built to catch.
+  const f = fixture();
+  f.write(
+    'adjudication_test.go',
+    [
+      'package fixture',
+      '',
+      '// TestCapacity kills the ARITHMETIC_BASE mutant at',
+      '// target.go:`len(groupAliases)*2+6`.',
+      'func TestCapacity(t *testing.T) {}',
+      '',
+      '// NOT KILLABLE — documented, not defended by a test.',
+      '//',
+      '// target.go:`len(groupAliases)*2+6` (ARITHMETIC_BASE) produces a',
+      '// byte-identical statement; only two dead allocations differ.',
+      '',
+    ].join('\n'),
+  );
+  const { status, output } = run(f.dir);
+  assert.equal(status, 1, output);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1140,6 +1140,28 @@ jobs:
       - name: Reject source citations that name a line instead of a construct
         run: node .github/scripts/verify-code-citations.mjs
 
+      # #2958: a mutant gets ONE verdict. `docs/test-strategy.md` §
+      # "Surviving-mutant policy" offers a surviving mutant two remedies —
+      # prove it equivalent and document it, or add a genuinely distinguishing
+      # test — and they are opposite conclusions about the same thing. Two
+      # mutants on `main` carried both, and the mutation lane recorded each of
+      # them LIVED while a `kills` header claimed otherwise; one conceded in
+      # its own prose that it existed to "give gremlins a path", the other was
+      # simply confidently wrong. A prose gate finds the first and misses the
+      # second, so the signature this gate uses is structural: the same cited
+      # construct carrying two verdicts, adjudicated per comment PARAGRAPH and
+      # discriminated by the mutator each side names. It runs after the
+      # citation gate, which owns every "this citation does not resolve"
+      # failure. The suite runs first: it is what proves the gate can go red,
+      # and it pins the shapes that must stay green — sibling mutants on one
+      # line, one construct carrying different mutators — each beside the
+      # one-token variant that must fail.
+      - name: Assert the contradicted-mutant gate fires and spares its controls
+        run: node --test .github/scripts/forbid-contradicted-mutants.test.mjs
+
+      - name: Reject a mutant adjudicated both killed and equivalent
+        run: node .github/scripts/forbid-contradicted-mutants.mjs
+
       # #1568: GitHub's server-side merge does NOT honour the `-merge`
       # .gitattributes driver (verified empirically — see the script's own
       # doc comment for the experiment). Most `-merge`-marked generated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1150,7 +1150,8 @@ jobs:
       # simply confidently wrong. A prose gate finds the first and misses the
       # second, so the signature this gate uses is structural: the same cited
       # construct carrying two verdicts, adjudicated per comment PARAGRAPH and
-      # discriminated by the mutator each side names. It runs after the
+      # discriminated by the mutator each side names — inherited from the note
+      # when a citation list sits under a preamble that names exactly one. It runs after the
       # citation gate, which owns every "this citation does not resolve"
       # failure. The suite runs first: it is what proves the gate can go red,
       # and it pins the shapes that must stay green — sibling mutants on one

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1356,6 +1356,15 @@ that names none cannot claim that defence. Both habits make the note
 more useful to the next reader, which is why the gate asks for them
 rather than for an exemption.
 
+Naming the mutator once per note is enough. A footer that states the
+rewrite in its opening paragraph and then enumerates the sites it
+applies to — as `internal/promql`'s `||` -> `&&` INVERT_LOGICAL ledger
+does across ten citations — is the clearer way to write it, and the gate
+reads the preamble's mutator for the citations it introduces. That
+inheritance needs the note to be unambiguous: a preamble discussing two
+mutators lends neither, because it cannot say which one the list is
+about.
+
 A mutator can also strike one construct twice — `*2` and `+6` in
 `len(groupAliases)*2+6` — and there the gate reports the pair even
 though both verdicts are true. Narrowing both citations to the operand

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1321,6 +1321,47 @@ suite carry the discipline:
    distinguishable.** This is pattern #11 (DEFEAT-MUTANT) — the
    codebase loses clarity to satisfy the mutation tool. Don't do it.
 
+Remedies 1 and 2 are opposite verdicts on one mutant, so recording both
+means one of them is false — and it is almost always the kill, because a
+`// TestX kills …` header costs nothing to write. Two mutants on `main`
+carried both, in one file, and the lane recorded each of them LIVED
+while a header claimed the kill: `exemplars.go`'s Attributes-map
+capacity hint, whose "kill" conceded in its own prose that it gave the
+tool "a path to call it dead anyway", and `exemplars.go`'s
+`maxPerSeries` guard, whose "kill" asserted the mutated form would emit
+`LIMIT 0 BY ...` when `Limit(0)` in fact leaves the statement
+byte-identical. The second is why grepping for hedged prose is not the
+answer: it was confidently worded and simply wrong. The required
+`forbid-skip` job therefore runs
+`.github/scripts/forbid-contradicted-mutants.mjs`, which resolves the
+construct each verdict cites and fails when one construct carries both
+(cerberus issue #2958). A false kill is worth retiring on its own
+terms: it never earned the leg an efficacy point, because the mutant it
+named was already counted as LIVED.
+
+One construct is not one mutant, so two verdicts on one construct are
+not automatically a contradiction. `prewhere.go`'s
+`best < 0 || r < best` hosts one CONDITIONALS_BOUNDARY per operand, one
+killed and one proven equivalent; and `builder.go`'s
+`err != nil && srcErr == nil` carries CONDITIONALS_NEGATION mutants a
+test kills alongside an INVERT_LOGICAL mutant a footer proves
+equivalent. Both pairings are legitimate.
+
+Keeping them legible costs two habits. **Cite the operand, not the
+expression** — a citation spanning both halves of a `||` adjudicates
+neither, and narrowing it is what lets the two notes stand side by side.
+**Name the mutator** when a construct carries more than one: two notes
+naming disjoint mutators are describing different mutants, and a note
+that names none cannot claim that defence. Both habits make the note
+more useful to the next reader, which is why the gate asks for them
+rather than for an exemption.
+
+A mutator can also strike one construct twice — `*2` and `+6` in
+`len(groupAliases)*2+6` — and there the gate reports the pair even
+though both verdicts are true. Narrowing both citations to the operand
+each is about is the remedy; it is the same habit as the first, and the
+note ends up saying something definite instead of something ambiguous.
+
 Prior PRs #504 and #664 carry pattern-#3 refactors. They are not
 reverted (their diffs are now load-bearing for the published
 thresholds), but new violations should follow remedy #1 or #2.

--- a/internal/chsql/exemplars_misc_mutation_test.go
+++ b/internal/chsql/exemplars_misc_mutation_test.go
@@ -61,6 +61,36 @@ func TestExemplarsMaxPerSeriesZeroNoLimit(t *testing.T) {
 	if !strings.Contains(sqlCapped, "LIMIT 3 BY") {
 		t.Errorf("maxPerSeries==3 must emit `LIMIT 3 BY`:\n%s", sqlCapped)
 	}
+
+	// The UNGROUPED shape takes the same branch with an empty alias list, so
+	// the LIMIT BY key list collapses to the anchor alone. The emitter appends
+	// it unconditionally —
+	// exemplars.go:`limitByFrags = append(limitByFrags, Col("anchor_ts"))` —
+	// which is what keeps `LIMIT n BY` from rendering an empty key list, which
+	// ClickHouse rejects. The grouped case above cannot show that, because its
+	// aliases would carry the clause on their own.
+	mUngrouped := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		ValueAlias: "Value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	rwUngrouped := &chplan.RangeWindow{
+		Input:           mUngrouped,
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "Timestamp",
+	}
+	sqlUngrouped, _, err := chsql.EmitMetricsExemplars(
+		context.Background(), rwUngrouped, mUngrouped, "TraceId", "SpanId", 2, "",
+	)
+	if err != nil {
+		t.Fatalf("EmitMetricsExemplars ungrouped: %v", err)
+	}
+	if !strings.Contains(sqlUngrouped, "LIMIT 2 BY `anchor_ts`") {
+		t.Errorf("an ungrouped cap must emit `LIMIT 2 BY `anchor_ts``:\n%s", sqlUngrouped)
+	}
 }
 
 // TestRangeBucketFanoutEmptyGroupBy kills the ARITHMETIC_BASE mutant at
@@ -244,6 +274,68 @@ func TestExemplarsRateAndCountIgnoreAttr(t *testing.T) {
 	})
 }
 
+// TestExemplarsAttributesMapKeyShape pins the key layout of the
+// exemplar Attributes map that attachExemplars depends on: one
+// `toString(<alias>)` value per group key, keyed by the Tempo-canonical
+// display name, plus the `trace:id` / `span:id` pair. Those four keys
+// are what internal/api/tempo/metrics_query_range.go reads back off
+// chclient.Sample.Attributes, so the emitter is the only place the
+// contract can be pinned against real emitted SQL and real bound args.
+//
+// It does NOT kill the ARITHMETIC_BASE mutant on
+// exemplars.go:`len(groupAliases)*2+6`, and does not try to: that
+// operand is a capacity hint, and the map this test inspects is
+// byte-identical under every capacity. See the NOT KILLABLE note at the
+// foot of this file. The contract is worth pinning on its own merits —
+// a dropped display-name key silently unmatches every exemplar from its
+// parent series.
+func TestExemplarsAttributesMapKeyShape(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 13, 12, 1, 0, 0, time.UTC)
+	m := &chplan.MetricsAggregate{
+		Op: chplan.MetricsOpRate,
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: "ServiceName"},
+			&chplan.ColumnRef{Name: "SpanName"},
+		},
+		GroupByAliases:      []string{"svc", "span"},
+		GroupByDisplayNames: []string{"service", "span"},
+		ValueAlias:          "Value",
+		Inner:               &chplan.Scan{Table: "otel_traces"},
+	}
+	rw := &chplan.RangeWindow{
+		Input: m, Step: time.Minute, Range: time.Minute,
+		Start: start, End: end, TimestampColumn: "Timestamp",
+	}
+	sql, args, err := chsql.EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1, "")
+	if err != nil {
+		t.Fatalf("EmitMetricsExemplars: %v", err)
+	}
+	// Every map KEY rides as a bound arg (the keys render as `?`
+	// placeholders), so both display names and both id keys must appear.
+	for _, want := range []string{"service", "span", "trace:id", "span:id"} {
+		found := false
+		for _, a := range args {
+			if s, ok := a.(string); ok && s == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected map key %q in bound args; got %v", want, args)
+		}
+	}
+	// And the VALUE side renders toString(<alias>) for each group key.
+	if !strings.Contains(sql, "toString(`svc`)") {
+		t.Errorf("expected toString(svc) as the `service` map value:\n%s", sql)
+	}
+	if !strings.Contains(sql, "toString(`span`)") {
+		t.Errorf("expected toString(span) as the `span` map value:\n%s", sql)
+	}
+}
+
 // NOT KILLABLE — documented, not defended by a test.
 //
 // exemplars.go:`if maxPerSeries > 0` (CONDITIONALS_BOUNDARY, `>` -> `>=`).
@@ -262,3 +354,29 @@ func TestExemplarsRateAndCountIgnoreAttr(t *testing.T) {
 // demand; `len/2 + 6` is non-negative for every input, so it cannot even
 // panic the way the sibling `+6` -> `-6` mutant does. Capacity is
 // unobservable from the emitted SQL, the args, or any exported surface.
+//
+// Two independent confirmations, because a bare "capacity is
+// unobservable" reads like an assumption (cerberus issue #2958):
+//
+//   - EMPIRICAL. With `*2` flipped to `/2` by hand, the whole
+//     internal/chsql package passes. With the sibling `+6` flipped to
+//     `-6`, TestEmitMetricsExemplars_PlainWindowedInnerAccepted panics
+//     with "makeslice: cap out of range". The two mutants on one
+//     expression land on opposite verdicts, which is exactly what the
+//     capacity/length distinction predicts.
+//
+//   - STRUCTURAL, and the stronger of the two. `cap` IS readable from
+//     inside this package, so "equivalent" would not follow from
+//     "invisible in the SQL" alone if the slice escaped. It does not:
+//     attrMapFrags leaves emitMetricsExemplars only through the
+//     `Call("map", attrMapFrags...)` at the end of the Attributes
+//     projection — named in prose, not cited, because a footer that
+//     cites a construct it is NOT adjudicating registers a verdict on
+//     it. Call closes over its variadic slice in a returned
+//     `func(*Builder)`. Go exposes
+//     no way to read a captured variable out of a func value, so no
+//     test in any package — internal or external — can observe this
+//     capacity. The mutant is unkillable, not merely unkilled.
+//
+// TestExemplarsAttributesMapKeyShape above pins the map's key layout and
+// is deliberately NOT presented as a kill for this mutant.

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -46,8 +46,11 @@ func TestSortRankFor_ContinueVsBreak(t *testing.T) {
 }
 
 // TestSortRankFor_BestNegativeBoundary kills the `<` ↔ `<=` boundary
-// flip on `best < 0` in prewhere.go:`best < 0 || r < best`. With the
-// mutant `best <= 0`
+// flip on prewhere.go:`best < 0`. The citation names that operand alone:
+// the `||` it sits in hosts a SECOND, independent CONDITIONALS_BOUNDARY on
+// `r < best` that prewhere_mutation_test.go's NOT KILLABLE footer proves
+// equivalent, and a citation covering both would adjudicate two mutants at
+// once. With the mutant `best <= 0`
 // the loop overwrites the rank-0 best when it sees any larger rank,
 // returning the wrong (later) sort column.
 func TestSortRankFor_BestNegativeBoundary(t *testing.T) {
@@ -60,11 +63,16 @@ func TestSortRankFor_BestNegativeBoundary(t *testing.T) {
 	}
 }
 
-// TestOrderedConjuncts_StableSortLogicalOr kills the flips of the
-// insertion-sort swap condition
+// TestOrderedConjuncts_StableSortLogicalOr kills the CONDITIONALS_BOUNDARY
+// and CONDITIONALS_NEGATION flips of the insertion-sort swap condition
 // prewhere.go:`prefix[j-1].rank > prefix[j].rank`. When the rank
 // comparison holds the original swaps the pair; a flipped comparison
 // never swaps, so an out-of-order pair is left in input order.
+//
+// The mutators are named because that line also hosts the INVERT_LOOPCTRL
+// mutant of the `break` below it, which prewhere_mutation_test.go's
+// NOT KILLABLE footer proves equivalent. Naming both sides is what keeps the
+// two verdicts on one line legible as the different mutants they are.
 func TestOrderedConjuncts_StableSortLogicalOr(t *testing.T) {
 	t.Parallel()
 	shape := TableShape{SortColumns: []string{"ServiceName", "Timestamp"}}
@@ -661,56 +669,6 @@ func TestEmitMetricsExemplars_ValueExprOpEquality(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestEmitMetricsExemplars_MaxPerSeriesBoundary kills the boundary
-// flip at exemplars.go:`maxPerSeries > 0`. maxPerSeries=0 must
-// disable LIMIT BY; the mutant `>= 0` would emit `LIMIT 0 BY ...`.
-func TestEmitMetricsExemplars_MaxPerSeriesBoundary(t *testing.T) {
-	t.Parallel()
-
-	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
-	end := time.Date(2026, 5, 13, 12, 1, 0, 0, time.UTC)
-	m := &chplan.MetricsAggregate{
-		Op:         chplan.MetricsOpRate,
-		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
-	}
-	rw := &chplan.RangeWindow{
-		Input: m, Step: time.Minute, Range: time.Minute,
-		Start: start, End: end, TimestampColumn: "Timestamp",
-	}
-
-	t.Run("maxPerSeries=0 → no LIMIT BY", func(t *testing.T) {
-		t.Parallel()
-		sql, _, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 0, "")
-		if err != nil {
-			t.Fatalf("Emit: %v", err)
-		}
-		if strings.Contains(sql, "LIMIT") && strings.Contains(sql, " BY ") {
-			t.Errorf("expected no LIMIT BY for maxPerSeries=0.\nSQL: %s", sql)
-		}
-	})
-	t.Run("maxPerSeries=1 → LIMIT 1 BY ...", func(t *testing.T) {
-		t.Parallel()
-		sql, _, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1, "")
-		if err != nil {
-			t.Fatalf("Emit: %v", err)
-		}
-		if !strings.Contains(sql, "LIMIT 1") {
-			t.Errorf("expected LIMIT 1 in SQL.\nSQL: %s", sql)
-		}
-	})
-	t.Run("maxPerSeries=5 → LIMIT 5 BY ...", func(t *testing.T) {
-		t.Parallel()
-		sql, _, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 5, "")
-		if err != nil {
-			t.Fatalf("Emit: %v", err)
-		}
-		if !strings.Contains(sql, "LIMIT 5") {
-			t.Errorf("expected LIMIT 5 in SQL.\nSQL: %s", sql)
-		}
-	})
 }
 
 // TestEmitMetricsAggregate_GroupByBoundary kills the boundary and
@@ -1863,67 +1821,6 @@ func TestEmitMetricsExemplars_ArithmeticBoundary118(t *testing.T) {
 	// Defensive: neither `least(5, ...)` nor an absurdly large literal.
 	if strings.Contains(sql, "least(5, intDiv(dateDiff('nanosecond'") {
 		t.Errorf("got least(5, ...) — `+ 1` may have flipped to `- 1`. SQL=%s", sql)
-	}
-}
-
-// TestEmitMetricsExemplars_AttributesMapCapacity185 kills the
-// ARITHMETIC_BASE mutant at exemplars.go:`len(groupAliases)*2+6`.
-// That value sizes the attrMapFrags slice; the slice still grows
-// implicitly under append, so the capacity expression is observation-
-// equivalent to the original at the SQL surface — the eventual map(...)
-// call lays out the same key/value pairs regardless. Pinning the exit
-// map shape forces the test to fail if the slice capacity arithmetic
-// regression somehow truncated content (which we don't expect, but
-// the assertion still raises the bar for the mutant).
-//
-// To make this test materially distinguish original vs mutant, we
-// project two group-by labels and check both keys appear; if a slice-
-// truncation bug ever sneaked in, this would catch it. (The mutant
-// is plausibly equivalent in practice; the test gives gremlins a path
-// to call it dead anyway.)
-func TestEmitMetricsExemplars_AttributesMapCapacity185(t *testing.T) {
-	t.Parallel()
-	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
-	end := time.Date(2026, 5, 13, 12, 1, 0, 0, time.UTC)
-	m := &chplan.MetricsAggregate{
-		Op: chplan.MetricsOpRate,
-		GroupBy: []chplan.Expr{
-			&chplan.ColumnRef{Name: "ServiceName"},
-			&chplan.ColumnRef{Name: "SpanName"},
-		},
-		GroupByAliases:      []string{"svc", "span"},
-		GroupByDisplayNames: []string{"service", "span"},
-		ValueAlias:          "Value",
-		Inner:               &chplan.Scan{Table: "otel_traces"},
-	}
-	rw := &chplan.RangeWindow{
-		Input: m, Step: time.Minute, Range: time.Minute,
-		Start: start, End: end, TimestampColumn: "Timestamp",
-	}
-	sql, args, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1, "")
-	if err != nil {
-		t.Fatalf("Emit: %v", err)
-	}
-	// Both display names must show up as bound args.
-	wantLabels := []string{"service", "span", "trace:id", "span:id"}
-	for _, want := range wantLabels {
-		found := false
-		for _, a := range args {
-			if s, ok := a.(string); ok && s == want {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("expected %q in bound args; got %v", want, args)
-		}
-	}
-	// And toString(<alias>) renders for each group key.
-	if !strings.Contains(sql, "toString(`svc`)") {
-		t.Errorf("expected toString(svc), SQL=%s", sql)
-	}
-	if !strings.Contains(sql, "toString(`span`)") {
-		t.Errorf("expected toString(span), SQL=%s", sql)
 	}
 }
 

--- a/internal/chsql/prewhere_mutation_test.go
+++ b/internal/chsql/prewhere_mutation_test.go
@@ -106,14 +106,17 @@ func TestOrderedConjunctsSingleFastPath(t *testing.T) {
 	}
 }
 
-// TestSortRankForMinimum defends sortRankFor's running-minimum update
-// (prewhere.go:`best < 0 || r < best`). It pins that sortRankFor returns the LOWEST matching
+// TestSortRankForMinimum defends sortRankFor's running-minimum update at
+// prewhere.go:`best < 0`. It pins that sortRankFor returns the LOWEST matching
 // rank across a predicate's columns regardless of the order the columns are
 // discovered — i.e. a later, larger rank never overwrites an earlier rank-0
-// (and would catch a `best < 0`→`best <= 0` flip, which lets a larger rank
-// clobber an existing rank-0 minimum). The `r < best`→`r <= best` boundary in
-// that same condition is a separate, genuinely equivalent mutation — see this
-// file's own "NOT KILLABLE" footer below for why.
+// (and would catch the CONDITIONALS_BOUNDARY flip to `best <= 0`, which lets a
+// larger rank clobber an existing rank-0 minimum).
+//
+// The citation names that operand alone. The `||` it sits in carries a SECOND,
+// independent CONDITIONALS_BOUNDARY on the other operand, which this file's
+// own "NOT KILLABLE" footer proves equivalent; a citation spanning both would
+// adjudicate two mutants at once and say nothing definite about either.
 func TestSortRankForMinimum(t *testing.T) {
 	t.Parallel()
 	shape := TableShape{SortColumns: []string{"ServiceName", "SeverityText", "Timestamp"}} // ranks 0,1,2
@@ -191,10 +194,18 @@ func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 //
 // NOT KILLABLE — documented, not defended by a test.
 //
-// The INVERT_LOOPCTRL mutants of the three terminal `break`s —
-// prewhere.go:`touchesWide = true`, prewhere.go:`hitsSkip = true` and the
-// stable-insertion-sort early exit at
-// prewhere.go:`if prefix[j-1].rank > prefix[j].rank` — each swap that `break`
+// The INVERT_LOOPCTRL mutants of the three terminal `break`s in prewhere.go.
+// The first is prewhere.go:classifyPredicate:`break`, guarding the
+// `touchesWide` latch. The other two both sit in orderedConjuncts — the
+// `hitsSkip` latch and the stable-insertion-sort early exit — and are named
+// in prose rather than cited, because the mutated token is a bare `break` and
+// that func contains two of them, so no construct citation can distinguish
+// one from the other. Citing an enclosing line instead would be worse than
+// leaving them uncited: `if prefix[j-1].rank > prefix[j].rank` carries the
+// sort's own comparison mutants, which
+// TestOrderedConjuncts_StableSortLogicalOr kills, so a note about the
+// `break` that cited it would read as adjudicating a mutant it says nothing
+// about. Each mutant swaps its `break`
 // for a `continue`, guarding a "found it, stop" boolean latch (touchesWide /
 // hitsSkip) or the sort's early exit. In
 // every case the flag is set exactly once and never reset, or (for the
@@ -212,7 +223,7 @@ func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 // the branch this condition guards can only ever produce the SAME final
 // (columnOK, literalOK) pair whether or not the swap runs.
 //
-// prewhere.go:`best < 0 || r < best` (CONDITIONALS_BOUNDARY, `r < best` →
+// prewhere.go:`r < best` (CONDITIONALS_BOUNDARY, `r < best` →
 // `r <= best` in
 // sortRankFor's running-minimum update) is equivalent because the boundary
 // (`r == best`) is unreachable for two DISTINCT columns under any


### PR DESCRIPTION
Two files adjudicated the same `internal/chsql/exemplars.go` mutant in opposite directions.
The decisive experiment settles it in favour of the `NOT KILLABLE` footer — and then the same
experiment, run mechanically, found a second false kill in the same file that no amount of
reading would have caught.

## Part 1 — the experiment, and which adjudication survived

**The footer was right.** Hand-applying the ARITHMETIC_BASE mutation to
exemplars.go:`len(groupAliases)*2+6` (`*2` → `/2`) leaves the claimed killer passing and the
**whole `internal/chsql` package** passing. CI's own gremlins report agrees: `phase2-compare`
records that mutant `LIVED` — at column 51, the `*` — with
`TestEmitMetricsExemplars_AttributesMapCapacity185` present in the tree at that commit. The
sibling at column 53 (the `+6` → `-6` flip) is recorded `KILLED`, and reproduces as a
`makeslice: cap out of range` panic. Two mutants on one expression, opposite verdicts,
exactly as the capacity/length distinction predicts.

So the "kill" was the one to retire, and it said so itself: *"The mutant is plausibly
equivalent in practice; the test gives gremlins a path to call it dead anyway."*

**Capacity does not leak through any surface** — the question the issue asked me to answer
precisely. `cap` IS readable from inside the package, so "invisible in the emitted SQL" would
not by itself imply equivalence. What does imply it is that the slice never escapes:
`attrMapFrags` leaves `emitMetricsExemplars` only through
exemplars.go:`Call("map", attrMapFrags...)`, and `Call` closes over its variadic slice inside
a returned `func(*Builder)`. Go exposes no way to read a captured variable out of a func
value, so no test in any package — internal or external — can observe this capacity. The
mutant is **unkillable**, not merely unkilled. Both confirmations are now written into the
footer, which previously asserted the conclusion without either.

The retired test's assertions pinned something real: the exemplar `Attributes` map key
layout (`toString(<alias>)` per group key under its Tempo-canonical display name, plus
`trace:id` / `span:id`), which `attachExemplars` matches series by, and which nothing else
pins at the chsql layer. They move to `TestExemplarsAttributesMapKeyShape` in
`exemplars_misc_mutation_test.go` — in the **external** `chsql_test` package, which makes the
point sharper: the map contents are observable from outside the package and the capacity is
not. It claims no kill and says why it cannot. It is verified non-vacuous (perturbing the
display-name projection fails it).

## A second false kill, in the same file

`TestEmitMetricsExemplars_MaxPerSeriesBoundary` claimed to kill the CONDITIONALS_BOUNDARY on
exemplars.go:`if maxPerSeries > 0`, asserting the `>= 0` mutant *"would emit `LIMIT 0 BY
...`"*. It does not. `Limit(0)` records `hasLimit = n > 0`, so the renderer emits no LIMIT
tail at all and the mutant is byte-identical — precisely what the footer already said. The
package passes under the mutation, and `phase2-compare` records that mutant `LIVED` too.

This one conceded nothing. Its prose was confident and simply wrong. It is removed;
`TestExemplarsMaxPerSeriesZeroNoLimit` already pins that contract honestly, and pins it
slightly harder: its positive counter-case asserts the full `LIMIT 3 BY`, where the removed
test asserted only the `LIMIT n` prefix.

The removed test did exercise one shape the survivor did not — an **ungrouped** plan, where
the LIMIT BY key list collapses to the anchor alone — so rather than argue about whether that
mattered, it is now asserted outright, and harder than before: `LIMIT 2 BY \`anchor_ts\``,
pinning the unconditional anchor append that keeps the clause from rendering an empty key
list. Verified non-vacuous by perturbing that append.

## Part 2 — the sweep, and why the gate is structural rather than textual

I swept all **91** mutation-adjudication files and read all **398** kill-claiming doc
comments. **Zero** other prose concessions. Every hedging phrase in the original — "gives
gremlins", "path to call it dead", "raises the bar", "materially distinguish", "which we
don't expect" — occurs **exactly once in the tree**, in that one comment. Five candidates my
greps flagged all resolved as legitimate on inspection (`internal/logql/range_aggregation_test.go`,
`internal/chsql/range_window_matrix_delta_prefix_guard_test.go`, `internal/logql/binary_test.go`,
`internal/logql/vector_aggregation_mutation_test.go`, `internal/chsql/prewhere_mutation_test.go` —
each either disclaims the kill and defers to a footer, or genuinely kills by forcing
`make([]T, 0, -1)` to panic).

A phrasing gate would therefore have caught the first false kill and **missed the second**,
while firing on the ~20 legitimate remedy-1 notes that also say "equivalent". That is the
false-positive machine, and I did not build it.

The signature that works is structural: **one mutant carrying two opposite verdicts.**
`.github/scripts/forbid-contradicted-mutants.mjs` reads every `// TestX kills …` header and
every `NOT KILLABLE` footer, resolves the construct each cites through
`verify-code-citations.mjs`'s own resolver (imported, not reimplemented), and fails when one
construct carries both. Fail-closed, no allow-list, no tolerance file. It found the second
false kill; reading did not.

**One construct is not one mutant**, and an adversarial review pass plus the gate flagging its
own legitimate pairs drove four refinements:

- **The unit is a comment PARAGRAPH, not a block.** One footer in this tree names three
  mutators across nine citations; attributing a whole `//` run's vocabulary to every citation
  in it smeared the evidence and defeated the discrimination below exactly where notes are
  densest.
- **By position.** prewhere.go:`best < 0 || r < best` hosts an independent
  CONDITIONALS_BOUNDARY per operand, one killed and one proven equivalent. Verdicts conflict
  only when their constructs **overlap by containment**. Three citations covering the whole
  `||` are narrowed here so each names one operand.
- **By mutator.** builder.go:`err != nil && srcErr == nil` carries CONDITIONALS_NEGATION
  mutants that `TestMutation_LabelReplaceSegment_SrcErrorPropagates` kills *and* an
  INVERT_LOGICAL mutant the same file's footer proves equivalent — one expression, three
  mutants, two compatible verdicts. Two notes naming **disjoint mutators** describe different
  mutants. Naming none is no evidence, so that pair is still reported: fail closed, not open.
- **The equivalence side reads more than the prescribed footer.** Several packages keep a
  file-header ledger instead (`EQUIVALENCE verdicts (no killing test possible …)`, "Genuinely
  equivalent"). Reading only `NOT KILLABLE` left **ten** verdicts invisible — including
  `internal/logql/range_aggregation_mutation_test.go`'s ARITHMETIC_BASE on a
  `len(e.Grouping.Groups)*2` **capacity hint**: this PR's own bug class, in another package.
  A footer paragraph still counts as a verdict even when it never writes the word, because
  the real exemplars footer argues byte-identity without it.

**One thing is deliberately *not* discriminated.** A single mutator can strike one construct
twice — `*2` and `+6` in `len(groupAliases)*2+6`. Keying on the spelled `` `X` -> `Y` ``
rewrite was implemented, then **removed**: two notes about the same mutant routinely spell it
differently (one writes `` `*2` -> `/2` ``, the other quotes the whole `make(...)` line), so
the rule bought a narrow false-positive fix at the price of silently *missing* real
contradictions — the one failure this gate must not have. Such a pair is reported, and the
remedy is the narrowing the position rule already asks for.

The kill-claim reader covers the three shapes the tree uses (`// TestX kills …`, a
sentence-initial `Kills …`, `killed by TestX`). Counted in the gate's own unit, the tree has
269 kill-claim paragraphs; the canonical header alone reads 224 of them, so the widened form
adds 45. `Kills` requires the capital and the
plural, which keeps `kill-switch`, `ch-pod-kill` and "tests that kill the LIVED mutants" out.
Vocabulary comes from `.gremlins.yaml`, not a hard-coded list; an empty vocabulary, an empty
scan, and an unreadable file are all hard errors, since each would silently *widen* the gate.

### Proof it can go red

Restoring the two real removed blocks makes the gate fail on exactly those two, by name —
re-verified after every refinement above. The `node --test` suite has **19** cases pairing
every rejection with its nearest-miss acceptance: the sibling-mutants-on-one-line and
different-mutators shapes that must stay green, each beside the one-token variant that must
fail; a footer paragraph that never says "equivalent" and must still count; a ledger outside
any footer that must count; per-paragraph attribution; the disclaiming test that defers to a
footer; a `kill-switch` that is not a claim; and the empty vocabulary and empty scan that must
both be errors.

I also verified the gate **resolves** rather than hides the third contradiction the review
raised. On `origin/main` the prewhere footer cited `if prefix[j-1].rank > prefix[j].rank` for a
mutant that actually lives on the `break` below it, colliding with
`TestOrderedConjuncts_StableSortLogicalOr`. Rather than drop the citation, the kill side now
names CONDITIONALS_BOUNDARY / CONDITIONALS_NEGATION: restoring the old colliding citation
leaves the gate **green**, because the mutators discriminate. The footer's claim that a bare
`break` is not uniquely citable was also wrong — `prewhere.go:classifyPredicate:`break``
resolves to exactly one line, and is now cited; only the two `break`s inside `orderedConjuncts`
are genuinely ambiguous, and the note now says exactly that.

## Efficacy arithmetic

`internal/chsql` is split four ways; `exemplars.go` belongs to **`phase2-compare`**
(`include_files` allowlist in `.github/scripts/mutation-phases.mjs`). Floor is 95%
(`const EFFICACY = 95`, with `MUTATION_MIN_EFFICACY = 95` in `mutation-matrix.mjs` as the
floor no entry may go below). Latest run on `main` (33669826536): **275 killed / 3 lived /
278 attempted = 98.92%**, by `gremlins-threshold.mjs`'s `attemptedEfficacy` (`NOT_COVERED` is
outside both sides of the ratio).

**Retiring both fake kills costs zero efficacy points.** Both mutants were *already* recorded
`LIVED` with the claiming tests present, so the leg was never being paid for them. The
efficacy stays 98.92%. No threshold was lowered, no denominator shrunk, no file excluded —
and none was needed. The issue's premise that a documented equivalent is a permanent cost
holds; what did not hold is that these tests were ever offsetting it.

## Filed

- #2966 — `test: kill claims citing a construct that hosts no mutant`. The other half of this
  class, which this gate does not reach: two verified kill claims in
  `internal/chsql/gremlins_kill_test.go` cite `internal/chsql/emit_node.go`'s
  `make([]Frag, 0, len(s.Columns))` and `make([]Frag, 0, len(scan.Columns))` as hosting
  "boundary mutants", when neither line carries a comparison, an arithmetic operator, or a
  loop-control token — the source comment above the first says *"No length guard is needed"*.
  15 further candidates need individual adjudication before any gate is written. Filed under
  epic #2891, milestone M1.

Closes #2958
