### PR TITLE
fix(logql,qlcommon): make a scanner that stops advancing an error, not a memory runaway

### DIFF
--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1546,14 +1546,56 @@ permanent cost:
   a proven equivalent, and for the arithmetic it is worse, because neither
   can be converted into a kill by writing a test.
 
-So a leg's ceiling is arithmetic rather than judgement: a leg whose
-BACKSTOP `TIMED OUT` count plus its documented-equivalent count exceeds 5%
-of its own attempted total cannot reach the 95% floor however strong its
-assertions are. `RUN TIMED OUT` no longer enters that sum. The remedy for
-what remains is the same dilution lever the surviving-mutant policy names
-— re-partition the leg wider against `gremlins unleash --dry-run` —
-applied to the package's scanner-bearing files, and it works only while
-the combined permanent cost stays under the margin.
+Neither half is converted by writing a test. The allocating half is
+converted by changing the SCANNER, which is a third remedy the
+surviving-mutant policy does not name because it is not about tests at
+all. A loop whose cursor is advanced independently by every arm has no
+structural guarantee that any arm advances it, and the mutation that
+stops one arm advancing is what exposes the absence. Two shapes close it:
+
+- **Collapse the advance to one site.** `NormalizeDottedLabels` in
+  `internal/logql/lsyntax/dotted_labels.go` computes `next := i + 1` once
+  and lets each arm override it, so the walker has one advancing
+  expression rather than one per branch.
+- **Check the advance once per iteration.** Where the arms compute their
+  own end offsets from scanned runs and so cannot share one expression,
+  the loop records the offset it began the iteration at and refuses when
+  an arm hands it back unmoved: `lexer.run` raises a `ParseError`,
+  `scanSourceGroups` and `skipCharClass` decline the way they decline
+  every construct they cannot classify, and the two replacement-template
+  scans stop.
+
+Both are production robustness properties before they are anything else.
+Every one of these scanners reads a string that arrived over HTTP inside
+a user's query, so an arm that fails to advance is not a wrong answer but
+an unbounded allocation driven by untrusted text — and the process dies
+under the OOM killer with no query attached to it, which is the hardest
+failure of all to attribute afterwards. What the lane gets out of it is a
+consequence: a decremented cursor becomes an observable refusal instead
+of a runaway the memory guard reaps. That ordering is the discipline. A
+progress check added to move a score, and justified by the score, is the
+same mistake as accepting a permanently red leg, inverted; the test to
+apply is whether the check survives a reviewer who has never heard of
+gremlins.
+
+The check is not free to the lane either. Comparing POSITIONS gives a
+`CONDITIONALS_BOUNDARY` site whose `<` form is unobservable — no arm moves
+the cursor backwards, so nothing distinguishes "did not advance" from
+"went backwards" — and each check therefore trades one proven equivalent
+for every runaway it converts. Comparing a consumed COUNT against 1 has no
+such site, because real input straddles that boundary on every
+single-byte step; prefer it where the arms already return counts, and
+take the equivalent where they set the cursor directly.
+
+So a leg's ceiling is arithmetic rather than judgement ONCE its scanners
+enforce their own progress: a leg whose BACKSTOP `TIMED OUT` count plus
+its documented-equivalent count exceeds 5% of its own attempted total
+cannot reach the 95% floor however strong its assertions are.
+`RUN TIMED OUT` no longer enters that sum. Where the residue is not a
+scanner at all, the remedy is the dilution lever the surviving-mutant
+policy names — re-partition the leg wider against
+`gremlins unleash --dry-run` — and it works only while the combined
+permanent cost stays under the margin.
 
 Recognising the class matters because it is easy to misread as budget
 starvation and answer with a bigger `--timeout-max`. It is not: these

--- a/internal/logql/lsyntax/lexer.go
+++ b/internal/logql/lsyntax/lexer.go
@@ -257,53 +257,92 @@ var singleCharTokens = map[byte]tokenKind{
 	'^': tkPow,
 }
 
+// errLexerStalled is raised by run's progress invariant. It names a lexer
+// defect rather than anything about the query: no input can reach it, because
+// every arm of the dispatch below either consumes input or records why it
+// could not.
+const errLexerStalled = "lexer made no progress"
+
+// run scans src into l.toks, terminating on the first error.
+//
+// PROGRESS INVARIANT. Every iteration must leave l.pos strictly greater than
+// it found it. The dispatch below picks an arm by the current byte and each
+// arm is individually responsible for consuming what it matched; nothing
+// about that structure forces an arm to consume anything. An arm that returns
+// without advancing does not produce a wrong token — it produces no answer at
+// all: the loop re-reads the same byte and takes the same arm forever, and on
+// every arm that emits a token that spin is also an unbounded append to
+// l.toks.
+//
+// That failure mode is reachable from a public HTTP surface. LogQL text
+// arrives from Grafana as user input, so a stalled scan is an unbounded
+// allocation driven by an untrusted string — the worst shape a scanner bug
+// can take, and the one hardest to attribute after the fact, since the
+// process dies under the OOM killer with no query attached to it. The
+// invariant turns that into a ParseError carrying the offset, which the head
+// reports like any other malformed query.
+//
+// The same reasoning produced the single-advance walker in dotted_labels.go,
+// which collapses the advance to one site rather than checking it. The
+// lexer's arms compute their own end offsets from scanned runs and cannot
+// share one advance, so the advance is checked instead — and the dispatch
+// stays inlined here rather than extracted into a step method because the
+// extraction measured 1.8-4.0% of the scan's own CPU across the three shapes
+// BenchmarkLex covers, against 0.3-2.0% for the check on its own.
+//
+// The check does not test l.err. fail is first-wins, so an arm that recorded
+// its own diagnostic without consuming — scanString on an unterminated literal
+// — keeps that diagnostic and this call is a no-op.
 func (l *lexer) run() {
 	for l.pos < len(l.src) && l.err == nil {
+		start := l.pos
 		c := l.src[l.pos]
 		if k, ok := singleCharTokens[c]; ok {
 			l.toks = append(l.toks, token{kind: k, pos: l.pos})
 			l.pos++
-			continue
-		}
-		switch {
-		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
-			l.pos++
-		case c == '#':
-			for l.pos < len(l.src) && l.src[l.pos] != '\n' {
+		} else {
+			switch {
+			case c == ' ' || c == '\t' || c == '\n' || c == '\r':
 				l.pos++
-			}
-		case c == '.' && !isDigit(l.peekByteAt(1)):
-			l.toks = append(l.toks, token{kind: tkDot, pos: l.pos})
-			l.pos++
-		case c == '[':
-			l.scanRange()
-		case c == '"' || c == '`':
-			l.scanString()
-		case c == '=':
-			l.scanFrom2('~', tkRe, '=', tkCmpEq, tkEq)
-		case c == '!':
-			l.scanBang()
-		case c == '|':
-			l.scanPipe()
-		case c == '>':
-			l.scanFrom1('=', tkGte, tkGt)
-		case c == '<':
-			l.scanFrom1('=', tkLte, tkLt)
-		case c == '-':
-			l.scanMinus()
-		case isDigit(c) || (c == '.' && isDigit(l.peekByteAt(1))):
-			l.scanNumber()
-		case isIdentStart(c):
-			l.scanIdent()
-		default:
-			// Non-ASCII identifier start (e.g. UTF-8 label names).
-			r, _ := utf8.DecodeRuneInString(l.src[l.pos:])
-			if unicode.IsLetter(r) {
+			case c == '#':
+				for l.pos < len(l.src) && l.src[l.pos] != '\n' {
+					l.pos++
+				}
+			case c == '.' && !isDigit(l.peekByteAt(1)):
+				l.toks = append(l.toks, token{kind: tkDot, pos: l.pos})
+				l.pos++
+			case c == '[':
+				l.scanRange()
+			case c == '"' || c == '`':
+				l.scanString()
+			case c == '=':
+				l.scanFrom2('~', tkRe, '=', tkCmpEq, tkEq)
+			case c == '!':
+				l.scanBang()
+			case c == '|':
+				l.scanPipe()
+			case c == '>':
+				l.scanFrom1('=', tkGte, tkGt)
+			case c == '<':
+				l.scanFrom1('=', tkLte, tkLt)
+			case c == '-':
+				l.scanMinus()
+			case isDigit(c) || (c == '.' && isDigit(l.peekByteAt(1))):
+				l.scanNumber()
+			case isIdentStart(c):
 				l.scanIdent()
-				continue
+			default:
+				// Non-ASCII identifier start (e.g. UTF-8 label names).
+				r, _ := utf8.DecodeRuneInString(l.src[l.pos:])
+				if unicode.IsLetter(r) {
+					l.scanIdent()
+				} else {
+					l.fail("syntax error: unexpected character " + string(rune(c)))
+				}
 			}
-			l.fail("syntax error: unexpected character " + string(rune(c)))
-			return
+		}
+		if l.pos <= start {
+			l.fail(errLexerStalled)
 		}
 	}
 	l.toks = append(l.toks, token{kind: tkEOF, pos: l.pos})

--- a/internal/logql/lsyntax/lexer_bench_test.go
+++ b/internal/logql/lsyntax/lexer_bench_test.go
@@ -1,0 +1,40 @@
+package lsyntax
+
+import "testing"
+
+// LogQL lexer micro-benchmarks (Layer 12). `lower_bench_test.go` times the
+// plan-building half of the head; these time the scan that feeds it.
+//
+// The three shapes are chosen for which parts of the token loop they drive
+// rather than for realism alone: a stream selector is almost all identifiers
+// and single-character punctuation, a pipeline is dominated by the
+// two-character operator scanners (`|=`, `|~`, `!=`, `=~`), and the metric
+// form adds the range, number and duration scanners. Between them every
+// branch of the loop's dispatch is executed except the error paths.
+
+// benchQueries are the lexer benchmark inputs, named by the dispatch arms
+// each one drives.
+var benchQueries = map[string]string{
+	"StreamMatcher": `{job="api", cluster="eu-west-1", namespace="prod"}`,
+	"PipelineOps":   `{job="api"} |= "error" != "debug" |~ "5[0-9]{2}" !~ "healthz" | json | line_format "{{.msg}}"`,
+	"MetricForm":    `sum by (job) (rate({job="api"} |= "error" [5m])) / sum by (job) (rate({job="api"}[5m]))`,
+}
+
+func BenchmarkLex(b *testing.B) {
+	for name, q := range benchQueries {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(q)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				toks, err := lex(q)
+				if err != nil {
+					b.Fatalf("lex(%q): %v", q, err)
+				}
+				if len(toks) == 0 {
+					b.Fatalf("lex(%q) returned no tokens", q)
+				}
+			}
+		})
+	}
+}

--- a/internal/logql/lsyntax/lexer_test.go
+++ b/internal/logql/lsyntax/lexer_test.go
@@ -480,11 +480,62 @@ func TestLexScanIdentToEOF(t *testing.T) {
 	}
 }
 
+// TestLexComments pins run's `#` arm, which nothing else in the tree reaches:
+// no unit test, spec fixture or oracle corpus entry lexes a LogQL comment.
+// Both directions the arm's inner loop can end matter — at a newline and at
+// the end of input — because they are the two ways it can stop consuming.
+func TestLexComments(t *testing.T) {
+	want := []tokenKind{tkOpenBrace, tkIdentifier, tkEq, tkString, tkCloseBrace, tkEOF}
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{"trailing, ends at EOF", `{job="api"} # what this query is for`},
+		{"leading, ends at newline", "# what this query is for\n" + `{job="api"}`},
+		{"between tokens", "{job=\n# why this label\n" + `"api"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			toks, err := lex(tc.in)
+			if err != nil {
+				t.Fatalf("lex(%q): %v", tc.in, err)
+			}
+			var got []tokenKind
+			for _, tok := range toks {
+				got = append(got, tok.kind)
+			}
+			if len(got) != len(want) {
+				t.Fatalf("lex(%q) produced %d tokens %v, want %d %v", tc.in, len(got), got, len(want), want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("lex(%q) token %d = %v, want %v (all: %v)", tc.in, i, got[i], want[i], got)
+				}
+			}
+		})
+	}
+}
+
 // NOT KILLABLE — documented, not defended by a test.
 //
-// Five surviving mutants in lexer.go for which no input distinguishes the
+// Six surviving mutants in lexer.go for which no input distinguishes the
 // mutated form from the original. Each was re-applied and the whole package
 // suite re-run to confirm it survives rather than merely lacking a test.
+//
+// lexer.go:`if l.pos <= start` (CONDITIONALS_BOUNDARY, run's progress
+// invariant, `<=` -> `<`). The invariant fails the scan when a dispatch arm
+// hands l.pos back unmoved; the mutant fails it only when an arm hands it
+// back SMALLER. Neither happens. Every arm either advances past the byte it
+// dispatched on — the `l.pos++` arms by construction, scanRange, scanString,
+// scanMinus, scanNumber and scanIdent by assigning an offset their own scan
+// established is past l.pos — or records a diagnostic without moving, in
+// which case both forms leave that diagnostic in place, the original because
+// fail is first-wins and the mutant because it never fires. So the two forms
+// differ only over a state no query produces. This mutant is the price of
+// the invariant: it is what a check on POSITIONS costs, where a check on a
+// consumed COUNT would have a boundary real input straddles. The lexer's
+// arms set l.pos rather than returning a count, and rewriting fourteen
+// scanners to return counts in order to move one mutant would be the score
+// driving the code.
 //
 // lexer.go:`b >= utf8.RuneSelf` (CONDITIONALS_BOUNDARY, `>=` -> `>`). The
 // two forms differ on exactly one byte value, b == 0x80, which is not a legal

--- a/internal/qlcommon/capture_probe.go
+++ b/internal/qlcommon/capture_probe.go
@@ -3,6 +3,7 @@ package qlcommon
 import (
 	"regexp"
 	"regexp/syntax"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -286,13 +287,15 @@ func negativeSiblingSpans(src string, groups []sourceGroup, at int) ([]sourceSpa
 	if !known {
 		return nil, false
 	}
-	fork := -1
-	for i := len(shape.spine) - 1; i >= 0; i-- {
-		if shape.spine[i].node.Op == syntax.OpAlternate {
-			fork = i
-			break
-		}
-	}
+	// Any alternation on the spine will do, because at most one survives:
+	// skippable reports true for OpAlternate, so a second one is caught by
+	// whichever of the two scans below covers it — above the fork by the
+	// first, below it by the second. Searching from either end therefore
+	// picks the same spine, and the lookup says that rather than implying,
+	// through a hand-rolled reverse walk, that innermost is what is wanted.
+	fork := slices.IndexFunc(shape.spine, func(step captureSpineStep) bool {
+		return step.node.Op == syntax.OpAlternate
+	})
 	if fork < 0 {
 		return nil, false
 	}
@@ -315,8 +318,12 @@ func negativeSiblingSpans(src string, groups []sourceGroup, at int) ([]sourceSpa
 	}
 	branch, _ := branchContaining(groups[parent], groups[at].open)
 	ordinal := captureOrdinalIn(groups, branch, groups[at].open)
-	branchShape, known := captureShapes(src[branch.start:branch.end])[ordinal]
-	if !known || !branchShape.unconditional {
+	// A missing entry yields the zero captureShape, which captureShapes
+	// documents as "nullable, conditional, and exclusive of nothing" — so
+	// unconditional is already false for it and a separate `known` test
+	// cannot decide anything this one does not.
+	branchShape := captureShapes(src[branch.start:branch.end])[ordinal]
+	if !branchShape.unconditional {
 		return nil, false
 	}
 	var siblings []sourceSpan
@@ -333,7 +340,11 @@ func negativeSiblingSpans(src string, groups []sourceGroup, at int) ([]sourceSpa
 		}
 		siblings = append(siblings, span)
 	}
-	return siblings, len(siblings) > 0
+	// At least one sibling: reaching here means groups[parent].alternations
+	// is non-empty, so the loop above ran over two or more disjoint spans,
+	// `branch` equals at most one of them, and every other span either
+	// appended or returned.
+	return siblings, true
 }
 
 // sourceSpan is a half-open byte range of a regex source.
@@ -437,8 +448,9 @@ func probeSpanFor(src string, groups []sourceGroup, at int) (sourceSpan, bool) {
 		if err != nil {
 			return sourceSpan{}, false
 		}
-		shape, known := captureShapes(body)[captureOrdinalIn(groups, span, carrierOpen)]
-		if !known || !shape.unconditional {
+		// See negativeSiblingSpans: the zero captureShape already rejects.
+		shape := captureShapes(body)[captureOrdinalIn(groups, span, carrierOpen)]
+		if !shape.unconditional {
 			return sourceSpan{}, false
 		}
 		if !matchesEmpty(parsed) {

--- a/internal/qlcommon/capture_probe_boundary_test.go
+++ b/internal/qlcommon/capture_probe_boundary_test.go
@@ -735,22 +735,9 @@ func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// Seven surviving mutants in capture_probe.go. Each was re-applied and the
+// Four surviving mutants in capture_probe.go. Each was re-applied and the
 // whole package suite re-run to confirm it survives rather than merely
 // lacking a test.
-//
-// capture_probe.go:`fork = i` (INVERT_LOOPCTRL on the `break` immediately
-// after it, -> `continue`). The assignment is what the citation names because
-// the mutated statement is a bare `break`. The loop descends the spine, so `break` leaves `fork` at the
-// DEEPEST syntax.OpAlternate and `continue` leaves it at the SHALLOWEST. With
-// zero or one alternation on the spine the two agree outright. With k >= 2 at
-// depths i1 < … < ik, the original's fork is ik and `shape.spine[:ik]` still
-// contains i1; the mutant's fork is i1 and `shape.spine[i1+1:]` still
-// contains i2. skippable reports true for syntax.OpAlternate
-// (capture_participation.go:`case syntax.OpStar, syntax.OpQuest,
-// syntax.OpAlternate`), so whichever way round it lands, one of the
-// two spine scans below rejects the carrier and the function returns
-// (nil, false). Both loops are side-effect-free and run before anything else.
 //
 // capture_probe.go:`for parent >= 0 && len(groups[parent].alternations) == 0`
 // (CONDITIONALS_BOUNDARY, `parent >= 0` -> `parent > 0`). Index 0 is the virtual whole-pattern group, minted with
@@ -762,31 +749,9 @@ func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
 // holding 0. It then reaches branchContaining(groups[0], …), which returns
 // (sourceSpan{}, false) for a group with no alternations; the ignored bool
 // leaves `branch` the zero span, captureShapes(src[0:0]) parses the empty
-// pattern into an empty map, `known` is false, and the next guard returns
-// (nil, false) — the answer the original returned one branch earlier.
-//
-// capture_probe.go:`if !known || !branchShape.unconditional` (INVERT_LOGICAL,
-// `||` -> `&&`). When `known` is false branchShape is
-// the zero captureShape, so `!branchShape.unconditional` is true and the
-// conjunction is true as well: the mutant declines exactly where the original
-// does. The only state that separates them is known && !unconditional, and it
-// is not reachable through this package's own producers. A conditional
-// ancestor of the carrier INSIDE the branch text is also an ancestor of the
-// carrier below the fork in the whole-pattern parse, and the spine scan four
-// branches above already returned (nil, false) for any skippable node in
-// `shape.spine[fork+1:]`. Go's parser can lift a common prefix out of the
-// branches, but two syntax.OpCapture nodes never compare equal (their Cap
-// differs), so the carrier is never inside the factored prefix, and removing
-// a prefix cannot introduce a skippable ancestor.
-//
-// capture_probe.go:`return siblings, len(siblings) > 0`
-// (CONDITIONALS_BOUNDARY, `> 0` -> `>= 0`). Reaching this line requires
-// groups[parent].alternations to be non-empty, so appending bodyEnd to it
-// yields at least two spans. They are consecutive disjoint ranges over the
-// parent's body, so at most one of them equals `branch` and is skipped, and
-// every other span either appends a sibling or returns (nil, false) at the
-// parse / matchesEmpty check above. len(siblings) is therefore never 0 here
-// and the two comparisons agree.
+// pattern into an empty map, indexing it yields the zero captureShape whose
+// unconditional field is false, and the next guard returns (nil, false) —
+// the answer the original returned one branch earlier.
 //
 // capture_probe.go:`return ordered[i].start < ordered[j].start`
 // (CONDITIONALS_BOUNDARY, the sort's `<` -> `<=`). The line is guarded by

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -200,6 +200,12 @@ const (
 	withCaptureProbes    captureProbeUse = true
 )
 
+// errTemplateStalled is raised by the replacement scanners' progress
+// invariant. It names a defect in the step functions rather than anything
+// about the template: no input reaches it, because every branch of
+// replacementStep and emptyCapturesStep consumes at least one byte.
+const errTemplateStalled = "replacement template scan made no progress"
+
 func resolveSegments(repl string, groups captureGroups) ([]chplan.LabelReplaceSegment, error) {
 	var segments []chplan.LabelReplaceSegment
 	var literal strings.Builder
@@ -222,6 +228,7 @@ func resolveSegments(repl string, groups captureGroups) ([]chplan.LabelReplaceSe
 	// #499 (the mutant-kill tests) and the follow-up PR that landed this
 	// refactor for the full diagnosis.
 	for i := 0; i < len(repl); {
+		prev := i
 		ref, step, err := replacementStep(&literal, repl, i, groups)
 		if err != nil {
 			return nil, err
@@ -236,6 +243,15 @@ func resolveSegments(repl string, groups captureGroups) ([]chplan.LabelReplaceSe
 			})
 		}
 		i += step
+		// Progress invariant. replacementStep's contract is at least one
+		// byte per call, and the comment above says the iterator clause is
+		// what makes that observable — but nothing enforced it. A template
+		// is user-supplied, so a step that consumes nothing is an unbounded
+		// `segments` append driven by untrusted text rather than a wrong
+		// answer, and the loop never returns to report it.
+		if i <= prev {
+			return nil, fmt.Errorf("replacement %q: %s", repl, errTemplateStalled)
+		}
 	}
 	flush()
 	return segments, nil
@@ -857,8 +873,16 @@ func EmptyCapturesReplacement(repl string) string {
 	// INVERT_LOOPCTRL operator has no `continue`/`break` to swap inside
 	// a dead-end switch case.
 	for i := 0; i < len(repl); {
-		step := emptyCapturesStep(&b, repl, i)
-		i += step
+		prev := i
+		i += emptyCapturesStep(&b, repl, i)
+		// Progress invariant — see resolveSegments. This function has no
+		// error channel, so a stalled step falls back to the rule it already
+		// applies to every `$` it cannot read as a reference: pass the rest
+		// of the template through verbatim.
+		if i <= prev {
+			b.WriteString(repl[prev:])
+			return b.String()
+		}
 	}
 	return b.String()
 }

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -358,6 +358,16 @@ func TestEmptyCapturesReplacement(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
+// label_replace.go:resolveSegments:`if i <= prev` and
+// label_replace.go:EmptyCapturesReplacement:`if i <= prev`, both
+// CONDITIONALS_BOUNDARY (`<=` -> `<`). Each is the progress invariant on a
+// step-based template scan, and it declines when a step hands the cursor
+// back unmoved; the mutant declines only when a step hands it back SMALLER.
+// replacementStep and emptyCapturesStep return a byte count, never a
+// position, and every branch of both returns 1, 2, or 1 + ref.width with
+// ref.width >= 1 — so the cursor never moves backwards and the two forms
+// differ only over a state no template produces.
+//
 // label_replace.go:`for end < len(rest)` (CONDITIONALS_BOUNDARY, extractRef's
 // loop condition, `<` -> `<=`). The extra iteration the mutant admits runs
 // at end == len(rest), where `rest[end:]` is the empty string — a legal

--- a/internal/qlcommon/regex_source_scan.go
+++ b/internal/qlcommon/regex_source_scan.go
@@ -59,6 +59,7 @@ func scanSourceGroups(src string) ([]sourceGroup, bool) {
 	captures := 0
 
 	for i := 0; i < len(src); {
+		start := i
 		switch src[i] {
 		case '\\':
 			// An escape covers the next byte whatever it is, so a `\(`
@@ -74,9 +75,9 @@ func scanSourceGroups(src string) ([]sourceGroup, bool) {
 				// later capture index and pointing the rewrite at literal
 				// text.
 				i = endOfQuotedRun(src, i)
-				continue
+			} else {
+				i += 2
 			}
-			i += 2
 		case '[':
 			end, ok := skipCharClass(src, i)
 			if !ok {
@@ -115,6 +116,17 @@ func scanSourceGroups(src string) ([]sourceGroup, bool) {
 		default:
 			i++
 		}
+		// Progress invariant. Every arm above computes its own end offset,
+		// so nothing structurally forces one to consume a byte; an arm that
+		// returns the cursor it was given spins on that byte forever,
+		// appending to `groups` or `alternations` on every lap. The pattern
+		// is a user's own regex arriving over HTTP, so that spin is an
+		// unbounded allocation driven by untrusted text. Declining is the
+		// answer this scanner already gives to everything it cannot
+		// classify, and a cursor that will not move is exactly that.
+		if i <= start {
+			return nil, false
+		}
 	}
 	if len(open) != 1 {
 		return nil, false
@@ -137,11 +149,14 @@ func skipCharClass(src string, i int) (int, bool) {
 		j++
 	}
 	for j < len(src) {
+		start := j
 		switch src[j] {
 		case '\\':
-			if j+1 >= len(src) {
-				return 0, false
-			}
+			// No bounds guard here, unlike the escape arm of
+			// scanSourceGroups: nothing reads src[j+1], and a trailing
+			// backslash puts j past the end, which ends the loop and falls
+			// through to the same `return 0, false` a guard would have
+			// taken.
 			j += 2
 		case '[':
 			// A POSIX name such as `[:alpha:]` nests inside the class and
@@ -152,13 +167,18 @@ func skipCharClass(src string, i int) (int, bool) {
 					return 0, false
 				}
 				j += 2 + end + 2
-				continue
+			} else {
+				j++
 			}
-			j++
 		case ']':
 			return j + 1, true
 		default:
 			j++
+		}
+		// Progress invariant — see scanSourceGroups. A class scan that
+		// stops advancing runs away on the same untrusted pattern.
+		if j <= start {
+			return 0, false
 		}
 	}
 	return 0, false

--- a/internal/qlcommon/regex_source_scan_test.go
+++ b/internal/qlcommon/regex_source_scan_test.go
@@ -188,28 +188,18 @@ func TestPlanCaptureProbesDeclines(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// Four surviving mutants in regex_source_scan.go, all of them in a `switch`
-// that is the ENTIRE body of its enclosing `for`.
+// Two surviving mutants in regex_source_scan.go, one per progress invariant.
+// Each was re-applied and the whole package suite re-run to confirm it
+// survives rather than merely lacking a test.
 //
-// The `continue` after regex_source_scan.go:`i = endOfQuotedRun(src, i)`
-// (INVERT_LOOPCTRL, scanSourceGroups' `\Q` arm) and the one after
-// regex_source_scan.go:`j += 2 + end + 2` (INVERT_LOOPCTRL, skipCharClass'
-// POSIX-name arm) are the same shape. Each citation names the statement above
-// the mutated `continue`, which is a bare keyword no construct can single
-// out. `break` inside a `switch` leaves the SWITCH, not the
-// loop. In both functions the switch is the whole loop body and the `for` has
-// an empty post statement, so the byte after the switch is the loop's closing
-// brace: `break` re-evaluates the loop condition exactly as `continue` does,
-// and it skips the `i += 2` / `j++` that follows in the same case arm for the
-// same reason. The two forms have identical control flow on every input.
-//
-// regex_source_scan.go:`if j+1 >= len(src)` carries two mutants —
-// CONDITIONALS_BOUNDARY (skipCharClass' `>=` -> `>`) and ARITHMETIC_BASE (the
-// same line's `j+1` -> `j-1`). The guard sits inside
-// `for j < len(src)`, so j+1 <= len(src) and j-1 <= len(src)-2: neither
-// `j+1 > len(src)` nor `j-1 >= len(src)` can hold, and both mutants delete
-// the guard rather than move it. The deleted case is a trailing `\` at
-// j == len(src)-1, where the original returns (0, false) directly. The
-// mutants instead run `j += 2`, which puts j past len(src), ends the loop,
-// and falls through to the function's own `return 0, false` — the identical
-// pair of values, with no character-class terminator found either way.
+// regex_source_scan.go:scanSourceGroups:`if i <= start` and
+// regex_source_scan.go:skipCharClass:`if j <= start`, both
+// CONDITIONALS_BOUNDARY (`<=` -> `<`). Each invariant declines when an arm
+// hands the cursor back unmoved; the mutant declines only when an arm hands
+// it back SMALLER. Neither happens: every arm of both switches computes an
+// end offset strictly past the byte it dispatched on, so the two forms differ
+// only over a state no pattern produces. Measured from the other side as
+// well — an exhaustive sweep of every string of up to five bytes over the
+// fifteen bytes either scanner branches on, 813,615 patterns, found no input
+// on which either invariant fires, and every one of them scanned to a result
+// identical to the pre-invariant form's.


### PR DESCRIPTION
## What this changes

Two scanners' loops in `internal/logql/lsyntax` and four in `internal/qlcommon` advanced a
cursor independently in every arm, with nothing forcing any arm to advance it. This makes
that a stated invariant, checked once per iteration, and deletes six pieces of
`internal/qlcommon` whose only defence was that no test could tell they were there.

### The progress invariant, and why it is production code

`lexer.run` dispatches on the current byte to fifteen arms, each responsible for consuming
what it matched. An arm that returns without consuming does not produce a wrong token — it
produces **no answer at all**: the loop re-reads the same byte, takes the same arm, and on
every arm that emits a token that spin is an unbounded append to `l.toks`. LogQL text
arrives from Grafana as user input, so the failure mode is an unbounded allocation driven by
an untrusted string, and it is the hardest kind to attribute afterwards because the process
dies under the OOM killer with no query attached to it. The invariant turns it into a
`ParseError` carrying the offset.

The same shape, and the same argument, applies to `scanSourceGroups`, `skipCharClass`,
`resolveSegments` and `EmptyCapturesReplacement` — all four scan a string lifted straight out
of a user's query. Two of them already carried the claim in prose — `replacementStep`'s doc comment says the
step contract is at least one byte per call and that the iterator clause is what makes it
observable. Nothing enforced it. Each scanner
refuses in its own idiom: the lexer raises a parse error, the two regex scans decline the way
they decline every construct they cannot classify, `resolveSegments` returns an error, and
`EmptyCapturesReplacement` — which has no error channel — passes the remainder through
verbatim, the rule it already applies to every `$` it cannot read as a reference.

`internal/logql/lsyntax/dotted_labels.go`'s single-advance walker is the in-repo precedent
for the technique. It collapses the advance to one `next := i + 1` site; these loops cannot,
because their arms compute end offsets from scanned runs, so the advance is checked instead.

### Perf

The lexer's hot loop is touched, so it was measured rather than assumed. `BenchmarkLex` is
new (`internal/logql/lsyntax/lexer_bench_test.go`, three shapes chosen for which dispatch
arms they drive). The host runs at load ~60 on 8 cores, where wall-clock benchmarking is
worthless and `perf` counters are blocked by `perf_event_paranoid=4`, so the metric is
**user CPU seconds for a fixed 400,000 iterations**, with the two binaries run strictly
interleaved so shared drift cancels, 12 repetitions each:

| shape | before (median) | with the invariant | delta (median) | delta (min) |
| --- | ---: | ---: | ---: | ---: |
| StreamMatcher | 1.615 s | 1.620 s | +0.31% | +0.63% |
| PipelineOps | 2.525 s | 2.575 s | +1.98% | −0.40% |
| MetricForm | 3.690 s | 3.700 s | +0.27% | +0.83% |

An earlier draft extracted the dispatch into a `step` method, which reads better and measured
**+1.8% / +2.3% / +4.0%** on the same harness — the non-inlinable call, not the check. The
dispatch therefore stays inlined in `run`, and the comment says so. Allocations are unchanged
at 6/op.

## The thirteen, and a fourteenth

Standing on the push-to-main run
[33683294083](https://github.com/tsouza/cerberus/actions/runs/33683294083) at `c3f43baa5`,
`phase4-logql-lsyntax` reports 17 backstop `TIMED OUT`. Thirteen are `l.pos++` -> `l.pos--`
in the token loop and its operator scanners. A fourteenth, `CONDITIONALS_NEGATION` on
`scanIdent`'s `for j < len(l.src)` guard, is the same shape by another route: the loop never
runs, the identifier is empty, `l.pos` is left where it was.

Every one was applied by hand, under `systemd-run --scope --user -p MemoryMax=2G`, and the
package suite run. **All fourteen are now DETECTED by tests that already existed**, each in
under 20 ms rather than reaching a memory ceiling — `TestParseExpr_Rejections`,
`TestExprString_Canonical`, `TestLogRangeOffsetAndUnwrap` and `TestLexScanFrom1` between them.
The six `l.pos++` sites the lane already credits were re-run as controls and stay detected.

Two of those controls did **not**, and both are findings rather than regressions:

- The `#` comment arm's `l.pos++` survives, because nothing in the tree lexes a LogQL
  comment — no unit test, no spec fixture, no oracle corpus entry. The lane reports it
  `NOT COVERED`, not `KILLED`. `TestLexComments` is new and covers all three ways the arm can
  end; with it, the mutation panics and the test fails, and reverting it passes.
- The `.` arm's `l.pos++` survives for the same reason, and looking into why turned up dead
  code: `tkDot` is emitted and **no parser arm consumes it**. Deleting it changes the error
  string a bare `.` produces, so it needs its rejection-parity ledger re-derived — filed as
  #2976 rather than done here.

## `internal/qlcommon`: six deletions, four kept

Re-read all thirteen documented equivalents, asking why each is equivalent.

**Deleted, because the code under them was dead, redundant, or invariantly true:**

| what | why it goes |
| --- | --- |
| the `!known` disjunct in `negativeSiblingSpans` and its twin in `probeSpanFor` | The `!known \|\| …` form re-tested a value `captureShapes` documents as the rejecting one ("nullable, conditional, and exclusive of nothing"), so `unconditional` is already false for a missing entry. The remaining form is behaviour-identical in **every** state, not only the reachable ones. |
| `negativeSiblingSpans`' `len(siblings) > 0` return | The old `len(siblings) > 0` was invariantly true: reaching it needs a non-empty `alternations`, so the loop ran over ≥ 2 disjoint spans, `branch` equals at most one, and every other span appended or returned. |
| the reverse walk that found `fork` in `negativeSiblingSpans` | The reverse walk implied innermost was wanted. It is not: `skippable` is true for `OpAlternate`, so a spine with two alternations is rejected by one of the two scans below whichever one is picked. The lookup says that instead of implying the opposite. |
| `skipCharClass`' trailing-backslash guard | Its `if j+1 >= len(src)` guard fired only at `j == len(src)-1`, where the fall-through re-derives the identical `(0, false)`. The visually identical guard in `scanSourceGroups` is **not** redundant — it protects a `src[i+1]` read — and now says so. |
| the switch-scoped `continue` in each of `scanSourceGroups` and `skipCharClass` | Equivalent to `break` because the switch is the whole loop body; replaced by explicit `if`/`else`, which the progress check requires anyway. |

**Kept, because the mutation is genuinely unobservable:** the two sort comparators
(`ordered[i].start`, `ordered[i].end` — guarded by `!=`, and `ordered` is deduplicated through
a map so no two spans are equal), `branchContaining`'s `if offset < bar` (an offset is a `(`
byte and a bar is a `|` byte; one byte cannot be both), `negativeSiblingSpans`' `parent >= 0`
walk, and `extractRef`'s `for end < len(rest)`.

### Proof

Every deletion carries PR #2952's bar.

- **Static.** Nothing in this package's probe/scan machinery is referenced outside
  `internal/qlcommon`; the only external surface is `ReplacementToCH` /
  `ReplacementSegments` / `EmptyCapturesReplacement`, called from
  `internal/promql/label_fns.go` and `internal/logql/label_fns.go`.
- **Byte-identical output, exhaustively.** A temporary differential harness held verbatim
  copies of `scanSourceGroups` and `skipCharClass` as they stood before, and compared them
  against the new forms over **every string of up to five bytes drawn from the fifteen bytes
  either scanner branches on** — 813,615 patterns, and 267,331 `(pattern, offset)` pairs for
  the class scan. Zero divergence, including `ok` and every returned offset.
- **Empirical, by panic injection.** All nine sites — the five progress checks and the four
  deleted predicates — were replaced by `panic(...)` and the whole of `./internal/qlcommon`,
  `./internal/logql/...`, `./internal/promql`, `./internal/api/...`, `./internal/engine` and
  `./test/spec/...` run, plus the 813,615-pattern corpus and a second exhaustive corpus of
  111,110 replacement templates. **Nothing fired.** The one probe that did fire on the first
  pass was the lexer's, on `TestLexScanStringUnterminated` — `scanString` records its
  diagnostic without consuming, exactly as the new comment says — which is why the check does
  not test `l.err` and relies on `fail` being first-wins.
- **Instrumentation removed**, tree verified clean, and **no golden regenerated** — nothing
  under `test/spec/`, `test/rejection-parity/` or `test/surface-parity/` moves.

## Arithmetic, with the removed mutants shown

`before` is measured on run
[33683294083](https://github.com/tsouza/cerberus/actions/runs/33683294083). `after` is
**projected per mutant**, not measured — this PR's own `mutation` run is the measurement, and
the projection is stated so it can be checked against it rather than trusted.

### `phase4-logql-lsyntax`

```
before   376 killed /  6 lived / 17 TIMED OUT / 8 RUN TIMED OUT / 407 attempted = 94.35%
```

| movement | killed | lived | TIMED OUT | attempted |
| --- | ---: | ---: | ---: | ---: |
| 14 backstop timeouts converted, each proven | +14 | | −14 | |
| the invariant's own `<=` -> `<` boundary, proven equivalent | | +1 | | +1 |
| the invariant's own `<=` -> `>` negation, proven detected | +1 | | | +1 |
| `NOT COVERED` -> killed: the `#` arm, via `TestLexComments` | +1 | | | +1 |
| **removed**: the `continue` after the single-char append (`INVERT_LOOPCTRL`, was KILLED) | −1 | | | −1 |
| **removed**: the `continue` in the default arm (was `NOT COVERED`, outside the ratio) | | | | |

```
after    391 killed /  7 lived /  3 TIMED OUT / 8 RUN TIMED OUT / 409 attempted = 97.56%
```

The three that remain are the `ARITHMETIC_BASE` mutants inside `dotted_labels.go`'s walker,
untouched here.

### `phase5-qlcommon`

```
before   282 killed / 13 lived /  8 TIMED OUT / 9 RUN TIMED OUT / 312 attempted = 93.27%
```

| movement | killed | lived | TIMED OUT | attempted |
| --- | ---: | ---: | ---: | ---: |
| 6 backstop timeouts converted, each proven | +6 | | −6 | |
| 5 `RUN TIMED OUT` in `skipCharClass` now terminate as kills (numerator either way) | +5 | | | |
| four progress checks' `<=` -> `<` boundaries, each proven equivalent | | +4 | | +4 |
| four progress checks' `<=` -> `>` negations | +4 | | | +4 |
| the `slices.IndexFunc` closure's `==` | +1 | | | +1 |
| **removed** with the reverse fork walk | **−8** | −1 | | −9 |
| **removed** with `len(siblings) > 0` | **−1** | −1 | | −2 |
| **removed** with `probeSpanFor`'s `!known` | **−1** | | | −1 |
| **removed** with `negativeSiblingSpans`' `!known` | | −1 | | −1 |
| **removed** with `skipCharClass`' trailing-backslash guard | **−1** | −2 | | −3 |
| **removed** with the two switch-scoped `continue`s | | −2 | | −2 |

```
after    287 killed / 10 lived /  2 TIMED OUT / 4 RUN TIMED OUT / 303 attempted = 96.04%
```

Eleven mutants leave as **KILLED** against eleven that arrive or convert — the deletions are
close to arithmetically neutral on their own, and the movement comes from the six converted
timeouts. The two that remain are `INVERT_NEGATIVES` and `ARITHMETIC_BASE` on
the `parent: -1` sentinel of the virtual whole-pattern group in `scanSourceGroups`, which
make that group its own ancestor and hang a **different** walk — the parent chain in
`candidateSpans`, not a byte scan. No threshold is lowered, no denominator narrowed, no file
excluded.

## Also

`docs/test-strategy.md` § "Non-terminating mutants and a leg's irreducible ceiling" said the
allocating half of the class is a permanent cost. That is right about tests and wrong about
the code: the section now names the scanner-side remedy, both shapes it takes, the ordering
that keeps it honest (the check has to survive a reviewer who has never heard of gremlins),
and the fact that a position check costs one proven equivalent where a consumed-count check
costs none.

No `Closes` keyword: "clears the floor" is a measured property and the numbers above are
projected from per-mutant evidence. #2917 should close on this PR's own `mutation` run if the
two legs land where the tables say.
