### PR TITLE
test(mutation): kill 13 survivors and clear the last three logql legs

### DIFF
--- a/internal/logql/gremlins_kill_2949_lower_test.go
+++ b/internal/logql/gremlins_kill_2949_lower_test.go
@@ -1,0 +1,199 @@
+package logql
+
+import (
+	"testing"
+
+	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Tests in this file kill LIVED gremlins mutants reported on the
+// phase4-logql-lower leg (cerberus issue #2949), whose mutated file is
+// lower.go.
+
+// TestPipelineLineExprScansPastNonUnpackStages kills the INVERT_LOOPCTRL
+// mutant on the `continue` that skips a non-`| unpack` stage in
+// [PipelineLineExpr]'s scan, guarded by
+// lower.go:PipelineLineExpr:`!ok || lp.Op != syntax.OpParserTypeUnpack`.
+//
+// The citation names that neighbouring `if` rather than the mutated
+// statement: the mutant rewrites a bare `continue`, which no substring
+// singles out.
+//
+// The loop looks for an `| unpack` stage ANYWHERE in the pipeline, so a
+// stage that is not one has to be stepped over rather than treated as the
+// end of the search. `| json | unpack` puts a non-unpack parser stage in
+// front of the unpack:
+//
+//   - ORIGINAL `continue`: the `| json` stage is skipped, the `| unpack`
+//     stage behind it is found, and the line expression is rewritten to
+//     read the packed payload's `_entry` member.
+//   - MUTANT `break`: the scan stops at `| json` and returns nil, so
+//     [lang.go]'s log-row projection falls back to the bare body column
+//     and hands callers the packed JSON under labels describing its
+//     contents — the exact regression PipelineLineExpr exists to prevent.
+func TestPipelineLineExprScansPastNonUnpackStages(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	const query = `{app="api"} | json | unpack`
+
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	got, err := PipelineLineExpr(expr, s)
+	if err != nil {
+		t.Fatalf("PipelineLineExpr(%q): %v", query, err)
+	}
+	if got == nil {
+		t.Fatalf("PipelineLineExpr(%q) = nil, want the unpack line rewrite — the scan stopped at the first non-unpack stage instead of stepping over it", query)
+	}
+	fc, ok := got.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnIf {
+		t.Fatalf("PipelineLineExpr(%q) = %T (%q), want *chplan.FuncCall(%q)", query, got, funcName(got), chplan.FnIf)
+	}
+}
+
+// TestPipelineLineExprSeedsFirstUnpackWithBodyColumn kills the
+// CONDITIONALS_NEGATION mutant on lower.go:PipelineLineExpr:`prev == nil`
+// (`== nil` -> `!= nil`).
+//
+// That guard seeds the FIRST `| unpack` in a pipeline with the stored body
+// column, because there is no earlier line rewrite to read from; a second
+// unpack instead chains onto the first one's result.
+//
+//   - ORIGINAL: on the single unpack of `{app="api"} | unpack`, prev is
+//     nil, so it is seeded with the body column and the emitted
+//     `if(isPacked, JSONExtractString(Body, '_entry'), Body)` has the body
+//     column as its else-branch.
+//   - MUTANT `!= nil`: prev stays nil, the seed is skipped, and the
+//     else-branch of the emitted `if` is a nil expression — an unpacked
+//     log line whose non-packed fallback reads nothing at all.
+func TestPipelineLineExprSeedsFirstUnpackWithBodyColumn(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	const query = `{app="api"} | unpack`
+
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	got, err := PipelineLineExpr(expr, s)
+	if err != nil {
+		t.Fatalf("PipelineLineExpr(%q): %v", query, err)
+	}
+	fc, ok := got.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnIf || len(fc.Args) != 3 {
+		t.Fatalf("PipelineLineExpr(%q) = %T (%q), want a 3-arg *chplan.FuncCall(%q)", query, got, funcName(got), chplan.FnIf)
+	}
+	col, ok := fc.Args[2].(*chplan.ColumnRef)
+	if !ok || col.Name != s.BodyColumn {
+		t.Fatalf("PipelineLineExpr(%q) not-packed branch = %#v, want *chplan.ColumnRef{Name: %q} — the first unpack was not seeded with the stored body column", query, fc.Args[2], s.BodyColumn)
+	}
+}
+
+// TestPipelineSkipsGoSideErrorFilterWithoutStopping kills the
+// INVERT_LOOPCTRL mutant on the `continue` that skips a post-dynamic-stage
+// `__error__` label filter in [lowerPipelineWithLabels]'s stage loop,
+// guarded by
+// lower.go:lowerPipelineWithLabels:`ok && dynamicLabels && FiltersErrorLabel(lf.LabelFilterer)`.
+//
+// The citation names that neighbouring `if` rather than the mutated
+// statement: the mutant rewrites a bare `continue`, which no substring
+// singles out.
+//
+// An `__error__` filter that follows a dynamic label stage (`| pattern`,
+// per [isDynamicLabelStage]) is deliberately NOT lowered into SQL —
+// internal/api/loki's newLabelFilterStep re-applies it in Go once the
+// stage's transform has computed the row's real `__error__` label.
+// Skipping it must not abandon the stages BEHIND it, which still lower
+// normally.
+//
+//   - ORIGINAL `continue`: the `__error__=""` stage is skipped and the
+//     `level="ZZ-KILL-MARKER"` stage behind it is lowered, so the marker
+//     appears in the plan's filter predicate.
+//   - MUTANT `break`: the loop abandons the pipeline at the `__error__`
+//     stage, silently dropping every later filter — the plan returns rows
+//     the query excluded, and the marker is absent.
+func TestPipelineSkipsGoSideErrorFilterWithoutStopping(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	const marker = "ZZ-KILL-MARKER"
+	const query = `{app="api"} | pattern "<ip> - <_>" | __error__="" | level="` + marker + `"`
+
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower(%q): %v", query, err)
+	}
+	if !planPredicateHasLiteral(plan, marker) {
+		t.Fatalf("lower(%q): the %q label filter is missing from the plan's predicates — the stage loop stopped at the Go-side `__error__` filter instead of stepping over it, dropping every stage behind it", query, marker)
+	}
+}
+
+// planPredicateHasLiteral reports whether any [chplan.Filter] predicate in
+// the plan's spine carries the string literal `want`.
+func planPredicateHasLiteral(plan chplan.Node, want string) bool {
+	found := false
+	var walk func(chplan.Node)
+	walk = func(n chplan.Node) {
+		switch v := n.(type) {
+		case *chplan.Filter:
+			walkExprTree(v.Predicate, func(e chplan.Expr) {
+				if ls, ok := e.(*chplan.LitString); ok && ls.V == want {
+					found = true
+				}
+			})
+			walk(v.Input)
+		case *chplan.Project:
+			walk(v.Input)
+		case *chplan.RangeWindow:
+			walk(v.Input)
+		case *chplan.Aggregate:
+			walk(v.Input)
+		}
+	}
+	walk(plan)
+	return found
+}
+
+// NOT KILLABLE — documented, not defended by a test. These are the four
+// LIVED mutants phase4-logql-lower reports that no input can distinguish.
+//
+// lower.go:`extension <= 0` — CONDITIONALS_BOUNDARY (`<=` -> `<`).
+// The two forms differ only at extension == 0, and there the guarded body
+// is the identity: it copies the context and rewrites Start as
+// `c.Start.Add(-0)`. `time.Time.Add(0)` adds zero to both the wall reading
+// and the monotonic reading and returns the receiver's exact value, so the
+// mutant's "extended" context is field-for-field the context the original
+// returns early. Nothing downstream can see a difference because there is
+// none to see.
+//
+// lower.go:`len(fields)*2` and lower.go:`len(segments)+1` —
+// ARITHMETIC_BASE on a make() CAPACITY hint. Both slices are built with
+// append from length 0, so contents and ordering are identical whatever
+// the pre-sized cap, and a capacity is not reachable from the returned
+// plan. Neither mutated form can go negative and panic either: `len(...)`
+// is never negative, and `len(segments)` is never 0 at that point — the
+// only producer of `segments` is jsonPathParse, which returns a non-empty
+// slice or an error, and the error path returns before the make().
+//
+// lower.go:`len(candidates) <= 1` — CONDITIONALS_BOUNDARY (`<=` -> `<`).
+// The forms differ only at len(candidates) == 1, and there they build the
+// same node. The original returns `MapAccess{labelsMap, key}`; the mutant
+// calls qlcommon.OTelDottedFallbackChain with the one candidate, whose
+// loop over the remaining candidates does not run, so it returns
+// `MapAccess{labelsMap, candidates[0]}`. A one-element candidate list is
+// produced only for a key with no `_` separator to re-spell, and
+// format.PromLabelToOTelCandidates always leads with the key verbatim, so
+// candidates[0] IS key and the two MapAccess nodes are field-identical.
+// len(candidates) == 0 does not distinguish them either: both forms take
+// the early return.

--- a/internal/logql/gremlins_kill_2949_other_b_test.go
+++ b/internal/logql/gremlins_kill_2949_other_b_test.go
@@ -1,0 +1,132 @@
+package logql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
+)
+
+// This file kills a LIVED gremlins mutant reported on the
+// phase4-logql-other-b leg (cerberus issue #2949) in drop_keep.go: the
+// INVERT_LOOPCTRL rewrite of the `continue` inside
+// [projectSyntheticLabelValue]'s MATCHER loop, where `break` abandons the
+// rest of the matcher list and silently returns the synthetic label
+// untouched — the plan then keeps a `detected_level` the query asked to
+// drop.
+//
+// The citation names the mutated statement's neighbouring `if` rather
+// than the statement itself: the mutant rewrites a bare `continue`, which
+// no substring singles out.
+//
+// NOT KILLABLE — the other two INVERT_LOOPCTRL mutants on this function,
+// on the `continue`s guarded by drop_keep.go:`if len(entries) == 0 {` and
+// drop_keep.go:`if unconditional {`, cannot be killed by any input.
+// Both of those `continue`s sit directly in a `case` body of the stage
+// TYPE SWITCH, so Go binds the mutant's `break` to the SWITCH rather than
+// to the `for`: it leaves the case, the loop body ends there anyway
+// (the switch is its last statement), and the walk proceeds to the next
+// stage exactly as `continue` would. Verified by hand-applying both
+// mutants — the keep-then-drop and empty-keep-then-drop projections come
+// out byte-identical. The matcher-loop `continue` killed below is
+// different precisely because its innermost breakable statement is the
+// inner `for _, e := range st.Matchers()`.
+
+// requireConditionalRetention asserts that the projection came out as the
+// per-row `if(<survives>, <value>, ”)` form rather than the untouched
+// value, which is what every one of these mutants degrades it to.
+func requireConditionalRetention(t *testing.T, got chplan.Expr, what string) {
+	t.Helper()
+	fc, ok := got.(*chplan.FuncCall)
+	if !ok || fc.Fn != chplan.FnIf {
+		t.Fatalf("%s: projectSyntheticLabelValue = %#v, want a *chplan.FuncCall(%q) row predicate — the stage walk stopped early and returned the synthetic label untouched, keeping a value the pipeline drops", what, got, chplan.FnIf)
+	}
+}
+
+// syntheticValue is the per-use-site value constructor
+// [projectSyntheticLabelValue] takes. The literal stands in for the
+// synthesised `detected_level` expression; only its identity as a
+// non-nil expr matters here.
+func syntheticValue() chplan.Expr { return &chplan.LitString{V: "info"} }
+
+// TestDropMatchersScanPastOtherLabels kills the INVERT_LOOPCTRL mutant on
+// the `continue` that skips a value-matcher naming a DIFFERENT label,
+// guarded by drop_keep.go:projectSyntheticLabelValue:`if e.Matcher.Name != key {`.
+//
+// `| drop` takes a comma-separated matcher list and the synthetic key can
+// sit anywhere in it, so a matcher for another label has to be stepped
+// over rather than end the scan. The selector below puts the unrelated
+// `foo="x"` FIRST for exactly that reason.
+//
+//   - ORIGINAL `continue`: `foo="x"` is skipped, the
+//     `detected_level="info"` matcher behind it is folded into the
+//     survival predicate, and the projection becomes conditional.
+//   - MUTANT `break`: the matcher scan ends at `foo="x"`, no predicate is
+//     built, and `detected_level` is retained on every row.
+func TestDropMatchersScanPastOtherLabels(t *testing.T) {
+	t.Parallel()
+
+	const query = `{a="b"} | drop foo="x", detected_level="info"`
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	got := projectSyntheticLabelValue(expr, detectedLevelLabel, syntheticValue)
+	requireConditionalRetention(t, got, query)
+}
+
+// NOT KILLABLE — documented, not defended by a test. These are the LIVED
+// mutants phase4-logql-other-b reports outside the logpattern subpackage
+// (whose own survivors are adjudicated in
+// logpattern/gremlins_kill_2949_test.go) that the kill above does not
+// reach.
+//
+// duration.go:`len(marks)*2+1` — ARITHMETIC_BASE on a make() CAPACITY
+// hint, carrying two mutants (one per operator). The slice is built with
+// append from length 0, so contents and ordering do not depend on the cap,
+// and the cap is not reachable from the returned expression. Neither
+// mutated form can go negative and panic: the function returns early for
+// an empty mark list, so len(marks) >= 1 at the make().
+//
+// ip.go:`err != nil || addr.Is6() != r.V6` — INVERT_LOGICAL (`||` ->
+// `&&`), which stops the loop skipping a candidate that fails ONE of the
+// two tests. Neither surviving case reaches the `return true`, because the
+// range comparison two lines down re-derives the same verdict:
+// netip.Addr.Compare orders by BitLen() first, so a zero address (BitLen 0
+// — what ParseAddr leaves behind on error) and a wrong-family address (32
+// against 128, or 128 against 32) both compare strictly outside any
+// well-formed range. Checked differentially as well as by argument: over a
+// 220-pair (subject, pattern) corpus spanning malformed IPv4 candidates,
+// IPv4 candidates matched by the IPv6 candidate regex, IPv4-in-IPv6 forms
+// and zone-suffixed addresses, original and mutant return a byte-identical
+// result set.
+//
+// jsonpath.go:`!ok || r != '"'` — INVERT_LOGICAL (`||` -> `&&`). Both
+// operands are always false at the only call site, so both forms are false
+// and the `return ""` body is unreachable either way: scanStr is called
+// only from next()'s `case r == '"'` arm, which unreads that quote
+// immediately beforehand. (The CONDITIONALS_NEGATION mutant on the same
+// line IS killed — negating an operand makes the unreachable body fire.)
+//
+// jsonpath.go:`len(digits) > 0` — CONDITIONALS_BOUNDARY (`>` -> `>=`),
+// widening an operand that is already invariantly true. scanInt is called
+// only from next()'s digit arm, which unreads that digit beforehand, so
+// iteration 1 always reads a digit and appends it; every later iteration
+// therefore has a non-empty `digits`. The float-index error the guard
+// raises is reachable, which is why the other three mutants on the same
+// line are killed — but its `len(digits) > 0` operand is not what decides
+// it.
+//
+// top_level_columns.go:`label == "" || len(s.MaterializedResourceColumns) == 0`
+// — INVERT_LOGICAL (`||` -> `&&`). Both operands lead to the `("", false)`
+// the fall-through already returns. A nil or empty map misses both
+// lookups. An empty label misses both too: the map is never user-supplied
+// (schema.Logs.MaterializedResourceColumns is either
+// defaultMaterializedResourceColumns()'s eight fixed OTel keys or nil,
+// with no config override path) and none of those keys is `""`, and the
+// dotted retry is skipped because strings.ReplaceAll("", "_", ".") equals
+// the label.
+//
+// The last three are conditions that decide nothing rather than conditions
+// no test happens to reach, and removing them is tracked as cerberus issue
+// #2973 — with PR #2952's proof bar, which a test-only change cannot meet.

--- a/internal/logql/gremlins_kill_2949_test.go
+++ b/internal/logql/gremlins_kill_2949_test.go
@@ -111,3 +111,35 @@ func findVectorSetOp(n chplan.Node) *chplan.VectorSetOp {
 	}
 	return nil
 }
+
+// NOT KILLABLE — documented, not defended by a test. With the two
+// outer-by threading mutants killed in vector_aggregation_mutation_test.go
+// these are the LIVED mutants phase4-logql-aggregation has left, and no
+// input distinguishes any of them.
+//
+// lang.go:`err == nil && parsed != nil` — INVERT_LOGICAL (`&&` -> `||`).
+// The two operands are not independent: they are the same fact. The guard
+// runs only under `HasLabelMutatingStage(expr)`, and BOTH of that
+// predicate's true-returning paths require expr to be a
+// *syntax.PipelineExpr. PipelineLabelsExpr on a *syntax.PipelineExpr
+// returns `(nil, err)` on failure and otherwise a labelsExpr that starts
+// non-nil and is only ever replaced by a non-nil merge — so `err == nil`
+// holds exactly when `parsed != nil`. The `||` form therefore selects the
+// same iterations as the `&&` form. (The two CONDITIONALS_NEGATION mutants
+// on the same line ARE killed: negating either operand breaks the
+// correlation instead of preserving it.) The redundancy itself is a
+// finding rather than a defence, and is tracked as cerberus issue #2973.
+//
+// range_aggregation.go:`len(e.Left.Unwrap.PostFilters) > 0` —
+// CONDITIONALS_BOUNDARY (`>` -> `>=`), so the mutant also enters the body
+// with an EMPTY post-filter list. applyUnwrapPostFilters is the identity
+// on an empty list: it peels the top-level Filter, folds no predicate onto
+// it, wraps the labels with an empty mark set (wrapLabelsWithMarks returns
+// its argument unchanged for zero marks) and rebuilds the same Filter over
+// the same Input with the same Predicate. Its third result is
+// `len(marks) > 0` — false — so the caller's `hasErrorMarks` is unchanged
+// too. Every field of every returned value is identical.
+//
+// range_aggregation.go:`len(e.Grouping.Groups)*2` — ARITHMETIC_BASE on a
+// make() CAPACITY hint, equivalent for the reason spelled out in
+// vector_aggregation_mutation_test.go's header for the sibling site.

--- a/internal/logql/logpattern/gremlins_kill_2949_test.go
+++ b/internal/logql/logpattern/gremlins_kill_2949_test.go
@@ -1,0 +1,119 @@
+package logpattern
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Tests in this file kill LIVED gremlins mutants reported on the
+// phase4-logql-other-b leg (cerberus issue #2949), whose scope includes
+// this package.
+
+// TestIdentifierAlphabetBoundaries kills the CONDITIONALS_BOUNDARY and
+// CONDITIONALS_NEGATION mutants on the capture-identifier alphabet,
+// pattern.go:isIdentStart:`b >= 'a'` and its three siblings on the same
+// line, plus pattern.go:isIdentCont:`b >= '0'` and `b <= '9'`.
+//
+// A capture is `<` then `[A-Za-z_][A-Za-z0-9_]*` then `>` (see the
+// package doc). Any `<` that does not open a valid capture stays an
+// ordinary literal, so shrinking the alphabet by one character at either
+// end of a range silently demotes a capture to text — the pattern still
+// compiles, it just stops extracting the field the user asked for.
+//
+// Each case below sits on one range endpoint, which is exactly what a
+// boundary mutant moves:
+//
+//   - `z`  — `b <= 'z'` -> `b < 'z'` drops the last lower-case start.
+//   - `A`  — `b >= 'A'` -> `b > 'A'` drops the first upper-case start;
+//     the same case also kills `b <= 'Z'` -> `b > 'Z'` (NEGATION), which
+//     makes the whole upper-case arm `b >= 'A' && b > 'Z'` reject `A`.
+//   - `Z`  — `b <= 'Z'` -> `b < 'Z'` drops the last upper-case start.
+//   - `a0` — `b >= '0'` -> `b > '0'` drops `0` from the CONTINUATION
+//     alphabet, so `<a0>` stops closing on `>`.
+//   - `a9` — `b <= '9'` -> `b < '9'` drops `9` the same way.
+func TestIdentifierAlphabetBoundaries(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		pattern string
+		want    []string
+	}{
+		{name: "lower-case upper endpoint", pattern: `<z> tail`, want: []string{"z"}},
+		{name: "upper-case lower endpoint", pattern: `<A> tail`, want: []string{"A"}},
+		{name: "upper-case upper endpoint", pattern: `<Z> tail`, want: []string{"Z"}},
+		{name: "digit continuation lower endpoint", pattern: `<a0> tail`, want: []string{"a0"}},
+		{name: "digit continuation upper endpoint", pattern: `<a9> tail`, want: []string{"a9"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m, err := New(tc.pattern)
+			if err != nil {
+				t.Fatalf("New(%q): %v — the identifier alphabet no longer accepts this capture name, so the `<…>` run stayed a literal and the pattern has no capture at all", tc.pattern, err)
+			}
+			if got := m.Names(); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("New(%q).Names() = %q, want %q — the identifier alphabet no longer accepts this capture name", tc.pattern, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLineFilterOffsetAdvancesCumulatively kills the
+// REMOVE_SELF_ASSIGNMENTS mutant on pattern.go:Test:`off += j + len(lit)`
+// (`+=` -> `=`).
+//
+// `off` is the cursor into the subject line: each literal run is searched
+// for in `in[off:]`, so the amount found must be ADDED to the cursor, not
+// assigned over it. The mutant is invisible while `off` is still 0, which
+// is why the pattern below carries THREE literal runs — the error only
+// appears from the second advance onwards, and then compounds.
+//
+// For pattern `a<_>b<_>c` against `aXbYc` the cursor walks 0 -> 1 -> 3 ->
+// 5 and lands exactly on the end of the line, so the trailing literal
+// leaves no remainder and Test reports a match. Under the mutant it walks
+// 0 -> 1 -> 2 -> 3, stops three bytes short, and the leftover tail makes
+// Test report no match.
+func TestLineFilterOffsetAdvancesCumulatively(t *testing.T) {
+	t.Parallel()
+
+	const pattern = `a<_>b<_>c`
+	m, err := ParseLineFilter([]byte(pattern))
+	if err != nil {
+		t.Fatalf("ParseLineFilter(%q): %v", pattern, err)
+	}
+	const line = "aXbYc"
+	if !m.Test([]byte(line)) {
+		t.Fatalf("ParseLineFilter(%q).Test(%q) = false, want true — the literal-run cursor was assigned instead of advanced, so it stopped short of the end of the line and reported a spurious remainder", pattern, line)
+	}
+}
+
+// NOT KILLABLE — documented, not defended by a test. These are the LIVED
+// and TIMED OUT mutants phase4-logql-other-b reports in this package that
+// the kills above do not reach.
+//
+// pattern.go:`i+1 >= len(e)` guards a bare `break` that INVERT_LOOPCTRL
+// rewrites to `continue`. The guard is true only on the LAST iteration of
+// `for i, n := range e`, and on the last iteration `continue` and `break`
+// do the same thing: the range is exhausted, so both leave the loop with
+// the same state and fall through to the same `return nil`. The
+// CONDITIONALS_BOUNDARY mutant on the same guard is killed, because
+// widening it to `i+1 > len(e)` lets `e[i+1]` index out of range.
+//
+// pattern.go:`len(s) < 2` — CONDITIONALS_BOUNDARY (`<` -> `<=`). The forms
+// differ only at len(s) == 2, i.e. a `<` and one identifier byte at the
+// very end of the input. The original then runs the scan: j starts at 2,
+// the continuation loop's `j < len(s)` is immediately false, and the
+// closing-`>` test `j < len(s)` is false too, so it returns
+// `("", 0, false)` — the same triple the mutant returns from the widened
+// guard. The `<` itself stays a literal either way. (The guard is NOT
+// redundant below that boundary: at len(s) < 2 it is what keeps `s[1]`
+// from indexing out of range.)
+//
+// pattern.go:`i += consumed` and pattern.go:`i += size` carry the leg's
+// three TIMED OUT mutants (INVERT_ASSIGNMENTS and REMOVE_SELF_ASSIGNMENTS).
+// Both statements are the sole advance of `parse`'s cursor, so every
+// mutant of either spins forever on the same input byte. They are the
+// memory-guard-reaped class recorded on cerberus issue #2949: the guard
+// holds after reaping precisely so no exit status can be read as a
+// verdict, which destroys the evidence a detection credit would be read
+// from. They stay in the denominator, credited to nobody.

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -334,9 +334,11 @@ func lowerPipelineWithLabels(e *syntax.PipelineExpr, s schema.Logs, lc lowerCtx)
 	return &chplan.Filter{Input: inner, Predicate: pred}, labelsExpr, nil
 }
 
-// isDynamicLabelStage reports whether stage is a `| unpack` / `|
-// pattern` parser stage — see [lowerPipelineWithLabels]'s dynamicLabels
-// gate.
+// isDynamicLabelStage reports whether stage is a `| pattern` parser
+// stage — see [lowerPipelineWithLabels]'s dynamicLabels gate. `| unpack`
+// is deliberately NOT one: its `__error__` markers come from SQL, so a
+// following `__error__` filter lowers normally and needs no Go-side
+// re-evaluation. internal/api/loki's pipelineSteps draws the same line.
 func isDynamicLabelStage(stage syntax.StageExpr) bool {
 	lp, ok := stage.(*syntax.LineParserExpr)
 	if !ok {
@@ -351,8 +353,8 @@ func isDynamicLabelStage(stage syntax.StageExpr) bool {
 // [lowerPipelineWithLabels]'s dynamicLabels gate, which only skips SQL
 // lowering for this family, not for arbitrary label names. Exported so
 // internal/api/loki's postProcessExtract can apply the exact same gate
-// when deciding which post-`| unpack` / `| pattern` label filters need
-// a Go-side re-evaluation (see post_process.go's newLabelFilterStep).
+// when deciding which post-`| pattern` label filters need a Go-side
+// re-evaluation (see post_process.go's newLabelFilterStep).
 func FiltersErrorLabel(lf syntax.LabelFilterer) bool {
 	switch f := lf.(type) {
 	case *syntax.StringLabelFilter:

--- a/internal/logql/vector_aggregation_mutation_test.go
+++ b/internal/logql/vector_aggregation_mutation_test.go
@@ -15,19 +15,26 @@ import (
 // is written so the mutated line produces a DIFFERENT lowered plan than
 // the original, making the assertion fail under mutation.
 //
-// Equivalence verdicts (no test can kill these — see reasoning in the
-// task return notes):
-//   - 46:72  CONDITIONALS_BOUNDARY (`> 0` → `>= 0`): the only
-//     distinguishing input is `by ()` (empty groups), and
-//     withOuterByLabels([]) ≡ withOuterByLabels(nil) because both
-//     topLevelColumnsReferencedBy and structuredOuterByKeys collapse a
-//     len-0 slice to nil. Byte-identical lowering ⇒ equivalent.
-//   - 390:72 CONDITIONALS_BOUNDARY (`> 0` → `>= 0`): same reasoning in
-//     sortableShapedInner ⇒ equivalent.
-//   - 454:56 ARITHMETIC_BASE (`len(...)*2` → `/2`/`+`/...): a make()
-//     capacity hint. The slice is built with append from len 0, so its
-//     final contents are identical regardless of the pre-sized cap; the
-//     cap is never observable in the returned plan ⇒ equivalent.
+// NOT KILLABLE — vector_aggregation.go:wrapVectorAggregateForSample:`len(e.Grouping.Groups)*2`
+// carries an ARITHMETIC_BASE mutant (`*2` -> `/2` and friends) that no
+// test can kill: it is a make() CAPACITY hint. The slice is built with
+// append from length 0, so its final contents and ordering are identical
+// whatever the pre-sized cap, and a cap is not reachable from the
+// returned plan. `len(...)` is never negative and the mutated forms stay
+// non-negative, so make() cannot panic either.
+//
+// The empty-`Grouping.Groups` CONDITIONALS_BOUNDARY mutants on the
+// outer-by threading guard were ADJUDICATED EQUIVALENT HERE AND THAT WAS
+// WRONG. The old argument was that the only distinguishing input is
+// `by ()` and that `withOuterByLabels([]) ≡ withOuterByLabels(nil)`. Both
+// halves fail. The parser materialises a non-nil EMPTY Grouping for a
+// plainly ungrouped `sum(v)` / `topk(K, v)`, so the distinguishing input
+// needs no `by ()` at all; and `withOuterByLabels` is an OVERWRITE, so
+// when `lc.OuterByLabels` is already non-empty — which is exactly what an
+// enclosing by-grouped aggregation makes it — threading an empty slice
+// ERASES the outer labels rather than reproducing them.
+// [TestUngroupedInnerAggregationKeepsOuterByLabels] and
+// [TestUngroupedInnerTopKKeepsOuterByLabels] below kill both mutants.
 
 // surfacedIdentityHasKey walks the lowered topk/sort plan
 // (TopK|OrderBy → Project(sampleShape) → RangeWindow → Project(identity))
@@ -195,5 +202,118 @@ func TestTopKPartitionNilForUngrouped(t *testing.T) {
 	got := topKPartition(vae)
 	if got != nil {
 		t.Fatalf("topKPartition(ungrouped topk) = %#v (len %d), want nil — the no-meaningful-grouping guard was inverted, building a spurious partition slice", got, len(got))
+	}
+}
+
+// innermostRangeWindowIdentity descends a lowered plan to the DEEPEST
+// [chplan.RangeWindow] and returns its identity projection expr. A nested
+// vector aggregation (`sum by (X) (sum(rate(...)))`) lowers to
+// Project → Aggregate → …outer shape… → RangeWindow → Project(identity),
+// and it is that innermost identity projection that records whether the
+// enclosing by-clause labels reached the range aggregation.
+func innermostRangeWindowIdentity(t *testing.T, plan chplan.Node) chplan.Expr {
+	t.Helper()
+	var found *chplan.RangeWindow
+	var walk func(chplan.Node)
+	walk = func(n chplan.Node) {
+		switch v := n.(type) {
+		case nil:
+			return
+		case *chplan.RangeWindow:
+			found = v
+			walk(v.Input)
+		case *chplan.Project:
+			walk(v.Input)
+		case *chplan.Aggregate:
+			walk(v.Input)
+		case *chplan.TopK:
+			walk(v.Input)
+		case *chplan.Filter:
+			walk(v.Input)
+		}
+	}
+	walk(plan)
+	if found == nil {
+		t.Fatalf("lowered plan has no *chplan.RangeWindow: %T", plan)
+	}
+	idProj, ok := found.Input.(*chplan.Project)
+	if !ok {
+		t.Fatalf("RangeWindow.Input = %T, want *chplan.Project (identity wrap)", found.Input)
+	}
+	if len(idProj.Projections) == 0 {
+		t.Fatalf("identity Project has no projections")
+	}
+	return idProj.Projections[0].Expr
+}
+
+// lowerNestedIdentity parses and lowers `query` in instant mode and
+// returns the innermost range aggregation's identity projection expr,
+// with the [canonicalIdentityExpr] key-order wrap already peeled.
+func lowerNestedIdentity(t *testing.T, query string, s schema.Logs) chplan.Expr {
+	t.Helper()
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := lower(expr, s, lowerCtx{})
+	if err != nil {
+		t.Fatalf("lower(%q): %v", query, err)
+	}
+	return requireCanonicalIdentity(t, innermostRangeWindowIdentity(t, plan))
+}
+
+// TestUngroupedInnerAggregationKeepsOuterByLabels kills the
+// CONDITIONALS_BOUNDARY mutant on the outer-by threading guard
+// vector_aggregation.go:lowerVectorAggregation:`e.Grouping != nil && !e.Grouping.Without && len(e.Grouping.Groups) > 0`
+// (`> 0` -> `>= 0`).
+//
+// The distinguishing input is an UNGROUPED inner vector aggregation
+// nested inside a by-grouped outer one. The parser materialises a
+// non-nil empty Grouping for `sum(v)` (see
+// [TestTopKPartitionNilForUngrouped]), so at the inner call
+// `e.Grouping != nil` and `!e.Grouping.Without` both hold and only
+// `len(e.Grouping.Groups) > 0` is false. Crucially, `lc` is NOT empty
+// there: the outer `sum by (ServiceName)` already threaded
+// `[ServiceName]` through this very guard, so the inner call decides
+// whether that value SURVIVES.
+//
+//   - ORIGINAL: guard false => innerLc = lc, the outer `[ServiceName]`
+//     is preserved and the innermost range aggregation surfaces
+//     `ServiceName` into its identity map.
+//   - MUTANT `>= 0`: guard true => innerLc = lc.withOuterByLabels(nil),
+//     OVERWRITING the outer labels with the inner aggregation's empty
+//     ones. `ServiceName` is no longer surfaced and the assertion fails.
+func TestUngroupedInnerAggregationKeepsOuterByLabels(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	const query = `sum by (ServiceName) (sum(rate({app="api"}[5m])))`
+
+	identity := lowerNestedIdentity(t, query, s)
+	if !surfacedIdentityHasKey(t, identity, s.ServiceNameColumn) {
+		t.Fatalf("%s: innermost identity map is missing the surfaced %q key — the ungrouped INNER aggregation overwrote the outer by-clause labels instead of leaving them alone (the outer-by threading guard's `len(Groups) > 0` was widened to `>= 0`)", query, s.ServiceNameColumn)
+	}
+}
+
+// TestUngroupedInnerTopKKeepsOuterByLabels kills the
+// CONDITIONALS_BOUNDARY mutant on the same guard in the topk/sort front
+// half,
+// vector_aggregation.go:sortableShapedInner:`e.Grouping != nil && !e.Grouping.Without && len(e.Grouping.Groups) > 0`
+// (`> 0` -> `>= 0`).
+//
+// Same shape as [TestUngroupedInnerAggregationKeepsOuterByLabels], with
+// the ungrouped inner aggregation being a `topk` so the inner lowering
+// routes through [sortableShapedInner] rather than the plain
+// vector-aggregation body. The outer `sum by (ServiceName)` supplies the
+// non-empty `lc.OuterByLabels` the mutant erases.
+func TestUngroupedInnerTopKKeepsOuterByLabels(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	const query = `sum by (ServiceName) (topk(2, rate({app="api"}[5m])))`
+
+	identity := lowerNestedIdentity(t, query, s)
+	if !surfacedIdentityHasKey(t, identity, s.ServiceNameColumn) {
+		t.Fatalf("%s: innermost identity map is missing the surfaced %q key — the ungrouped INNER topk overwrote the outer by-clause labels instead of leaving them alone (sortableShapedInner's `len(Groups) > 0` was widened to `>= 0`)", query, s.ServiceNameColumn)
 	}
 }


### PR DESCRIPTION
Finishes the three legs #2949 left open. Test-only, plus two stale doc comments in `lower.go` that
the adjudication proved wrong. No threshold lowered, no denominator shrunk, no file excluded, no
`include_files` narrowed, no golden regenerated.

| leg | before | kills | after | verdict |
| --- | ---: | ---: | ---: | --- |
| `phase4-logql-aggregation` | 93.75% | 2 | **95.83%** | clears |
| `phase4-logql-lower` | 92.39% | 3 | **95.65%** | clears |
| `phase4-logql-other-b` | 93.18% | 8 | **95.78%** | clears |

Baseline per-mutant inventories come from run
[33689900147](https://github.com/tsouza/cerberus/actions/runs/33689900147)'s artifacts at
`cc241ec58`, recomputed from `files[].mutations[].status` with the same closed status set
`gremlins-threshold.mjs` gates on.

## Every kill proven individually

Each of the thirteen was proven by hand: apply exactly that mutation, the named test FAILS; revert,
it PASSES. Nothing below is inferred from a percentage.

**`phase4-logql-aggregation` (2).** Both on the outer-by threading guard, one copy per call site —
`lowerVectorAggregation`'s and `sortableShapedInner`'s `len(e.Grouping.Groups) > 0` widened to
`>= 0`. `TestUngroupedInnerAggregationKeepsOuterByLabels` and
`TestUngroupedInnerTopKKeepsOuterByLabels`.

**`phase4-logql-lower` (3).** `PipelineLineExpr`'s two: the `continue` that steps over a non-`|
unpack` stage (`break` returns nil for `| json | unpack`, so the log row falls back to the packed
body), and `prev == nil` negated (the first unpack's `if` gets a nil else-branch). Plus
`lowerPipelineWithLabels`'s `continue` past a Go-side `__error__` filter, whose `break` silently
drops every stage behind it.

**`phase4-logql-other-b` (8).** Six on the capture-identifier alphabet in `logpattern`, one per
range endpoint — shrinking any of them demotes `<z>`, `<A>`, `<Z>`, `<a0>` or `<a9>` from a capture
to literal text. One on `Matcher.Test`'s `off += j + len(lit)`, where assigning instead of advancing
leaves the cursor short of the end of the line from the second literal run onwards. One on
`projectSyntheticLabelValue`'s matcher-loop `continue`, whose `break` stops at the first matcher
naming another label and keeps a `detected_level` the query dropped.

## Two of the kills refute a verdict this tree already carried

`vector_aggregation_mutation_test.go`'s header adjudicated both outer-by boundary mutants EQUIVALENT
on two grounds, and both are wrong:

- *"the only distinguishing input is `by ()`"* — the parser materialises a non-nil EMPTY `Grouping`
  for a plainly ungrouped `sum(v)` / `topk(K, v)`, which the file's own
  `TestTopKPartitionNilForUngrouped` already documents. No `by ()` needed.
- *"`withOuterByLabels([])` is equivalent to `withOuterByLabels(nil)`"* — true in isolation, and
  irrelevant, because `withOuterByLabels` OVERWRITES. When `lc.OuterByLabels` is already non-empty —
  exactly what an enclosing by-grouped aggregation makes it — threading an empty slice ERASES the
  outer labels instead of reproducing them.

So `sum by (ServiceName) (sum(rate(...)))` and `sum by (ServiceName) (topk(2, rate(...)))` both
surface `ServiceName` into the innermost range aggregation's identity map under the original and
lose it under the mutant. The header is rewritten, not appended to, so no mutant carries two
verdicts.

## Three first attempts were neutralized, and were not kept

- Two drop_keep tests passed under their own mutant. Cause: those `continue`s sit directly in a
  `case` body of the stage type switch, so Go binds the mutant's `break` to the SWITCH, it leaves
  the case, and the loop proceeds exactly as `continue` would. Both mutants are genuinely
  equivalent; the tests were deleted and the argument recorded.
- The `__error__`-filter test passed because it used `| unpack`, and `isDynamicLabelStage` matches
  only `| pattern`. Its doc comment claimed both — as did `FiltersErrorLabel`'s. `internal/api/loki`
  draws the same `| pattern`-only line, and `lowerPipelineWithLabels`'s own comment explains why
  (`| unpack`'s markers come from SQL). Both comments are corrected; the test now uses `| pattern`
  and kills the mutant.

## What is adjudicated instead of tested

`NOT KILLABLE` footers cover every remaining survivor, each citing the construct it rewrites:
capacity hints proven unable to reach a negative `make` argument; `withMatcherWindowExtension`'s
`extension <= 0`, where `time.Time.Add(0)` returns the receiver's exact value; the one-candidate
`OTelDottedFallbackChain`, which builds the same `MapAccess` the early return does;
`applyUnwrapPostFilters` on an empty filter list, which is the identity down to `hasErrorMarks`; the
two switch-bound `break`s above; `matchCapture`'s `len(s) < 2` at exactly 2; and
`validateNoConsecutiveCaptures`'s last-iteration `break`. Where the mutated token is a bare
`break` / `continue`, the footer cites the neighbouring `if` and says so.

The three `TIMED OUT` mutants in `logpattern/pattern.go` are the memory-guard-reaped class and stay
in the denominator, credited to nobody; the three `RUN TIMED OUT` in `jsonpath.go`'s walker are
already credited as detections. Neither split is re-derived here.

## Filed

- #2973 — five conditions in `internal/logql` that decide nothing, each the root cause under an
  unkillable mutant: `lang.go`'s `err == nil && parsed != nil` (the operands are the same fact),
  `jsonpath.go`'s `!ok || r != '"'` (invariantly false at the only call site) and `len(digits) > 0`
  (invariantly true, which makes a second arm dead), `ip.go`'s family check (re-derived by the range
  comparison, checked differentially over a 220-pair corpus), and `top_level_columns.go`'s
  fast-path. Removing them carries PR #2952's proof bar, which a test-only change cannot meet.
- #2974 — `phase4-logql-other-a`'s root-cause attribution, the thread #2949's standing-decision
  comment left open. Its ceiling is 94.00%, pinned by three `make()` capacity-hint mutants against
  code that is not wrong: neither of the usual remedies applies, because there is no defective code
  to delete and no sound blanket generator rule (a capacity that can reach zero makes the
  negative-cap mutant genuinely killable).

Closes #2949
