### PR TITLE
ci: derive the update path's lane guard from the profile, not from libchdb.so on disk

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1011,15 +1011,28 @@ what actually runs.
   UP only and refuses to lower an entry, so a coverage drop has to be a
   hand-edited, reviewable line in the diff. `coverage-summary.test.mjs` is the
   `node --test` guard.
+
+  The compare path writes a lane record beside the profile
+  (`<profile>.lanes.json`: the `COVERAGE_LANES` value, keyed by the SHA-256 of
+  the profile's bytes), and the update path refuses to record floors unless that
+  record exists, hashes to the profile in hand, and names `default+chdb`. Floors
+  measured without the chdb lane under-record every package it reaches, and the
+  ratchet never lowers one, so a floor written too low is never corrected. The
+  digest is what makes the record evidence about the profile rather than about
+  the directory — the failure of the `libchdb.so` test it replaces
+  (tsouza/cerberus#2988), which proved only that the lane could have run on this
+  machine.
   - Env: `COVERAGE_PROFILE` (default `cover-merged.out`), `COVERAGE_FLOORS`
     (default `test/coverage-floor`), `COVERAGE_LANES` (`default+chdb` or
-    `default`; the Justfile sets it from whether libchdb.so was found),
+    `default`; the Justfile sets it from whether libchdb.so was found, and the
+    compare path stamps it into the lane record),
     `COVERAGE_REQUIRE_LANES` (CI sets `default+chdb` so a soft-failing chdb
     install cannot silently downgrade the gate to a skip),
     `COVERAGE_UPDATE_FLOORS=1` (rewrite instead of compare),
     `GITHUB_STEP_SUMMARY`.
   - Exit: `0` when every package clears its floor (or the ledger was
-    rewritten), `1` on unreadable input, a lane mismatch, or a violation.
+    rewritten), `1` on unreadable input, a lane mismatch, a lane set the update
+    path cannot prove is `default+chdb`, or a violation.
 - **`coverage-package-floor.mjs`** — `coverage.yml`'s cheap structural gate on
   every PR, in its own `coverage-enrollment` job. Enumerates the default and `chdb,agpl_oracle,chdb_agpl_oracle`
   builds with `go list`, asks `go tool cover` whether each active source file

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1013,19 +1013,20 @@ what actually runs.
   `node --test` guard.
 
   The compare path writes a lane record beside the profile
-  (`<profile>.lanes.json`: the `COVERAGE_LANES` value, keyed by the SHA-256 of
+  (`<profile>.lanes.json`: the `COVERAGE_LANES` value, bound to the SHA-256 of
   the profile's bytes), and the update path refuses to record floors unless that
   record exists, hashes to the profile in hand, and names `default+chdb`. Floors
   measured without the chdb lane under-record every package it reaches, and the
   ratchet never lowers one, so a floor written too low is never corrected. The
   digest is what makes the record evidence about the profile rather than about
-  the directory — the failure of the `libchdb.so` test it replaces
-  (tsouza/cerberus#2988), which proved only that the lane could have run on this
-  machine.
+  the directory it sits in. That distinction is what the `libchdb.so` test this
+  replaces got wrong (tsouza/cerberus#2988): it proved only that the chdb lane
+  could have run on this machine.
   - Env: `COVERAGE_PROFILE` (default `cover-merged.out`), `COVERAGE_FLOORS`
     (default `test/coverage-floor`), `COVERAGE_LANES` (`default+chdb` or
-    `default`; the Justfile sets it from whether libchdb.so was found, and the
-    compare path stamps it into the lane record),
+    `default`; `just coverage-merge` sets it from whether a non-empty
+    `cover-chdb.out` was there to merge, and the compare path stamps it into the
+    lane record),
     `COVERAGE_REQUIRE_LANES` (CI sets `default+chdb` so a soft-failing chdb
     install cannot silently downgrade the gate to a skip),
     `COVERAGE_UPDATE_FLOORS=1` (rewrite instead of compare),

--- a/.github/scripts/coverage-package-floor.mjs
+++ b/.github/scripts/coverage-package-floor.mjs
@@ -211,7 +211,9 @@ function main() {
       `${failures.join('\n\n')}\n\nA floor is derived from a merged coverage profile, so obtain one ` +
         "of those and run 'just update-coverage-floor' against it: either 'just coverage' locally, or " +
         "'gh workflow run coverage.yml --ref <branch>' and download that run's coverage-profile " +
-        'artifact — its cover-merged.out is uploaded even when the floor gate is red. Restore any ' +
+        'artifact WHOLE — it carries cover-merged.out plus the lane record that proves the profile ' +
+        'holds both lanes, without which the update refuses to derive a floor from it, and it is ' +
+        'uploaded even when the floor gate is red. Restore any ' +
         'coverage regression rather than lowering a floor. See docs/toolchain.md. A zero floor or an ' +
         'exclusion is not enrollment.',
     );

--- a/.github/scripts/coverage-summary.mjs
+++ b/.github/scripts/coverage-summary.mjs
@@ -56,24 +56,32 @@
 // The lane record (`<profile>.lanes.json`):
 //
 // Floors are only meaningful when they come from a profile carrying BOTH lanes,
-// and the update path cannot ask the environment for that — whoever runs it
-// supplies the environment. It cannot ask the filesystem either: an installed
+// and the update path cannot establish that from the filesystem: an installed
 // libchdb.so proves the chdb lane COULD have run, never that the profile in
 // hand contains it, and a CI `coverage-profile` artifact is routinely enrolled
 // from a machine that has no libchdb.so at all (docs/toolchain.md).
 //
-// So the compare path — the one invocation that legitimately knows, because
-// `just coverage-merge` computed the lane set from the profiles it merged —
-// records it beside the profile, keyed by the SHA-256 of the profile's own
-// bytes. The digest is what makes the record a statement about THIS profile
-// rather than about the directory it sits in: a record left behind by an
-// earlier run, or shipped alongside a different profile, no longer matches and
-// is refused. The update path reads the record and refuses anything it cannot
-// prove is `default+chdb`.
+// So the compare path records the lane set beside the profile, bound to the
+// SHA-256 of the profile's own bytes, and the update path reads that record and
+// refuses anything it cannot prove is `default+chdb`. The digest is what makes
+// the record a statement about THIS profile rather than about the directory it
+// sits in: a record left behind by an earlier run, or shipped alongside a
+// different profile, no longer matches and is refused.
+//
+// The property this buys is that every WIRED producer derives the lane set from
+// the files it merged (`coverage-merge` sets COVERAGE_LANES from whether a
+// non-empty cover-chdb.out was there to merge) and binds it to their bytes, so
+// no ordinary run of the recipes can enroll a package from a narrow profile.
+// It is not proof against a hand-written record or a hand-set COVERAGE_LANES —
+// nothing short of re-deriving coverage would be — and it does not need to be:
+// a forged floor still lands as a reviewable line in test/coverage-floor/,
+// which is where a deliberate act belongs. The failure this closes is the
+// accidental one, which left no line to review at all.
 //
 // Exit codes:
 //   0  every package clears its floor (or the ledger was rewritten).
-//   1  unreadable input, an unprovable or narrow lane set, or a floor violation.
+//   1  unreadable input, a COVERAGE_REQUIRE_LANES mismatch, a lane set the
+//      update path cannot prove is `default+chdb`, or a floor violation.
 
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -82,7 +90,7 @@ import { pathToFileURL } from 'node:url';
 import { appendStepSummary, error, log, notice } from './lib/gh.mjs';
 import { loadShardedMap, writeShardedMap } from './lib/sharded-json.mjs';
 
-const DEFAULT_PROFILE = 'cover-merged.out';
+export const DEFAULT_PROFILE = 'cover-merged.out';
 const DEFAULT_FLOORS = 'test/coverage-floor';
 
 // The lane set the floors are measured with. A chdb-tagged run reaches code the
@@ -342,7 +350,18 @@ export function profileDigest(profileText) {
 // consumer, and a path that wrote its own evidence would be asserting nothing.
 function writeLaneRecord(profilePath, profileText, lanes) {
   const record = { lanes, profileSha256: profileDigest(profileText) };
-  writeFileSync(laneRecordPath(profilePath), `${JSON.stringify(record, null, 2)}\n`);
+  const recordPath = laneRecordPath(profilePath);
+  try {
+    writeFileSync(recordPath, `${JSON.stringify(record, null, 2)}\n`);
+  } catch (e) {
+    // This runs inside the required `coverage` context, so an unwritable
+    // directory must arrive as the gate's own annotated failure rather than as
+    // a bare stack trace indistinguishable from a coverage regression.
+    fail(
+      `could not write ${recordPath}: ${e.message}. Without it the profile carries no lane ` +
+        `provenance, so \`just update-coverage-floor\` would refuse to derive floors from it.`,
+    );
+  }
 }
 
 // resolveUpdateLanes decides whether a profile may be turned into floors.

--- a/.github/scripts/coverage-summary.mjs
+++ b/.github/scripts/coverage-summary.mjs
@@ -41,7 +41,11 @@
 //                           Justfile recipe observed them: `default+chdb` or
 //                           `default`. Floors are measured with both lanes, so
 //                           enforcement is skipped (with a notice) on a
-//                           `default`-only profile.
+//                           `default`-only profile. Set on the COMPARE path,
+//                           where it is also written into the lane record
+//                           described below; the UPDATE path reads that record
+//                           instead of trusting an environment variable it
+//                           cannot check.
 //   COVERAGE_REQUIRE_LANES  the lane set the caller guarantees. Set by CI to
 //                           `default+chdb`; a mismatch fails rather than
 //                           downgrading to the skip above, so a chdb install
@@ -49,11 +53,30 @@
 //   COVERAGE_UPDATE_FLOORS  `1` rewrites the ledger instead of comparing.
 //   GITHUB_STEP_SUMMARY     appended to when present (set by Actions).
 //
+// The lane record (`<profile>.lanes.json`):
+//
+// Floors are only meaningful when they come from a profile carrying BOTH lanes,
+// and the update path cannot ask the environment for that — whoever runs it
+// supplies the environment. It cannot ask the filesystem either: an installed
+// libchdb.so proves the chdb lane COULD have run, never that the profile in
+// hand contains it, and a CI `coverage-profile` artifact is routinely enrolled
+// from a machine that has no libchdb.so at all (docs/toolchain.md).
+//
+// So the compare path — the one invocation that legitimately knows, because
+// `just coverage-merge` computed the lane set from the profiles it merged —
+// records it beside the profile, keyed by the SHA-256 of the profile's own
+// bytes. The digest is what makes the record a statement about THIS profile
+// rather than about the directory it sits in: a record left behind by an
+// earlier run, or shipped alongside a different profile, no longer matches and
+// is refused. The update path reads the record and refuses anything it cannot
+// prove is `default+chdb`.
+//
 // Exit codes:
 //   0  every package clears its floor (or the ledger was rewritten).
-//   1  unreadable input, a lane mismatch, or a floor violation.
+//   1  unreadable input, an unprovable or narrow lane set, or a floor violation.
 
-import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { appendStepSummary, error, log, notice } from './lib/gh.mjs';
@@ -77,6 +100,11 @@ const FLOOR_SLACK_PCT = 1.0;
 const FLOOR_DECIMALS = 1;
 
 const MODULE_PREFIX = 'github.com/tsouza/cerberus/';
+
+// The lane record sits beside the profile it describes, named after it, so a
+// profile and its provenance travel together — through a CI artifact upload, a
+// download into somebody else's checkout, or a plain `cp`.
+const LANE_RECORD_SUFFIX = '.lanes.json';
 
 class GateFailure extends Error {}
 
@@ -300,6 +328,92 @@ function writeSummary(packages) {
   log(`total: ${pct(covered, total).toFixed(1)}% (${covered} / ${total} statements)`);
 }
 
+export function laneRecordPath(profilePath) {
+  return `${profilePath}${LANE_RECORD_SUFFIX}`;
+}
+
+// profileDigest binds a lane record to the exact bytes it describes.
+export function profileDigest(profileText) {
+  return createHash('sha256').update(profileText).digest('hex');
+}
+
+// writeLaneRecord stamps the lane set the caller observed onto the profile it
+// observed it from. Written on the COMPARE path only: the update path is the
+// consumer, and a path that wrote its own evidence would be asserting nothing.
+function writeLaneRecord(profilePath, profileText, lanes) {
+  const record = { lanes, profileSha256: profileDigest(profileText) };
+  writeFileSync(laneRecordPath(profilePath), `${JSON.stringify(record, null, 2)}\n`);
+}
+
+// resolveUpdateLanes decides whether a profile may be turned into floors.
+//
+// Every answer but "this record describes this profile and names both lanes" is
+// a refusal, because the alternative to refusing is recording a floor measured
+// without the chdb lane. That floor is not merely low: it passes the enrollment
+// scan and passes the compare gate, and the ratchet — which refuses to LOWER a
+// floor — has no mechanism that ever corrects it upward. Refusing to write
+// costs a re-run; writing costs a package its gate, silently and indefinitely.
+//
+// `recordText` is null when the record could not be read at all.
+export function resolveUpdateLanes(recordText, profileText, recordPath) {
+  const remedy =
+    `Produce the profile with a full \`just coverage\` (after \`just chdb-install\`), or ` +
+    `download the \`coverage-profile\` artifact of a heavy CI run whose lane jobs all ` +
+    `succeeded — it carries this record alongside the profile. See docs/toolchain.md.`;
+
+  if (recordText === null) {
+    return {
+      err:
+        `${recordPath} does not exist, so the lane set of the profile the floors would be ` +
+        `recorded from cannot be established. Floors are measured with both lanes, and one ` +
+        `recorded from a default-tag-only profile under-records every package the chdb lane ` +
+        `reaches — it still passes enrollment and still passes the gate, so nothing ever ` +
+        `corrects it. ${remedy}`,
+    };
+  }
+
+  let record;
+  try {
+    record = JSON.parse(recordText);
+  } catch (e) {
+    return { err: `${recordPath} is not readable as JSON (${e.message}), so it proves nothing. ${remedy}` };
+  }
+  const shaped =
+    record !== null &&
+    typeof record === 'object' &&
+    typeof record.lanes === 'string' &&
+    typeof record.profileSha256 === 'string';
+  if (!shaped) {
+    return {
+      err:
+        `${recordPath} is not a lane record: it must be a JSON object carrying a string ` +
+        `\`lanes\` and a string \`profileSha256\`. ${remedy}`,
+    };
+  }
+
+  const digest = profileDigest(profileText);
+  if (record.profileSha256 !== digest) {
+    return {
+      err:
+        `${recordPath} describes a different profile (it records sha256 ` +
+        `${record.profileSha256}, the profile on disk hashes to ${digest}), so its lane set is ` +
+        `not evidence about the profile the floors would come from. A record left over from an ` +
+        `earlier run, or shipped next to a profile it did not come from, is exactly the case ` +
+        `this digest exists to catch. ${remedy}`,
+    };
+  }
+  if (record.lanes !== FULL_LANES) {
+    return {
+      err:
+        `the profile was produced by the '${record.lanes}' lane set, not '${FULL_LANES}'. Floors ` +
+        `recorded from it would under-record every package the chdb lane reaches, and the ` +
+        `ratchet never lowers a floor, so nothing would ever correct one written too low. ` +
+        `${remedy}`,
+    };
+  }
+  return { lanes: record.lanes };
+}
+
 // resolveLanes decides whether the profile can be held to the ledger.
 export function resolveLanes(lanes, required) {
   if (required && lanes !== required) {
@@ -330,9 +444,27 @@ function main() {
 
   writeSummary(packages);
 
+  const updating = process.env.COVERAGE_UPDATE_FLOORS === '1';
+  const lanesEnv = process.env.COVERAGE_LANES || '';
+
+  // Stamp the provenance BEFORE the comparison below can fail: a red floor gate
+  // is precisely when somebody needs to enroll a package from this profile, and
+  // the CI artifact that carries it is uploaded whatever the gate said.
+  if (!updating && lanesEnv) writeLaneRecord(profilePath, text, lanesEnv);
+
   const floors = readFloors(floorsDir);
 
-  if (process.env.COVERAGE_UPDATE_FLOORS === '1') {
+  if (updating) {
+    const recordPath = laneRecordPath(profilePath);
+    let recordText = null;
+    try {
+      recordText = readFileSync(recordPath, 'utf8');
+    } catch {
+      recordText = null;
+    }
+    const update = resolveUpdateLanes(recordText, text, recordPath);
+    if (update.err) fail(update.err);
+
     const { next, regressions, unfloorable } = nextFloors(packages, floors);
     if (regressions.length) {
       fail(
@@ -358,7 +490,7 @@ function main() {
     return;
   }
 
-  const lanes = resolveLanes(process.env.COVERAGE_LANES || '', process.env.COVERAGE_REQUIRE_LANES || '');
+  const lanes = resolveLanes(lanesEnv, process.env.COVERAGE_REQUIRE_LANES || '');
   if (lanes.err) fail(lanes.err);
   if (!lanes.enforce) {
     notice(

--- a/.github/scripts/coverage-summary.test.mjs
+++ b/.github/scripts/coverage-summary.test.mjs
@@ -8,7 +8,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -17,6 +17,7 @@ import { test } from 'node:test';
 
 import {
   compare,
+  DEFAULT_PROFILE,
   floorFor,
   laneRecordPath,
   nextFloors,
@@ -31,6 +32,8 @@ import {
 import { loadShardedMap, writeShardedMap } from './lib/sharded-json.mjs';
 
 const SCRIPT = fileURLToPath(new URL('./coverage-summary.mjs', import.meta.url));
+const WORKFLOW = fileURLToPath(new URL('../workflows/coverage.yml', import.meta.url));
+const UPLOAD_STEP = 'Upload merged coverage profile';
 
 // profile renders a cover profile from `[file, stmts, count]` triples.
 function profile(blocks) {
@@ -453,6 +456,58 @@ test('end to end: COVERAGE_LANES in the environment cannot talk the update path 
     assert.deepEqual(loadShardedMap(floorsDir), {});
     // Nor does the update path rewrite the record it just refused.
     assert.equal(JSON.parse(readFileSync(laneRecordPath(profilePath), 'utf8')).lanes, 'default');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the compare path leaves a good record alone when it is told no lane set', () => {
+  // The guard against a FALSE refusal. Overwriting a valid record with an empty
+  // lane set on any bare invocation would turn the next legitimate
+  // `just update-coverage-floor` into a refusal, which is the failure mode this
+  // change exists to avoid inflicting on people.
+  const { dir, profilePath, floorsDir } = fixture([['internal/a/one.go', 10, 1]], { 'internal/a': 50 });
+  try {
+    const before = readFileSync(laneRecordPath(profilePath), 'utf8');
+    assert.equal(run(profilePath, floorsDir, { COVERAGE_LANES: '' }).status, 0);
+    assert.equal(readFileSync(laneRecordPath(profilePath), 'utf8'), before, 'the record was rewritten');
+    assert.equal(run(profilePath, floorsDir, { COVERAGE_UPDATE_FLOORS: '1' }).status, 0, 'and it still enrolls');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the coverage-profile artifact uploads the record the update path demands", () => {
+  // The record is only useful to the documented CI-artifact enrollment route if
+  // it TRAVELS with the profile. Nothing else ties this script's file-naming to
+  // that upload step's `path:` list, so renaming the record here would silently
+  // dead-end the route: the reader downloads the whole artifact and is told the
+  // record does not exist. Pinned the way perf-coverage-fanout.test.mjs pins
+  // RATCHET_FANOUT against the matrix that has to agree with it.
+  const workflow = readFileSync(WORKFLOW, 'utf8');
+  const at = workflow.indexOf(UPLOAD_STEP);
+  assert.notEqual(at, -1, `${WORKFLOW} has no step named ${JSON.stringify(UPLOAD_STEP)}`);
+  // The step's own body: up to the next step, or the end of the file.
+  const rest = workflow.slice(at);
+  const end = rest.indexOf('\n      - ');
+  const step = end === -1 ? rest : rest.slice(0, end);
+  for (const wanted of [DEFAULT_PROFILE, laneRecordPath(DEFAULT_PROFILE)]) {
+    assert.ok(step.includes(wanted), `the ${JSON.stringify(UPLOAD_STEP)} step does not upload ${wanted}:\n${step}`);
+  }
+});
+
+test('a lane record that cannot be written fails the gate with an explanation, not a stack trace', () => {
+  // writeLaneRecord runs inside the required `coverage` context. A read-only or
+  // otherwise unwritable location has to arrive as this gate's own annotated
+  // failure; a raw stack trace reads in the check output exactly like a
+  // coverage regression, which is the wrong thing to go looking for.
+  const { dir, profilePath, floorsDir } = fixture([['internal/a/one.go', 10, 1]], { 'internal/a': 50 }, null);
+  try {
+    mkdirSync(laneRecordPath(profilePath)); // a directory where the record belongs
+    const { status, out } = run(profilePath, floorsDir);
+    assert.equal(status, 1, `expected a refusal; output was:\n${out}`);
+    assert.match(out, /::error title=coverage floor::could not write/);
+    assert.doesNotMatch(out, /at file:\/\//, 'the failure escaped as a stack trace');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/.github/scripts/coverage-summary.test.mjs
+++ b/.github/scripts/coverage-summary.test.mjs
@@ -8,7 +8,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
@@ -18,11 +18,14 @@ import { test } from 'node:test';
 import {
   compare,
   floorFor,
+  laneRecordPath,
   nextFloors,
   packageKeySegments,
   packageOf,
   parseProfile,
+  profileDigest,
   resolveLanes,
+  resolveUpdateLanes,
   rows,
 } from './coverage-summary.mjs';
 import { loadShardedMap, writeShardedMap } from './lib/sharded-json.mjs';
@@ -40,14 +43,32 @@ function profile(blocks) {
   return `${lines.join('\n')}\n`;
 }
 
+// laneRecord writes the provenance stamp `just coverage-merge` leaves beside a
+// profile: the lane set that produced it, bound to that profile's own bytes.
+// `lanes` of null writes no record at all — the "provenance unknown" case.
+function laneRecord(profilePath, lanes) {
+  if (lanes === null) return;
+  const text = readFileSync(profilePath, 'utf8');
+  writeFileSync(
+    laneRecordPath(profilePath),
+    `${JSON.stringify({ lanes, profileSha256: profileDigest(text) }, null, 2)}\n`,
+  );
+}
+
 // fixture lays down a profile and a sharded floor ledger in a scratch
 // directory — one shard file per package, matching the on-disk shape
 // coverage-summary.mjs now reads/writes (see lib/sharded-json.mjs).
-function fixture(blocks, floors) {
+//
+// It also stamps the both-lane record, because a fixture stands in for a
+// COMPLETE profile: a test that wants the narrow or missing-provenance case
+// says so with `lanes`, so those cases are visible at the call site rather than
+// being whatever the helper happened to omit.
+function fixture(blocks, floors, lanes = 'default+chdb') {
   const dir = mkdtempSync(path.join(tmpdir(), 'coverage-floor-'));
   const profilePath = path.join(dir, 'cover-merged.out');
   const floorsDir = path.join(dir, 'coverage-floor');
   writeFileSync(profilePath, profile(blocks));
+  laneRecord(profilePath, lanes);
   if (floors !== undefined) writeShardedMap(floorsDir, floors, packageKeySegments);
   return { dir, profilePath, floorsDir };
 }
@@ -286,6 +307,152 @@ test('end to end: a package with no floor fails rather than being waved through'
     assert.equal(status, 1, `expected a refusal; output was:\n${out}`);
     assert.match(out, /no floor/);
     assert.match(out, /internal\/new/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the update path refuses a profile whose lane provenance is unknown', () => {
+  // The guard this replaces asked whether libchdb.so was on the machine, which
+  // is a fact about the machine. With no record beside it, a profile could have
+  // come from anywhere — including a CI run whose chdb lane never produced one.
+  const err = resolveUpdateLanes(null, 'mode: set\n', 'cover-merged.out.lanes.json');
+  assert.match(err.err, /does not exist/);
+  assert.match(err.err, /cannot be established/);
+});
+
+test('the update path refuses a default-only profile and accepts a both-lane one', () => {
+  const text = profile([['internal/a/one.go', 4, 1]]);
+  const narrow = JSON.stringify({ lanes: 'default', profileSha256: profileDigest(text) });
+  const full = JSON.stringify({ lanes: 'default+chdb', profileSha256: profileDigest(text) });
+  assert.match(resolveUpdateLanes(narrow, text, 'r.json').err, /'default' lane set, not 'default\+chdb'/);
+  assert.equal(resolveUpdateLanes(full, text, 'r.json').lanes, 'default+chdb');
+});
+
+test('a lane record that describes some other profile is not evidence about this one', () => {
+  // The reason the record carries a digest at all: a stale record sitting in
+  // the directory from an earlier local run would otherwise vouch for a profile
+  // downloaded on top of it, which is the same "fact about the directory, not
+  // about the profile" mistake as testing for libchdb.so.
+  const text = profile([['internal/a/one.go', 4, 1]]);
+  const other = JSON.stringify({ lanes: 'default+chdb', profileSha256: profileDigest('mode: set\n') });
+  assert.match(resolveUpdateLanes(other, text, 'r.json').err, /describes a different profile/);
+});
+
+test('a lane record that is not JSON, or not shaped like a record, proves nothing', () => {
+  const text = profile([['internal/a/one.go', 4, 1]]);
+  assert.match(resolveUpdateLanes('not json', text, 'r.json').err, /not readable as JSON/);
+  assert.match(resolveUpdateLanes('{"lanes":"default+chdb"}', text, 'r.json').err, /is not a lane record/);
+  assert.match(resolveUpdateLanes('[]', text, 'r.json').err, /is not a lane record/);
+});
+
+test('end to end: the update refuses a default-only profile and writes no floor', () => {
+  // The defect in full: a NEW package enrolled from a default-tag-only profile
+  // gets a positive-but-too-low floor that passes enrollment, passes the gate,
+  // and is never corrected — the ratchet only raises, and nothing raises it.
+  const { dir, profilePath, floorsDir } = fixture([['internal/new/a.go', 10, 1]], {}, 'default');
+  try {
+    const { status, out } = run(profilePath, floorsDir, { COVERAGE_UPDATE_FLOORS: '1' });
+    assert.equal(status, 1, `expected a refusal; output was:\n${out}`);
+    assert.match(out, /'default' lane set, not 'default\+chdb'/);
+    assert.deepEqual(loadShardedMap(floorsDir), {}, 'the ledger gained no entry');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('end to end: the update refuses a profile with no lane record at all', () => {
+  const { dir, profilePath, floorsDir } = fixture([['internal/new/a.go', 10, 1]], {}, null);
+  try {
+    const { status, out } = run(profilePath, floorsDir, { COVERAGE_UPDATE_FLOORS: '1' });
+    assert.equal(status, 1, `expected a refusal; output was:\n${out}`);
+    assert.match(out, /does not exist/);
+    assert.deepEqual(loadShardedMap(floorsDir), {}, 'the ledger gained no entry');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('end to end: the update accepts the both-lane profile and enrolls the package', () => {
+  // The positive control for the two refusals above: same package, same
+  // measurement, provenance the only difference.
+  const { dir, profilePath, floorsDir } = fixture([['internal/new/a.go', 10, 1]], {});
+  try {
+    const { status, out } = run(profilePath, floorsDir, { COVERAGE_UPDATE_FLOORS: '1' });
+    assert.equal(status, 0, `expected acceptance; output was:\n${out}`);
+    assert.equal(loadShardedMap(floorsDir)['internal/new'], 99);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('end to end: the compare path stamps the record the update path reads', () => {
+  // The handoff `just coverage-merge` -> `just update-coverage-floor` depends
+  // on. It is stamped even when the comparison itself fails, because a red
+  // floor gate is exactly when a package needs enrolling from that profile.
+  const { dir, profilePath, floorsDir } = fixture([['internal/new/a.go', 10, 1]], {}, null);
+  try {
+    assert.equal(existsSync(laneRecordPath(profilePath)), false);
+    const { status } = run(profilePath, floorsDir, { COVERAGE_LANES: 'default+chdb' });
+    assert.equal(status, 1, 'the unfloored package still fails the comparison');
+    const record = JSON.parse(readFileSync(laneRecordPath(profilePath), 'utf8'));
+    assert.equal(record.lanes, 'default+chdb');
+    assert.equal(record.profileSha256, profileDigest(readFileSync(profilePath, 'utf8')));
+    // ...and the update path now accepts what the compare path stamped.
+    assert.equal(run(profilePath, floorsDir, { COVERAGE_UPDATE_FLOORS: '1' }).status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('end to end: a narrow compare path stamps a narrow record, which the update refuses', () => {
+  // The full local shape of the defect: no libchdb.so, so `just coverage-merge`
+  // produces a default-only profile, reports (rather than enforces) — and the
+  // record it leaves behind is what stops those floors being written.
+  const { dir, profilePath, floorsDir } = fixture([['internal/new/a.go', 10, 1]], {}, null);
+  try {
+    assert.equal(run(profilePath, floorsDir, { COVERAGE_LANES: 'default' }).status, 0, 'a narrow run only reports');
+    assert.equal(JSON.parse(readFileSync(laneRecordPath(profilePath), 'utf8')).lanes, 'default');
+    const { status, out } = run(profilePath, floorsDir, { COVERAGE_UPDATE_FLOORS: '1' });
+    assert.equal(status, 1, `expected a refusal; output was:\n${out}`);
+    assert.deepEqual(loadShardedMap(floorsDir), {}, 'the ledger gained no entry');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('end to end: the lane guard runs BEFORE the ratchet, and neither writes on a regression', () => {
+  // The pre-existing fail-closed property, re-pinned now that a second guard
+  // sits in front of it: a package below its committed floor still aborts the
+  // update with the ledger untouched, on a profile whose provenance is fine.
+  const { dir, profilePath, floorsDir } = fixture([['internal/thin/a.go', 10, 0]], { 'internal/thin': 80 });
+  try {
+    const { status, out } = run(profilePath, floorsDir, { COVERAGE_UPDATE_FLOORS: '1' });
+    assert.equal(status, 1, `expected a refusal; output was:\n${out}`);
+    assert.match(out, /reviewable line/, 'the ratchet, not the lane guard, is what refused');
+    assert.equal(loadShardedMap(floorsDir)['internal/thin'], 80);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('end to end: COVERAGE_LANES in the environment cannot talk the update path round', () => {
+  // The obvious bypass, and the reason the update path reads a record rather
+  // than an environment variable: whoever runs the update supplies the
+  // environment, so an env var is a claim by the caller, not evidence about the
+  // profile. (`run` already sets COVERAGE_LANES=default+chdb for every case
+  // here — this names the property so it cannot be lost by changing a default.)
+  const { dir, profilePath, floorsDir } = fixture([['internal/new/a.go', 10, 1]], {}, 'default');
+  try {
+    const { status } = run(profilePath, floorsDir, {
+      COVERAGE_UPDATE_FLOORS: '1',
+      COVERAGE_LANES: 'default+chdb',
+      COVERAGE_REQUIRE_LANES: 'default+chdb',
+    });
+    assert.equal(status, 1, 'the environment claimed both lanes; the record on the profile did not');
+    assert.deepEqual(loadShardedMap(floorsDir), {});
+    // Nor does the update path rewrite the record it just refused.
+    assert.equal(JSON.parse(readFileSync(laneRecordPath(profilePath), 'utf8')).lanes, 'default');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -478,14 +478,17 @@ jobs:
             cover.out
             cover-chdb.out
             cover-merged.out
+            cover-merged.out.lanes.json
           retention-days: 30
 
       # The structural enrollment verdict lands HERE, and last. `coverage` is
       # the required context and `coverage-enrollment` is not, so an unfloored
       # package has to fail this job or it does not block a merge at all. Last
       # and `always()` so the merge and the upload above still happen first:
-      # that uploaded cover-merged.out is exactly what the author of the
-      # unfloored package needs to run `just update-coverage-floor` against,
+      # that uploaded cover-merged.out — with the cover-merged.out.lanes.json
+      # record that proves it carries both lanes, without which
+      # `update-coverage-floor` refuses it (tsouza/cerberus#2988) — is exactly
+      # what the author of the unfloored package needs to run against,
       # and failing ahead of it would recreate tsouza/cerberus#2987's loop one
       # job further along. `always()` also means a genuinely cancelled or
       # errored coverage-enrollment fails here rather than passing silently.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 
 # Code coverage profiles and other test artifacts
 *.out
+# The lane-provenance record coverage-summary.mjs stamps onto a merged profile
+# (cover-merged.out.lanes.json). It describes a generated profile and is as
+# untracked as the profile itself; `*.out` above does not cover it.
+*.out.lanes.json
 /coverage.*
 *.coverprofile
 profile.cov

--- a/Justfile
+++ b/Justfile
@@ -789,6 +789,12 @@ coverage-chdb:
 # same tree, or after a CI job downloads each lane's profile artifact into
 # one directory (tsouza/cerberus#2634) — either way the merge is a fact about
 # the files, not about how they got there.
+#
+# The lane set computed below is passed to coverage-summary.mjs, which records
+# it beside the profile as cover-merged.out.lanes.json, keyed by the profile's
+# own SHA-256. That record is the ONLY thing `update-coverage-floor` will accept
+# as proof that a profile carries both lanes — this recipe is the one step that
+# legitimately knows, because it is the step that decided.
 coverage-merge:
     @test -s cover.out || { echo "error: cover.out not found — run 'just coverage-default' first" >&2; exit 1; }
     # Fold TestCardinalityRatchet's extra shard profiles (cover-chdb-ratchet-
@@ -853,8 +859,21 @@ coverage: coverage-default coverage-chdb coverage-merge
 # package could be deleted and the gate would stay green. Give the package a
 # test (the profile is built with `-coverpkg` over the whole module, so a test
 # in ANY package counts), or delete the code nothing reaches.
+#
+# And it never records floors from a profile it cannot prove carries BOTH
+# lanes. coverage-summary.mjs reads cover-merged.out.lanes.json — the record
+# `coverage-merge` stamps onto the profile, bound to its bytes — and refuses
+# anything narrower, unstamped, or stamped for some other profile. This recipe
+# used to test for libchdb.so instead, which proves the chdb lane COULD have
+# run on this machine and nothing at all about the profile on disk
+# (tsouza/cerberus#2988). The test below survives as an up-front HINT, not a
+# gate: a machine without libchdb.so cannot produce a profile this recipe will
+# accept, and saying so before the refusal is a better error than after it. It
+# is deliberately not fatal — enrolling from a CI `coverage-profile` artifact
+# (docs/toolchain.md) is a supported route, and that artifact is complete on a
+# machine that has never installed chDB.
 update-coverage-floor:
-    @test -f "{{CHDB_INSTALL_PATH}}" || { echo "error: {{CHDB_INSTALL_PATH}} not found — run 'just chdb-install' first; floors recorded without the chdb lane would under-record every package that lane reaches" >&2; exit 1; }
+    @test -f "{{CHDB_INSTALL_PATH}}" || echo "note: {{CHDB_INSTALL_PATH}} not found — a 'just coverage' run on this machine produces a default-tag-only profile, which this recipe refuses (floors are measured with both lanes). Run 'just chdb-install' first, or enroll from a CI coverage-profile artifact; see docs/toolchain.md." >&2
     @test -s cover-merged.out || { echo "error: cover-merged.out not found — run 'just coverage' first; the floors are derived from the profile it writes" >&2; exit 1; }
     @COVERAGE_UPDATE_FLOORS=1 node .github/scripts/coverage-summary.mjs
     @echo

--- a/Justfile
+++ b/Justfile
@@ -791,7 +791,7 @@ coverage-chdb:
 # the files, not about how they got there.
 #
 # The lane set computed below is passed to coverage-summary.mjs, which records
-# it beside the profile as cover-merged.out.lanes.json, keyed by the profile's
+# it beside the profile as cover-merged.out.lanes.json, bound to the profile's
 # own SHA-256. That record is the ONLY thing `update-coverage-floor` will accept
 # as proof that a profile carries both lanes — this recipe is the one step that
 # legitimately knows, because it is the step that decided.
@@ -863,17 +863,20 @@ coverage: coverage-default coverage-chdb coverage-merge
 # And it never records floors from a profile it cannot prove carries BOTH
 # lanes. coverage-summary.mjs reads cover-merged.out.lanes.json — the record
 # `coverage-merge` stamps onto the profile, bound to its bytes — and refuses
-# anything narrower, unstamped, or stamped for some other profile. This recipe
-# used to test for libchdb.so instead, which proves the chdb lane COULD have
-# run on this machine and nothing at all about the profile on disk
-# (tsouza/cerberus#2988). The test below survives as an up-front HINT, not a
-# gate: a machine without libchdb.so cannot produce a profile this recipe will
-# accept, and saying so before the refusal is a better error than after it. It
-# is deliberately not fatal — enrolling from a CI `coverage-profile` artifact
-# (docs/toolchain.md) is a supported route, and that artifact is complete on a
-# machine that has never installed chDB.
+# anything narrower, unstamped, or stamped for some other profile.
+#
+# This recipe used to test for libchdb.so instead, which proves the chdb lane
+# COULD have run on this machine and nothing at all about the profile on disk
+# (tsouza/cerberus#2988). That test is gone rather than demoted to a warning:
+# it fires on a condition that is neither necessary nor sufficient for what
+# this recipe does. It would print in the one flow the fix exists to keep
+# working — enrolling from a downloaded CI `coverage-profile` artifact, which
+# is complete on a machine that has never installed chDB — and stay silent
+# when a stale or narrow record is about to be refused on a machine that has
+# it. The early diagnostic lives where the long run is: `coverage-chdb` says
+# "libchdb.so not found, skipping chdb lane" as it skips, and the refusal here
+# names `just chdb-install` in its own remedy text.
 update-coverage-floor:
-    @test -f "{{CHDB_INSTALL_PATH}}" || echo "note: {{CHDB_INSTALL_PATH}} not found — a 'just coverage' run on this machine produces a default-tag-only profile, which this recipe refuses (floors are measured with both lanes). Run 'just chdb-install' first, or enroll from a CI coverage-profile artifact; see docs/toolchain.md." >&2
     @test -s cover-merged.out || { echo "error: cover-merged.out not found — run 'just coverage' first; the floors are derived from the profile it writes" >&2; exit 1; }
     @COVERAGE_UPDATE_FLOORS=1 node .github/scripts/coverage-summary.mjs
     @echo

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -56,7 +56,7 @@ Either way, the floors come from a profile carrying BOTH lanes or they are not r
 floor measured without the chdb-tagged lane under-records every package that lane reaches, and
 because the ratchet only ever raises a floor, nothing corrects one written too low — it passes
 enrollment and passes the gate indefinitely. `just coverage-merge` therefore stamps the lane set it
-merged onto the profile as `cover-merged.out.lanes.json`, keyed by that profile's own SHA-256, and
+merged onto the profile as `cover-merged.out.lanes.json`, bound to that profile's own SHA-256, and
 `just update-coverage-floor` refuses a profile whose record is missing, narrower than
 `default+chdb`, or bound to different bytes. That record is part of the `coverage-profile` artifact,
 which is why the whole artifact is what gets downloaded; a run whose lane jobs did not all succeed

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -46,13 +46,22 @@ of two ways, both ending in the same command:
   `just update-coverage-floor`.
 - **From CI**, when the local sweep is not practical on the machine at hand.
   `gh workflow run coverage.yml --ref <branch>` runs the measuring lanes on that branch; download the
-  run's `coverage-profile` artifact into the repository root and run `just update-coverage-floor`
-  against the `cover-merged.out` it contains. Take the artifact from a run whose `coverage-default`,
-  `coverage-chdb` and `coverage-chdb-ratchet` jobs all succeeded — that is what makes the merged
-  profile the both-lane profile the floors are measured with. The upload happens even when the floor
-  gate itself is red, which is what makes an unenrolled package recoverable at all
-  (tsouza/cerberus#2987: the enrollment check used to run inside `coverage-plan`, whose failure
+  run's `coverage-profile` artifact into the repository root — all of it, not just the profile — and
+  run `just update-coverage-floor` against the `cover-merged.out` it contains. The upload happens
+  even when the floor gate itself is red, which is what makes an unenrolled package recoverable at
+  all (tsouza/cerberus#2987: the enrollment check used to run inside `coverage-plan`, whose failure
   skipped every lane that could have measured the remedy).
+
+Either way, the floors come from a profile carrying BOTH lanes or they are not recorded at all. A
+floor measured without the chdb-tagged lane under-records every package that lane reaches, and
+because the ratchet only ever raises a floor, nothing corrects one written too low — it passes
+enrollment and passes the gate indefinitely. `just coverage-merge` therefore stamps the lane set it
+merged onto the profile as `cover-merged.out.lanes.json`, keyed by that profile's own SHA-256, and
+`just update-coverage-floor` refuses a profile whose record is missing, narrower than
+`default+chdb`, or bound to different bytes. That record is part of the `coverage-profile` artifact,
+which is why the whole artifact is what gets downloaded; a run whose lane jobs did not all succeed
+produces no record naming both lanes, so the recipe declines it rather than relying on the reader to
+have checked.
 
 `just update-coverage-floor` only ratchets up. It refuses to lower a floor to match a coverage drop
 and never records a `0`, so both of those stay hand-edited, reviewable lines in a diff.


### PR DESCRIPTION
## The defect, verified

`just update-coverage-floor` guarded against recording floors from a narrow profile by testing that
`libchdb.so` exists on the machine. I re-read `coverage-summary.mjs` rather than inheriting the
issue's reading, and it holds exactly as stated:

- `main` reads the profile, renders the summary, loads the ledger, and then branches on
  `COVERAGE_UPDATE_FLOORS === '1'`. That branch ends in `writeFloors` and **returns**.
- `resolveLanes` — the fail-closed lane check — is called on the line *after* that return, so it has
  only ever guarded the COMPARE path. The WRITE path consulted no lane set at all.
- The Justfile passed neither `COVERAGE_LANES` nor `COVERAGE_REQUIRE_LANES` to the update
  invocation, so there was nothing for it to consult even if it had.

So the guard asked whether the chdb lane *could* have run on this machine, never whether the
`cover-merged.out` in hand *contains* it — and the machine question is the wrong one twice over,
because enrolling from a downloaded CI `coverage-profile` artifact is a supported route on a machine
that has never installed chDB.

The uncontained cost is a NEW package: enrolled from a default-tag-only profile it gets a
positive-but-too-low floor that passes `coverage-enrollment` and passes the compare gate, and the
ratchet only ever raises a floor, so nothing corrects it.

## How lane provenance is now determined

`just coverage-merge` is the one step that legitimately knows the lane set, because it is the step
that decides it: it merges `cover.out` with `cover-chdb.out` when the latter exists and computes
`default+chdb` or `default` from that fact. It already handed that answer to `coverage-summary.mjs`
as `COVERAGE_LANES`; now the compare path also **stamps it onto the profile** as
`cover-merged.out.lanes.json` — the lane set plus the SHA-256 of the profile's own bytes.

The digest is what makes the record evidence about *this profile* rather than about the directory it
sits in, which is the original defect's exact shape. A record left behind by an earlier local run
would otherwise vouch for a profile downloaded on top of it; bound to the bytes, it cannot.

`resolveUpdateLanes` in `coverage-summary.mjs` is the whole decision, and every answer but "this
record describes this profile and names `default+chdb`" is a refusal:

| profile handed to the update path | verdict |
| --- | --- |
| no record beside it | refused — provenance cannot be established |
| record is not JSON / not a `{lanes, profileSha256}` object | refused — it proves nothing |
| record's digest names other bytes | refused — not evidence about this profile |
| record says `default` | refused — floors would under-record every package the chdb lane reaches |
| record says `default+chdb`, digest matches | accepted |

**Fail closed:** the refusal happens before `nextFloors` is even called, and refusing costs a re-run
while writing costs a package its gate silently and indefinitely.

## Evidence the guard can fire

One profile, one measurement, `internal/newpkg` at 100% of 10 statements, an empty ledger. The only
variable is provenance. Running the real script (`COVERAGE_UPDATE_FLOORS=1`):

```
default-only record:  exit=1  ledger entries=0
no record:            exit=1  ledger entries=0
both-lane record:     exit=0  ledger entries=1   -> {"internal/newpkg": 99}
```

That is the defect end to end: without this change the first two rows wrote `99` into the ledger
from a profile that never ran the chdb lane. The stale-record case refuses the same way:

```
::error title=coverage floor::...lanes.json describes a different profile (it records sha256
22b0c386..., the profile on disk hashes to d497900e...), so its lane set is not evidence about the
profile the floors would come from.
```

`coverage-summary.test.mjs` pins all of it — extended, not paralleled: twelve new cases, four unit
(`resolveUpdateLanes` on each refusal shape) and five end-to-end through a spawned script and a real
sharded ledger on disk, including a positive control (`the update accepts the both-lane profile and
enrolls the package`) so the refusals are not vacuous, and the round trip
(`the compare path stamps the record the update path reads`) that pins the
`coverage-merge` -> `update-coverage-floor` handoff. `node --test` on the two suites this change
touches: 36 tests, 36 pass.

### The tests go red when the guard is broken

`neutralized === missing`, so I mutated the guard in a scratch copy of `.github/` under `/tmp` (never
the worktree) and re-ran the suite. Each mutant is killed:

| mutant | result |
| --- | --- |
| the `default+chdb` requirement is never checked | 28 tests, 4 fail |
| the guard's verdict is never acted on (the original defect restored) | 28 tests, 4 fail |
| the digest binding is dropped, so any record vouches for any profile | 28 tests, 1 fail |

The third is killed by exactly the one case that exists for it — a record describing other bytes —
which is what a single-property test should look like.

**The pre-existing fail-closed property still holds**, and is now pinned rather than assumed:
`nextFloors` still collects every package measuring below its committed floor and `fail()`s before
`writeFloors` runs. `the lane guard runs BEFORE the ratchet, and neither writes on a regression`
drives a *valid* both-lane profile whose package sits below its floor, and asserts both that the run
exits 1 with the ratchet's own "reviewable line" message (so it was the ratchet that refused, not
the new guard shadowing it) and that the committed floor is still `80` afterwards.

## What `libchdb.so` does now

**Nothing — the test is gone from this recipe.** It was first demoted to a non-fatal `note:`, and
adversarial review was right that the demotion did not survive contact: the hint fires on a condition
neither necessary nor sufficient for what the recipe does. It would print in exactly the flow this
change exists to keep working — enrolling from a downloaded artifact on a chDB-less machine, where
the command then succeeds — and stay silent when a stale or narrow record is about to be refused on a
machine that has the library.

The early diagnostic it was meant to be already exists, in the right place: the long run is
`just coverage`, and `coverage-chdb` announces `libchdb.so not found, skipping chdb lane` as it
skips. The remedy text is already in the refusal, which names `just chdb-install`. So the last
machine-fact leaves this recipe rather than lingering as duplicated, mistimed guidance.

## Other things carried

- The `coverage-profile` artifact now uploads `cover-merged.out.lanes.json` alongside the profile, so
  the CI enrollment route stays open — that is what makes the record travel with the profile it
  describes.
- `.gitignore` covers `*.out.lanes.json`. `*.out` does not, and `repo-hygiene.mjs`'s root-allowlist
  scan reads untracked-but-not-ignored paths; verified the check stays green with the record present
  in the repository root.
- `docs/toolchain.md` now states the rule as a mechanism rather than as guidance to the reader
  ("take the artifact from a run whose lane jobs all succeeded" was correct and unenforced), and
  `.github/scripts/README.md`'s env contract and exit codes describe the record.
- `coverage-package-floor.mjs`'s enrollment remedy message says to download the artifact WHOLE, since
  the profile alone is no longer sufficient.

No allow-list, no tolerance file, no floor lowered, no new numeric constant.

## Adversarial review

I had a reviewer attack the diff before this was final. It found no bypass and no falsely-refused
legitimate flow, and six things worth fixing — all six are in the second commit:

1. **The record's name and the artifact's `path:` list were coupled by an unpinned literal.**
   Renaming `LANE_RECORD_SUFFIX` left every test green while the artifact silently stopped carrying
   the record — which dead-ends the documented route in a refusal telling the reader to download the
   artifact they just downloaded, a weaker replay of #2987's loop. Now pinned from the suite, the way
   `perf-coverage-fanout.test.mjs` pins `RATCHET_FANOUT` against the matrix that must agree with it.
2. **The `libchdb.so` hint is removed**, per the section above.
3. **A write fault escaped the gate's failure vocabulary.** `writeLaneRecord` runs inside the
   required `coverage` context, and an unwritable location threw past `main`'s catch as a raw stack
   trace — indistinguishable in the check output from a coverage regression. It now fails through
   `::error::` with an explanation.
4. **The header overclaimed.** It said the update path reads a record "instead of trusting an
   environment variable it cannot check", but the record's `lanes` field *is* a `COVERAGE_LANES`
   value an earlier invocation was handed, so a hand-set one forges an accepted record. The header
   now states the property that actually holds — every *wired* producer derives the value from the
   files it merged and binds it to their bytes — and says why the residual is proportionate: a forged
   floor is still a reviewable line in the ledger, which is where a deliberate act belongs. The
   failure this closes is the accidental one, which left no line to review at all.
5. **The `lanesEnv` conjunct was untested.** Dropping it survives every original test, and it
   introduces a *false refusal*: a bare compare run with `COVERAGE_LANES` unset would overwrite a good
   record with an empty lane set and turn the next legitimate update into a refusal. Pinned.
6. **Prose.** The README still described `COVERAGE_LANES` as a fact about whether libchdb.so was
   found — the model this change repudiates; `coverage-merge` sets it from whether a non-empty
   `cover-chdb.out` was there to merge. Also a dangling appositive that read as though the digest were
   the failure, an exit-code list that had dropped the still-live `COVERAGE_REQUIRE_LANES` mismatch,
   and "keyed by" for a digest that is a field of the record rather than a key of it.

Each new pin was mutation-checked in turn — dropping the conjunct, renaming the suffix, removing the
record from the artifact, and letting a write fault escape raw each turn exactly one test red. Suite
is now 31 tests, 31 pass.

Checks run locally: `node --test` on `coverage-summary.test.mjs` and `coverage-package-floor.test.mjs`,
`just lint-actions`, `just lint-md`, `repo-hygiene.mjs` (all three checks),
`verify-code-citations.mjs`, `forbid-contradicted-mutants.mjs`, and `just --summary` for the Justfile
parse. I did not run any coverage recipe: another agent owns that lane in a parallel worktree.

Closes #2988
