### PR TITLE
test: kill the 17 capacity-hint survivors whose slice escapes to a readable surface

### DIFF
--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -459,9 +459,13 @@ export const PHASES = [
   //     change only allocator behaviour and not output, but observability is not
   //     confined to output: all three build a slice that becomes a returned
   //     `chplan.FuncCall`'s exported `Args` and fill the hint exactly, so `cap`
-  //     reads the arithmetic back. detected_level.go's two hints are killed that
-  //     way; cerberus issue #2984 tracks applying the same check here and across
-  //     the rest of the matrix's capacity survivors.
+  //     reads the arithmetic back. All three are killed that way now, in
+  //     capacity_hint_mutation_test.go alongside detected_level.go's two, and
+  //     cerberus issue #2984 swept the same check across the whole matrix: of
+  //     the 21 surviving capacity hints it found, 17 escaped to a readable
+  //     surface and are killed, and the 4 that do not are adjudicated where
+  //     they live (internal/chsql/exemplars_misc_mutation_test.go,
+  //     detected_level_test.go, internal/promql/gremlins_kill_window_bounds_test.go).
   //   - empty-group CONDITIONALS_BOUNDARY guards (`len(...) > 0` vs `>= 0`) whose
   //     only distinguishing input (`by ()`) threads a len-0 label slice the
   //     lowering collapses to nil — a byte-identical no-op.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1397,20 +1397,48 @@ hold, and each has to be checked at the site:
   same function earns opposite verdicts. Reaching the header through an
   unexported field is enough; the closure in `exemplars.go` that settled
   cerberus issue #2958 is the one shape Go offers no way to read at all.
-- **The appends do not fill the hint exactly.** Where they DO — the
-  builder appends exactly as many elements as it pre-allocated for — the
-  finished slice still reports the hint, `cap` reads the arithmetic
-  straight back, and every substitution is observable. Under-filling
-  leaves the mutated hint on the slice, over-filling re-grows through the
-  runtime's size classes; neither lands back on the true capacity by
-  accident, but "does not land back" is a claim to assert rather than
-  narrate, per "How a note states a number" below.
+- **The finished capacity does not read the hint back.** `cap` is the
+  observation, and it answers the hint only while the builder has not
+  grown past the pre-allocation. Where it has not — whether the appends
+  fill the hint exactly or leave it under-filled, since an under-filled
+  slice never grows and keeps the capacity it was made with — the
+  finished slice still reports the hint and `cap` reads the arithmetic
+  straight back.
 
-Both cap-hint pairings in `detected_level_test.go` are written that way:
-one test asserts `cap` against a derived count, and a second enumerates
-every operator substitution and asserts the resulting capacity differs.
-That second test is what makes the first re-checkable, and it is what a
-prose equivalence note cannot do for itself.
+  That is necessary and not sufficient, and the gap is where the sweep
+  found its one real equivalence: the MUTATED hint has to finish on a
+  different capacity too, and `append`'s growth schedule can land it back
+  on the true one. `internal/promql/schema_lookup.go`'s
+  `make([]chplan.Expr, 0, len(pairs)*2)` escapes into a returned
+  expression's exported `Args` and still survives, because `pairs` is 1
+  at every reachable call: the true hint is 2, the `*` -> `/` rewrite
+  gives 0, and the single two-element `append` grows a zero-capacity
+  slice to exactly capacity 2. Both builds finish at cap 2. "Does not
+  land back" is therefore a claim to assert rather than narrate, per
+  "How a note states a number" below.
+
+`ARITHMETIC_BASE` rewrites each arithmetic token to exactly **one**
+other token — `+`->`-`, `-`->`+`, `*`->`/`, `/`->`*`, `%`->`*`, the
+mapping the pinned `tsouza/gremlins` fork carries in
+`internal/engine/mappings.go` — so a hint spelling P operators carries P
+mutants and a completed run reports P verdicts on its line.
+Adjudicating against the four other operators instead answers about
+mutants no run emits, and the two answers differ: the `schema_lookup.go`
+hint above is unkillable under the `/` gremlins writes and killable
+under a `+` it never writes.
+
+`test/capmutant` is the shared driver. `AssertKilled` takes the hint's
+operator positions, a replay of the builder's append sequence, and a
+closure that reads the capacity back through the escape surface; it
+asserts the real value's capacity against the unmutated hint, checks the
+replay against the real builder so a drifted simulation is reported
+rather than trusted, and then requires each emitted mutant to move the
+finished capacity. That last step is what makes the first re-checkable,
+and it is what a prose equivalence note cannot do for itself.
+`internal/{chplan,logql,promql}/capacity_hint_mutation_test.go` carry
+one call per adjudicated hint; `detected_level_test.go`'s two pairings
+predate the driver and enumerate a deliberate superset of the mutant
+set, which its own comment says.
 
 Cerberus issue #2974 asked whether `tsouza/gremlins` should stop
 EMITTING these instead — a generator-side narrowing in the family of

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1418,14 +1418,24 @@ hold, and each has to be checked at the site:
   "How a note states a number" below.
 
 `ARITHMETIC_BASE` rewrites each arithmetic token to exactly **one**
-other token — `+`->`-`, `-`->`+`, `*`->`/`, `/`->`*`, `%`->`*`, the
-mapping the pinned `tsouza/gremlins` fork carries in
-`internal/engine/mappings.go` — so a hint spelling P operators carries P
-mutants and a completed run reports P verdicts on its line.
-Adjudicating against the four other operators instead answers about
-mutants no run emits, and the two answers differ: the `schema_lookup.go`
-hint above is unkillable under the `/` gremlins writes and killable
-under a `+` it never writes.
+other token — `+`->`-`, `-`->`+`, `*`->`/`, `/`->`*`, `%`->`*`. That is
+the `tokenMutations` table the pinned `tsouza/gremlins` fork declares for
+this mutator, in its engine's token-mapping source. The table is named
+rather than addressed by path because an upstream file cannot be cited
+from here — see "How a note cites the mutant it adjudicates" below;
+`docs/upstream-forks.md` is the pointer to the fork boundary, and
+`.github/workflows/mutation.yml` installs the fork by version. So a hint
+spelling P operators carries P mutants, and a completed run reports P
+verdicts on its line.
+
+Enumerating the four other operators per position instead adjudicates
+mutants no run emits, and that is not a harmless over-approximation: it
+can report a kill the lane will never collect. The two answers genuinely
+differ — the `schema_lookup.go` hint above is unkillable under the `/`
+gremlins writes and killable under a `+` it never writes, so an
+enumeration of the superset would have called it dead while its leg went
+on carrying it as a survivor. An adjudication is against the emitted
+mutant set, or it is against nothing.
 
 `test/capmutant` is the shared driver. `AssertKilled` takes the hint's
 operator positions, a replay of the builder's append sequence, and a

--- a/internal/chplan/capacity_hint_mutation_test.go
+++ b/internal/chplan/capacity_hint_mutation_test.go
@@ -1,0 +1,117 @@
+package chplan
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/test/capmutant"
+)
+
+// TestRecollapseIdentityKeyAliases_CapHintMutantKilled kills the ARITHMETIC_BASE
+// mutant gremlins reports on
+// canonical_series_keys.go:recollapseIdentityKeyAliases:`len(pass)+len(r.Recollapse)`.
+//
+// The mutant sizes a slice, and a capacity hint changes only allocator
+// behaviour — which is exactly why this class was written off across the
+// matrix. Observability is not confined to the emitted SQL, though: the slice
+// this hint sizes IS the value [recollapseIdentityKeyAliases] returns, which
+// [seriesIdentityKeyAliases] hands back to every caller. `cap` is readable on
+// a return value from any test in this package, the appends do not grow past
+// the pre-allocation, and so the finished slice still reports the hint's
+// arithmetic. See docs/test-strategy.md's "When a capacity mutant is
+// equivalent".
+//
+// [capmutant.AssertKilled] asserts that capacity against the hint AND replays
+// every operator substitution to prove the assertion discriminates, so the
+// claim this test makes is re-checked by the test itself rather than asserted
+// in prose here.
+func TestRecollapseIdentityKeyAliases_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	// The operand sizes are chosen so that no mutated hint's growth schedule
+	// lands back on the true capacity; capmutant.AssertKilled reports by name
+	// any substitution that would.
+	const (
+		passKeys   = 3
+		recollapse = 2
+	)
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "canonical_series_keys.go:recollapseIdentityKeyAliases:`len(pass)+len(r.Recollapse)`",
+		Positions: []capmutant.Position{{Name: "the `+`", Op: "+"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{passKeys, recollapse}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			n := recollapseNodeForCapHint(passKeys, recollapse)
+			// Guard the fixture rather than the arithmetic: a node whose
+			// partition differs from the one this test thinks it built would
+			// adjudicate a hint with the wrong operands.
+			if pass, _ := n.PartitionRecollapseGroupBy(mustGroupByColumns(t, n)); len(pass) != passKeys {
+				t.Fatalf("fixture partitions %d pass-through keys, want %d", len(pass), passKeys)
+			}
+			aliases := seriesIdentityKeyAliases(n)
+			return len(aliases), cap(aliases)
+		},
+		Build: func(hint int) (int, int) {
+			// recollapseIdentityKeyAliases appends the pass-through aliases one
+			// at a time, then the Recollapse aliases in a single variadic
+			// append. The element type and the grouping both steer append's
+			// growth schedule, so the replay mirrors them.
+			aliases := make([]string, 0, hint)
+			for i := 0; i < passKeys; i++ {
+				aliases = append(aliases, "")
+			}
+			aliases = append(aliases, make([]string, recollapse)...)
+			return len(aliases), cap(aliases)
+		},
+	})
+}
+
+// mustGroupByColumns answers the node's GroupBy column names, failing the test
+// if any key is computed — the partition the hint's operands come from is
+// undefined for such a node.
+func mustGroupByColumns(t *testing.T, n *RangeWindowGridNative) []string {
+	t.Helper()
+
+	cols, computed := n.GroupByColumns()
+	if computed != nil {
+		t.Fatalf("fixture GroupBy carries a computed key %#v; the deferred-shaping "+
+			"shape requires plain column references", computed)
+	}
+	return cols
+}
+
+// recollapseNodeForCapHint builds a deferred-shaping [RangeWindowGridNative]
+// with exactly `pass` pass-through GroupBy keys and `recollapse` shaped ones.
+// Each shaped Projection reads its OWN GroupBy key, which is what moves that
+// key out of the pass-through set — see
+// [RangeWindowGridNative.PartitionRecollapseGroupBy].
+func recollapseNodeForCapHint(pass, recollapse int) *RangeWindowGridNative {
+	groupBy := make([]Expr, 0, pass+recollapse)
+	for i := 0; i < pass; i++ {
+		groupBy = append(groupBy, &ColumnRef{Name: fmt.Sprintf("pass_%d", i)})
+	}
+	shaped := make([]Projection, 0, recollapse)
+	for i := 0; i < recollapse; i++ {
+		src := fmt.Sprintf("shaped_src_%d", i)
+		groupBy = append(groupBy, &ColumnRef{Name: src})
+		shaped = append(shaped, Projection{
+			Expr:  &FuncCall{Fn: FnMapSort, Args: []Expr{&ColumnRef{Name: src}}},
+			Alias: fmt.Sprintf("shaped_%d", i),
+		})
+	}
+	return &RangeWindowGridNative{
+		Input:           &Scan{Table: "otel_metrics_sum", Columns: []string{"Attributes", "Value"}},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Step:            time.Minute,
+		Start:           time.Unix(1000, 0).UTC(),
+		End:             time.Unix(4600, 0).UTC(),
+		TimestampColumn: "TimeUnix",
+		ValueColumn:     "Value",
+		GroupBy:         groupBy,
+		Recollapse:      shaped,
+	}
+}

--- a/internal/logql/capacity_hint_mutation_test.go
+++ b/internal/logql/capacity_hint_mutation_test.go
@@ -1,0 +1,327 @@
+// Capacity-hint adjudication for internal/logql.
+//
+// Every hint in this file sizes a slice that becomes an EXPORTED field of a
+// value its builder returns — a `chplan.FuncCall`'s `Args` or a
+// `chplan.Project`'s `Projections` — and none of them grows past its
+// pre-allocation, so `cap` reads the hint's arithmetic straight back and a
+// plain assertion kills every `ARITHMETIC_BASE` substitution gremlins can
+// make. `docs/test-strategy.md`'s "When a capacity mutant is equivalent"
+// states the rule; the two hints in detected_level_test.go were the worked
+// instances it was derived from, and this file applies the same check to the
+// package's remaining capacity survivors.
+//
+// Each test names the escape surface it reads the capacity back through.
+// [capmutant.AssertKilled] then replays every operator substitution against
+// the builder's own append sequence and requires each one to move the finished
+// capacity, so "the assertion discriminates" is re-run rather than asserted.
+package logql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	syntax "github.com/tsouza/cerberus/internal/logql/lsyntax"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/capmutant"
+)
+
+// capHintExprArgs reads the `Args` slice of the [chplan.FuncCall] e is, failing
+// the test when the expression is some other shape — a navigation that silently
+// answered an empty slice would report a capacity nobody allocated.
+func capHintExprArgs(t *testing.T, e chplan.Expr, what string) []chplan.Expr {
+	t.Helper()
+
+	fn, ok := e.(*chplan.FuncCall)
+	if !ok {
+		t.Fatalf("%s is %T; want *chplan.FuncCall", what, e)
+	}
+	return fn.Args
+}
+
+// TestWrapLabelsWithMarks_CapHintMutantsKilled kills the two ARITHMETIC_BASE
+// mutants gremlins reports on duration.go:`len(marks)*2+1`.
+//
+// Escape surface: [wrapLabelsWithMarks] returns a `mapMerge` FuncCall whose
+// second argument is the `multiIf` cascade this hint sizes, so the slice is
+// reachable as an exported `Args` field two levels down from the return value.
+func TestWrapLabelsWithMarks_CapHintMutantsKilled(t *testing.T) {
+	t.Parallel()
+
+	// Four marks keeps the cascade on its multiIf branch (a single mark
+	// switches wrapLabelsWithMarks to `if`, which builds the same slice but
+	// stops being the shape the mutant's own callers exercise), and no mutated
+	// hint's growth schedule lands back on the true capacity at this size.
+	const marks = 4
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "duration.go:`len(marks)*2+1`",
+		Positions: []capmutant.Position{
+			{Name: "the `*2`", Op: "*"},
+			{Name: "the trailing `+1`", Op: "+"},
+		},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{marks, 2, 1}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			merged := wrapLabelsWithMarks(&chplan.ColumnRef{Name: "labels"}, capHintMarks(marks))
+			outer := capHintExprArgs(t, merged, "wrapLabelsWithMarks result")
+			if len(outer) != 2 {
+				t.Fatalf("mapMerge carries %d args; want the labels expression and the cascade", len(outer))
+			}
+			args := capHintExprArgs(t, outer[1], "the mark cascade")
+			return len(args), cap(args)
+		},
+		Build: func(hint int) (int, int) {
+			// One (condition, value) pair per mark, then the trailing empty-map
+			// branch: the grouping of the appends steers append's growth
+			// schedule, so the replay mirrors it call for call.
+			args := make([]chplan.Expr, 0, hint)
+			for i := 0; i < marks; i++ {
+				args = append(args, nil, nil)
+			}
+			args = append(args, nil)
+			return len(args), cap(args)
+		},
+	})
+}
+
+// capHintMarks builds n distinct [labelFilterMark]s. The values are immaterial
+// to a capacity — only the count is — but they are distinct so a shape
+// assertion added later reads something meaningful.
+func capHintMarks(n int) []labelFilterMark {
+	marks := make([]labelFilterMark, 0, n)
+	for i := 0; i < n; i++ {
+		marks = append(marks, labelFilterMark{
+			cond:    &chplan.LitInt{V: int64(i)},
+			kind:    "SampleExtractionErr",
+			details: &chplan.LitString{V: "detail"},
+		})
+	}
+	return marks
+}
+
+// TestMergeParsedFields_CapHintMutantKilled kills the ARITHMETIC_BASE mutant
+// gremlins reports on lower.go:`len(fields)*2`.
+//
+// Escape surface: [mergeParsedFields] returns a `mapMerge` FuncCall whose
+// second argument is the `map(...)` literal this hint sizes, so the slice is
+// its exported `Args`.
+func TestMergeParsedFields_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	const fields = 5
+
+	s := schema.DefaultOTelLogs()
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "lower.go:`len(fields)*2`",
+		Positions: []capmutant.Position{{Name: "the `*2`", Op: "*"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{fields, 2}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			parsed := make([]parsedField, 0, fields)
+			for i := 0; i < fields; i++ {
+				parsed = append(parsed, parsedField{
+					name:  string(rune('a' + i)),
+					value: &chplan.LitString{V: "v"},
+				})
+			}
+			merged := mergeParsedFields(&chplan.ColumnRef{Name: s.AttributesColumn}, s, parsed)
+			outer := capHintExprArgs(t, merged, "mergeParsedFields result")
+			if len(outer) != 2 {
+				t.Fatalf("mapMerge carries %d args; want the previous labels and the map literal", len(outer))
+			}
+			args := capHintExprArgs(t, outer[1], "the parsed-field map literal")
+			return len(args), cap(args)
+		},
+		Build: func(hint int) (int, int) {
+			args := make([]chplan.Expr, 0, hint)
+			for i := 0; i < fields; i++ {
+				args = append(args, nil, nil) // (renamed key, value)
+			}
+			return len(args), cap(args)
+		},
+	})
+}
+
+// TestJSONExtractStringExpr_CapHintMutantKilled kills the ARITHMETIC_BASE
+// mutant gremlins reports on lower.go:`len(segments)+1`.
+//
+// Escape surface: the slice IS the returned `JSONExtractString` FuncCall's
+// exported `Args`.
+func TestJSONExtractStringExpr_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	// A five-segment path; the leading Body column makes six arguments.
+	const (
+		path     = "a.b.c.d.e"
+		segments = 5
+	)
+
+	s := schema.DefaultOTelLogs()
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "lower.go:`len(segments)+1`",
+		Positions: []capmutant.Position{{Name: "the `+1`", Op: "+"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{segments, 1}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			expr, err := jsonExtractStringExpr(s, path)
+			if err != nil {
+				t.Fatalf("jsonExtractStringExpr(%q): %v", path, err)
+			}
+			args := capHintExprArgs(t, expr, "jsonExtractStringExpr result")
+			if len(args) != segments+1 {
+				t.Fatalf("JSONExtractString carries %d args; want the Body column plus "+
+					"%d path segments — the fixture path no longer parses into the "+
+					"segment count this hint's operands assume", len(args), segments)
+			}
+			return len(args), cap(args)
+		},
+		Build: func(hint int) (int, int) {
+			args := make([]chplan.Expr, 0, hint)
+			args = append(args, nil) // the Body column
+			for i := 0; i < segments; i++ {
+				args = append(args, nil)
+			}
+			return len(args), cap(args)
+		},
+	})
+}
+
+// TestRangeAggregationGroupBy_CapHintMutantKilled kills the ARITHMETIC_BASE
+// mutant gremlins reports on
+// range_aggregation.go:`len(e.Grouping.Groups)*2`.
+//
+// Escape surface: the slice IS the returned `map(...)` FuncCall's exported
+// `Args`.
+func TestRangeAggregationGroupBy_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		query  = `avg_over_time({app="api"} | logfmt | unwrap latency [5m]) by (region, tenant, env, zone, shard)`
+		groups = 5
+	)
+
+	s := schema.DefaultOTelLogs()
+	ra := parseRangeAggregationForCapHint(t, query, groups)
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "range_aggregation.go:`len(e.Grouping.Groups)*2`",
+		Positions: []capmutant.Position{{Name: "the `*2`", Op: "*"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{groups, 2}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			got, err := rangeAggregationGroupBy(ra, s, &chplan.ColumnRef{Name: s.ResourceAttributesColumn},
+				func() chplan.Expr { return detectedLevelIdentityExpr(s, ra.Left.Left) })
+			if err != nil {
+				t.Fatalf("rangeAggregationGroupBy: %v", err)
+			}
+			args := capHintExprArgs(t, got, "rangeAggregationGroupBy result")
+			return len(args), cap(args)
+		},
+		Build: func(hint int) (int, int) {
+			args := make([]chplan.Expr, 0, hint)
+			for i := 0; i < groups; i++ {
+				args = append(args, nil, nil) // (label literal, group-key value)
+			}
+			return len(args), cap(args)
+		},
+	})
+}
+
+// TestWrapVectorAggregateForSample_CapHintMutantKilled kills the
+// ARITHMETIC_BASE mutant gremlins reports on
+// vector_aggregation.go:`len(e.Grouping.Groups)*2`.
+//
+// Escape surface: the slice becomes the `map(...)` FuncCall the returned
+// [chplan.Project] projects as its Attributes column, so it is reachable as an
+// exported `Args` under an exported `Projections`.
+func TestWrapVectorAggregateForSample_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		query  = `sum by (region, tenant, env, zone, shard) (rate({app="api"}[5m]))`
+		groups = 5
+	)
+
+	s := schema.DefaultOTelLogs()
+
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	va, ok := expr.(*syntax.VectorAggregationExpr)
+	if !ok {
+		t.Fatalf("ParseExpr(%q) -> %T, want *syntax.VectorAggregationExpr", query, expr)
+	}
+	if va.Grouping == nil || len(va.Grouping.Groups) != groups {
+		t.Fatalf("fixture must group on exactly %d labels; got %v", groups, va.Grouping)
+	}
+
+	aliases := make([]string, groups)
+	for i := range aliases {
+		aliases[i] = string(rune('a' + i))
+	}
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "vector_aggregation.go:`len(e.Grouping.Groups)*2`",
+		Positions: []capmutant.Position{{Name: "the `*2`", Op: "*"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{groups, 2}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			node := wrapVectorAggregateForSample(&chplan.Aggregate{}, va, s, aliases, false, "")
+			proj, ok := node.(*chplan.Project)
+			if !ok {
+				t.Fatalf("wrapVectorAggregateForSample -> %T; want *chplan.Project", node)
+			}
+			attrs := findProjectionExpr(t, proj, sampleAttributesCol)
+			args := capHintExprArgs(t, attrs, "the Attributes map literal")
+			return len(args), cap(args)
+		},
+		Build: func(hint int) (int, int) {
+			args := make([]chplan.Expr, 0, hint)
+			for i := 0; i < groups; i++ {
+				args = append(args, nil, nil) // (label literal, alias column)
+			}
+			return len(args), cap(args)
+		},
+	})
+}
+
+// parseRangeAggregationForCapHint parses query and asserts it groups on
+// exactly `groups` labels, so a fixture edit that changed the grouping is
+// reported instead of quietly adjudicating a hint with different operands.
+func parseRangeAggregationForCapHint(t *testing.T, query string, groups int) *syntax.RangeAggregationExpr {
+	t.Helper()
+
+	expr, err := syntax.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	ra, ok := expr.(*syntax.RangeAggregationExpr)
+	if !ok {
+		t.Fatalf("ParseExpr(%q) -> %T, want *syntax.RangeAggregationExpr", query, expr)
+	}
+	if ra.Grouping == nil || len(ra.Grouping.Groups) != groups {
+		t.Fatalf("fixture must group on exactly %d labels; got %v", groups, ra.Grouping)
+	}
+	return ra
+}
+
+// findProjectionExpr answers the expression p projects under alias.
+func findProjectionExpr(t *testing.T, p *chplan.Project, alias string) chplan.Expr {
+	t.Helper()
+
+	for _, pr := range p.Projections {
+		if pr.Alias == alias {
+			return pr.Expr
+		}
+	}
+	t.Fatalf("no projection aliased %q in %d projections", alias, len(p.Projections))
+	return nil
+}

--- a/internal/logql/detected_level_test.go
+++ b/internal/logql/detected_level_test.go
@@ -512,10 +512,22 @@ func TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape(t *testing.T) {
 	}
 }
 
-// capHintOps are the binary arithmetic operators gremlins' ARITHMETIC_BASE
-// operator substitutes into an expression. Applying each of them to each
-// operator position of the capacity hint enumerates that hint's whole mutant
-// set.
+// capHintOps are the binary arithmetic operators the two enumerations below
+// substitute into each operator position of a capacity hint.
+//
+// This is deliberately a SUPERSET of the mutant set a run reports, and saying
+// so is the point: gremlins' ARITHMETIC_BASE rewrites each arithmetic token to
+// exactly ONE other token (`+`->`-`, `-`->`+`, `*`->`/`, `/`->`*`, `%`->`*`),
+// so a hint spelling P operators carries P mutants and not 4P. The
+// authoritative table is `Substitution` in test/capmutant, which mirrors the
+// pinned tsouza/gremlins fork's own mapping; requiring the four other operators to be
+// distinguished as well is strictly stronger than the lane needs and costs
+// nothing here, because both of this file's hints distinguish all of them.
+//
+// A hint that did NOT would have to be adjudicated against the real table
+// rather than this one — internal/promql/schema_lookup.go's `len(pairs)*2` is
+// exactly that case, and over-approximating there would have claimed a kill
+// the lane cannot collect.
 var capHintOps = []string{"+", "-", "*", "/", "%"}
 
 // applyCapHintOp evaluates `a op b` for the operators ARITHMETIC_BASE can
@@ -593,8 +605,9 @@ func capAfterBuild(hint, groups int) (length, capacity int) {
 
 // TestNormaliseLevelExpr_CapHintMutantsAreKilled proves that the `cap`
 // assertion in [TestNormaliseLevelExpr_MultiIfArgsCapacityAndShape] actually
-// discriminates. For every ARITHMETIC_BASE operator substitution gremlins can
-// make in detected_level.go:`(len(levelNormalizationGroups)+1)*2+1`, the
+// discriminates. For every operator substitution [capHintOps] enumerates in
+// detected_level.go:`(len(levelNormalizationGroups)+1)*2+1` — a superset of
+// the one-per-token set ARITHMETIC_BASE actually emits, see [capHintOps] — the
 // capacity the finished slice ends up with must differ from the capacity the
 // unmutated hint produces — otherwise that assertion passes on the mutant and
 // the equivalence note above is claiming a kill it does not deliver.
@@ -915,11 +928,12 @@ func sourceCapHint(t *testing.T, n int, mulOp, tailOp string) int {
 
 // TestDetectedLevelSource_CapHintMutantsAreKilled proves that the `cap`
 // assertion in [TestDetectedLevelSource_PrecedenceCascade] actually
-// discriminates. For every ARITHMETIC_BASE operator substitution gremlins can
-// make in detected_level.go:`args := make([]chplan.Expr, 0, len(keys)*2+1)`,
-// the capacity the finished slice ends up with must differ from the capacity
-// the unmutated hint produces — otherwise that assertion passes on the mutant
-// and claims a kill it does not deliver.
+// discriminates. For every operator substitution [capHintOps] enumerates in
+// detected_level.go:`args := make([]chplan.Expr, 0, len(keys)*2+1)` — a
+// superset of the one-per-token set ARITHMETIC_BASE actually emits, see
+// [capHintOps] — the capacity the finished slice ends up with must differ from
+// the capacity the unmutated hint produces — otherwise that assertion passes
+// on the mutant and claims a kill it does not deliver.
 //
 // NOT KILLABLE — the third ARITHMETIC_BASE mutant this function carries, on
 // the sibling hint detected_level.go:`keys := make([]string, 0,
@@ -932,10 +946,12 @@ func sourceCapHint(t *testing.T, n int, mulOp, tailOp string) int {
 // and measured with `len` inside [detectedLevelSourceExpr] and never stored,
 // returned or captured, so no caller — test or otherwise — holds the header
 // whose capacity the mutation changes. Nor does that mutant die on a panic:
-// `allowedLevelFields` carries four fixed entries, so every substitution
-// (`-` → 3, `*` → 4, `/` → 4, `%` → 0) stays non-negative and `make` accepts
-// it. It is an equivalent mutant, and the only honest thing to do with it is
-// leave it counted as a survivor.
+// `allowedLevelFields` carries four fixed entries, so the `+` -> `-` rewrite
+// ARITHMETIC_BASE emits there computes 3 — non-negative, and `make` accepts
+// it. (The three other operators land on 4, 4 and 0, all equally accepted;
+// gremlins writes none of them, and the escape argument above does not depend
+// on which one it writes.) It is an equivalent mutant, and the only honest
+// thing to do with it is leave it counted as a survivor.
 //
 // So "an ARITHMETIC_BASE mutant on a `make` capacity argument is equivalent"
 // is FALSE as a general claim: it holds for one of this function's two hints

--- a/internal/logql/gremlins_kill_2949_lower_test.go
+++ b/internal/logql/gremlins_kill_2949_lower_test.go
@@ -165,8 +165,8 @@ func planPredicateHasLiteral(plan chplan.Node, want string) bool {
 	return found
 }
 
-// NOT KILLABLE — documented, not defended by a test. These are the four
-// LIVED mutants phase4-logql-lower reports that no input can distinguish.
+// NOT KILLABLE — documented, not defended by a test. These are the LIVED
+// mutants phase4-logql-lower reports that no input can distinguish.
 //
 // lower.go:`extension <= 0` — CONDITIONALS_BOUNDARY (`<=` -> `<`).
 // The two forms differ only at extension == 0, and there the guarded body
@@ -177,14 +177,19 @@ func planPredicateHasLiteral(plan chplan.Node, want string) bool {
 // returns early. Nothing downstream can see a difference because there is
 // none to see.
 //
-// lower.go:`len(fields)*2` and lower.go:`len(segments)+1` —
-// ARITHMETIC_BASE on a make() CAPACITY hint. Both slices are built with
-// append from length 0, so contents and ordering are identical whatever
-// the pre-sized cap, and a capacity is not reachable from the returned
-// plan. Neither mutated form can go negative and panic either: `len(...)`
-// is never negative, and `len(segments)` is never 0 at that point — the
-// only producer of `segments` is jsonPathParse, which returns a non-empty
-// slice or an error, and the error path returns before the make().
+// The ARITHMETIC_BASE mutants on mergeParsedFields's and
+// jsonExtractStringExpr's capacity hints were adjudicated EQUIVALENT here,
+// and that was wrong (cerberus issue #2984). The argument ran: both slices
+// are built with append from length 0, so contents and ordering are
+// identical whatever the pre-sized cap, and a capacity is not reachable
+// from the returned plan. The first half is true and the second is false —
+// one slice becomes the map literal's exported Args inside the mapMerge the
+// first function returns, and the other IS the JSONExtractString FuncCall's
+// Args. Their verdicts now live with the kills, in
+// [TestMergeParsedFields_CapHintMutantKilled] and
+// [TestJSONExtractStringExpr_CapHintMutantKilled], which is where the
+// citations went too: a mutant carries one verdict, so leaving them under a
+// footer here would leave them carrying two.
 //
 // lower.go:`len(candidates) <= 1` — CONDITIONALS_BOUNDARY (`<=` -> `<`).
 // The forms differ only at len(candidates) == 1, and there they build the

--- a/internal/logql/gremlins_kill_2949_other_b_test.go
+++ b/internal/logql/gremlins_kill_2949_other_b_test.go
@@ -75,15 +75,18 @@ func TestDropMatchersScanPastOtherLabels(t *testing.T) {
 	requireConditionalRetention(t, got, query)
 }
 
-// NOT KILLABLE — documented, not defended by a test. These are the LIVED
-// mutants phase4-logql-other-b reports outside the logpattern subpackage
-// (whose own survivors are adjudicated in
-// logpattern/gremlins_kill_2949_test.go) that the kill above does not
-// reach.
+// The two ARITHMETIC_BASE mutants on wrapLabelsWithMarks's mark-cascade
+// capacity hint in duration.go were adjudicated EQUIVALENT here, and that
+// was wrong (cerberus issue #2984). The argument ran: the slice is built
+// with append from length 0, so contents and ordering do not depend on the
+// cap, and the cap is not reachable from the returned expression. The first
+// half is true and the second is false — the slice becomes the cascade's
+// exported Args, two levels down from the mapMerge FuncCall that function
+// returns. Its verdict now lives with the kill, in
+// [TestWrapLabelsWithMarks_CapHintMutantsKilled], which is where the
+// citation went too: a mutant carries one verdict, so leaving the citation
+// under a footer here would leave it carrying two.
 //
-// duration.go:`len(marks)*2+1` — ARITHMETIC_BASE on a make() CAPACITY
-// hint, carrying two mutants (one per operator). The slice is built with
-// append from length 0, so contents and ordering do not depend on the cap,
-// and the cap is not reachable from the returned expression. Neither
-// mutated form can go negative and panic: the function returns early for
-// an empty mark list, so len(marks) >= 1 at the make().
+// Outside the logpattern subpackage (whose own survivors are adjudicated in
+// logpattern/gremlins_kill_2949_test.go), phase4-logql-other-b has no LIVED
+// mutant this file leaves undefended.

--- a/internal/logql/gremlins_kill_2949_test.go
+++ b/internal/logql/gremlins_kill_2949_test.go
@@ -127,6 +127,11 @@ func findVectorSetOp(n chplan.Node) *chplan.VectorSetOp {
 // `len(marks) > 0` — false — so the caller's `hasErrorMarks` is unchanged
 // too. Every field of every returned value is identical.
 //
-// range_aggregation.go:`len(e.Grouping.Groups)*2` — ARITHMETIC_BASE on a
-// make() CAPACITY hint, equivalent for the reason spelled out in
-// vector_aggregation_mutation_test.go's header for the sibling site.
+// The ARITHMETIC_BASE mutant on rangeAggregationGroupBy's grouping-map
+// capacity hint in range_aggregation.go was adjudicated EQUIVALENT here, by
+// deferring to vector_aggregation_mutation_test.go's header for the sibling
+// site, and that was wrong (cerberus issue #2984). The slice IS the map
+// FuncCall that function returns, so cap reads the hint's arithmetic
+// straight back. Its verdict now lives with the kill, in
+// [TestRangeAggregationGroupBy_CapHintMutantKilled], which is where the
+// citation went too; the sibling's own correction is in that header.

--- a/internal/logql/range_aggregation_mutation_test.go
+++ b/internal/logql/range_aggregation_mutation_test.go
@@ -32,13 +32,17 @@ import (
 //     The emitted plan is structurally identical, so no assertion can
 //     observe the flip. Genuinely equivalent.
 //
-//   - range_aggregation.go:`len(e.Grouping.Groups)*2` ARITHMETIC_BASE
-//     `make([]chplan.Expr, 0, len(e.Grouping.Groups)*2)` → `/2`. The `*2`
-//     is a slice CAPACITY pre-allocation hint; the loop appends exactly
-//     two entries per group regardless, so the resulting slice's contents,
-//     length, and order are unchanged. Capacity is not observable in the
-//     emitted SQL or plan. Genuinely equivalent (matches the project's
-//     "slice-capacity hints are out of scope" rule).
+// A second entry stood here, on rangeAggregationGroupBy's grouping-map
+// capacity hint, and it was wrong (cerberus issue #2984). It reasoned that
+// the loop appends exactly two entries per group regardless, so the slice's
+// contents, length and order are unchanged, and that capacity is not
+// observable in the emitted SQL or plan. Every clause of that is true and
+// the conclusion does not follow: cap is readable on any slice a test can
+// reach, and this one IS the map FuncCall the function returns. Its verdict
+// now lives with the kill, in
+// [TestRangeAggregationGroupBy_CapHintMutantKilled], which is where the
+// citation went too — a mutant carries one verdict, and leaving the
+// citation in this ledger would leave it carrying two.
 
 // TestAbsentOverTimeExtendsMatcherWindowByIntervalPlusOffset pins the
 // ARITHMETIC_BASE mutant on

--- a/internal/logql/vector_aggregation_mutation_test.go
+++ b/internal/logql/vector_aggregation_mutation_test.go
@@ -15,13 +15,18 @@ import (
 // is written so the mutated line produces a DIFFERENT lowered plan than
 // the original, making the assertion fail under mutation.
 //
-// NOT KILLABLE — vector_aggregation.go:wrapVectorAggregateForSample:`len(e.Grouping.Groups)*2`
-// carries an ARITHMETIC_BASE mutant (`*2` -> `/2` and friends) that no
-// test can kill: it is a make() CAPACITY hint. The slice is built with
+// The ARITHMETIC_BASE mutant on wrapVectorAggregateForSample's
+// grouping-map capacity hint was adjudicated EQUIVALENT here, and that was
+// wrong (cerberus issue #2984). The argument ran: the slice is built with
 // append from length 0, so its final contents and ordering are identical
-// whatever the pre-sized cap, and a cap is not reachable from the
-// returned plan. `len(...)` is never negative and the mutated forms stay
-// non-negative, so make() cannot panic either.
+// whatever the pre-sized cap, and a cap is not reachable from the returned
+// plan. The first half is true and the second is false — the slice becomes
+// the map FuncCall the returned [chplan.Project] projects as its Attributes
+// column, an exported Args under an exported Projections. Its verdict now
+// lives with the kill, in
+// [TestWrapVectorAggregateForSample_CapHintMutantKilled], which is where the
+// citation went too: a mutant carries one verdict, so leaving the citation
+// under a header here would leave it carrying two.
 //
 // The empty-`Grouping.Groups` CONDITIONALS_BOUNDARY mutants on the
 // outer-by threading guard were ADJUDICATED EQUIVALENT HERE AND THAT WAS

--- a/internal/promql/capacity_hint_mutation_test.go
+++ b/internal/promql/capacity_hint_mutation_test.go
@@ -1,0 +1,487 @@
+// Capacity-hint adjudication for internal/promql.
+//
+// Every hint in this file sizes a slice that becomes an EXPORTED field of a
+// value its builder returns — a `chplan.Project`'s `Projections` or a
+// `chplan.FuncCall`'s `Args` — and none of them grows past its
+// pre-allocation, so `cap` reads the hint's arithmetic straight back and a
+// plain assertion kills the `ARITHMETIC_BASE` mutant gremlins emits on it.
+// `docs/test-strategy.md`'s "When a capacity mutant is equivalent" states the
+// rule; `internal/logql/detected_level_test.go` carries the worked instances
+// it was derived from.
+//
+// Each test names the escape surface it reads the capacity back through.
+// [capmutant.AssertKilled] then replays the substitution against the builder's
+// own append sequence and requires it to move the finished capacity, so "the
+// assertion discriminates" is re-run rather than asserted.
+package promql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/capmutant"
+)
+
+// capHintProjections reads the `Projections` slice of the [chplan.Project] n
+// is, failing the test when the node is some other shape — a navigation that
+// silently answered an empty slice would report a capacity nobody allocated.
+func capHintProjections(t *testing.T, n chplan.Node, what string) []chplan.Projection {
+	t.Helper()
+
+	p, ok := n.(*chplan.Project)
+	if !ok {
+		t.Fatalf("%s is %T; want *chplan.Project", what, n)
+	}
+	return p.Projections
+}
+
+// capHintMapArgs reads the `Args` of the `map(...)` FuncCall wrapped in the
+// [chplan.MapWithoutEmptyValues] e is.
+func capHintMapArgs(t *testing.T, e chplan.Expr, what string) []chplan.Expr {
+	t.Helper()
+
+	w, ok := e.(*chplan.MapWithoutEmptyValues)
+	if !ok {
+		t.Fatalf("%s is %T; want *chplan.MapWithoutEmptyValues", what, e)
+	}
+	fn, ok := w.Map.(*chplan.FuncCall)
+	if !ok {
+		t.Fatalf("%s wraps %T; want the map(...) *chplan.FuncCall", what, w.Map)
+	}
+	return fn.Args
+}
+
+// capHintProjectionExpr answers the expression the projection list projects
+// under alias.
+func capHintProjectionExpr(t *testing.T, projs []chplan.Projection, alias string) chplan.Expr {
+	t.Helper()
+
+	for _, p := range projs {
+		if p.Alias == alias {
+			return p.Expr
+		}
+	}
+	t.Fatalf("no projection aliased %q in %d projections", alias, len(projs))
+	return nil
+}
+
+// capHintAliases builds n distinct column names for a grouping key list.
+func capHintAliases(n int) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, fmt.Sprintf("cap_key_%d", i))
+	}
+	return out
+}
+
+// TestExpHistogramPairCountStage_CapHintMutantKilled kills the ARITHMETIC_BASE
+// mutant gremlins reports on histogram_native_resets.go:`len(keyAliases)+1`.
+//
+// Escape surface: the slice IS the returned [chplan.Project]'s exported
+// `Projections`, after the pair-count projection is appended onto it in the
+// struct literal.
+func TestExpHistogramPairCountStage_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	const keys = 5
+
+	s := schema.DefaultOTelMetrics()
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "histogram_native_resets.go:`len(keyAliases)+1`",
+		Positions: []capmutant.Position{{Name: "the `+1`", Op: "+"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{keys, 1}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			node := expHistogramPairCountStage(&chplan.OneRow{}, rateWindowFn, capHintAliases(keys), s)
+			projs := capHintProjections(t, node, "expHistogramPairCountStage result")
+			return len(projs), cap(projs)
+		},
+		Build: func(hint int) (int, int) {
+			projs := make([]chplan.Projection, 0, hint)
+			for i := 0; i < keys; i++ {
+				projs = append(projs, chplan.Projection{})
+			}
+			projs = append(projs, chplan.Projection{}) // the pair-count value
+			return len(projs), cap(projs)
+		},
+	})
+}
+
+// TestScaleHistogramProjection_CapHintMutantsKilled kills the two
+// ARITHMETIC_BASE mutants gremlins reports on
+// histogram_native_scalar_binop.go:`len(passthroughCols)+len(scalarCols)+len(ladderCols)`.
+//
+// Escape surface: the slice becomes the `Projections` of the [chplan.Project]
+// the returned [chplan.HistogramProjection] wraps as its `Input`.
+//
+// The three operand lists are fixed by the schema rather than by this test, so
+// their sizes are read back from the builder's own inputs instead of written
+// down: a schema whose histogram columns changed shape would otherwise silently
+// adjudicate a hint with different operands.
+func TestScaleHistogramProjection_CapHintMutantsKilled(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	histSchema := histogramProjectionSchema(s)
+	passthrough := len([]string{
+		s.AttributesColumn,
+		s.TimestampColumn,
+		histSchema.ScaleColumn,
+		histSchema.ZeroThresholdColumn,
+		histSchema.PositiveOffsetColumn,
+		histSchema.NegativeOffsetColumn,
+	})
+	scalars := len([]string{histSchema.CountColumn, histSchema.SumColumn, histSchema.ZeroCountColumn})
+	ladders := len([]string{histSchema.PositiveBucketCountsColumn, histSchema.NegativeBucketCountsColumn})
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "histogram_native_scalar_binop.go:`len(passthroughCols)+len(scalarCols)+len(ladderCols)`",
+		Positions: []capmutant.Position{
+			{Name: "the `+len(scalarCols)`", Op: "+"},
+			{Name: "the `+len(ladderCols)`", Op: "+"},
+		},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{passthrough, scalars, ladders}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			hp := scaleHistogramProjection(&chplan.OneRow{}, chplan.OpMul, &chplan.LitFloat{V: 2}, s)
+			projs := capHintProjections(t, hp.Input, "scaleHistogramProjection's inner node")
+			return len(projs), cap(projs)
+		},
+		Build: func(hint int) (int, int) {
+			projs := make([]chplan.Projection, 0, hint)
+			for i := 0; i < passthrough+scalars+ladders; i++ {
+				projs = append(projs, chplan.Projection{})
+			}
+			return len(projs), cap(projs)
+		},
+	})
+}
+
+// TestExpHistogramWindowFactorStage_CapHintMutantsKilled kills the three
+// ARITHMETIC_BASE mutants gremlins reports on
+// histogram_quantile_native_window.go:`len(keyAliases)+len(aggs)+len(extraAliases)+1`.
+//
+// Escape surface: the slice IS the returned [chplan.Project]'s exported
+// `Projections`.
+//
+// The stage only builds the slice on its hoistable branch, which needs a
+// `rate`/`increase` window with a series-wide count series — see
+// [histogramWindowInvariantFactorExpr] — so the inputs below set exactly that.
+func TestExpHistogramWindowFactorStage_CapHintMutantsKilled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		keys   = 4
+		aggs   = 3
+		extras = 2
+	)
+
+	in := histogramWindowInputs{
+		rangeStart:  &chplan.LitInt{V: 0},
+		rangeEnd:    &chplan.LitInt{V: 1},
+		countValues: &chplan.ColumnRef{Name: "counts"},
+	}
+	aggFuncs := make([]chplan.AggFunc, 0, aggs)
+	for i := 0; i < aggs; i++ {
+		aggFuncs = append(aggFuncs, chplan.AggFunc{Fn: chplan.FnCount, Alias: fmt.Sprintf("agg_%d", i)})
+	}
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "histogram_quantile_native_window.go:`len(keyAliases)+len(aggs)+len(extraAliases)+1`",
+		Positions: []capmutant.Position{
+			{Name: "the `+len(aggs)`", Op: "+"},
+			{Name: "the `+len(extraAliases)`", Op: "+"},
+			{Name: "the trailing `+1`", Op: "+"},
+		},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{keys, aggs, extras, 1}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			node, _ := expHistogramWindowFactorStage(
+				&chplan.OneRow{}, aggFuncs, capHintAliases(keys), capHintAliases(extras),
+				rateWindowFn, in, histogramWindowFold(rateWindowFn, in),
+			)
+			projs := capHintProjections(t, node, "expHistogramWindowFactorStage result")
+			return len(projs), cap(projs)
+		},
+		Build: func(hint int) (int, int) {
+			projs := make([]chplan.Projection, 0, hint)
+			for i := 0; i < keys+aggs+extras; i++ {
+				projs = append(projs, chplan.Projection{})
+			}
+			projs = append(projs, chplan.Projection{}) // the hoisted factor
+			return len(projs), cap(projs)
+		},
+	})
+}
+
+// TestExpHistogramWindowReshape_CapHintMutantsKilled kills the ARITHMETIC_BASE
+// mutants gremlins reports on
+// histogram_quantile_native_window.go:`len(keyAliases)+len(scalars)+7`.
+//
+// Escape surface: the slice IS the returned [chplan.Project]'s exported
+// `Projections`, after the four merge/bucket projections are appended onto it.
+//
+// The `7` covers a projection the schema's optional zero-threshold column
+// gates, so on a schema that leaves that column unset the builder appends one
+// slot fewer than it reserved. Capacity is still the hint either way — an
+// under-filled slice never grows, so it keeps the capacity it was made with —
+// which is why the adjudication turns on the finished capacity rather than on
+// the finished length.
+func TestExpHistogramWindowReshape_CapHintMutantsKilled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		keys    = 4
+		scalars = 3
+		// The projections the reshape appends beyond the keys and the
+		// scalars: the merged scale and the zero-count fold, then the two
+		// signed offset/bucket pairs in the closing append.
+		fixedProjections = 6
+	)
+
+	s := schema.DefaultOTelMetrics()
+	in := histogramWindowInputs{
+		rangeStart:  &chplan.LitInt{V: 0},
+		rangeEnd:    &chplan.LitInt{V: 1},
+		countValues: &chplan.ColumnRef{Name: "counts"},
+	}
+	scalarProjs := make([]chplan.Projection, 0, scalars)
+	for i := 0; i < scalars; i++ {
+		scalarProjs = append(scalarProjs, chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: fmt.Sprintf("scalar_%d", i)},
+			Alias: fmt.Sprintf("scalar_%d", i),
+		})
+	}
+
+	if s.ZeroThresholdColumn != "" {
+		t.Fatalf("the default metrics schema now configures a zero-threshold column (%q), "+
+			"so the reshape appends one projection more than this test's fixedProjections "+
+			"assumes", s.ZeroThresholdColumn)
+	}
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "histogram_quantile_native_window.go:`len(keyAliases)+len(scalars)+7`",
+		Positions: []capmutant.Position{
+			{Name: "the `+len(scalars)`", Op: "+"},
+			{Name: "the trailing `+7`", Op: "+"},
+		},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{keys, scalars, 7}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			node := expHistogramWindowReshape(
+				&chplan.OneRow{}, nil, capHintAliases(keys), nil,
+				histogramWindowFold(rateWindowFn, in), rateWindowFn, in, scalarProjs, s,
+			)
+			projs := capHintProjections(t, node, "expHistogramWindowReshape result")
+			return len(projs), cap(projs)
+		},
+		Build: func(hint int) (int, int) {
+			projs := make([]chplan.Projection, 0, hint)
+			for i := 0; i < keys; i++ {
+				projs = append(projs, chplan.Projection{})
+			}
+			projs = append(projs, scalarProjs...)
+			projs = append(projs, chplan.Projection{}, chplan.Projection{})
+			projs = append(projs, make([]chplan.Projection, fixedProjections-2)...)
+			return len(projs), cap(projs)
+		},
+	})
+}
+
+// TestClassicBucketReshape_CapHintMutantKilled kills the ARITHMETIC_BASE
+// mutant gremlins reports on
+// histogram_quantile.go:`projections := make([]chplan.Projection, 0, len(passthrough)+2)`.
+//
+// The citation names the whole assignment rather than the hint alone because
+// the sibling `merged := …` a few lines below spells an identical hint, and a
+// citation that resolved to both would register this verdict on a mutant it is
+// not adjudicating.
+//
+// Escape surface: the slice IS the returned [chplan.Project]'s exported
+// `Projections`.
+func TestClassicBucketReshape_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	const passthrough = 5
+
+	s := schema.DefaultOTelMetrics()
+	pass := make([]chplan.Projection, 0, passthrough)
+	for i := 0; i < passthrough; i++ {
+		pass = append(pass, chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: fmt.Sprintf("pass_%d", i)},
+			Alias: fmt.Sprintf("pass_%d", i),
+		})
+	}
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "histogram_quantile.go:`projections := make([]chplan.Projection, 0, len(passthrough)+2)`",
+		Positions: []capmutant.Position{{Name: "the `+2`", Op: "+"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{passthrough, 2}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			// A nil fold selects the branch this hint sizes — the argMax
+			// newest-row path, which has no layouts to merge.
+			node, _ := classicBucketShaping{}.reshape(&chplan.OneRow{}, pass, s)
+			projs := capHintProjections(t, node, "classicBucketShaping.reshape result")
+			return len(projs), cap(projs)
+		},
+		Build: func(hint int) (int, int) {
+			projs := make([]chplan.Projection, 0, hint)
+			projs = append(projs, pass...)
+			projs = append(projs, chplan.Projection{}, chplan.Projection{})
+			return len(projs), cap(projs)
+		},
+	})
+}
+
+// TestHistogramAggGroupBy_CapHintMutantKilled kills the ARITHMETIC_BASE mutant
+// gremlins reports on histogram_quantile.go:`len(labels)*2`.
+//
+// Escape surface: the slice is the `map(...)` FuncCall's exported `Args` inside
+// the [chplan.MapWithoutEmptyValues] the builder returns as its third result.
+func TestHistogramAggGroupBy_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		query  = `sum by (job, instance, region, zone, shard) (latency_bucket)`
+		labels = 5
+	)
+
+	s := schema.DefaultOTelMetrics()
+	agg := mustAggregateExpr(t, query, labels)
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "histogram_quantile.go:`len(labels)*2`",
+		Positions: []capmutant.Position{{Name: "the `*2`", Op: "*"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{labels, 2}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			_, _, attrs := histogramAggGroupBy(agg, &chplan.ColumnRef{Name: s.AttributesColumn}, s)
+			args := capHintMapArgs(t, attrs, "histogramAggGroupBy's Attributes map")
+			return len(args), cap(args)
+		},
+		Build: func(hint int) (int, int) {
+			args := make([]chplan.Expr, 0, hint)
+			for i := 0; i < labels; i++ {
+				args = append(args, nil, nil) // (label literal, gkey column)
+			}
+			return len(args), cap(args)
+		},
+	})
+}
+
+// TestLowerCountValuesOverPlan_CapHintMutantsKilled kills the two
+// ARITHMETIC_BASE mutants gremlins reports on
+// lower.go:`(len(a.Grouping)+1)*2`.
+//
+// Escape surface: the slice is the `map(...)` FuncCall's exported `Args`,
+// inside the [chplan.MapWithoutEmptyValues] the returned [chplan.Project]
+// projects as its Attributes column.
+func TestLowerCountValuesOverPlan_CapHintMutantsKilled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		query  = `count_values by (job, instance, region, zone) ("v", up)`
+		groups = 4
+	)
+
+	s := schema.DefaultOTelMetrics()
+	agg := mustAggregateExpr(t, query, groups)
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "lower.go:`(len(a.Grouping)+1)*2`",
+		Positions: []capmutant.Position{
+			{Name: "the inner `+1`", Op: "+"},
+			{Name: "the `*2`", Op: "*"},
+		},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			// The parentheses fix a grouping no substitution can move, so the
+			// inner sum is evaluated on its own and fed to the outer factor.
+			inner, ok := capmutant.Eval(t, []int{groups, 1}, ops[:1])
+			if !ok {
+				return 0, false
+			}
+			return capmutant.Eval(t, []int{inner, 2}, ops[1:])
+		},
+		Observe: func(t *testing.T) (int, int) {
+			node := lowerCountValuesOverPlan(agg, "v", &chplan.OneRow{},
+				&chplan.ColumnRef{Name: s.ValueColumn}, s, lowerCtx{})
+			projs := capHintProjections(t, node, "lowerCountValuesOverPlan result")
+			attrs := capHintProjectionExpr(t, projs, s.AttributesColumn)
+			args := capHintMapArgs(t, attrs, "the count_values Attributes map")
+			return len(args), cap(args)
+		},
+		Build: func(hint int) (int, int) {
+			args := make([]chplan.Expr, 0, hint)
+			for i := 0; i < groups; i++ {
+				args = append(args, nil, nil) // (label literal, gkey column)
+			}
+			args = append(args, nil, nil) // the synthetic value-as-label pair
+			return len(args), cap(args)
+		},
+	})
+}
+
+// TestPromAggregateAttributesExpr_CapHintMutantKilled kills the
+// ARITHMETIC_BASE mutant gremlins reports on lower.go:`len(a.Grouping)*2`.
+//
+// Escape surface: the slice is the `map(...)` FuncCall's exported `Args` inside
+// the [chplan.MapWithoutEmptyValues] the builder returns.
+func TestPromAggregateAttributesExpr_CapHintMutantKilled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		query  = `sum by (job, instance, region, zone, shard) (up)`
+		groups = 5
+	)
+
+	agg := mustAggregateExpr(t, query, groups)
+
+	capmutant.AssertKilled(t, capmutant.Hint{
+		Construct: "lower.go:`len(a.Grouping)*2`",
+		Positions: []capmutant.Position{{Name: "the `*2`", Op: "*"}},
+		Eval: func(t testing.TB, ops []string) (int, bool) {
+			return capmutant.Eval(t, []int{groups, 2}, ops)
+		},
+		Observe: func(t *testing.T) (int, int) {
+			attrs := promAggregateAttributesExpr(agg, capHintAliases(groups))
+			args := capHintMapArgs(t, attrs, "promAggregateAttributesExpr result")
+			return len(args), cap(args)
+		},
+		Build: func(hint int) (int, int) {
+			args := make([]chplan.Expr, 0, hint)
+			for i := 0; i < groups; i++ {
+				args = append(args, nil, nil) // (label literal, alias column)
+			}
+			return len(args), cap(args)
+		},
+	})
+}
+
+// mustAggregateExpr parses query and asserts it groups on exactly `groups`
+// labels, so a fixture edit that changed the grouping is reported instead of
+// quietly adjudicating a hint with different operands.
+func mustAggregateExpr(t *testing.T, query string, groups int) *parser.AggregateExpr {
+	t.Helper()
+
+	expr := mustParse(t, query)
+	agg, ok := expr.(*parser.AggregateExpr)
+	if !ok {
+		t.Fatalf("parsing %q gave %T; want *parser.AggregateExpr", query, expr)
+	}
+	if len(agg.Grouping) != groups {
+		t.Fatalf("fixture must group on exactly %d labels; got %v", groups, agg.Grouping)
+	}
+	return agg
+}

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -157,41 +157,51 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 //
 //	schema_lookup.go:`make([]chplan.Expr, 0, len(pairs)*2)`
 //	resource_attributes.go:`make(map[string]struct{}, len(dedicatedResourceKeys)*2)`
-//	histogram_quantile_native_window.go:`len(keyAliases)+len(aggs)+len(extraAliases)+1`
-//	histogram_quantile_native_window.go:`len(keyAliases)+len(scalars)+7`
-//	histogram_native_resets.go:`make([]chplan.Projection, 0, len(keyAliases)+1)`
-//	histogram_native_scalar_binop.go:`len(passthroughCols)+1+5`
-//	histogram_quantile.go:`projections := make([]chplan.Projection, 0, len(passthrough)+2)`
-//	histogram_quantile.go:`make([]chplan.Expr, 0, len(labels)*2)`
 //
-// The first two `+` expressions each carry TWO mutants, one per operator; the
-// `passthrough+2` citation names its assignment because two sibling statements
-// in the same method allocate with the identical capacity expression.
+// This class USED to carry six more citations, and the reason it gave for all
+// eight — "a slice's capacity is not observable behaviour: `append` grows past
+// a short one, and every element, ordering and identity is unchanged" — was
+// true in its premise and wrong in its conclusion. Observability is not
+// confined to the emitted SQL or to the elements: `cap` is readable on any
+// slice a test can reach, and six of the eight sized a slice that becomes an
+// exported field of a value its builder RETURNS. Those six are killed in
+// capacity_hint_mutation_test.go, one test each, and their citations moved
+// there with them (cerberus issue #2984). docs/test-strategy.md's "When a
+// capacity mutant is equivalent" states the rule the eight were adjudicated
+// against without.
 //
-// A slice's capacity is not observable behaviour: `append` grows past a short
-// one, and every element, ordering and identity is unchanged. The one way a
-// capacity rewrite CAN be observed is a negative argument, which makes `make`
-// panic — so each site was checked for that rather than waved through:
+// The two that remain fail that rule on DIFFERENT halves of it, which is why
+// neither inherits the other's argument:
 //
-//   - The `*2` and `/2` forms cannot go negative from a length.
-//   - `len(passthroughCols)+1+5` reads the `passthroughCols` slice literal
-//     built immediately above it with exactly six elements, so the two
-//     rewrites compute 10 and 2. Neither is negative.
-//   - `projections := make(..., len(passthrough)+2)` sits in
-//     classicBucketShaping.reshape's `sh.fold == nil` branch. The only shaping
-//     constructed with a nil fold is
-//     histogram_quantile_range.go:`classicBucketShaping{aggs: classicBucketLatestAggs(s)}`,
-//     and both of its reshape call sites —
-//     histogram_quantile_range.go:`shaping.reshape(guardedCollapse,` and
-//     histogram_quantile_range.go:`shaping.reshape(agg,` — pass a TWO-element
-//     passthrough, so the rewrite computes 0. Instrumenting the branch across
-//     the whole package suite observed `foldNil: true` only ever with
-//     `passthrough: 2`; the one-element call site,
-//     histogram_quantile.go:`shaping.reshape(guardedAgg,`, never reaches the
-//     nil-fold branch.
-//   - `len(keyAliases)+1` and the `+len(...)+N` forms are reached only with
-//     the aggregation's own alias set, which the emitting code has already
-//     populated.
+//   - `make(map[string]struct{}, len(dedicatedResourceKeys)*2)` sizes a MAP.
+//     Go publishes no accessor for a map's capacity — `len` counts the entries
+//     the loop inserted, `cap` is not defined for maps at all, and the runtime
+//     hint reaches no exported or unexported surface. No test in any package
+//     can read the rewritten arithmetic back, so the escape question never
+//     arises: this one is unobservable whatever the map does next.
+//
+//   - `make([]chplan.Expr, 0, len(pairs)*2)` DOES escape — the slice becomes
+//     the `map(...)` FuncCall's exported `Args` inside the expression
+//     augmentAttributesForTopLevelExpr returns — and it is still unkillable,
+//     because the finished capacity does not distinguish the mutant gremlins
+//     writes. That mutant is `*` -> `/` (ARITHMETIC_BASE rewrites each
+//     arithmetic token to exactly one other, so this hint carries one mutant,
+//     not four). `pairs` is promqlTopLevelKeys' answer over
+//     resource_attributes.go:`var dedicatedResourceKeys = []dedicatedResourceKey{`,
+//     which holds one entry, and the function returns before the `make` when
+//     that answer is empty — so `pairs` is 1 at every reachable call. The
+//     unmutated hint is 2 and the mutated one is 0, and the single
+//     `append(args, key, value)` that follows grows a zero-capacity slice
+//     straight to capacity 2: `append` asks for length 2, which exceeds twice
+//     the old capacity, so the runtime allocates exactly the two elements
+//     asked for. Both builds finish at len 2 / cap 2, so a `cap` assertion
+//     reads the SAME number either way.
+//
+//     This equivalence is a property of the registry's current size, exactly
+//     as class 3's is: at two dedicated keys the true hint is 4 and the mutant
+//     hint is 1, whose growth finishes at capacity 4 as well — but at three
+//     the mutant finishes at 8 against a true 6, and the mutant becomes
+//     killable and should be killed rather than re-adjudicated.
 //
 // 2. A BOUND THE ENCLOSING CODE HAS ALREADY NORMALISED.
 //

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -356,17 +356,25 @@ func scaleHistogramProjection(hp chplan.Node, op chplan.BinaryOp, scale chplan.E
 		histSchema.NegativeOffsetColumn,
 	}
 
-	projs := make([]chplan.Projection, 0, len(passthroughCols)+1+5)
+	// The count-bearing scalars and the two signed bucket ladders are named
+	// here rather than inline in their loops so the capacity hint below counts
+	// them instead of restating their sizes as literals — a hint that says a
+	// different number than the loops append is a hint nobody can read the
+	// arithmetic back out of.
+	scalarCols := []string{histSchema.CountColumn, histSchema.SumColumn, histSchema.ZeroCountColumn}
+	ladderCols := []string{histSchema.PositiveBucketCountsColumn, histSchema.NegativeBucketCountsColumn}
+
+	projs := make([]chplan.Projection, 0, len(passthroughCols)+len(scalarCols)+len(ladderCols))
 	for _, col := range passthroughCols {
 		projs = append(projs, chplan.Projection{Expr: &chplan.ColumnRef{Name: col}, Alias: col})
 	}
-	for _, col := range []string{histSchema.CountColumn, histSchema.SumColumn, histSchema.ZeroCountColumn} {
+	for _, col := range scalarCols {
 		projs = append(projs, chplan.Projection{
 			Expr:  scaleHistogramScalarExpr(op, &chplan.ColumnRef{Name: col}, scale),
 			Alias: col,
 		})
 	}
-	for _, col := range []string{histSchema.PositiveBucketCountsColumn, histSchema.NegativeBucketCountsColumn} {
+	for _, col := range ladderCols {
 		projs = append(projs, chplan.Projection{
 			Expr:  scaleHistogramLadderExpr(op, &chplan.ColumnRef{Name: col}, scale),
 			Alias: col,

--- a/test/capmutant/capmutant.go
+++ b/test/capmutant/capmutant.go
@@ -32,15 +32,18 @@ import "testing"
 // than a set of alternatives on purpose: gremlins rewrites each arithmetic
 // token to exactly ONE other token, so a hint spelling P arithmetic operators
 // yields exactly P mutants and a completed run reports exactly P verdicts on
-// its line. The table mirrors `tokenMutations[mutator.ArithmeticBase]` in the
-// pinned `tsouza/gremlins` fork (`internal/engine/mappings.go`), which
-// `.github/workflows/mutation.yml` installs by version.
+// its line. It mirrors the `tokenMutations` entry this mutator carries in the
+// pinned `tsouza/gremlins` fork's engine — named rather than addressed by
+// path, because an upstream file cannot be cited from this repository
+// (docs/test-strategy.md, "How a note cites the mutant it adjudicates").
+// docs/upstream-forks.md describes the fork boundary, and
+// .github/workflows/mutation.yml installs the fork by version.
 //
 // Enumerating the four other operators per position instead would adjudicate
-// mutants no run emits — and the verdicts differ: `internal/promql/
-// schema_lookup.go`'s `len(pairs)*2` is unkillable under the `/` gremlins
-// actually writes and killable under a `+` it never writes. An
-// over-approximation there reports a kill the lane cannot collect.
+// mutants no run emits, and that is not a harmless over-approximation: it can
+// report a kill the lane will never collect. The verdicts genuinely differ —
+// `internal/promql/schema_lookup.go`'s `len(pairs)*2` is unkillable under the
+// `/` gremlins actually writes and killable under a `+` it never writes.
 var Substitution = map[string]string{
 	"+": "-",
 	"-": "+",

--- a/test/capmutant/capmutant.go
+++ b/test/capmutant/capmutant.go
@@ -1,0 +1,270 @@
+// Package capmutant adjudicates the `ARITHMETIC_BASE` mutants gremlins emits
+// on a `make([]T, 0, <hint>)` capacity argument.
+//
+// "An `ARITHMETIC_BASE` mutant on a `make` capacity argument is equivalent" is
+// the single most attractive wrong claim in the mutation lane's adjudication
+// history, and `docs/test-strategy.md`'s "When a capacity mutant is equivalent"
+// states the rule it is wrong about: such a mutant survives only where the
+// slice never escapes its builder, OR the finished slice no longer reports the
+// hint. Where the slice DOES escape to a surface a test can reach and the
+// appends do not grow past the pre-allocation, `cap` reads the mutated
+// arithmetic straight back and a plain assertion kills the substitution.
+//
+// [AssertKilled] is that assertion, plus the proof that it discriminates.
+// A `cap` assertion on its own is a claim about arithmetic nobody re-ran: it
+// passes on a mutant whose shifted hint happens to land back on the true
+// capacity through `append`'s growth schedule, and prose cannot rule that out
+// for itself. So the caller hands over the hint's operator positions and a
+// replay of the builder's append sequence, and every mutant gremlins emits on
+// that hint is required to move the finished capacity.
+//
+// Two hints in `internal/logql/detected_level.go`'s `detectedLevelSourceExpr`
+// are the worked instances the rule was derived from, and they earn opposite
+// verdicts under the same mutator: `keys := make([]string, 0,
+// len(allowedLevelFields)+1)` never leaves the function, while `args :=
+// make([]chplan.Expr, 0, len(keys)*2+1)` becomes the returned `FuncCall`'s
+// exported `Args`.
+package capmutant
+
+import "testing"
+
+// Substitution is the `ARITHMETIC_BASE` operator table, and it is a MAP rather
+// than a set of alternatives on purpose: gremlins rewrites each arithmetic
+// token to exactly ONE other token, so a hint spelling P arithmetic operators
+// yields exactly P mutants and a completed run reports exactly P verdicts on
+// its line. The table mirrors `tokenMutations[mutator.ArithmeticBase]` in the
+// pinned `tsouza/gremlins` fork (`internal/engine/mappings.go`), which
+// `.github/workflows/mutation.yml` installs by version.
+//
+// Enumerating the four other operators per position instead would adjudicate
+// mutants no run emits — and the verdicts differ: `internal/promql/
+// schema_lookup.go`'s `len(pairs)*2` is unkillable under the `/` gremlins
+// actually writes and killable under a `+` it never writes. An
+// over-approximation there reports a kill the lane cannot collect.
+var Substitution = map[string]string{
+	"+": "-",
+	"-": "+",
+	"*": "/",
+	"/": "*",
+	"%": "*",
+}
+
+// mulPrecedence reports whether op binds tighter than `+` and `-`, i.e.
+// whether Go's precedence rules group it first. [Eval] needs this because a
+// mutation can MOVE a multiplicative operator: rewriting the second `*` of
+// `a*b*c` to `/` keeps the grouping, but rewriting the `-` of `a-b*c`
+// would not, and answering a different arithmetic than the compiler does would
+// adjudicate a mutant nobody compiled.
+func mulPrecedence(op string) bool { return op == "*" || op == "/" || op == "%" }
+
+// Apply evaluates `a op b` for the operators `ARITHMETIC_BASE` can produce and
+// reports whether the result is defined. `/` and `%` by zero are NOT: the
+// mutant that produces them panics before `make` is ever reached, which kills
+// it in any test that exercises the builder at all. Reporting that rather than
+// panicking here is what lets [AssertKilled] count such a mutant as killed
+// instead of crashing the enumeration.
+func Apply(t testing.TB, a int, op string, b int) (int, bool) {
+	t.Helper()
+
+	switch op {
+	case "+":
+		return a + b, true
+	case "-":
+		return a - b, true
+	case "*":
+		return a * b, true
+	case "/":
+		if b == 0 {
+			return 0, false
+		}
+		return a / b, true
+	case "%":
+		if b == 0 {
+			return 0, false
+		}
+		return a % b, true
+	}
+	t.Fatalf("capmutant: unknown arithmetic operator %q", op)
+	return 0, false
+}
+
+// Eval evaluates `operands[0] ops[0] operands[1] … ops[n-1] operands[n]` under
+// Go's own operator precedence, and reports whether the result is defined.
+//
+// A hint written with parentheses — `(n+1)*2` — is evaluated as one Eval call
+// per parenthesised group by its caller, because the parentheses fix a grouping
+// no operator substitution can move.
+func Eval(t testing.TB, operands []int, ops []string) (int, bool) {
+	t.Helper()
+
+	if len(ops) != len(operands)-1 {
+		t.Fatalf("capmutant: %d operands need %d operators, got %d",
+			len(operands), len(operands)-1, len(ops))
+	}
+
+	// Pass one collapses every multiplicative operator, leaving a list of
+	// terms joined only by `+` and `-`; pass two folds those left to right.
+	terms := []int{operands[0]}
+	var addOps []string
+	for i, op := range ops {
+		if mulPrecedence(op) {
+			v, ok := Apply(t, terms[len(terms)-1], op, operands[i+1])
+			if !ok {
+				return 0, false
+			}
+			terms[len(terms)-1] = v
+			continue
+		}
+		terms = append(terms, operands[i+1])
+		addOps = append(addOps, op)
+	}
+
+	acc := terms[0]
+	for i, op := range addOps {
+		v, ok := Apply(t, acc, op, terms[i+1])
+		if !ok {
+			return 0, false
+		}
+		acc = v
+	}
+	return acc, true
+}
+
+// Position names one arithmetic operator position of a capacity hint, with the
+// operator the unmutated source spells there. The list of them IS the mutant
+// set under adjudication, so it has to mirror the cited construct operator for
+// operator: a position left out is a mutant nobody enumerated, and a position
+// invented is a verdict on a mutant no run reports.
+type Position struct {
+	// Name describes the position the way a reader of the source would — "the
+	// `*2`", "the trailing `+1`" — so a survivor is reported by name.
+	Name string
+	// Op is the operator the unmutated hint spells at this position.
+	Op string
+}
+
+// Hint is one `make(..., 0, <expr>)` capacity argument under adjudication.
+type Hint struct {
+	// Construct cites the capacity argument in the construct form
+	// `.github/scripts/verify-code-citations.mjs` resolves — the source file's
+	// base name, a colon, and the backticked expression, scoped to a function
+	// name when the expression repeats in the file. It is quoted in every
+	// failure this file reports, so a survivor names the source site rather
+	// than a test-local variable.
+	Construct string
+
+	// Positions are the hint's arithmetic operator positions, in the order
+	// Eval receives them.
+	Positions []Position
+
+	// Eval evaluates the hint with ops[i] substituted into Positions[i], and
+	// reports whether the result is defined. [Eval] is the workhorse.
+	Eval func(t testing.TB, ops []string) (int, bool)
+
+	// Observe builds the real value the way production does and reads back the
+	// length and capacity of the slice the hint sized, through the escape
+	// surface the calling test's note names. This is the half that makes the
+	// adjudication a kill: it is what fails on the mutated binary.
+	Observe func(t *testing.T) (length, capacity int)
+
+	// Build replays the builder's append sequence against a slice
+	// pre-allocated with `hint`, reporting the finished length and capacity.
+	//
+	// It MUST append the builder's REAL element type in the builder's real
+	// grouping. Go rounds a growing slice's capacity up to an allocator size
+	// class measured in BYTES and the growth schedule depends on the order and
+	// grouping of the appends, so a replay that appends a different type, or
+	// the same total in one call, answers a question nobody asked.
+	// [AssertKilled] cross-checks the replay against Observe rather than
+	// trusting that, so a replay that has drifted from its builder is reported
+	// instead of quietly standing in for it.
+	Build func(hint int) (length, capacity int)
+}
+
+// AssertKilled adjudicates h: it asserts that the real value's capacity reads
+// the unmutated hint back, and that every `ARITHMETIC_BASE` mutant gremlins
+// emits in the hint moves that capacity — so the assertion is a kill for the
+// whole mutant set rather than for the subset that happens to shift it.
+//
+// A mutant whose hint goes negative, or whose `/` divides by zero, panics
+// inside `make` or before it and so dies in Observe itself rather than in the
+// capacity comparison. Those are counted and reported separately, because a
+// run where every mutant fell into that bucket would mean the capacity
+// comparison never ran and the note above the test should say so.
+func AssertKilled(t *testing.T, h Hint) {
+	t.Helper()
+
+	if len(h.Positions) == 0 {
+		t.Fatalf("capmutant: %s enumerates no operator positions, so it "+
+			"adjudicates no mutant at all", h.Construct)
+	}
+
+	orig := make([]string, len(h.Positions))
+	for i, p := range h.Positions {
+		if _, ok := Substitution[p.Op]; !ok {
+			t.Fatalf("capmutant: %s names operator %q at %s, which ARITHMETIC_BASE "+
+				"does not rewrite", h.Construct, p.Op, p.Name)
+		}
+		orig[i] = p.Op
+	}
+	trueHint, ok := h.Eval(t, orig)
+	if !ok {
+		t.Fatalf("capmutant: %s does not evaluate under its own operators — the "+
+			"unmutated hint divides by zero, so the operands this test drives the "+
+			"builder with cannot adjudicate anything", h.Construct)
+	}
+
+	obsLen, obsCap := h.Observe(t)
+
+	// The kill. `make([]T, 0, N)` hands back a slice whose cap is exactly N,
+	// and a builder that does not grow past the pre-allocation still reports it
+	// when it is done — so cap reads the hint's arithmetic straight back.
+	if obsCap != trueHint {
+		t.Fatalf("cap of the slice %s sizes = %d; want %d (its own hint). The appends "+
+			"have grown past the pre-allocation, so cap no longer reads the hint "+
+			"back and asserting it has stopped being a capacity kill",
+			h.Construct, obsCap, trueHint)
+	}
+
+	// …and the replay below has to be the builder this test just observed, or
+	// every mutant verdict it produces describes a slice nobody builds.
+	repLen, repCap := h.Build(trueHint)
+	if repLen != obsLen || repCap != obsCap {
+		t.Fatalf("the append replay for %s finishes at len %d / cap %d, but the real "+
+			"builder finishes at len %d / cap %d — the replay has drifted from the "+
+			"builder it stands in for", h.Construct, repLen, repCap, obsLen, obsCap)
+	}
+
+	distinguished, panicking := 0, 0
+	for i, pos := range h.Positions {
+		op := Substitution[pos.Op]
+
+		ops := append([]string(nil), orig...)
+		ops[i] = op
+		hint, defined := h.Eval(t, ops)
+		if !defined || hint < 0 {
+			// `make` panics on a negative capacity, and a `/` by zero panics
+			// before it is reached: either way the mutant dies inside Observe.
+			panicking++
+			continue
+		}
+		distinguished++
+
+		if _, got := h.Build(hint); got == obsCap {
+			t.Errorf("rewriting %s of %s to %q gives capacity hint %d, and the finished "+
+				"slice still ends at cap %d — identical to the unmutated build, so "+
+				"asserting cap does NOT kill this mutant", pos.Name, h.Construct, op, hint, got)
+		}
+	}
+
+	// Anti-vacuity: the enumeration has to cover one mutant per operator
+	// position, which is the number of verdicts a completed run reports on this
+	// hint's line.
+	if want := len(h.Positions); distinguished+panicking != want {
+		t.Fatalf("adjudicated %d mutants of %s, want %d (one per arithmetic operator "+
+			"position) — the enumeration is not covering the mutant set it claims to",
+			distinguished+panicking, h.Construct, want)
+	}
+	t.Logf("%s: %d mutants adjudicated, %d distinguished by capacity, %d killed by a "+
+		"panicking make() capacity", h.Construct, distinguished+panicking, distinguished, panicking)
+}

--- a/test/coverage-floor/test__capmutant.json
+++ b/test/coverage-floor/test__capmutant.json
@@ -1,0 +1,3 @@
+{
+  "test/capmutant": 72.1
+}


### PR DESCRIPTION
## What this is

The mutation matrix carried **21 LIVED `ARITHMETIC_BASE` mutants on a `make` capacity argument**,
adjudicated equivalent across six separate notes on one shared premise: a capacity hint changes only
allocator behaviour. The premise is true. The conclusion does not follow — `cap` is readable on any
slice a test can reach — and **17 of the 21 are killed here**.

The distinguishing fact is escape, and it is invisible in the mutated expression. Each of the 17
sizes a slice that becomes an **exported field of a value its builder returns** (a
`chplan.FuncCall`'s `Args`, a `chplan.Project`'s `Projections`, or the return value itself) and none
grows past its pre-allocation, so the finished slice still reports the hint and `cap` reads the
mutated arithmetic straight back.

## Re-verified inventory

Measured against run **33710407535** (main, completed, success), not the numbers in the issue:

| | |
|---|---|
| capacity mutants matrix-wide | 92 — 58 KILLED, 21 LIVED, 13 NOT COVERED |
| LIVED and killable | 17 |
| LIVED and genuinely unobservable | 4 |

The issue said 18/23/3. The 23 predates #2985, which killed two in `detected_level.go`. The extra
unobservable one is `schema_lookup.go` — the issue predicted it killable on escape alone, and the
escape check passes, but it survives for a different reason (below).

### Killed, with the surface each is read through

| Construct | Escape surface | Mutants |
|---|---|---|
| `canonical_series_keys.go:recollapseIdentityKeyAliases:` `len(pass)+len(r.Recollapse)` | the returned `[]string` itself | 1 |
| `duration.go:` `len(marks)*2+1` | the `multiIf` cascade's `Args`, under the returned `mapMerge` | 2 |
| `lower.go:` `len(fields)*2` | the map literal's `Args`, under the returned `mapMerge` | 1 |
| `lower.go:` `len(segments)+1` | the returned `JSONExtractString`'s `Args` | 1 |
| `range_aggregation.go:` `len(e.Grouping.Groups)*2` | the returned `map(...)`'s `Args` | 1 |
| `vector_aggregation.go:` `len(e.Grouping.Groups)*2` | `Args` under the returned `Project`'s `Projections` | 1 |
| `histogram_native_resets.go:` `len(keyAliases)+1` | the returned `Project`'s `Projections` | 1 |
| `histogram_native_scalar_binop.go:` `len(passthroughCols)+len(scalarCols)+len(ladderCols)` | `Projections` of the `Project` the returned `HistogramProjection` wraps | 2 |
| `histogram_quantile_native_window.go:` `len(keyAliases)+len(aggs)+len(extraAliases)+1` | the returned `Project`'s `Projections` | 3 |
| `histogram_quantile_native_window.go:` `len(keyAliases)+len(scalars)+7` | the returned `Project`'s `Projections` | 2 |
| `histogram_quantile.go:` `projections := make([]chplan.Projection, 0, len(passthrough)+2)` | the returned `Project`'s `Projections` | 1 |
| `histogram_quantile.go:` `len(labels)*2` | `Args` inside the returned `MapWithoutEmptyValues` | 1 |
| `lower.go:` `(len(a.Grouping)+1)*2` | `Args` under the returned `Project`'s Attributes projection | 2 |
| `lower.go:` `len(a.Grouping)*2` | `Args` inside the returned `MapWithoutEmptyValues` | 1 |

Two of those lines carry an operator position whose mutant was already KILLED, so 20 positions are
adjudicated to move 17 LIVED verdicts. Every one was proved individually: the substitution applied by
hand makes the named test FAIL, reverting makes it PASS. A test that passed either way would be a gap,
not a kill.

## The mutant set itself was wrong

`ARITHMETIC_BASE` rewrites each arithmetic token to **exactly one** other token — `+`→`-`, `-`→`+`,
`*`→`/`, `/`→`*`, `%`→`*` — read from `tokenMutations[mutator.ArithmeticBase]` in the pinned
`tsouza/gremlins` fork. A hint spelling P operators carries P mutants, not 4P. The precedent test in
`detected_level_test.go` enumerated all five operators per position and described that as "every
substitution gremlins can make", which is not what the tool does.

That is not pedantry, and it produced the one real surprise:

> `schema_lookup.go:` `len(pairs)*2` **escapes** — the slice becomes the returned expression's `Args`
> — **and is still unkillable.** `pairs` is 1 at every reachable call (`dedicatedResourceKeys` holds
> one entry, and the function returns before the `make` when the list is empty). The true hint is 2,
> the `*`→`/` rewrite gives 0, and the single two-element `append` grows a zero-capacity slice to
> exactly capacity 2. Both builds finish at cap 2. It is killable only under a `+` gremlins never
> writes — so an over-approximating enumeration would have claimed a kill the lane cannot collect.

Measured, not argued: `build(2,1)` and `build(0,1)` both return `len 2, cap 2`.

### The four genuine survivors

| Construct | Why nothing can read it |
|---|---|
| `resource_attributes.go:` `make(map[string]struct{}, len(dedicatedResourceKeys)*2)` | a **map** size hint; Go defines no `cap` for maps and the hint reaches no surface |
| `schema_lookup.go:` `make([]chplan.Expr, 0, len(pairs)*2)` | escapes, but the emitted mutant's growth lands back on the true capacity at the only reachable operand |
| `exemplars.go:` `len(groupAliases)*2+6` | closure capture (#2958 — correctly decided) |
| `detected_level.go:` `keys := make([]string, 0, len(allowedLevelFields)+1)` | never leaves the function (#2985) |

## Notes corrected, not contradicted

Six notes claimed equivalence for mutants this PR kills. Each is corrected in place and its citation
**moves to the kill**, so no mutant carries two verdicts — `forbid-contradicted-mutants` is green
(274 kill claims, 68 equivalence verdicts, no overlap).

- `internal/promql/gremlins_kill_window_bounds_test.go` — class 1 listed eight capacity citations
  under one wrong reason; six are killed and removed, and the two survivors now carry their own
  distinct arguments.
- `internal/logql/gremlins_kill_2949_other_b_test.go`, `gremlins_kill_2949_lower_test.go`,
  `gremlins_kill_2949_test.go`, `vector_aggregation_mutation_test.go`,
  `range_aggregation_mutation_test.go` — each said the cap "is not reachable from the returned
  plan/expression". It is.
- `internal/logql/detected_level_test.go` — verdicts correct, mutator description not; its
  enumeration is now labelled as the deliberate superset it is.
- `.github/scripts/mutation-phases.mjs` — the `phase4-logql` rationale's forward reference replaced
  with the outcome.

## The shared driver

`test/capmutant`. `AssertKilled` takes the hint's operator positions, a closure reading the capacity
back through the escape surface, and a replay of the builder's append sequence. It asserts the real
value's capacity against its own hint, **cross-checks the replay against the real builder** so a
drifted simulation is reported rather than silently standing in for it, then requires each emitted
mutant to move the finished capacity. Anti-vacuity guards fail a run that adjudicated the wrong
number of mutants.

`Eval` honours Go's operator precedence rather than folding left to right, because a substitution can
move a multiplicative operator: rewriting the second `+` of `a+b+c` to `*` yields `a+(b*c)`, and a
left-to-right evaluator would answer a different arithmetic than the compiler compiled.

## One production change

`histogram_native_scalar_binop.go` reserved `len(passthroughCols)+1+5` = 12 slots for 11 appends.
Naming the two column lists it was counting makes the hint exact and removes two bare literals.

## Per-leg arithmetic (run 33710407535)

| leg | before | after |
|---|---|---|
| `phase1` | 865/897 = 96.43% | 866/897 = 96.54% |
| `phase4-logql-aggregation` | 91/94 = 96.81% | 93/94 = 98.94% |
| `phase4-logql-lower` | 88/92 = 95.65% | 90/92 = 97.83% |
| `phase4-logql-other-b` | 281/287 = 97.91% | 283/287 = 98.61% |
| `phase4-promql-f` | 117/122 = 95.90% | 121/122 = 99.18% |
| `phase4-promql-lower` | 249/257 = 96.89% | 251/257 = 97.67% |
| `phase4-promql-other` | 99/101 = 98.02% | 101/101 = 100.00% |
| `phase4-promql-quantile` | 65/67 = 97.01% | 67/67 = 100.00% |

Every leg rises; none falls. No threshold lowered, no denominator shrunk, no file excluded.

## Verification

- Per-mutant fail-then-pass table run for all 20 adjudicated operator positions.
- `verify-code-citations` — 2176 files, every citation resolves.
- `forbid-contradicted-mutants` — no mutant carries two verdicts.
- `forbid-skip` (all checks), `repo-hygiene` (all checks), `forbid-sql-raw`, `doc-counts`,
  `forbid-chplan-fn-literal`, `forbid-verbatim-concat` — green.
- `coverage-package-floor` — `test/capmutant` enrolled at 72.1, derived from a measured 73.13% with
  the ledger's own 1.0 slack.
- `go vet` and the narrowed `-run CapHint` suites across `chplan`, `logql`, `promql`.

Closes #2984
