### PR TITLE
test: repoint 32 unmarked line addresses and re-adjudicate the bare-unwrap kill claim

### DIFF
--- a/.github/scripts/verify-code-citations.mjs
+++ b/.github/scripts/verify-code-citations.mjs
@@ -132,14 +132,17 @@ const OPENER = /\.go:/g;
 //
 // The marker is what makes the address identifiable, and its absence is why an
 // UNMARKED pair (`223:11`, `at 76:23`) is not modelled here. That is measured,
-// not overlooked: 108 unmarked `N:M` pairs sit in note scope and only about a
-// third are addresses — the rest are `1:1` correspondences, clock times in
-// chDB fixtures (`23:59:30`), slice bounds (`src[0:0]`) and a `host:9000`.
-// Nothing lexical separates `76:23` the address from `23:59` the timestamp,
-// and a gate that guessed would be the false-positive machine #2966 refused.
-// `docs/test-strategy.md` records that refusal, and it is not an escape
-// hatch: the unmarked pair is the SAME unverifiable address, left to the
-// reviewer rather than blessed.
+// not overlooked. The 32 that existed were repointed by hand (#2981); the 383
+// bare pairs left in note scope are all data — `1:1` correspondences, clock
+// times in chDB fixtures (`23:59:30`), slice bounds (`src[0:0]`) and a
+// `host:9000`. Nothing lexical separates `76:23` the address from `23:59` the
+// timestamp. The closest rule that works — the pair, scoped to a unit also
+// carrying mutation vocabulary — flagged 36 pre-cleanup (30 real, 6 prose)
+// while MISSING both `// --- file.go … ---` section headers, and on the tree
+// today it flags those 6 and nothing else: the false-positive machine #2966
+// refused. `docs/test-strategy.md` records the measurement, and it is not an
+// escape hatch: the unmarked pair is the SAME unverifiable address, left to
+// the reviewer rather than blessed.
 //
 // The HYPHENATED attributive form (`the line-116 condition`, `both line-277
 // mutants`) is out for the same reason and measured the same way: of the four

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1527,13 +1527,29 @@ oversight, and none is an escape hatch:
   space after the keyword costs the single real instance — repointed by
   hand when this landed, leaving none — and buys immunity to the three.
 - **An unmarked `N:M` pair** (`at 223:11`, `- 76:23`) is the same
-  unverifiable address, and it is unmodelled because nothing lexical
-  separates it from data. Of the 108 unmarked pairs in note scope only
-  about a third are addresses; the rest are `1:1` correspondences, chDB
-  fixture clock times, slice bounds such as `src[0:0]`, and a
-  `host:9000`. `76:23` the address and `23:59` the timestamp are the
-  same token. Reviewer attention is the control here, exactly as it is
-  for the kill-claim residue above.
+  unverifiable address, and it stays unmodelled because nothing lexical
+  separates it from data. The 32 that existed were repointed by hand
+  (tsouza/cerberus#2981), so what a rule would face today is the data
+  alone. Counting the bare pair in note scope — a comment's own prose,
+  excluding tab-indented quoted blocks, plus `t.Errorf` / `t.Fatalf`
+  message text — it matches 383 times, and every one of those is a
+  `1:1` correspondence, a chDB fixture clock time, a slice bound such
+  as `src[0:0]`, or a `host:9000`. `76:23` the address and `23:59` the
+  timestamp are the same token.
+
+  Narrowing the match to a unit that ALSO carries mutation vocabulary
+  was measured rather than assumed, and it is the variant that comes
+  closest. On the pre-cleanup tree it flagged 36: 30 addresses and 6
+  ordinary prose — two fixture clock times, an anchor timestamp inside
+  a `t.Errorf`, and `src[0:0]`. It also missed two, both
+  `// --- file.go … ---` section headers, which is the shape most
+  likely to reappear. On the cleaned tree that same rule flags the 6
+  and nothing else: precision zero, six reds on correct prose, and no
+  tolerance file exists to hide them. Rescuing it takes three further
+  lexical exclusions each fitted to one of those six items, and it
+  still fails open on the header shape. Refused, on the same evidence
+  the kill-claim gate above was refused on. Reviewer attention is the
+  control here.
 
 #### The code block quoted under the citation
 

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -2846,9 +2846,10 @@ func TestEmitRangeWindowCompare_RangeFallback(t *testing.T) {
 
 // TestEmitRangeWindowCompare_SpanBoundaryAndArithmetic kills three
 // mutants on the Start/End anchor-count path:
-//   - CONDITIONALS_BOUNDARY at 223:11 (`if span < 0`) — Start==End is a
-//     valid single-anchor window, not an error.
-//   - ARITHMETIC_BASE at 226:20 (`span/stepNS`) and 226:28 (`+ 1`) — the
+//   - CONDITIONALS_BOUNDARY on metrics_compare.go:`if span < 0` —
+//     Start==End is a valid single-anchor window, not an error.
+//   - ARITHMETIC_BASE on both halves of
+//     metrics_compare.go:`numAnchors = span/stepNS + 1` — the
 //     `least(<numAnchors>, …)` literal in the sample-side fanout pins the
 //     exact anchor count, so `/`→`*`/`%`/`±` and `+`→`-`/`*` all diverge.
 //
@@ -2909,11 +2910,14 @@ func TestEmitRangeWindowCompare_SpanBoundaryAndArithmetic(t *testing.T) {
 
 // TestEmitRangeWindowCompare_OuterRangePath covers + kills the
 // NOT_COVERED mutants on the OuterRange anchor branch:
-//   - CONDITIONALS_BOUNDARY / CONDITIONALS_NEGATION at 219:20
-//     (`case r.OuterRange > 0`).
-//   - ARITHMETIC_BASE at 220:42/50 (`OuterRange.Nanoseconds()/stepNS + 1`).
-//   - INVERT_LOGICAL at 221:25 (the `&&` joining the Start/End fallback
-//     case — covered by exercising both branches: OuterRange>0 takes the
+//   - CONDITIONALS_BOUNDARY / CONDITIONALS_NEGATION on
+//     metrics_compare.go:`case r.OuterRange > 0`.
+//   - ARITHMETIC_BASE on
+//     metrics_compare.go:`numAnchors = r.OuterRange.Nanoseconds()/stepNS + 1`.
+//   - INVERT_LOGICAL on the `&&` of
+//     metrics_compare.go:`case !r.Start.IsZero() && !r.End.IsZero()`, the
+//     Start/End fallback case — covered by exercising both branches:
+//     OuterRange>0 takes the
 //     first case, so the second-case guard never fires here, but the
 //     anchor-count assertion distinguishes the OuterRange formula from the
 //     Start/End one).
@@ -3666,12 +3670,12 @@ func TestEmitStructuralSiblingJoin_Succeeds(t *testing.T) {
 // produces observably-different output.
 // =====================================================================
 
-// --- range_lwr.go column-validation disjunct (65:26/46/71) ---
+// --- range_lwr.go column-validation disjunct ---
 
 // TestEmitRangeLWR_EachColumnEmptyErrors kills the INVERT_LOGICAL
-// mutants on the `TimestampCol == "" || ValueCol == "" || MetricNameCol
-// == "" || AttributesCol == ""` validation chain. Each case blanks
-// exactly ONE column; `||` → `&&` would require every column blank
+// mutants on range_lwr.go:`r.TimestampCol == "" || r.ValueCol == ""`,
+// the four-way column validation chain. Each case blanks exactly ONE
+// column; `||` → `&&` would require every column blank
 // before erroring, so a single missing name must still be rejected.
 func TestEmitRangeLWR_EachColumnEmptyErrors(t *testing.T) {
 	t.Parallel()
@@ -3706,16 +3710,17 @@ func TestEmitRangeLWR_EachColumnEmptyErrors(t *testing.T) {
 	}
 }
 
-// --- range_lwr.go Start/End guard + span boundary (76:23, 78:11) ---
+// --- range_lwr.go Start/End guard + span boundary ---
 
 // TestEmitRangeLWR_AnchorCountBounds kills two mutants in the anchor-
 // count computation:
-//   - 76:23 INVERT_LOGICAL on `!Start.IsZero() && !End.IsZero()`: with a
-//     pinned [Start,End] grid the anchor count is computed from the span
+//   - INVERT_LOGICAL on range_lwr.go:`!r.Start.IsZero() && !r.End.IsZero()`:
+//     with a pinned [Start,End] grid the anchor count is computed from
+//     the span
 //     (least(11, …)); the `&&` → `||` flip would still take the computed
 //     branch when only one bound is set, but more importantly the
 //     pinned-grid case below proves the computed branch runs (least(11)).
-//   - 78:11 CONDITIONALS_BOUNDARY on `span < 0` → `span <= 0`: a
+//   - CONDITIONALS_BOUNDARY on range_lwr.go:`if span < 0` (→ `span <= 0`): a
 //     ZERO-span grid (Start == End) is legal — one anchor — and must NOT
 //     error; the `<=` mutant would reject it.
 func TestEmitRangeLWR_AnchorCountBounds(t *testing.T) {
@@ -3758,7 +3763,7 @@ func TestEmitRangeLWR_AnchorCountBounds(t *testing.T) {
 		t.Errorf("zero-span grid must yield exactly one anchor (least(1, …)); got:\n%s", zsSQL)
 	}
 
-	// 76:23 INVERT_LOGICAL on `!Start.IsZero() && !End.IsZero()`: only
+	// INVERT_LOGICAL on range_lwr.go:`!r.Start.IsZero() && !r.End.IsZero()`: only
 	// when BOTH bounds are pinned is the span computed. With Start set
 	// but End zero the guard is false → single anchor, no span math, must
 	// emit cleanly. The `&&` → `||` mutant would enter the span branch on
@@ -3781,11 +3786,12 @@ func TestEmitRangeLWR_AnchorCountBounds(t *testing.T) {
 	}
 }
 
-// --- range_lwr.go lookback sign in the floor-index numerator (189:72) ---
+// --- range_lwr.go lookback sign in the floor-index numerator ---
 
 // TestEmitRangeLWR_LookbackSign kills the INVERT_NEGATIVES /
-// ARITHMETIC_BASE on `-lookbackNS` in the floor-index numerator. The
-// window floor walks BACK by the lookback, so the emitted numerator is
+// ARITHMETIC_BASE on range_lwr.go:`-lookbackNS`, the floor-index
+// numerator's addend. The window floor walks BACK by the lookback, so
+// the emitted numerator is
 // `dist - <lookbackNS>`; flipping the sign to `+ <lookbackNS>` (or
 // changing the op) would walk the window the wrong way and is caught by
 // the exact subtraction substring.
@@ -3815,11 +3821,13 @@ func TestEmitRangeLWR_LookbackSign(t *testing.T) {
 	}
 }
 
-// --- histogram_quantile_native.go computed-phi guard (196:15) ---
+// --- histogram_quantile_native.go computed-phi guard ---
 
 // TestEmitHistogramQuantileNative_ComputedPhiNaNGuard kills the
-// CONDITIONALS_NEGATION on `if h.PhiExpr == nil`. With a computed phi
-// (PhiExpr set) the emitter wraps the core in an `isNaN(phi)` guard
+// CONDITIONALS_NEGATION on
+// histogram_quantile_native.go:histogramQuantileNativeValueFrag:`h.PhiExpr == nil`.
+// With a computed phi (PhiExpr set) the emitter wraps the core in an
+// `isNaN(phi)` guard
 // (Prometheus's NaN-phi contract); the literal-phi path omits it. The
 // `== nil` → `!= nil` flip would swap which path gets the wrapper, so
 // the isNaN(phi) token must be PRESENT for computed phi and ABSENT for
@@ -3866,11 +3874,12 @@ func TestEmitHistogramQuantileNative_ComputedPhiNaNGuard(t *testing.T) {
 	}
 }
 
-// --- nested_set_annotate.go optQualColFrag qualifier branch (410:10) ---
+// --- nested_set_annotate.go optQualColFrag qualifier branch ---
 
 // TestOptQualColFrag_QualifierBranch kills the CONDITIONALS_NEGATION on
-// `if qual == ""` in optQualColFrag: an empty qualifier renders the bare
-// `col`, a non-empty one renders `qual`.`col`. The `== ""` → `!= ""`
+// nested_set_annotate.go:optQualColFrag:`qual == ""`: an empty qualifier
+// renders the bare `col`, a non-empty one renders `qual`.`col`. The
+// `== ""` → `!= ""`
 // flip would swap the two branches.
 func TestOptQualColFrag_QualifierBranch(t *testing.T) {
 	t.Parallel()
@@ -3950,10 +3959,10 @@ func TestEmitRangeWindowOverTime_OuterRangeBoundary(t *testing.T) {
 	}
 }
 
-// --- builder.go Window PARTITION-BY boundary (1575:23) ---
+// --- builder.go Window PARTITION-BY boundary ---
 
 // TestWindowFrag_PartitionByBoundary kills the CONDITIONALS_BOUNDARY on
-// `if len(partitionBy) > 0` inside the Window OVER frag. An empty
+// builder.go:`len(partitionBy) > 0` inside the Window OVER frag. An empty
 // partition list must omit `PARTITION BY` entirely; the `> 0` → `>= 0`
 // mutant would emit a dangling `PARTITION BY ` with no columns.
 func TestWindowFrag_PartitionByBoundary(t *testing.T) {
@@ -3976,7 +3985,7 @@ func TestWindowFrag_PartitionByBoundary(t *testing.T) {
 	}
 }
 
-// --- range_window.go predict_linear slope-column dispatch (411:5) ---
+// --- range_window.go predict_linear slope-column dispatch ---
 
 // TestPredictLinear_SlopeColumnDispatch kills the CONDITIONALS_NEGATION
 // mutant at range_window.go:`r.PredictLinearSlopeColumn == ""`.
@@ -4034,7 +4043,7 @@ func TestPredictLinear_SlopeColumnDispatch(t *testing.T) {
 	})
 }
 
-// --- range_window.go anchorGridCeilIdxFrag arithmetic (1812:41) ---
+// --- range_window.go anchorGridCeilIdxFrag arithmetic ---
 
 // TestAnchorGridCeilIdxFrag_ShiftsAddNSDownByOne kills the ARITHMETIC_BASE
 // mutant at range_window.go:`addNS-1` (→ `addNS+1`) inside
@@ -4068,7 +4077,7 @@ func TestAnchorGridCeilIdxFrag_ShiftsAddNSDownByOne(t *testing.T) {
 	}
 }
 
-// --- range_window.go prefixAnchorIndexFrag arithmetic (1733:37) ---
+// --- range_window.go prefixAnchorIndexFrag arithmetic ---
 
 // TestPrefixAnchorIndexFrag_NegatesRangeNS kills both the INVERT_NEGATIVES
 // and ARITHMETIC_BASE mutants at
@@ -4108,7 +4117,7 @@ func TestPrefixAnchorIndexFrag_NegatesRangeNS(t *testing.T) {
 	}
 }
 
-// --- range_window.go instantDeltaPrefixSource guard + join dispatch (3562:11, 3574:23) ---
+// --- range_window.go instantDeltaPrefixSource guard + join dispatch ---
 
 // instantDeltaPrefixSourceStubWindow builds a syntactically valid (but
 // otherwise semantically opaque) *QueryBuilder standing in for the
@@ -4221,7 +4230,7 @@ func TestInstantDeltaPrefixSource_JoinDispatch(t *testing.T) {
 	})
 }
 
-// --- range_window.go plainGroupColumnNames validation (5104:10, 5104:33) ---
+// --- range_window.go plainGroupColumnNames validation ---
 
 // TestPlainGroupColumnNames_EmptyNameRejected kills the INVERT_LOGICAL
 // mutant on the outer `||` of

--- a/internal/logql/lsyntax/dotted_labels_test.go
+++ b/internal/logql/lsyntax/dotted_labels_test.go
@@ -199,13 +199,16 @@ func TestNormalizeLokiDottedLabels(t *testing.T) {
 		// backtick MUST end the string and a subsequent `b.c=...`
 		// matcher MUST still be rewritten.
 		//
-		// Pins the FIRST `&&` in
-		// `state != lokiInBacktick && ch == '\\' && i+1 < len(q)` at
-		// lokiAdvanceInString. An INVERT_LOGICAL mutant `&&` → `||`
-		// makes the escape branch fire even inside backtick strings,
-		// which would consume the closing backtick as the "escaped
-		// char" and leave the walker permanently inside the string —
-		// the trailing `b.c` would then NOT be rewritten.
+		// Pins the per-state split at the head of lokiAdvanceInString,
+		// dotted_labels.go:`if state == lokiInBacktick`, on the
+		// backslash route. A CONDITIONALS_NEGATION mutant flipping it
+		// to `!=` drops a backtick body through to the escape branch,
+		// which consumes the closing backtick as the "escaped char"
+		// and leaves the walker permanently inside the string — the
+		// trailing `b.c` would then NOT be rewritten. Applying that
+		// rewrite by hand fails this case; reverting it passes. The
+		// no-backslash case below reaches the same mutant by the other
+		// route.
 		{
 			name: "backtick_with_backslash_then_dotted_key",
 			in:   "{a=`x\\`, b.c=\"y\"}",
@@ -216,16 +219,14 @@ func TestNormalizeLokiDottedLabels(t *testing.T) {
 		// the closing `"` at the next position ends the string and a
 		// subsequent `c.d=...` matcher MUST be rewritten.
 		//
-		// Pins the SECOND `&&` in
-		// `state != lokiInBacktick && ch == '\\' && i+1 < len(q)`. An
-		// INVERT_LOGICAL mutant turning the second `&&` into `||`
-		// expands the predicate to
-		// `(state != lokiInBacktick && ch == '\\') || i+1 < len(q)` —
-		// which fires the escape path on EVERY non-final byte
-		// regardless of backslash presence. With a single-byte body
-		// the mutant swallows the closing `"` as the "escaped byte",
-		// leaving the walker permanently inside the string and
-		// skipping the trailing `c.d` rewrite.
+		// Pins the `&&` of the escape-branch guard, whose right operand
+		// is dotted_labels.go:`i+1 < len(q)`. An INVERT_LOGICAL mutant
+		// turning that `&&` into `||` fires the escape path on EVERY
+		// non-final byte regardless of backslash presence. With a
+		// single-byte body the mutant swallows the closing `"` as the
+		// "escaped byte", leaving the walker permanently inside the
+		// string and skipping the trailing `c.d` rewrite. Applying
+		// that rewrite by hand fails this case; reverting it passes.
 		{
 			name: "double_string_one_byte_body_then_dotted_key",
 			in:   `{a="b",c.d="y"}`,

--- a/internal/logql/range_aggregation_test.go
+++ b/internal/logql/range_aggregation_test.go
@@ -528,11 +528,14 @@ func TestLowerRangeAggregationExtendsMatcherWindowByIntervalPlusOffset(t *testin
 }
 
 // TestLowerRangeAggregationBareUnwrapSkipsMaterialisedColumn pins the
-// `&&` boundary of the materialise gate [lowerRangeAggregation] reaches
-// AND the `!=` invariant in [hasParserMergedLabels]:
+// `!=` invariant in [hasParserMergedLabels], reached through the
+// second of [materialiseParserMergedLabels]'s two guards:
 //
-//	if e.Left.Unwrap != nil && hasParserMergedLabels(labelsExpr, s) {
-//	    // materialise into `_logql_merged_labels` intermediate column
+//	if !hasUnwrap && !outerByNeedsParsedLabels {
+//		return inner, nil
+//	}
+//	if !hasParserMergedLabels(labelsExpr, s) {
+//		return inner, nil
 //	}
 //
 //	func hasParserMergedLabels(...) bool {
@@ -542,28 +545,33 @@ func TestLowerRangeAggregationExtendsMatcherWindowByIntervalPlusOffset(t *testin
 //
 // A bare-unwrap query (no `| logfmt` / `| json` / `| regexp` parser
 // stage) reads its labels map directly from ResourceAttributes — so
-// [hasParserMergedLabels] must return false, the materialise gate's
-// condition short-circuits to the else-if branch, and the SQL never
-// references the `_logql_merged_labels` intermediate alias.
+// [hasParserMergedLabels] must return false, the SECOND guard returns
+// early, and the SQL never references the `_logql_merged_labels`
+// intermediate alias.
 //
-// Two LIVED mutants both surface as the SAME observable regression on
-// this fixture, so the single assertion kills both at once:
-//
-//   - INVERT_LOGICAL on the materialise gate's `&&`: `&&` → `||`. With
-//     Unwrap non-nil the condition is now always true regardless of
-//     hasParserMergedLabels; the materialised-column branch fires even
-//     on bare unwrap.
+// The mutant this fixture kills:
 //
 //   - CONDITIONALS_NEGATION on
 //     range_aggregation.go:`col.Name != s.ResourceAttributesColumn`:
 //     `!=` → `==`. With labelsExpr = `ColumnRef(ResourceAttributes)`,
-//     hasParserMergedLabels returns true instead of false; the
-//     materialise gate's condition becomes true; the
-//     materialised-column branch fires.
+//     hasParserMergedLabels returns true instead of false, so the
+//     second guard stops returning early and the materialised-column
+//     branch fires, carrying the `_logql_merged_labels` alias into the
+//     bare-unwrap SQL. Applying that rewrite by hand fails this test;
+//     reverting it passes.
 //
-// Both mutations cause the bare-unwrap SQL to carry the
-// `_logql_merged_labels` alias the materialised Project introduces.
-// Assert its absence — the original code path keeps the SQL lean.
+// The INVERT_LOGICAL mutant on the FIRST guard's `&&` is NOT killed
+// here, and no bare-unwrap fixture can kill it: with
+// [hasParserMergedLabels] false, the original reads `!true && !false`
+// → false and falls through to the second guard, which returns `inner`,
+// while the `||` mutant reads `!true || !false` → true and returns
+// `inner` immediately. Both leave the alias ABSENT and the assertion
+// below passes either way. That mutant dies in
+// [TestLowerRangeAggregationParserUnwrapMaterialisesIntermediateColumn]
+// instead, whose `| logfmt` fixture makes [hasParserMergedLabels] true.
+//
+// Assert the alias's absence — the original code path keeps the SQL
+// lean.
 func TestLowerRangeAggregationBareUnwrapSkipsMaterialisedColumn(t *testing.T) {
 	t.Parallel()
 
@@ -602,40 +610,43 @@ func TestLowerRangeAggregationBareUnwrapSkipsMaterialisedColumn(t *testing.T) {
 
 	// The materialised-column alias `_logql_merged_labels` is the
 	// fingerprint of the two-stage Project path. If it appears in the
-	// emitted SQL for a bare-unwrap query, EITHER:
-	//   - the materialise gate's `&&` flipped to `||` (mutant entered
-	//     the branch despite hasParserMergedLabels == false), OR
-	//   - the `col.Name != s.ResourceAttributesColumn` invariant
-	//     flipped to `==` (hasParserMergedLabels reported true for a
-	//     bare ResourceAttributes ColumnRef).
+	// emitted SQL for a bare-unwrap query, the
+	// `col.Name != s.ResourceAttributesColumn` invariant flipped to
+	// `==` and hasParserMergedLabels reported true for a bare
+	// ResourceAttributes ColumnRef.
 	if strings.Contains(sqlStr, "_logql_merged_labels") {
 		t.Errorf("bare-unwrap SQL unexpectedly carries the `_logql_merged_labels` alias\n"+
-			"  → INVERT_LOGICAL on the materialise gate (`&&` → `||`) OR\n"+
 			"  → CONDITIONALS_NEGATION on range_aggregation.go:`col.Name != s.ResourceAttributesColumn` (`!=` → `==`) lived\nsql=%s", sqlStr)
 	}
 
 	// Companion positive assertion: the bare-unwrap path MUST surface
 	// the `MapWithoutKeys` strip via the `mapFilter((k, v) -> NOT (k IN
-	// (?)), ...)` shape compiled from the else-if branch. Without it
-	// the test only checks one direction of the toggle.
+	// (?)), ...)` shape compiled from the non-materialised path. Without
+	// it the test only checks one direction of the toggle.
 	if !strings.Contains(sqlStr, "mapFilter((k, v) -> NOT (k IN") {
-		t.Errorf("bare-unwrap SQL missing the else-if branch's mapFilter strip shape\nsql=%s", sqlStr)
+		t.Errorf("bare-unwrap SQL missing the non-materialised path's mapFilter strip shape\nsql=%s", sqlStr)
 	}
 }
 
 // TestLowerRangeAggregationParserUnwrapMaterialisesIntermediateColumn
 // is the dual of [TestLowerRangeAggregationBareUnwrapSkipsMaterialisedColumn]:
 // when the unwrap query DOES carry a parser stage, the SQL MUST surface
-// the `_logql_merged_labels` materialised-column alias. Together with
-// the bare-unwrap test, this pins both legs of the materialise gate's
-// `&&` condition and the `col.Name != s.ResourceAttributesColumn`
-// return so a flipped operator can't pass both halves silently.
+// the `_logql_merged_labels` materialised-column alias. Between them the
+// two fixtures pin both guards of [materialiseParserMergedLabels] — this
+// one the first guard's `&&`, the bare-unwrap one the
+// `col.Name != s.ResourceAttributesColumn` return — so a flipped
+// operator cannot pass both.
 //
-// The materialise gate's INVERT_LOGICAL mutant flips `&&` to `||`. With Unwrap
-// non-nil AND hasParserMergedLabels true, both legs of the original
-// `&&` are true so the mutant's `||` also evaluates true — the test
-// covers this case to confirm the happy path stays intact (no false
-// positive from the dual assertion).
+// This test is where the INVERT_LOGICAL mutant on
+// range_aggregation.go:`if !hasUnwrap && !outerByNeedsParsedLabels`
+// dies. On this fixture `hasUnwrap` is true and
+// `outerByNeedsParsedLabels` false, so the original guard reads
+// `!true && !false` → false and falls through to materialise, while the
+// `||` mutant reads `!true || !false` → true and returns `inner`
+// unmodified — dropping the very alias the assertion below requires.
+// Applying that rewrite by hand fails this test; reverting it passes.
+// The bare-unwrap dual cannot kill it: there [hasParserMergedLabels] is
+// false, so original and mutant both return `inner`.
 //
 // The CONDITIONALS_NEGATION mutant on
 // range_aggregation.go:`col.Name != s.ResourceAttributesColumn` flips

--- a/internal/logql/vector_aggregation_mutation_test.go
+++ b/internal/logql/vector_aggregation_mutation_test.go
@@ -122,15 +122,16 @@ func lowerTopKIdentityExpr(t *testing.T, query string, s schema.Logs) chplan.Exp
 // surfaced as a synthesised `ServiceName` key.
 //
 // Mutants this pins:
-//   - 390:16 CONDITIONALS_NEGATION (`!= nil` → `== nil`): Grouping is
-//     non-nil here, so the mutant's first operand becomes false ⇒ guard
-//     skipped ⇒ ServiceName NOT surfaced. Assertion (present) fails.
-//   - 390:72 CONDITIONALS_NEGATION (`> 0` → `<= 0`): len(Groups)==1, so
-//     `<= 0` is false ⇒ guard skipped ⇒ ServiceName NOT surfaced.
-//     Assertion (present) fails.
+//   - CONDITIONALS_NEGATION on `e.Grouping != nil` (`!= nil` → `== nil`):
+//     Grouping is non-nil here, so the mutant's first operand becomes false ⇒
+//     guard skipped ⇒ ServiceName NOT surfaced. Assertion (present) fails.
+//   - CONDITIONALS_NEGATION on `len(e.Grouping.Groups) > 0` (`> 0` → `<= 0`):
+//     len(Groups)==1, so `<= 0` is false ⇒ guard skipped ⇒ ServiceName NOT
+//     surfaced. Assertion (present) fails.
 //
-// (The two INVERT_LOGICAL mutants at 390:23 / 390:46 still surface the
-// key for this `by`-input — they're killed by the `without` test below.)
+// (The two INVERT_LOGICAL mutants on the guard's two `&&` operators still
+// surface the key for this `by`-input — they're killed by the `without` test
+// below.)
 func TestSortableShapedInnerThreadsOuterByColumn(t *testing.T) {
 	t.Parallel()
 

--- a/internal/promql/gremlins_kill_histogram_subquery_select_test.go
+++ b/internal/promql/gremlins_kill_histogram_subquery_select_test.go
@@ -58,8 +58,9 @@ import (
 )
 
 // TestSelectFnOverExpHistogramSubquery_ZeroRangeRejected kills the
-// CONDITIONALS_BOUNDARY mutant at histogram_native_subquery_select.go:
-// 118:22 (`sub.Range <= 0` -> `< 0`). A zero-duration subquery with an
+// CONDITIONALS_BOUNDARY mutant at
+// histogram_native_subquery_select.go:`sub.Range <= 0` (-> `< 0`). A
+// zero-duration subquery with an
 // otherwise valid histogram-native inner and a resolvable eval anchor
 // isolates the Range check alone: subqueryGridCtx tolerates a zero Range
 // via its own sub-step-window clamp, so subqueryHasEvalAnchor genuinely
@@ -89,8 +90,9 @@ func TestSelectFnOverExpHistogramSubquery_ZeroRangeRejected(t *testing.T) {
 }
 
 // TestLowerSelectFnOverExpHistogramSubquery_ZeroStepDefaults kills the
-// CONDITIONALS_NEGATION mutant at histogram_native_subquery_select.go:
-// 167:10 (`step == 0` -> `step != 0`). A subquery with no explicit step
+// CONDITIONALS_NEGATION mutant at
+// histogram_native_subquery_select.go:`step == 0` (-> `step != 0`). A
+// subquery with no explicit step
 // (`[5m:]`) must fall back to defaultSubqueryStep. With the negation, step
 // stays 0 and flows into subqueryGridCtx -> epochFloor, which divides by
 // the step duration — a genuine divide-by-zero panic, not merely a wrong

--- a/internal/promql/gremlins_kill_metadata_catalog_test.go
+++ b/internal/promql/gremlins_kill_metadata_catalog_test.go
@@ -216,7 +216,8 @@ func TestFloatOnlyAggOverMixedExpHistogramSetOp_ParamlessOpsAccepted(t *testing.
 	if !ok {
 		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) = ok false; want true — `min` carries "+
 			"no parameter, so the QUANTILE/Param guard must not fire (mutants "+
-			"`!=`->`==` at :91:44 and `&&`->`||` at :91:31 both make it fire)", q)
+			"`!=`->`==` on histogram_native_mixed_or_aggregate_float_only.go:`agg.Param != nil` "+
+			"and `&&`->`||` on the `&&` joining it to the Op test both make it fire)", q)
 	}
 	if agg == nil || agg.Op != parser.MIN {
 		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) returned agg %#v; want the MIN "+
@@ -252,8 +253,9 @@ func TestFloatOnlyAggOverMixedExpHistogramSetOp_QuantileKeepsItsParam(t *testing
 	agg, _, ok := floatOnlyAggOverMixedExpHistogramSetOp(expr, s, lowerCtx{})
 	if !ok {
 		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) = ok false; want true — QUANTILE is "+
-			"the op the Param exception exists for (mutant `!=`->`==` at :91:12 rejects every "+
-			"quantile instead)", q)
+			"the op the Param exception exists for (mutant `!=`->`==` on "+
+			"histogram_native_mixed_or_aggregate_float_only.go:`agg.Op != parser.QUANTILE` "+
+			"rejects every quantile instead)", q)
 	}
 	if agg == nil || agg.Op != parser.QUANTILE {
 		t.Fatalf("floatOnlyAggOverMixedExpHistogramSetOp(%q) returned agg %#v; want the QUANTILE "+


### PR DESCRIPTION
Two adjudication-note integrity defects found by the same work, closed together.

## #2981 — 32 unmarked `N:M` line addresses

Re-verified against current `main` first: **32, exactly as filed**, in the four
files named — chsql 23, logql 4, promql 3 + 2. The `Start=10:00, End=10:03`
clock times and the `1767225600 == 2026-01-01T00:00:00Z` epoch line sit in the
same notes and are correctly outside the count.

Each was repointed by reading its note, never by converting the number. That
matters: **the numbers had already rotted.** The two `TestEmitRangeWindowCompare_*`
notes address `223:11` / `226:20` while the constructs they describe sit at
`metrics_compare.go` 617 and 620; the `range_lwr` note addresses `76:23` / `78:11`
against constructs at 169 and 171. A mechanical conversion would have named
whatever now sits on those lines.

Twelve of them become machine-verified `file.go:`construct`` citations —
including two that needed function scope, because `h.PhiExpr == nil` occurs three
times in `histogram_quantile_native.go` and `qual == ""` twice in
`nested_set_annotate.go`. The rest lose a number that the prose beside it already
named in backticks, which is the remedy the convention prescribes.

`git diff` residue check: the note-scope population falls 415 → 383, i.e. exactly
32 removed and nothing else touched.

## #2981 — the gate: refused, with the measurement

A bare `N:M` in note scope matches **415 times against 32 real addresses — 7.7%**.

The one variant worth measuring is the pair scoped to a unit that also carries
mutation vocabulary. Pre-cleanup it flagged **36: 30 real, 6 ordinary prose**
(two fixture clock times, an anchor timestamp inside a `t.Errorf`, and a
`src[0:0]` slice bound), and it **missed two** — both `// --- file.go … ---`
section headers, which is the shape most likely to come back, so it fails open
exactly where a ratchet would need to hold.

On the cleaned tree that same rule flags those 6 and nothing else: **precision
zero**, six reds on correct prose, with no tolerance file available (invariant 7).
Rescuing it takes three further lexical exclusions each fitted to one of the six
survivors, and it still fails open on the header shape.

Refused, on the same evidence #2966 and #2982 were refused on. The refusal is
recorded in `docs/test-strategy.md` beside the other three, and the superseded
"108 pairs, about a third are addresses" estimate is replaced in both the doc and
the gate script's own header so the two no longer disagree.

## #2983 — a note crediting a kill its own fixture cannot make

Re-adjudicated against the real mutant inventory, from the `mutation` lane's own
artifact (`phase4-logql-aggregation`, run on `d417cc179`, whose
`range_aggregation.go` is byte-identical to current `main`), not by reading:

| mutant | mutator | report verdict |
| --- | --- | --- |
| `range_aggregation.go` 934:78 | CONDITIONALS_BOUNDARY / NEGATION | KILLED |
| `range_aggregation.go` 935:16 | INVERT_LOGICAL (the first guard's `&&`) | KILLED |
| `range_aggregation.go` 776:18 | CONDITIONALS_NEGATION (`col.Name != …`) | KILLED |
| `range_aggregation.go` 938 | — | no mutant exists |

The second guard generates **no mutant at all** — gremlins has nothing to rewrite
in a unary `!` on a call — so its untested-ness is invisible to the lane either
way.

Each verdict was then proven by hand, applying one mutation and running the
ordinary Go test:

- **776:18** (`!=` → `==`): the bare-unwrap test **FAILS**; reverted, it passes.
  That leg of the note was true and stands.
- **935:16** (`&&` → `||`): the bare-unwrap test **PASSES** — the mutant survives
  it, exactly as the issue's truth table predicted — and
  `TestLowerRangeAggregationParserUnwrapMaterialisesIntermediateColumn` **FAILS**.
  The credit moves there.

Both tests keep every assertion; only the false kill claim is removed, as #2968
and #2975 did. The tab-indented block quoting the deleted single guard is
replaced by the two guards that exist.

The **sibling note was stale in the opposite direction** and is fixed in the same
pass: it claimed the `||` mutant "also evaluates true — the happy path stays
intact", i.e. that it saw nothing, when it is in fact the test that kills it.
Both notes were written against the pre-De-Morgan form; one over-claimed and one
under-claimed the same mutant.

Also in scope per the issue: `lsyntax/dotted_labels_test.go`'s "FIRST"/"SECOND
`&&`" descriptions of a compound guard that the same class of refactor split.
Re-adjudicated against `197:11 CONDITIONALS_NEGATION` and `203:16 INVERT_LOGICAL`
(both KILLED in the lsyntax leg's report) and proven by hand — each case fails
with its mutation applied and passes reverted. The citation names
`i+1 < len(q)` rather than the operand containing `'\\'`, because the gate's
`unescape` would collapse `\\` to `\` and the construct would stop resolving.

## Verification

- `verify-code-citations.mjs` — green, 2172 files; its own `node --test` suite 40/40.
- `forbid-contradicted-mutants.mjs` — green; the "survives here / killed there"
  split is not an EQUIVALENT-vs-KILLED contradiction.
- `forbid-skip.mjs CHECK=all`, `gofmt`, `markdownlint-cli2` on the doc — clean.
- `go test -race ./internal/chsql/ ./internal/logql/... ./internal/promql/` — pass.

No assertion, case table, test name, threshold or production line changed. No
mutation run was executed locally.

Closes #2981
Closes #2983
