### PR TITLE
test(mutation): make every kill claim name the mutant it actually kills

### DIFF
--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1419,6 +1419,59 @@ other than a digit or a construct carries no address and is left alone,
 which is what keeps `test/rejection-parity`'s `path.go:func#hash` site
 identifiers — a data format, not a citation — out of the gate's way.
 
+#### When the citation locates the mutant instead of hosting it
+
+A construct citation has to resolve to exactly one code line, and the
+mutated token frequently cannot. `INVERT_LOOPCTRL` rewrites a bare
+`continue` or `break`, which no substring singles out; a guard such as
+`if shape == chplan.HistogramRowShape` is often spelled identically in
+every arm of the switch it dispatches. In both cases the citation names
+the nearest construct that IS unique, and the note **says which
+relation it is naming**:
+
+```go
+// TestAbsentSynthLabels_DroppedNameSkipsNotStops kills the INVERT_LOOPCTRL
+// mutant on the `continue` taken for a dropped name, guarded by
+// range_aggregation.go:`if dropped[name] {`.
+//
+// The citation names that neighbouring `if` rather than the mutated statement
+// itself: the mutant is a bare `continue`, which no substring singles out.
+```
+
+Four anchors recur, and each is legitimate: the guard whose body is the
+mutated statement, the statement immediately above it, the assignment
+that opens the closure the mutant sits in, and the `case` label of the
+arm that holds it. What makes any of them honest is that the **mutated
+token is named in prose** — the mutator plus the expression it
+rewrites — while the citation supplies the address. A header that names
+only the anchor asserts a kill on a construct no mutator can touch, and
+is unfalsifiable by reading: the mutation lane reports per mutant and
+never per claim, so nothing contradicts it.
+
+The same sentence is what a reviewer checks. A `// TestX kills …`
+header is the only record that a mutant was adjudicated, so read it
+against the construct it points at: if that construct carries no
+comparison, no arithmetic operator and no loop-control token, the note
+must say what it is anchoring and where the real mutant sits, or it is
+claiming something no run can confirm.
+
+No gate enforces this either, and the mechanical version was built and
+measured before being rejected. Resolving every kill-claim citation
+through the resolver above and testing the resolved line against the
+mutant inventory a completed `mutation` run reports flags **16 of the
+235 citations** that land in a file the lane measures, across every
+phase of the lane — and all 16 are
+correct locator citations of the four kinds above, including every
+example in this section. Precision is zero, and the rule cannot be
+tightened into one a note could satisfy: the two ways to clear it are to
+drop the citation out of the sentence that claims the kill, which is the
+citation requirement this section exists to impose, or to invent a
+unique construct where the source deliberately repeats one. A gate whose
+only compliant forms are worse than the violation is a false-positive
+machine, and the residue it would catch — a kill claim naming an anchor
+without naming its mutant — is one sentence of reviewer attention
+(cerberus issue #2966).
+
 ### How a note states a number
 
 A citation that resolves is only half of a re-checkable note. The other

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -1163,10 +1163,15 @@ func TestEmitMetricsHistogramOverTime_BadStartEndErrors(t *testing.T) {
 	}
 }
 
-// TestEmitMetricsSecondStage_PartitionByBoundary kills the boundary
-// on metrics_second_stage.go:`sb.LimitBy(parts...)`. An empty
-// PartitionBy must render no `LIMIT … BY` keys at all; emitting one
-// would break the global top-K shape.
+// TestEmitMetricsSecondStage_PartitionByBoundary kills the
+// CONDITIONALS_BOUNDARY mutant on builder.go:`len(s.limitBy) > 0`. An
+// empty PartitionBy must render no `LIMIT … BY` keys at all; the `>=`
+// mutant opens the clause over an empty key list and emits a trailing
+// `LIMIT 5 BY `, breaking the global top-K shape.
+//
+// metrics_second_stage.go:`sb.LimitBy(parts...)` is the call site that
+// reaches the guard, not a mutant: a bare call expression has no operator
+// to rewrite.
 func TestEmitMetricsSecondStage_PartitionByBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1252,11 +1257,19 @@ func TestEmitVectorJoin_LogicalOr(t *testing.T) {
 	}
 }
 
-// TestEmitScan_NoColumnsBoundary kills the boundary mutants on
-// emit_node.go:`make([]Frag, 0, len(s.Columns))`. Without explicit
-// Columns, the SELECT must be the bare `SELECT *`; a mutated column
-// list would emit an empty SELECT list (invalid SQL).
-func TestEmitScan_NoColumnsBoundary(t *testing.T) {
+// TestEmitScan_EmptySelectList kills the CONDITIONALS_NEGATION mutant on
+// builder.go:`len(s.selectList) == 0`, the guard that renders the bare
+// `SELECT *` when a Scan carries no explicit Columns.
+//
+// The behaviour is decided one call deeper than it is written:
+// emit_node.go:`make([]Frag, 0, len(s.Columns))` is a capacity hint, and a
+// capacity hint carries no comparison, no arithmetic on a variable and no
+// loop-control token, so no gremlins mutator has a surface there. What can
+// be rewritten is the builder guard the empty slice reaches. The `!=`
+// mutant renders the empty list in place of the star and emits
+// `SELECT  FROM ...` — invalid SQL — which the `SELECT *` assertion below
+// catches.
+func TestEmitScan_EmptySelectList(t *testing.T) {
 	t.Parallel()
 	t.Run("no columns → SELECT *", func(t *testing.T) {
 		t.Parallel()
@@ -1282,10 +1295,13 @@ func TestEmitScan_NoColumnsBoundary(t *testing.T) {
 	})
 }
 
-// TestEmitProject_NoProjectionsBoundary kills the mutants of
-// emit_node.go:`for _, pr := range p.Projections`. With no projections
-// the SELECT degenerates to bare `SELECT *`.
-func TestEmitProject_NoProjectionsBoundary(t *testing.T) {
+// TestEmitProject_EmptySelectList kills the same CONDITIONALS_NEGATION on
+// builder.go:`len(s.selectList) == 0` reached through emitProject: with no
+// projections the SELECT degenerates to the bare `SELECT *`. The range
+// statement emit_node.go:`for _, pr := range p.Projections` hosts no
+// mutant of its own — INVERT_LOOPCTRL rewrites a `break` or a `continue`,
+// and this loop body has neither.
+func TestEmitProject_EmptySelectList(t *testing.T) {
 	t.Parallel()
 	plan := &chplan.Project{
 		Projections: nil,
@@ -1300,9 +1316,13 @@ func TestEmitProject_NoProjectionsBoundary(t *testing.T) {
 	}
 }
 
-// TestEmitLimit_NonPositiveBoundary kills the boundary mutants reaching
-// emit_node.go:`sb.Limit(l.Count)`. Count==0 must skip the LIMIT clause;
-// a `>=`-style flip would emit `LIMIT 0`.
+// TestEmitLimit_NonPositiveBoundary kills the CONDITIONALS_BOUNDARY mutant
+// on builder.go:`s.hasLimit = n > 0`. Count==0 must skip the LIMIT clause;
+// the `>=` mutant emits `LIMIT 0`, which truncates every result to nothing.
+//
+// emit_node.go:`sb.Limit(l.Count)` is the call site, not the mutant: it is
+// a bare call expression with no operator to rewrite. The comparison that
+// decides the clause lives in the builder method it calls.
 func TestEmitLimit_NonPositiveBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1340,11 +1360,14 @@ func TestEmitLimit_NonPositiveBoundary(t *testing.T) {
 	}
 }
 
-// TestEmitAggregateNoGroup_BoundaryAt245 kills the boundary at
-// emit_node.go:`make([]Frag, 0, len(scan.Columns))` (inside emitFilter). A
-// Filter on a Scan with no explicit Columns must omit the SELECT list;
-// with explicit Columns those names appear.
-func TestEmitAggregateNoGroup_BoundaryAt245(t *testing.T) {
+// TestEmitFilter_EmptySelectList kills the same CONDITIONALS_NEGATION on
+// builder.go:`len(s.selectList) == 0` reached through emitFilter, which
+// assembles its own SELECT list rather than delegating to scanQuery. A
+// Filter over a Scan with no explicit Columns must render `SELECT *`; with
+// explicit Columns those names must appear.
+// emit_node.go:`make([]Frag, 0, len(scan.Columns))` is again a capacity
+// hint and hosts no mutant.
+func TestEmitFilter_EmptySelectList(t *testing.T) {
 	t.Parallel()
 	t.Run("no columns → SELECT *", func(t *testing.T) {
 		t.Parallel()
@@ -1486,9 +1509,13 @@ func TestEmitWindowedArray_StepBoundary(t *testing.T) {
 }
 
 // TestEmitWindowedExtrapolated_GroupByBoundary kills the
-// mutants of the innermost GROUP BY
-// range_window.go:emitWindowedArrayExtrapolated:`innermost.GroupBy(groupFrags...)`.
-// Two cases: with and without GroupBy.
+// CONDITIONALS_BOUNDARY mutant on builder.go:`len(s.groupBy) > 0`, the
+// guard that decides whether a GROUP BY clause is opened at all, reached
+// here through the innermost GROUP BY of
+// range_window.go:emitWindowedArrayExtrapolated:`innermost.GroupBy(groupFrags...)`
+// — a call site, not a mutant. Two cases: with and without GroupBy. The
+// `>=` mutant opens the clause for an empty key list and emits a dangling
+// `GROUP BY `, which the no-GroupBy case rejects.
 func TestEmitWindowedExtrapolated_GroupByBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1613,10 +1640,12 @@ func TestEmitWindowedArrayMatrix_MinWindowBoundary(t *testing.T) {
 	})
 }
 
-// TestEmitWindowedArrayPairsMatrix_GroupByBoundary kills the
-// boundary on the pairs-path matrix regroup
-// range_window.go:emitWindowedArrayPairsMatrix:`regroup.GroupBy(regroupKeys...)`.
-// The condition mirrors the values-only emission.
+// TestEmitWindowedArrayPairsMatrix_GroupByBoundary kills the same
+// CONDITIONALS_BOUNDARY mutant on builder.go:`len(s.groupBy) > 0` reached
+// through the pairs-path matrix regroup,
+// range_window.go:emitWindowedArrayPairsMatrix:`regroup.GroupBy(regroupKeys...)`
+// — again the call site rather than the mutant. The condition mirrors the
+// values-only emission.
 func TestEmitWindowedArrayPairsMatrix_GroupByBoundary(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -2241,13 +2270,20 @@ func TestEmitWindowedArrayPairsMatrix_AnchorArithmetic(t *testing.T) {
 }
 
 // TestEmitWindowedArrayPairsMatrix_GroupByNegation kills the
-// CONDITIONALS_NEGATION reaching
-// range_window.go:emitWindowedArrayPairsMatrix:`regroup.GroupBy(regroupKeys...)`.
-// With a non-empty GroupBy the original emits `GROUP BY`
-// in the innermost SELECT so the per-series groupArray collapses each
-// series into one array; the mutant `<= 0` skips the GROUP BY and
-// rolls every input row into a single super-series — wrong shape, no
-// per-series fanout.
+// CONDITIONALS_NEGATION mutant on builder.go:`len(s.groupBy) > 0`, reached
+// through the pairs-path matrix regroup,
+// range_window.go:emitWindowedArrayPairsMatrix:`regroup.GroupBy(regroupKeys...)`
+// — the call site, not the mutant. With a non-empty GroupBy the original
+// emits a KEYED `GROUP BY` so the per-series groupArray collapses each
+// series into one array; the `<= 0` mutant skips it and rolls every input
+// row into a single super-series — wrong shape, no per-series fanout.
+//
+// The assertion has to name the KEY, not the keyword. Under the mutant the
+// polarity inverts rather than disappearing: every builder holding keys
+// skips its clause and every builder holding none opens one, so the string
+// `GROUP BY` survives — the emitted SQL goes from one keyed clause to
+// three empty ones. A `strings.Contains(sql, "GROUP BY")` assertion is
+// satisfied by those empty clauses and adjudicates nothing.
 func TestEmitWindowedArrayPairsMatrix_GroupByNegation(t *testing.T) {
 	t.Parallel()
 	e := &emitter{}
@@ -2267,11 +2303,14 @@ func TestEmitWindowedArrayPairsMatrix_GroupByNegation(t *testing.T) {
 		t.Fatalf("emitWindowedArrayPairsMatrix: %v", err)
 	}
 	sql := e.b.String()
-	if !strings.Contains(sql, "GROUP BY") {
-		t.Errorf("expected GROUP BY clause for non-empty GroupBy (negation mutant dropped it).\nSQL=%s", sql)
+	if !strings.Contains(sql, "GROUP BY `Attributes`") {
+		t.Errorf("expected a GROUP BY keyed on `Attributes` for non-empty GroupBy "+
+			"(mutant `<= 0` at builder.go:`len(s.groupBy) > 0` drops the key and "+
+			"leaves only empty GROUP BY clauses).\nSQL=%s", sql)
 	}
-	if !strings.Contains(sql, "Attributes") {
-		t.Errorf("expected `Attributes` group key surfaced in the SQL.\nSQL=%s", sql)
+	if strings.Contains(sql, "GROUP BY )") {
+		t.Errorf("emitted an empty GROUP BY clause; the guard must open the clause "+
+			"only for a non-empty key list.\nSQL=%s", sql)
 	}
 }
 
@@ -3217,11 +3256,13 @@ func TestWriteOptQualCol_QualifierBranch(t *testing.T) {
 // --- prewhere.go survivors ------------------------------------------------
 
 // TestOrderedConjuncts_SkipBucketContinue kills the INVERT_LOOPCTRL
-// mutant (`continue` → `break`) after
-// prewhere.go:`skip = append(skip, c)` appends a skip-index conjunct. A
-// skip-bucket conjunct ahead of a plain "rest" conjunct must NOT abort the
-// loop — the `break` mutant would drop every
-// conjunct after the first skip hit, losing them from the output.
+// mutant (`continue` → `break`) on the statement immediately after
+// prewhere.go:`skip = append(skip, c)` appends a skip-index conjunct. The
+// citation names that append rather than the mutated statement, which is a
+// bare `continue` no substring singles out. A skip-bucket conjunct ahead
+// of a plain "rest" conjunct must NOT abort the loop — the `break` mutant
+// would drop every conjunct after the first skip hit, losing them from the
+// output.
 //
 // The shape registers a SkipIndexColumn but no SortColumns, so the first
 // conjunct lands in the skip bucket and the second in the rest bucket.

--- a/internal/chsql/histogram_quantile_test.go
+++ b/internal/chsql/histogram_quantile_test.go
@@ -25,10 +25,16 @@ func TestHistogramQuantileValueFrag_DividesRankBeforeWidth(t *testing.T) {
 }
 
 // TestHistogramQuantileValueFrag_PhiExprGating kills the two
-// CONDITIONALS_NEGATION mutants on `h.PhiExpr != nil` inside the
-// arrayFirstIndex predicate (histogram_quantile.go:`w.idx = func() Frag`) and
-// on histogram_quantile.go:`h.PhiExpr == nil`, the early return before the
+// CONDITIONALS_NEGATION mutants that gate the computed-phi path: the
+// `h.PhiExpr != nil` inside the arrayFirstIndex predicate built at
+// histogram_quantile.go:`w.idx = func() Frag`, and
+// histogram_quantile.go:`h.PhiExpr == nil`, the early return before the
 // isNaN wrapper.
+//
+// The first citation names the assignment that opens the closure rather
+// than the guard itself: `h.PhiExpr != nil` is spelled identically at two
+// code lines in this file, so no substring of the guard singles one out,
+// while the closure it lives in is unique.
 //
 // The literal-Phi path (h.PhiExpr == nil) must render the BARE `c >=
 // <target>` comparison as the arrayFirstIndex predicate and must NOT
@@ -40,11 +46,11 @@ func TestHistogramQuantileValueFrag_DividesRankBeforeWidth(t *testing.T) {
 // runtime phi CAN be NaN, so the isNaN guard must wrap the whole
 // expression.
 //
-// Negating 217 alone would apply the wrapped `if(...)  = 1)` predicate
-// to the literal-Phi path (and the bare predicate to the PhiExpr path);
-// negating 318 alone would apply (or skip) the isNaN wrapper on the
-// wrong path. Asserting both markers on both cases pins each
-// independently.
+// Negating the predicate guard alone would apply the wrapped
+// `if(...)  = 1)` predicate to the literal-Phi path (and the bare
+// predicate to the PhiExpr path); negating the early return alone would
+// apply (or skip) the isNaN wrapper on the wrong path. Asserting both
+// markers on both cases pins each independently.
 func TestHistogramQuantileValueFrag_PhiExprGating(t *testing.T) {
 	t.Parallel()
 
@@ -58,13 +64,13 @@ func TestHistogramQuantileValueFrag_PhiExprGating(t *testing.T) {
 		}, hqClassicHelperColumns{})(b)
 		sql := b.String()
 		if !strings.Contains(sql, "arrayFirstIndex(c -> c >=") {
-			t.Errorf("literal phi must use the bare `c >= target` predicate (line 457 flipped?):\n%s", sql)
+			t.Errorf("literal phi must use the bare `c >= target` predicate (histogram_quantile.go:`w.idx = func() Frag`'s guard flipped?):\n%s", sql)
 		}
 		if strings.Contains(sql, "arrayFirstIndex(c -> (if(") {
-			t.Errorf("literal phi must NOT wrap the predicate in if(...)=1 (line 457 flipped?):\n%s", sql)
+			t.Errorf("literal phi must NOT wrap the predicate in if(...)=1 (histogram_quantile.go:`w.idx = func() Frag`'s guard flipped?):\n%s", sql)
 		}
 		if strings.Contains(sql, "isNaN(") {
-			t.Errorf("literal phi must NOT carry the isNaN guard (line 266 flipped?):\n%s", sql)
+			t.Errorf("literal phi must NOT carry the isNaN guard (histogram_quantile.go:`h.PhiExpr == nil` flipped?):\n%s", sql)
 		}
 	})
 
@@ -78,7 +84,7 @@ func TestHistogramQuantileValueFrag_PhiExprGating(t *testing.T) {
 		}, hqClassicHelperColumns{})(b)
 		sql := b.String()
 		if !strings.Contains(sql, "arrayFirstIndex(c -> (if(c >=") {
-			t.Errorf("computed phi must wrap the predicate as (if(c >= ..., 1, 0) = 1) (line 457 flipped?):\n%s", sql)
+			t.Errorf("computed phi must wrap the predicate as (if(c >= ..., 1, 0) = 1) (histogram_quantile.go:`w.idx = func() Frag`'s guard flipped?):\n%s", sql)
 		}
 		if !strings.Contains(sql, "= 1),") {
 			t.Errorf("computed phi predicate must close with `= 1)` "+

--- a/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
@@ -58,9 +58,12 @@ func mixedDiscriminatorProjected(n chplan.Node) bool {
 
 // TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch
 // kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the
-// `if shape == chplan.HistogramRowShape` guard of
+// `if shape == chplan.HistogramRowShape` guard that opens the arm
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`,
-// inside lowerHistogramOrMixedSubqueryOuterFnInput:
+// inside lowerHistogramOrMixedSubqueryOuterFnInput. The citation names the
+// `case` label rather than the mutated guard because that guard is spelled
+// identically in all three arms of this switch, so no substring of it
+// singles one out, while the label above it does:
 //
 //	if shape == chplan.HistogramRowShape {
 //	    node, err = lowerSelectFnOverExpHistogramSubqueryInput(...)
@@ -101,10 +104,12 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 }
 
 // TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch
-// kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on
-// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`, the
-// resets/changes sibling of the last_over_time/first_over_time dispatch
-// above. Both shapes ultimately produce the same four-column canonical
+// kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the same
+// `if shape == chplan.HistogramRowShape` guard one arm further down,
+// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:` —
+// the label locates the arm, the guard inside it is the mutant. This is
+// the resets/changes sibling of the last_over_time/first_over_time
+// dispatch above. Both shapes ultimately produce the same four-column canonical
 // Project, so the two paths are told apart by whether the underlying
 // Aggregate collected the Mixed-only groupArrays
 // [mixedPairCountAggs] adds.
@@ -137,10 +142,12 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t 
 }
 
 // TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch kills
-// the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on
-// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`, the
-// FOLD-family (rate/increase/delta/...) sibling of the two dispatches
-// above. Over a MixedRowShape input this case routes to
+// the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the same
+// `if shape == chplan.HistogramRowShape` guard in the third arm,
+// histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:` —
+// again the label locates the arm and the guard inside it is the mutant.
+// This is the FOLD-family (rate/increase/delta/...) sibling of the two
+// dispatches above. Over a MixedRowShape input this case routes to
 // [lowerFurtherWrapMixedOrSubqueryFoldFn], whose own
 // [combineMixedAggregateBranches] always returns a *chplan.VectorSetOp at
 // the root — a shape the plain-histogram continuation

--- a/internal/promql/gremlins_kill_subquery_call_subquery_test.go
+++ b/internal/promql/gremlins_kill_subquery_call_subquery_test.go
@@ -75,7 +75,11 @@ func gremlinsFanoutAggAliases(rbf *chplan.RangeBucketFanout) map[string]bool {
 
 // TestGremlinsKill_CallSubqueryLastFirst_HistVsMixedRouting kills the
 // CONDITIONALS_NEGATION mutant on the `if shape == chplan.HistogramRowShape`
-// guard of histogram_native_subquery_call_subquery.go:lowerHistogramOrMixedCallSubqueryInput:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`.
+// guard that opens the arm
+// histogram_native_subquery_call_subquery.go:lowerHistogramOrMixedCallSubqueryInput:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`.
+// The citation names the `case` label rather than the mutated guard
+// because that guard is spelled identically in all three arms of this
+// switch, so no substring of it singles one out, while the label does.
 // A HistogramRowShape inner must route through
 // [lowerSelectFnOverCallSubqueryInput] ([nativeHistogramProjection], a
 // *chplan.HistogramProjection — chplan.HistogramRowShape); a MixedRowShape
@@ -101,7 +105,9 @@ func TestGremlinsKill_CallSubqueryLastFirst_HistVsMixedRouting(t *testing.T) {
 }
 
 // TestGremlinsKill_CallSubqueryFold_HistVsMixedRouting kills the
-// CONDITIONALS_NEGATION mutant on the identical guard in the FOLD-family arm,
+// CONDITIONALS_NEGATION mutant on the identical
+// `if shape == chplan.HistogramRowShape` guard in the FOLD-family arm,
+// located the same way by its label,
 // histogram_native_subquery_call_subquery.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`.
 // A HistogramRowShape inner routes through [lowerExpHistogramFoldOverCallSubqueryInput]
 // ([aggregatedHistogramProjection], chplan.HistogramRowShape); a
@@ -125,8 +131,10 @@ func TestGremlinsKill_CallSubqueryFold_HistVsMixedRouting(t *testing.T) {
 }
 
 // TestGremlinsKill_CallSubqueryResetsChanges_HistVsMixedRouting kills the
-// CONDITIONALS_NEGATION mutant on the identical guard in the resets/changes
-// arm, histogram_native_subquery_call_subquery.go:lowerHistogramOrMixedCallSubqueryInput:`case resetsWindowFn, changesWindowFn:`.
+// CONDITIONALS_NEGATION mutant on the identical
+// `if shape == chplan.HistogramRowShape` guard in the resets/changes arm,
+// located the same way by its label,
+// histogram_native_subquery_call_subquery.go:lowerHistogramOrMixedCallSubqueryInput:`case resetsWindowFn, changesWindowFn:`.
 // Both branches wrap
 // their result in the SAME [expHistogramPairCountProjection] outer node,
 // so chplan.RowShapeOf cannot distinguish them — the two branches differ

--- a/internal/promql/gremlins_kill_test.go
+++ b/internal/promql/gremlins_kill_test.go
@@ -951,23 +951,22 @@ func mixedDiscriminatorMarkerProject(input chplan.Node) *chplan.Project {
 	}
 }
 
-// TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop kills
-// the INVERT_LOOPCTRL mutant on the `continue` of
-// duplicate_labelset_guard.go:`if mixed && mixedPayload[name]`, inside
-// guardLabelRewriteCollision's per-projection switch:
-//
-//	default:
-//		if mixed && mixedPayload[name] {
-//			continue
-//		}
-//
-// flips to `break`. A single qualifying projection cannot distinguish
-// `continue` from `break` (the loop would end either way), so the
-// fixture needs a mixed-payload column FOLLOWED by another projection
-// that must still be reachable. This test forces `keyOnStep = true`
-// (via an Aggregate input whose GroupByAliases already names the
-// timestamp column, see guardKeysOnTimestamp) so the trailing
+// TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop pins that a
+// mixed-payload column does not swallow the projection after it: the
+// payload column is skipped by the `continue` under
+// duplicate_labelset_guard.go:`if mixed && mixedPayload[name]` and the
+// trailing projection still reaches the group key. The fixture needs a
+// mixed-payload column FOLLOWED by another projection, and forces
+// `keyOnStep = true` (via an Aggregate input whose GroupByAliases already
+// names the timestamp column, see guardKeysOnTimestamp) so that trailing
 // projection lands in the group key, then asserts its alias survived.
+//
+// It does NOT kill the INVERT_LOOPCTRL mutant on that `continue`, and no
+// test can: the rewrite is equivalent, adjudicated in this package's NOT
+// KILLABLE footer (gremlins_kill_window_bounds_test.go, class 7). The
+// `continue` sits inside a `switch` that is the whole body of the `for`,
+// so `break` binds to the switch rather than to the loop and control
+// reaches the next iteration either way.
 func TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop(t *testing.T) {
 	t.Parallel()
 
@@ -998,28 +997,24 @@ func TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop(t *testing.T) 
 		}
 	}
 	if !found {
-		t.Fatalf("GroupByAliases = %#v; want %q present (mutant `continue` -> `break` at "+
-			"duplicate_labelset_guard.go:`if mixed && mixedPayload[name]` "+
-			"would abandon the loop at the mixed-payload "+
-			"histogram column and never reach the projection after it)", agg.GroupByAliases, extraStepCol)
+		t.Fatalf("GroupByAliases = %#v; want %q present (the skip under "+
+			"duplicate_labelset_guard.go:`if mixed && mixedPayload[name]` must pass over the "+
+			"mixed-payload histogram column and still reach the projection after it)",
+			agg.GroupByAliases, extraStepCol)
 	}
 }
 
-// TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop kills the
-// INVERT_LOOPCTRL mutant on the `continue` of
-// duplicate_labelset_guard.go:`if keyOnStep`:
+// TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop pins that two
+// consecutive key-on-step projections BOTH reach the group key, rather
+// than the first one ending the walk. The fixture uses two non-payload,
+// non-canonical projections in a row and an Aggregate input that already
+// names the timestamp column, so `keyOnStep` is true and both take the
+// duplicate_labelset_guard.go:`if keyOnStep` branch.
 //
-//	if keyOnStep {
-//		groupBy = append(groupBy, &chplan.ColumnRef{Name: name})
-//		aliases = append(aliases, name)
-//		continue
-//	}
-//
-// flips to `break`. Two non-payload, non-canonical projections in a
-// row.Input needs `keyOnStep = true` (this test's Aggregate input
-// already names the timestamp column) so BOTH hit this branch; the
-// second is reachable only if the first's `continue` doesn't end the
-// loop.
+// Like its mixed-payload sibling above, it does NOT kill the
+// INVERT_LOOPCTRL mutant on that branch's `continue` — the rewrite is
+// equivalent for the same reason, and is adjudicated in this package's
+// NOT KILLABLE footer (gremlins_kill_window_bounds_test.go, class 7).
 func TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop(t *testing.T) {
 	t.Parallel()
 
@@ -1048,9 +1043,9 @@ func TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop(t *testing.T) {
 	}
 	for name := range wantAliases {
 		if !gotAliases[name] {
-			t.Fatalf("GroupByAliases = %#v; want both %q and %q present (mutant `continue` "+
-				"-> `break` at duplicate_labelset_guard.go:`if keyOnStep` would abandon the loop after "+
-				"the first key-on-step projection and never reach the second)",
+			t.Fatalf("GroupByAliases = %#v; want both %q and %q present (the branch under "+
+				"duplicate_labelset_guard.go:`if keyOnStep` must key the first key-on-step "+
+				"projection and still reach the second)",
 				agg.GroupByAliases, colA, colB)
 		}
 	}

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -265,3 +265,39 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // both readings error. The complementary case — matched with a non-histogram
 // shape — is the invariant the line exists to report, and producing it would
 // require lowerExpHistogramValuedShape to break its own contract.
+//
+// 7. A `continue` WHOSE `break` BINDS TO A SWITCH, NOT TO THE LOOP.
+//
+//	duplicate_labelset_guard.go:`if mixed && mixedPayload[name] {`
+//	duplicate_labelset_guard.go:`if keyOnStep`
+//
+// Each citation names the guard whose body holds the mutated statement,
+// because that statement is a bare `continue` and no substring of it singles
+// one out. Both sit in guardLabelRewriteCollision's per-projection walk,
+// whose loop body is a single `switch` with nothing after it:
+//
+//	for _, proj := range rewritten.Projections {
+//		switch name := chplan.ProjectionOutputName(proj); name {
+//		...
+//		}
+//	}
+//
+// INVERT_LOOPCTRL rewrites each `continue` to `break`, and inside a `switch`
+// a bare `break` leaves the switch rather than the loop. Because the switch
+// IS the whole loop body, leaving it and continuing the loop reach the same
+// place: the next iteration, with the remainder of the arm skipped either
+// way. Both readings therefore visit every projection and build the identical
+// groupBy / aliases / aggs triple.
+//
+// Confirmed by applying each rewrite by hand and running the package's two
+// walk-order tests (TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop
+// and TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop, above in
+// gremlins_kill_test.go): both pass under both mutants, matching the
+// phase4-promql-e leg, which reports both as LIVED. Those two tests pin the
+// walk's OUTPUT, which is real behaviour worth holding; they do not pin the
+// keyword, and no test can.
+//
+// The equivalence is a property of the switch being the last statement in
+// the loop body. It dissolves the moment a statement is added after the
+// switch, at which point both mutants become killable and should be killed
+// rather than re-adjudicated.


### PR DESCRIPTION
## What this is

Seventeen `// TestX kills …` headers cite a construct that hosts no gremlins mutant. A kill claim is
the only record that a mutant was ever adjudicated, so one naming a construct with no rewritable
token is unfalsifiable by reading and invisible to the lane, which reports per mutant and never per
claim.

All seventeen are adjudicated individually against the per-mutant inventory a completed `mutation`
run reports (file, line, column, mutator, verdict), and every verdict is confirmed by applying the
named rewrite by hand and running the claimed killer. They do not resolve into one bucket.

## The three outcomes

### Eight cited the wrong file (real defects)

`emit_node.go`'s two `make([]Frag, 0, len(...))` capacity hints, its `for _, pr := range
p.Projections`, `sb.Limit(l.Count)`, `metrics_second_stage.go`'s `sb.LimitBy(parts...)` and
`range_window.go`'s two `GroupBy(...)` calls carry no comparison, no arithmetic on a variable and no
loop-control token. The inventory confirms zero mutants on each of those lines.

The comparisons these tests actually pin live one call deeper, in `builder.go`:

| test | real mutant | mutator |
| --- | --- | --- |
| `TestEmitScan_EmptySelectList` | `len(s.selectList) == 0` | CONDITIONALS_NEGATION |
| `TestEmitFilter_EmptySelectList` | `len(s.selectList) == 0` | CONDITIONALS_NEGATION |
| `TestEmitProject_EmptySelectList` | `len(s.selectList) == 0` | CONDITIONALS_NEGATION |
| `TestEmitLimit_NonPositiveBoundary` | `s.hasLimit = n > 0` | CONDITIONALS_BOUNDARY |
| `TestEmitMetricsSecondStage_PartitionByBoundary` | `len(s.limitBy) > 0` | CONDITIONALS_BOUNDARY |
| `TestEmitWindowedExtrapolated_GroupByBoundary` | `len(s.groupBy) > 0` | CONDITIONALS_BOUNDARY |
| `TestEmitWindowedArrayPairsMatrix_GroupByBoundary` | `len(s.groupBy) > 0` | CONDITIONALS_BOUNDARY |
| `TestEmitWindowedArrayPairsMatrix_GroupByNegation` | `len(s.groupBy) > 0` | CONDITIONALS_NEGATION |

Each was verified by rewriting the builder guard and re-running: the test fails, revert, it passes.
Three test names that read `Boundary` for a mutant with no boundary form are corrected — one of them
also carried a fossilised line number in its own name and called a `chplan.Filter` an Aggregate.

`TestEmitWindowedArrayPairsMatrix_GroupByNegation` additionally **did not kill** what it claimed.
Under `len(s.groupBy) <= 0` the polarity inverts rather than disappearing: every builder holding keys
skips its clause and every builder holding none opens one, so the emitted SQL goes from one keyed
`GROUP BY` to three empty ones and `Contains(sql, "GROUP BY")` still passes. It now asserts the key,
and fails under the rewrite.

### Two claims are false at the root (equivalent mutants)

Both `continue`s in `duplicate_labelset_guard.go`'s per-projection walk sit inside a `switch` that is
the whole body of the `for`. `INVERT_LOOPCTRL` rewrites them to `break`, and a bare `break` inside a
switch leaves the switch, not the loop — so control reaches the next iteration either way, with the
remainder of the arm skipped either way. The phase4-promql-e leg reports both as LIVED against a tree
that already contained the tests claiming to kill them, and applying each rewrite by hand leaves both
tests passing.

The tests keep their assertions, which pin the walk's output and are worth holding; they stop
claiming a kill. The equivalence joins this package's `NOT KILLABLE` footer as class 7. The leg is
green at 95.54% either way, so no floor moves.

### Eight are legitimate locator citations

The remaining eight cannot host the mutant they name, because the rewritten token is a bare
`continue` or a guard spelled identically in every arm of its switch — nothing a construct citation
can single out. All eight were verified to kill: rewriting the guard the prose names fails the test.
Their wording now says which relation it is naming, matching the convention already in use across ten
files, and `docs/test-strategy.md` records that convention with its four recurring anchors.

## The gate: measured, and refused

The mechanical pass was built and run over the whole tree — resolve every kill-claim citation through
`verify-code-citations.mjs`'s resolver, test the resolved line against the inventory from a completed
run, across every phase of the lane.

**16 of the 235 citations that land in a measured file are flagged, and all 16 are correct locator
citations** — including every example the new documentation section gives. Precision is zero.

It cannot be tightened into a rule a note could satisfy. The two compliant forms are to drop the
citation out of the sentence that claims the kill, which is exactly the requirement #2953 exists to
impose, or to invent a unique construct where the source deliberately repeats one. A gate whose only
compliant forms are worse than the violation is a false-positive machine, and #2957 refused a prose
gate on the same footing after measuring it.

So the refutation is recorded where #2957's went — `docs/test-strategy.md`, under
§ "How a note cites the mutant it adjudicates" — together with what a reviewer should look for
instead: if the cited construct carries no comparison, no arithmetic operator and no loop-control
token, the note must say what it is anchoring and where the real mutant sits.

## Verification

- Every kill claim asserted here was proven by hand-mutation: apply, test fails; revert, test passes.
- Every equivalence claim was proven the other way: apply, test still passes, plus the structural
  argument and the lane's own LIVED verdict.
- `verify-code-citations.mjs`, `forbid-contradicted-mutants.mjs` (and its 22-case suite),
  `forbid-sql-raw.mjs`, `forbid-skip.mjs` and `doc-counts.mjs` all clean.
- Narrowed `go test -run` over every touched test in `internal/chsql` and `internal/promql`.

Closes #2966
