### PR TITLE
fix(promql): delete histogram_quantile's invariantly-true zero-window guard

### DIFF
--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -148,7 +148,7 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // NOT KILLABLE — documented, not defended by a test.
 //
 // The remaining survivors on cerberus issue #2949's phase4-promql-* legs fall
-// into six equivalence classes. Each mutant is named by the construct it
+// into five equivalence classes. Each mutant is named by the construct it
 // rewrites — a line number cannot be machine-verified and rots on every
 // insertion above it (#2953) — scoped to its enclosing function wherever the
 // construct repeats within the file.
@@ -207,24 +207,7 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // a negative zero is caught by that `lhs == 0` too, since IEEE equality holds
 // for it.
 //
-// 3. A GUARD WHOSE CONDITION IS INVARIANTLY TRUE.
-//
-//	histogram_quantile.go:lowerHistogramQuantileAgg:`shape.windowRange > 0`
-//	histogram_quantile.go:lowerHistogramQuantileNativeAgg:`shape.windowRange > 0`
-//
-// `> 0` -> `>= 0` widens a test that already always holds. histogramAggShape's
-// windowRange is set at exactly two places in the shape's construction,
-// histogram_quantile.go:`windowRange: instantLookback` — which is
-// qlcommon.InstantLookback = 5m — and
-// histogram_quantile.go:`windowRange: ms.Range`, which the PromQL grammar
-// refuses to parse as anything but strictly positive ("duration must be
-// greater than 0"). Instrumenting both guards across the package suite
-// observed no zero. The comment beside each one, describing a
-// `shape.windowRange == 0` bare-selector case, predates that construction and
-// no longer describes a reachable state; cerberus issue #2961 tracks the stale
-// comment and the guard it describes.
-//
-// 4. A LOOP OVER A REGISTRY THAT HOLDS ONE ENTRY.
+// 3. A LOOP OVER A REGISTRY THAT HOLDS ONE ENTRY.
 //
 //	schema_lookup.go:promqlTopLevelKeys:`if col == "" {`
 //	resource_attributes.go:excludedResourceKeys:`if d.column(s) == "" {`
@@ -240,7 +223,7 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // second dedicated key is added — at which point both mutants become killable
 // and should be killed rather than re-adjudicated.
 //
-// 5. A REWRITE THE LANGUAGE MAKES A NO-OP.
+// 4. A REWRITE THE LANGUAGE MAKES A NO-OP.
 //
 //	histogram_native_mixed_or_vector_plain_comparison.go:`len(b.VectorMatching.Include) > 0`
 //	histogram_native_mixed_or_vector_comparison.go:`len(b.VectorMatching.Include) > 0`
@@ -252,7 +235,7 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // `append([]string(nil), src...) == nil` for both a nil and an empty-non-nil
 // src.
 //
-// 6. AN INTERNAL-INVARIANT ERROR PATH.
+// 5. AN INTERNAL-INVARIANT ERROR PATH.
 //
 //	histogram_native_range_fn.go:`!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
 //	histogram_native_subquery_select.go:`!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -761,14 +761,21 @@ func openMetricsFloatExpr(newPhi func() (chplan.Expr, error)) (chplan.Expr, erro
 // aggregated-input plan for `histogram_quantile(phi, <agg>(rate(<sel>[range])))`.
 //
 // `selector` is the underlying bare VectorSelector (carrying the metric
-// name + label matchers). `windowRange` is the `[range]` duration from
-// the wrapping `rate`/`increase` (zero if there's no range-vector
-// function — currently always set when this struct is built, but
-// kept explicit for clarity). `agg` carries
+// name + label matchers). `agg` carries
 // the AggregateExpr metadata (Op, Grouping, Without) when a wrapping
 // aggregation is present; nil means "no aggregation wrap, just rate(...)".
 type histogramAggShape struct {
-	selector    *parser.VectorSelector
+	selector *parser.VectorSelector
+	// windowRange is the window the shape reduces over, and every shape
+	// matchHistogramAggIdiom yields carries a STRICTLY POSITIVE one: the
+	// `[range]` of the wrapping rate / increase / sum_over_time, which the
+	// PromQL grammar's positive_duration_expr refuses to parse as anything
+	// else, or instantLookback (5m) for the #1692 no-range-wrapper shape.
+	// lowerHistogramQuantileAgg and lowerHistogramQuantileNativeAgg bind the
+	// window's left bound and its staleness lower bound from it
+	// unconditionally, and
+	// histogram_quantile_window_range_test.go:`func TestMatchHistogramAggIdiomAlwaysYieldsPositiveWindowRange(`
+	// pins that positivity at both sources.
 	windowRange time.Duration
 	// windowFn is the matched range-vector function name. It decides
 	// both how a series' in-window samples reduce to one value per `le`
@@ -1249,15 +1256,11 @@ func lowerHistogramQuantileAgg(shape histogramAggShape, phi phiArg, s schema.Met
 	rangeEnd := windowRightBoundExpr(anchor)
 	pred = andExpr(pred, timeBoundExpr(s.TimestampColumn, anchor))
 	// Lower bound: TimeUnix > anchor - Range (Prom's left-open window).
-	// rangeStart defaults to rangeEnd (a zero-width window) for the #1692
-	// bare-selector shape (shape.windowRange == 0): classicBucketWindowStage's
-	// fold is latestSampleFold there, which ignores both bounds, so the
-	// placeholder never reaches SQL.
-	rangeStart := rangeEnd
-	if shape.windowRange > 0 {
-		rangeStart = windowLeftBoundExpr(anchor, shape.windowRange)
-		pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, shape.windowRange))
-	}
+	// shape.windowRange is strictly positive on every shape
+	// matchHistogramAggIdiom produces — see [histogramAggShape.windowRange] —
+	// so the window always has a real left bound.
+	rangeStart := windowLeftBoundExpr(anchor, shape.windowRange)
+	pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, shape.windowRange))
 
 	var input chplan.Node = scan
 	if pred != nil {
@@ -2201,13 +2204,10 @@ func lowerHistogramQuantileNativeAgg(shape histogramAggShape, phi phiArg, s sche
 	}
 	rangeEnd := windowRightBoundExpr(anchor)
 	pred = andExpr(pred, timeBoundExpr(s.TimestampColumn, anchor))
-	// rangeStart defaults to rangeEnd for the #1692 bare-selector shape —
-	// see lowerHistogramQuantileAgg's identical comment.
-	rangeStart := rangeEnd
-	if shape.windowRange > 0 {
-		rangeStart = windowLeftBoundExpr(anchor, shape.windowRange)
-		pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, shape.windowRange))
-	}
+	// The window's left bound, from the same always-positive windowRange
+	// lowerHistogramQuantileAgg binds it from.
+	rangeStart := windowLeftBoundExpr(anchor, shape.windowRange)
+	pred = andExpr(pred, stalenessLowerBoundExpr(s.TimestampColumn, anchor, shape.windowRange))
 
 	var input chplan.Node = scan
 	if pred != nil {

--- a/internal/promql/histogram_quantile_window_range_test.go
+++ b/internal/promql/histogram_quantile_window_range_test.go
@@ -1,0 +1,201 @@
+// Tests in this file pin the invariant the two aggregated histogram-quantile
+// lowerings rest on: every [histogramAggShape] that [matchHistogramAggIdiom]
+// yields carries a STRICTLY POSITIVE windowRange. Both
+// [lowerHistogramQuantileAgg] and [lowerHistogramQuantileNativeAgg] bind the
+// window's left bound and its staleness lower bound unconditionally from that
+// field, so a non-positive value would emit a degenerate window — a
+// zero-width `TimeUnix` range on the classic path, and a scan with no lower
+// time bound at all once the staleness predicate is dropped.
+package promql
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// windowRangeProbeParser mirrors the options every production cerberus parser
+// is built with — internal/api/prom/handler.go:`parser:    promparser.NewParser(`,
+// internal/api/prom/explain.go and internal/migrate/rulegraph.go:`var ruleGraphParser = promparser.NewParser(`.
+// None of them sets Options.ExperimentalDurationExpr, which is what
+// [TestPromQLGrammarRefusesNonPositiveMatrixRange] turns on its head.
+var windowRangeProbeParser = parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+// histogramQuantileShapeCorpus enumerates the histogram_quantile arguments
+// that can reach [matchHistogramAggIdiom]: both histogram families, every
+// selector spelling the matcher's own name test distinguishes, every
+// aggregation wrapper, both window arms (the #1692 no-range-wrapper arm and
+// each supported range-vector function), and every eval modifier.
+//
+// The phi argument is deliberately absent: the matcher only ever inspects
+// `c.Args[1]`, so varying `c.Args[0]` would multiply the corpus without
+// reaching a single new shape.
+func histogramQuantileShapeCorpus() []string {
+	metrics := []string{
+		"http_req_duration_seconds_bucket",
+		"http_req_duration_exp_hist",
+	}
+	selectors := []string{
+		"%s",
+		`%s{job="api"}`,
+		`%s{le="0.5"}`,
+		`%s{le=~"0\\.5|1"}`,
+		`%s{job!="api", le!="+Inf"}`,
+		`{__name__=~"%s"}`,
+	}
+	// "" is the #1692 arm: an aggregation directly over a bucket selector,
+	// with no range-vector wrapper at all.
+	windows := []string{
+		"",
+		"rate(%s[1s])",
+		"rate(%s[30s])",
+		"rate(%s[5m])",
+		"rate(%s[1h])",
+		"rate(%s[1d])",
+		"increase(%s[1s])",
+		"increase(%s[5m])",
+		"sum_over_time(%s[5m])",
+		"sum_over_time(%s[2h])",
+	}
+	aggregations := []string{
+		"",
+		"sum",
+		"sum by(le)",
+		"sum by(le, job)",
+		"sum without(le)",
+		"sum without(job)",
+		"sum by(job)",
+		"avg by(le)",
+		"max by(le)",
+		"min by(le)",
+		"count by(le)",
+		"group by(le)",
+		"stddev by(le)",
+		"quantile by(le)",
+		"topk by(le)",
+	}
+	modifiers := []string{"", " offset 5m", " offset -5m", " @ 1700000000", " @ start()", " @ end()"}
+
+	seen := map[string]bool{}
+	var out []string
+	for _, metric := range metrics {
+		for _, selector := range selectors {
+			base := fmt.Sprintf(selector, metric)
+			for _, modifier := range modifiers {
+				for _, window := range windows {
+					inner := base + modifier
+					if window != "" {
+						// The modifier binds inside the range-vector call:
+						// `rate(m[5m] offset 5m)`.
+						inner = strings.TrimSuffix(fmt.Sprintf(window, base), ")") + modifier + ")"
+					}
+					for _, aggregation := range aggregations {
+						arg := inner
+						switch {
+						case aggregation == "":
+						case strings.HasPrefix(aggregation, "quantile"), strings.HasPrefix(aggregation, "topk"):
+							arg = aggregation + "(2, " + inner + ")"
+						default:
+							arg = aggregation + "(" + inner + ")"
+						}
+						q := "histogram_quantile(0.9, " + arg + ")"
+						if !seen[q] {
+							seen[q] = true
+							out = append(out, q)
+						}
+					}
+				}
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestMatchHistogramAggIdiomAlwaysYieldsPositiveWindowRange sweeps
+// [histogramQuantileShapeCorpus] and pins that no accepted shape carries a
+// non-positive windowRange.
+//
+// The two assignments the matcher makes are
+// histogram_quantile.go:`windowRange: instantLookback` (the #1692
+// no-range-wrapper arm; instantLookback is qlcommon.InstantLookback, 5m) and
+// histogram_quantile.go:`windowRange: ms.Range` (the rate / increase /
+// sum_over_time arm), and this test fails the moment either stops being
+// strictly positive.
+func TestMatchHistogramAggIdiomAlwaysYieldsPositiveWindowRange(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	corpus := histogramQuantileShapeCorpus()
+	matched := 0
+	for _, q := range corpus {
+		expr, err := windowRangeProbeParser.ParseExpr(q)
+		if err != nil {
+			t.Fatalf("ParseExpr(%q): %v", q, err)
+		}
+		call, ok := expr.(*parser.Call)
+		if !ok || len(call.Args) != 2 {
+			t.Fatalf("ParseExpr(%q) is not a two-argument Call: %T", q, expr)
+		}
+		shape, ok := matchHistogramAggIdiom(call.Args[1], s)
+		if !ok {
+			continue
+		}
+		matched++
+		if shape.windowRange <= 0 {
+			t.Fatalf("matchHistogramAggIdiom(%q) yielded windowRange = %v; "+
+				"lowerHistogramQuantileAgg and lowerHistogramQuantileNativeAgg "+
+				"bind the window's left bound and staleness lower bound from it "+
+				"unconditionally, so a non-positive value emits a degenerate window",
+				q, shape.windowRange)
+		}
+	}
+	// A corpus that stopped matching would pass the loop above vacuously.
+	if matched < len(corpus)/2 {
+		t.Fatalf("matchHistogramAggIdiom accepted %d of %d corpus arguments; "+
+			"the corpus has stopped exercising the matcher", matched, len(corpus))
+	}
+}
+
+// TestPromQLGrammarRefusesNonPositiveMatrixRange pins the other half of the
+// invariant: `ms.Range`, the matcher's second windowRange source, can never
+// reach it as zero.
+//
+// The grammar's `positive_duration_expr` nonterminal rejects a non-positive
+// literal outright, and a MatrixSelector's Range is populated from a
+// *NumberLiteral only — a duration EXPRESSION leaves Range at zero and moves
+// the value into RangeExpr. That second spelling is what
+// [windowRangeProbeParser]'s options close off: with
+// Options.ExperimentalDurationExpr unset, the grammar records
+// "experimental duration expression is not enabled" and ParseExpr returns an
+// error instead of an expression with a zero Range.
+func TestPromQLGrammarRefusesNonPositiveMatrixRange(t *testing.T) {
+	t.Parallel()
+
+	for _, q := range []string{
+		// Non-positive literals.
+		"rate(http_req_duration_seconds_bucket[0s])",
+		"rate(http_req_duration_seconds_bucket[0m])",
+		"rate(http_req_duration_seconds_bucket[0])",
+		"rate(http_req_duration_seconds_bucket[-5m])",
+		"histogram_quantile(0.9, sum by(le)(rate(http_req_duration_seconds_bucket[0s])))",
+		// Duration expressions — the only spelling that leaves
+		// MatrixSelector.Range at zero on a successful parse.
+		"rate(http_req_duration_seconds_bucket[1m+1m])",
+		"rate(http_req_duration_seconds_bucket[2m-2m])",
+		"rate(http_req_duration_seconds_bucket[1m*0])",
+		"rate(http_req_duration_seconds_bucket[step()])",
+		"rate(http_req_duration_seconds_bucket[range()])",
+		"histogram_quantile(0.9, sum by(le)(rate(http_req_duration_seconds_bucket[2m-2m])))",
+	} {
+		if _, err := windowRangeProbeParser.ParseExpr(q); err == nil {
+			t.Fatalf("ParseExpr(%q) succeeded; a zero MatrixSelector.Range would then "+
+				"reach matchHistogramAggIdiom's `windowRange: ms.Range` assignment", q)
+		}
+	}
+}


### PR DESCRIPTION
# promql: delete histogram_quantile's invariantly-true zero-window guard

`internal/promql/histogram_quantile.go` guarded the window's left bound twice — once in
`lowerHistogramQuantileAgg` (the classic `_bucket` path) and once in
`lowerHistogramQuantileNativeAgg` (the exp-histogram sibling) — with a condition that is
invariantly true, under a comment describing a state the code cannot reach.

#2961 named the fork explicitly and did not assume the answer:

- **(a)** the zero case is genuinely impossible, and the guard, the `rangeStart := rangeEnd`
  placeholder and the comment all go; or
- **(b)** the shape is supposed to be able to carry a zero window and something upstream stopped
  producing it — a behaviour bug, where the remedy is restoring the producer, not removing the
  consumer.

**Both sites land on (a).** The evidence is below, and the deletion is justified by that evidence
rather than by a mutation score.

## Why (a), not (b): no zero producer was ever removed

`git log -p --all` over `internal/promql/histogram_quantile.go` shows exactly three `windowRange:`
assignments ever written into the file: `instantLookback`, and `ms.Range` twice (the second is the
present-day line, the first its predecessor). There is no removed producer to restore.

The three commits that shaped the guard tell the same story in order:

- `2f99c936a` (#281) introduced `if shape.windowRange > 0` in the *first* aggregated-input
  lowering. At that commit `matchHistogramAggIdiom`'s only producer was `windowRange: ms.Range`.
  The guard was defensive from birth — it never had a zero producer to consume.
- `8b5ff8739` (#1742, which closed #1692) added the second producer. It arrived already spelled
  `windowRange: instantLookback` — the 5-minute staleness lookback, never zero. So the
  bare-selector shape the comment names has never carried a zero window.
- `f013a03e8` (#1958) added the `rangeStart := rangeEnd` placeholder *and* the comment that
  attributes the zero to the #1692 shape. That rationale was already false when it was written:
  #1742 had already set that shape to `instantLookback`.

The comment is therefore not a record of a lost behaviour. It is a rationale invented after the
fact for a branch that had never been taken.

## Static proof

`histogramAggShape` values reach these two functions from exactly one place —
histogram_quantile.go:`shape, matched := matchHistogramAggIdiom(` — and the four call sites
(`lowerHistogramQuantileNativeAgg` twice, `lowerHistogramQuantileAgg` twice) all pass that one
`shape`. `matchHistogramAggIdiom` is called nowhere else in non-test code. The other
`histogramAggShape` composite literals in the package (`histogram_native_range_fn.go`,
`histogram_native_over_time.go`, `histogram_native_resets.go`,
`histogram_native_subquery_call_subquery.go`,
`histogram_native_mixed_or_subquery_aggregate_range_fn.go`) feed their own lowerings and never
reach these two.

The matcher writes `windowRange` at two places, and each source excludes zero:

1. histogram_quantile.go:`windowRange: instantLookback` — `instantLookback` is
   modifiers.go:`const instantLookback = qlcommon.InstantLookback`, and
   `qlcommon/lookback.go` defines it as `5 * time.Minute`, pinned by
   `internal/qlcommon/lookback_test.go`.
2. histogram_quantile.go:`windowRange: ms.Range` — enforced by the upstream grammar. The
   `matrix_selector` production takes a `positive_duration_expr`, whose action rejects a
   non-positive literal with `"duration must be greater than 0"`.

That second source has one non-obvious zero path, and cerberus closes it. The grammar populates
`MatrixSelector.Range` from a `*NumberLiteral` only; a duration *expression* (`[1m+1m]`,
`[step()]`) leaves `Range` at zero and carries the value in `RangeExpr` instead. Every parser
cerberus constructs — `internal/api/prom/handler.go`, `internal/api/prom/explain.go` (twice) and
`internal/migrate/rulegraph.go` — leaves `parser.Options.ExperimentalDurationExpr` unset, so the
grammar records `"experimental duration expression is not enabled"` and `ParseExpr` returns an
error rather than an expression with a zero `Range`.

The unconditional form this PR adopts is also already the package's dominant spelling: the sibling
lowerings at histogram_native_range_fn.go:`rangeStart := windowLeftBoundExpr(anchor, shape.windowRange)`
and histogram_native_over_time.go:`windowLeftBoundExpr(anchor, shape.windowRange),` bind the same
bound from the same field with no guard at all.

## Empirical proof

The `shape.windowRange > 0` guard's false branch was replaced with a `panic`, so any reachable
zero would abort rather than be silently absorbed. Under that instrumentation:

- the whole `internal/promql` suite under `-race` — `ok`, 24.7s;
- the shape matrix itself, 54,000 generated histogram_quantile queries lowered
  and emitted in instant, 30s-step and 5m-step range mode — 162,000 passes through the
  two functions — `PASS`, 587s;
- `go test -tags chdb ./test/spec/...` — `traceql` and `wire` green, and 40 minutes of the
  `test/spec/promql` chDB roundtrip shard before it hit the *run's own* `-timeout 40m`
  (load average on the host was ~50 from concurrent work; the stack is chDB inside
  `runRoundTripSQL`, not an assertion). The suite is re-run below at a realistic timeout.

`grep -c PROBE2961` over the combined output of all three: **0** — neither panic fired. The
instrumentation was then removed, and `git diff` against `HEAD` confirmed the file was back to its
unmodified state before the real edit was applied.

## Byte-identical output

Emitted SQL and bound args were dumped over the full histogram-quantile shape matrix — both
histogram families, six selector spellings, ten window arms (including the #1692 no-range-wrapper
arm), fifteen aggregation wrappers, six eval modifiers, five phi spellings, in instant, 30s-step
and 5m-step range mode — before and after the deletion. Lowering and emit errors were captured as
payloads too, so an error-string change would show up as a difference.

`cmp` is clean on both artefacts:

| artefact | size | result |
|---|---|---|
| digest, one SHA-256 per query x mode over all 162,000 pairs | 28,603,800 B | byte-identical |
| verbatim SQL + `%#v` bound args over a strided sub-matrix | 72,478,939 B | byte-identical |

As a control, the panic-instrumented build's dump is byte-identical to the uninstrumented
baseline too, which is what an unreachable branch should produce.

No golden was regenerated and no fixture churned — `git status` over `test/` is empty. That
follows from the dump above: the spec goldens pin emitted SQL and the chplan IR, and the emitted
SQL is byte-identical over a matrix that strictly contains the corpus's histogram-quantile shapes.
The chdb spec lane itself is a required check on this PR and runs on a dedicated runner; the local
box was saturated (load average 60-74 from concurrent work) while this was written.

## The replacement is not itself dead

The deletion makes positivity load-bearing rather than optional, so it is pinned by a test rather
than by a runtime branch — a rejection branch for a state the production code cannot construct
would be new machinery for an unreachable input, and the silently-degrading branch that was there
is what this PR removes.

`internal/promql/histogram_quantile_window_range_test.go` adds two tests, and both were checked by
breaking them:

| what was broken | result |
|---|---|
| producer A neutered: `windowRange: instantLookback` -> `0` | `TestMatchHistogramAggIdiomAlwaysYieldsPositiveWindowRange` FAILS |
| producer B neutered: `windowRange: ms.Range` -> `0` | same test FAILS, on a different corpus entry |
| assertion widened: `shape.windowRange <= 0` -> `< 0`, producer A still neutered | test PASSES again, so the assertion is load-bearing exactly at its boundary |
| `Options.ExperimentalDurationExpr: true` on the probe parser | `TestPromQLGrammarRefusesNonPositiveMatrixRange` FAILS on `rate(...[1m+1m])` |

The corpus test also refuses to pass vacuously: it fails if fewer than half its arguments
match a shape, so a corpus that stopped reaching the matcher is a failure rather than a
silent green.

## Re-measured `phase4-promql-quantile`

Measured from CI artifacts — run `33673967810`, `push` to `main` at `cd1198a220d7`, the newest
completed post-#2947 main run carrying a `gremlins-phase4-promql-quantile` artifact.
Cross-checked byte-identical against the previous post-#2947 run `33669826536`, so the
numbers are reproducible rather than one runner's noise.

The leg is defined in `.github/scripts/mutation-phases.mjs` with scope `./internal/promql` and
`include_files: '^(histogram_quantile)\\.go$'`, so its file scope is exactly the file this PR
edits, and its floor is the shared `EFFICACY = 95`. The scorer
(`.github/scripts/gremlins-threshold.mjs`) computes
`(killed + runTimedOut) / (killed + lived + timedOut + runTimedOut)`.

Before: killed 67, lived 4, timed out 0, run timed out 0 -> **67/71 = 94.3662%**, 0.63 pp under
floor, with **zero killable survivors**. The four were the two `shape.windowRange > 0`
CONDITIONALS_BOUNDARY mutants and two capacity hints, `len(passthrough)+2` and `len(labels)*2`.

Each guard line carried **two** mutants — the LIVED CONDITIONALS_BOUNDARY and a KILLED
CONDITIONALS_NEGATION at the same line and column — so deleting a guard drops one from the
numerator and two from the denominator.

After: killed 65, lived 2 -> **65/67 = 97.0149%**, above the floor.

The two remaining survivors are the capacity hints, which belong to the class cerberus issue
#2958 is settling; they are untouched here and stay adjudicated in
`internal/promql/gremlins_kill_window_bounds_test.go`. That file's NOT KILLABLE inventory loses
its "A GUARD WHOSE CONDITION IS INVARIANTLY TRUE" class along with the code — the class cited
both guards by construct, and `verify-code-citations` is a required step that would fail on the
dangling citations — leaving five classes, renumbered.

No threshold was lowered, no denominator shrunk and no file excluded. The denominator falls only
because two mutants' host statements no longer exist.

Closes #2961
