### PR TITLE
test(logql): kill the cascade capacity mutants a cap assertion always could

### DIFF
--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -452,15 +452,20 @@ export const PHASES = [
   // (10 killed: absent-window Interval+Offset arithmetic, the absent synth-label
   // conjunction, the post-filter error-mark return gate, the topk/quantile outer-by
   // threading + ungrouped-partition guards — each verified by hand-applying the
-  // mutation). The remaining survivors are GENUINELY EQUIVALENT and can't be killed:
+  // mutation). Of the remaining survivors:
   //   - `make([]Expr, 0, len(Groups)*2 (+1))` slice-CAPACITY hints
-  //     (range_aggregation.go, vector_aggregation.go, duration.go) — a cap literal
-  //     changes only allocator behaviour, not output (CLAUDE.md: capacity hints
-  //     out of scope).
+  //     (range_aggregation.go, vector_aggregation.go, duration.go) are NOT
+  //     equivalent, though this block long claimed they were. A cap literal does
+  //     change only allocator behaviour and not output, but observability is not
+  //     confined to output: all three build a slice that becomes a returned
+  //     `chplan.FuncCall`'s exported `Args` and fill the hint exactly, so `cap`
+  //     reads the arithmetic back. detected_level.go's two hints are killed that
+  //     way; cerberus issue #2984 tracks applying the same check here and across
+  //     the rest of the matrix's capacity survivors.
   //   - empty-group CONDITIONALS_BOUNDARY guards (`len(...) > 0` vs `>= 0`) whose
   //     only distinguishing input (`by ()`) threads a len-0 label slice the
   //     lowering collapses to nil — a byte-identical no-op.
-  // With the killable set covered the bar is back at 95; the equivalents sit
+  // With the killable set covered the bar is back at 95; the survivors sit
   // comfortably under it (~97.7%).
   //
   // Round 13 (2026-07-25): all four ./internal/logql legs started dying with the

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1273,9 +1273,11 @@ verdicts (killed or lived) only.
 
 A surviving mutant is either (a) a legitimately weak assertion that
 needs strengthening, (b) a functionally-equivalent mutation (`<` vs
-`<=` on a boundary that's never hit, slice-cap arithmetic that
-`append` regrows past), or (c) a missing test. The gremlins JSON
-artifact on each run names the file + line + mutation kind.
+`<=` on a boundary that's never hit, slice-cap arithmetic on a hint
+whose slice never leaves its builder), or (c) a missing test. The
+gremlins JSON artifact on each run names the file + line + mutation
+kind. Slice-cap arithmetic belongs to (b) far less often than it
+looks — see "When a capacity mutant is equivalent" below.
 
 ### Surviving-mutant policy
 
@@ -1374,6 +1376,59 @@ note ends up saying something definite instead of something ambiguous.
 Prior PRs #504 and #664 carry pattern-#3 refactors. They are not
 reverted (their diffs are now load-bearing for the published
 thresholds), but new violations should follow remedy #1 or #2.
+
+#### When a capacity mutant is equivalent
+
+"An `ARITHMETIC_BASE` mutant on a `make` capacity argument is
+equivalent" is the single most attractive wrong claim in this file's
+adjudication history, and it is wrong on a property that is not visible
+anywhere in the mutated expression. It survives only where BOTH of these
+hold, and each has to be checked at the site:
+
+- **The slice never escapes its builder.** `cap` is the observation, and
+  a test can only take it on a header it can reach. A slice that is
+  ranged over and measured with `len` inside one function and then
+  dropped is genuinely unobservable; one that becomes a field of a
+  returned value is not. `internal/logql/detected_level.go`'s
+  `detectedLevelSourceExpr` hosts one of each — `keys := make([]string,
+  0, len(allowedLevelFields)+1)` stays local, while `args :=
+  make([]chplan.Expr, 0, len(keys)*2+1)` becomes the returned
+  `FuncCall`'s exported `Args` — so the same mutator on two hints in the
+  same function earns opposite verdicts. Reaching the header through an
+  unexported field is enough; the closure in `exemplars.go` that settled
+  cerberus issue #2958 is the one shape Go offers no way to read at all.
+- **The appends do not fill the hint exactly.** Where they DO — the
+  builder appends exactly as many elements as it pre-allocated for — the
+  finished slice still reports the hint, `cap` reads the arithmetic
+  straight back, and every substitution is observable. Under-filling
+  leaves the mutated hint on the slice, over-filling re-grows through the
+  runtime's size classes; neither lands back on the true capacity by
+  accident, but "does not land back" is a claim to assert rather than
+  narrate, per "How a note states a number" below.
+
+Both cap-hint pairings in `detected_level_test.go` are written that way:
+one test asserts `cap` against a derived count, and a second enumerates
+every operator substitution and asserts the resulting capacity differs.
+That second test is what makes the first re-checkable, and it is what a
+prose equivalence note cannot do for itself.
+
+Cerberus issue #2974 asked whether `tsouza/gremlins` should stop
+EMITTING these instead — a generator-side narrowing in the family of
+cerberus issue #2932's type-check gate, which stopped crediting mutants
+that never compiled. It should not, and the reason is the measurement
+above rather than a principle about denominators. That gate's predicate
+is sound and local: whether a candidate compiles is decided by the candidate, and a
+mutant that cannot compile tested nothing on either side of the ratio.
+Equivalence is neither. The predicate that would have to be implemented
+here — "the capacity argument of a slice that neither escapes nor is
+exactly filled" — needs whole-program escape analysis that an AST-level
+mutation operator does not have, and its available syntactic proxy
+("do not mutate a `make` capacity argument") is refuted by the two
+mutants a `cap` assertion kills in the same function as one it cannot. A gate
+that suppresses killable mutants because a cheaper predicate could not
+tell them apart is an allow-list wearing an operator's clothes,
+whatever it does to the denominator. The distinction that matters is
+whether the predicate is sound, not whether the count goes down.
 
 ### How a note cites the mutant it adjudicates
 

--- a/internal/logql/detected_level_test.go
+++ b/internal/logql/detected_level_test.go
@@ -562,22 +562,33 @@ func capHint(t *testing.T, n int, innerOp, mulOp, tailOp string) int {
 // integer down, so the two cannot state it differently.
 func multiIfArgCount(groups int) int { return 2*(groups+1) + 1 }
 
-// capAfterBuild replays [normaliseLevelExpr]'s exact append sequence against a
-// slice pre-allocated with `hint`, and reports the length and the capacity the
-// finished slice carries.
+// capAfterPairedAppends replays the append sequence BOTH multiIf builders in
+// detected_level.go share — `pairs` (condition, value) pairs appended two at a
+// time, then one trailing default branch — against a slice pre-allocated with
+// `hint`, and reports the length and the capacity the finished slice carries.
+//
+// The growth schedule depends on the exact order and grouping of the appends,
+// not just on the final count, so the replay has to mirror the builder rather
+// than append the total in one call.
 //
 // The element type has to be the real one. Go rounds a growing slice's
 // capacity up to an allocator size class measured in BYTES, so a slice whose
 // elements are a different width grows to different capacities and the
 // simulation would answer a question nobody asked.
-func capAfterBuild(hint, groups int) (length, capacity int) {
+func capAfterPairedAppends(hint, pairs int) (length, capacity int) {
 	args := make([]chplan.Expr, 0, hint)
-	args = append(args, nil, nil) // leading (empty, unknown) pair
-	for i := 0; i < groups; i++ {
-		args = append(args, nil, nil) // (cond, canonical literal)
+	for i := 0; i < pairs; i++ {
+		args = append(args, nil, nil) // (condition, value)
 	}
 	args = append(args, nil) // trailing default branch
 	return len(args), cap(args)
+}
+
+// capAfterBuild replays [normaliseLevelExpr]'s exact append sequence: the
+// leading (empty, unknown) pair, one (cond, canonical literal) pair per group,
+// and the lowercased default — i.e. `groups+1` pairs and a trailing branch.
+func capAfterBuild(hint, groups int) (length, capacity int) {
+	return capAfterPairedAppends(hint, groups+1)
 }
 
 // TestNormaliseLevelExpr_CapHintMutantsAreKilled proves that the `cap`
@@ -852,6 +863,23 @@ func TestDetectedLevelSource_PrecedenceCascade(t *testing.T) {
 		t.Fatalf("cascade has %d args; want %d (%d keys × 2 + fallback)", got, wantArgs, len(wantKeys))
 	}
 
+	// Kill for the ARITHMETIC_BASE mutants on the slice-capacity hint
+	// detected_level.go:`args := make([]chplan.Expr, 0, len(keys)*2+1)`. The
+	// appends below fill that pre-allocation EXACTLY, so the finished slice
+	// still reports the hint and `cap` reads the arithmetic straight back;
+	// [TestDetectedLevelSource_CapHintMutantsAreKilled] proves no operator
+	// substitution lands back on it. This works here — where the identical
+	// argument fails for the sibling `keys := make([]string, 0,
+	// len(allowedLevelFields)+1)` — because `args` ESCAPES: it becomes the
+	// returned FuncCall's exported Args field, so its capacity is reachable
+	// from a test, while `keys` never leaves the function.
+	if got := cap(cascade.Args); got != wantArgs {
+		t.Errorf("cap(cascade.Args) = %d; want %d — the capacity hint no longer "+
+			"matches the args the cascade builds (mutant `*` → `+`/`-`/`/`/`%%` or "+
+			"`+` → `-`/`*`/`/`/`%%` in detected_level.go:`len(keys)*2+1` shifts the "+
+			"pre-allocation and append re-grows off the exact count)", got, wantArgs)
+	}
+
 	for i, key := range wantKeys {
 		valIdx := 2*i + 1
 		ma, ok := cascade.Args[valIdx].(*chplan.MapAccess)
@@ -872,6 +900,134 @@ func TestDetectedLevelSource_PrecedenceCascade(t *testing.T) {
 	if !ok || fallback.Name != s.SeverityColumn {
 		t.Errorf("fallback branch = %#v; want ColumnRef(%q)", cascade.Args[len(cascade.Args)-1], s.SeverityColumn)
 	}
+}
+
+// sourceCapHint evaluates the SHAPE of detected_level.go's cascade capacity
+// hint `len(keys)*2+1` with each of its two operator positions supplied
+// explicitly: `n mulOp 2 tailOp 1`. Passing the operators in is what lets the
+// caller enumerate the hint's mutants without writing any of their values
+// down.
+func sourceCapHint(t *testing.T, n int, mulOp, tailOp string) int {
+	t.Helper()
+
+	return applyCapHintOp(t, applyCapHintOp(t, n, mulOp, 2), tailOp, 1)
+}
+
+// TestDetectedLevelSource_CapHintMutantsAreKilled proves that the `cap`
+// assertion in [TestDetectedLevelSource_PrecedenceCascade] actually
+// discriminates. For every ARITHMETIC_BASE operator substitution gremlins can
+// make in detected_level.go:`args := make([]chplan.Expr, 0, len(keys)*2+1)`,
+// the capacity the finished slice ends up with must differ from the capacity
+// the unmutated hint produces — otherwise that assertion passes on the mutant
+// and claims a kill it does not deliver.
+//
+// NOT KILLABLE — the third ARITHMETIC_BASE mutant this function carries, on
+// the sibling hint detected_level.go:`keys := make([]string, 0,
+// len(allowedLevelFields)+1)`, has no test that can observe it, and the reason
+// is worth writing down because it is exactly what does NOT hold for the hint
+// enumerated below. A capacity mutation is observable through `cap`, and `cap`
+// is only reachable where the slice ESCAPES the builder. `args` escapes: it
+// becomes the returned `*chplan.FuncCall`'s exported `Args` field, and the
+// assertion above reads its capacity back. `keys` does not: it is ranged over
+// and measured with `len` inside [detectedLevelSourceExpr] and never stored,
+// returned or captured, so no caller — test or otherwise — holds the header
+// whose capacity the mutation changes. Nor does that mutant die on a panic:
+// `allowedLevelFields` carries four fixed entries, so every substitution
+// (`-` → 3, `*` → 4, `/` → 4, `%` → 0) stays non-negative and `make` accepts
+// it. It is an equivalent mutant, and the only honest thing to do with it is
+// leave it counted as a survivor.
+//
+// So "an ARITHMETIC_BASE mutant on a `make` capacity argument is equivalent"
+// is FALSE as a general claim: it holds for one of this function's two hints
+// and fails for the other, on a property (escape) that is not visible in the
+// mutated expression at all.
+func TestDetectedLevelSource_CapHintMutantsAreKilled(t *testing.T) {
+	t.Parallel()
+
+	// The operators the unmutated hint uses, in the two positions `n * 2 + 1`.
+	const (
+		origMulOp  = "*"
+		origTailOp = "+"
+	)
+	positions := []struct{ name, orig string }{
+		{"the `*2`", origMulOp},
+		{"the trailing `+1`", origTailOp},
+	}
+
+	// The cascade contributes one (condition, value) pair per source key and
+	// one trailing severity-column fallback, so the pair count IS the key
+	// count — the same `n` the hint measures with `len(keys)`.
+	n := len(append([]string{detectedLevelLabel}, allowedLevelFields...))
+	trueHint := sourceCapHint(t, n, origMulOp, origTailOp)
+	trueLen, trueCap := capAfterPairedAppends(trueHint, n)
+
+	// The premise of the whole argument: the appends FILL the pre-allocation
+	// exactly — neither growing past it nor leaving slack. Only then does the
+	// finished cap read back the hint, and only then does asserting cap pin the
+	// hint's arithmetic.
+	if trueLen != trueHint || trueCap != trueHint {
+		t.Fatalf("the unmutated hint %d does not exactly fit the append sequence "+
+			"(finished len %d, cap %d): the appends no longer fill the "+
+			"pre-allocation exactly, so cap() has stopped reading back the hint "+
+			"and asserting it has stopped being a capacity kill",
+			trueHint, trueLen, trueCap)
+	}
+
+	// …and the sequence replayed here has to be the one the sibling test pins
+	// on the real cascade, or this whole test measures a slice nobody builds.
+	s := schema.DefaultOTelLogs()
+	cascade, ok := detectedLevelSourceExpr(s).(*chplan.FuncCall)
+	if !ok {
+		t.Fatalf("source = %#v; want the multiIf cascade", detectedLevelSourceExpr(s))
+	}
+	if got := len(cascade.Args); got != trueLen {
+		t.Fatalf("the replayed append sequence produces %d args, but the cascade "+
+			"under test carries %d — the simulation has drifted from the builder "+
+			"it stands in for", trueLen, got)
+	}
+
+	mutants, checked, negative := 0, 0, 0
+	for i, pos := range positions {
+		for _, op := range capHintOps {
+			if op == pos.orig {
+				continue
+			}
+			mutants++
+
+			ops := []string{origMulOp, origTailOp}
+			ops[i] = op
+			hint := sourceCapHint(t, n, ops[0], ops[1])
+
+			if hint < 0 {
+				// `make` panics on a negative capacity, so this mutant dies in
+				// any test that reaches detectedLevelSourceExpr at all.
+				negative++
+				continue
+			}
+			checked++
+
+			if _, got := capAfterPairedAppends(hint, n); got == trueCap {
+				t.Errorf("mutating %s to %q gives capacity hint %d, and the finished "+
+					"slice still ends at cap %d — identical to the unmutated build, so "+
+					"the `cap(cascade.Args) == wantArgs` assertion does NOT kill this mutant",
+					pos.name, op, hint, got)
+			}
+		}
+	}
+
+	// Anti-vacuity: a loop that enumerated nothing would report a clean run
+	// while proving nothing at all.
+	if want := len(positions) * (len(capHintOps) - 1); mutants != want {
+		t.Fatalf("enumerated %d hint mutants, want %d (one per operator substitution "+
+			"in each of the %d positions) — the enumeration is not covering the "+
+			"mutant set it claims to", mutants, want, len(positions))
+	}
+	if checked == 0 {
+		t.Fatalf("every one of the %d hint mutants was skipped as a negative capacity, "+
+			"so the discriminating comparison never ran", mutants)
+	}
+	t.Logf("hint mutants: %d enumerated, %d distinguished by capacity, %d killed by a "+
+		"negative make() capacity", mutants, checked, negative)
 }
 
 // TestDetectedLevelSource_NoAttributesColumnCollapses verifies that a


### PR DESCRIPTION
`phase4-logql-other-a` sat at 94.00% (47 killed / 50 attempted) against a 95% floor, pinned by three
`ARITHMETIC_BASE` mutants on `make` capacity hints in `internal/logql/detected_level.go`. The issue
recorded all three as equivalent by construction and asked whether the answer was a generator-side
narrowing in `tsouza/gremlins` — stop emitting capacity mutants where the mutated expression is
provably non-negative.

It is not. Two of the three are killable, and the fork must not change.

## What was actually wrong

The premise "a capacity hint is not observable behaviour" is false wherever the slice ESCAPES its
builder. `detectedLevelSourceExpr` builds its cascade arguments with
`args := make([]chplan.Expr, 0, len(keys)*2+1)`; the appends fill that pre-allocation exactly, and
the slice becomes the returned `FuncCall`'s exported `Args` field. `cap` therefore reads the
arithmetic straight back off a value a test already holds.

`TestDetectedLevelSource_PrecedenceCascade` already derived the expected argument count and asserted
`len` against it. It never asserted `cap`. That single missing assertion was the whole impasse.

The strongest evidence that this was an oversight rather than a hard limit is that the same file
already kills the sibling hint in `normaliseLevelExpr` exactly this way, and those three mutants
came back KILLED in the same run that left these three alive.

## What this changes

- `cap(cascade.Args)` is asserted against the count the test already derives.
- `TestDetectedLevelSource_CapHintMutantsAreKilled` enumerates every operator substitution at both
  positions of the hint and asserts each yields a different capacity — 8 enumerated, 8
  distinguished — so the assertion above cannot silently stop discriminating.
- The growth replay both meta-tests need is now one helper instead of two copies.

Verified by hand-applying all six substitutions to the production line: each fails the test. The
capacities are not written down anywhere; they are computed.

## The third mutant stays a survivor

`keys := make([]string, 0, len(allowedLevelFields)+1)` is genuinely equivalent, and for a reason the
other two do not share: `keys` is ranged over and measured inside `detectedLevelSourceExpr` and never
stored, returned or captured, so nothing can reach the header whose capacity the mutation changes.
Its four fixed entries keep every substitution non-negative, so `make` never panics either. It is
adjudicated in place, not absorbed.

Expected leg movement: 47/50 (94.00%) to 49/50 (98.00%). One documented equivalent against 50
attempted is 2%, inside the 5% margin the surviving-mutant policy sets.

## Why not the fork

The predicate that would have to be implemented is "the capacity argument of a slice that neither
escapes nor is exactly filled". Escape is not visible in the mutated expression, and an AST-level
mutation operator has no whole-program analysis to decide it. The available syntactic proxy — do not
mutate a `make` capacity argument — is refuted by measurement, not by principle: run 33703302531
carries 91 such mutants across the matrix, and **55 of them are KILLED today**. The rule would delete
55 real detections to excuse 23 survivors, and it would have suppressed the two killed here.

That is also the answer to "no denominator shrunk". #2932's type-check gate is sound and local —
whether a candidate compiles is decided by the candidate, and a mutant that cannot compile tested
nothing on either side of the ratio. Equivalence is neither local nor decidable, so a syntactic proxy
for it is an allow-list wearing an operator's clothes. The distinction is whether the predicate is
sound, not whether the count goes down. Nothing here shrinks a denominator: no production code
changes and no mutant leaves the matrix.

Cross-leg arithmetic for what actually ships: `internal/logql/detected_level.go` is mutated by
`phase4-logql-other-a` and no other leg, and a test-only change can only raise efficacy. Every other
leg is untouched.

## Documentation

`docs/test-strategy.md` gains "When a capacity mutant is equivalent" beside the existing refusals,
stating the two-part rule and recording why the generator narrowing is refused. The surviving-mutant
policy's over-broad "slice-cap arithmetic that `append` regrows past" is corrected in place, and
`.github/scripts/mutation-phases.mjs`'s claim that the `range_aggregation.go` / `vector_aggregation.go`
/ `duration.go` capacity hints "can't be killed" is corrected — all three escape into a returned
`FuncCall.Args` and fill their hints exactly.

## Filed

tsouza/cerberus#2984 — 18 of the 23 LIVED capacity mutants across the matrix escape into an exported
field of a returned value and are killable by this same pair of tests; 3 are genuinely unobservable
(one local slice, one closure-captured slice per the #2958 precedent, one map hint Go gives no `cap`
for). No leg is red on it, so it is evidence quality rather than a broken gate.

Closes #2974
