### PR TITLE
test: restore seven packages to their committed coverage floors

### DIFF
--- a/cmd/cerberus/cmd_optdocs_test.go
+++ b/cmd/cerberus/cmd_optdocs_test.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chopt"
+)
+
+// optdocFixture returns a doc whose generated block is surrounded by
+// hand-authored prose on both sides — the arrangement optdocReplaceBlock
+// exists to preserve. The prose is deliberately distinctive so a slice that
+// took the wrong offset shows up as lost or duplicated text.
+func optdocFixture(block string) []byte {
+	return []byte("# Heading\n\nPROSE BEFORE THE BLOCK\n\n" +
+		block +
+		"\n\nPROSE AFTER THE BLOCK\n")
+}
+
+// TestOptdocReplaceBlock_PreservesSurroundingProse pins the contract the
+// generator's doc comment states: "the generator owns an existing block, it
+// does not invent the surrounding section." docs/clickhouse-optimizations.md
+// carries hand-authored columns and commentary OUTSIDE the markers, and this
+// function rewrites the file in place — so an offset error here silently
+// deletes human-written documentation, which no test of the table's contents
+// would notice.
+func TestOptdocReplaceBlock_PreservesSurroundingProse(t *testing.T) {
+	original := optdocFixture(optdocBeginMarker + "\nOLD TABLE\n" + optdocEndMarker)
+	replacement := optdocBeginMarker + "\nNEW TABLE\n" + optdocEndMarker
+
+	got, err := optdocReplaceBlock(original, replacement)
+	if err != nil {
+		t.Fatalf("optdocReplaceBlock: %v", err)
+	}
+
+	want := optdocFixture(replacement)
+	if !bytes.Equal(got, want) {
+		t.Errorf("optdocReplaceBlock =\n%q\nwant\n%q", got, want)
+	}
+	if bytes.Contains(got, []byte("OLD TABLE")) {
+		t.Errorf("result still contains the old block body; want it replaced")
+	}
+	if !bytes.Contains(got, []byte("PROSE BEFORE THE BLOCK")) {
+		t.Errorf("result lost the prose preceding the block")
+	}
+	if !bytes.Contains(got, []byte("PROSE AFTER THE BLOCK")) {
+		t.Errorf("result lost the prose following the block")
+	}
+	// The END marker must be consumed, not left behind: an endStop that
+	// stopped at the marker instead of past it would leave a second, orphan
+	// END marker in the file and make the NEXT run's Index find the wrong one.
+	if n := bytes.Count(got, []byte(optdocEndMarker)); n != 1 {
+		t.Errorf("result contains %d END markers; want exactly 1", n)
+	}
+	if n := bytes.Count(got, []byte(optdocBeginMarker)); n != 1 {
+		t.Errorf("result contains %d BEGIN markers; want exactly 1", n)
+	}
+}
+
+// TestOptdocReplaceBlock_RejectsMalformedMarkers pins the three refusals.
+// Each is a case where writing SOMETHING would corrupt the doc: with no
+// markers there is no block to own, and with the markers reversed the byte
+// range between them is negative, so a function that sliced anyway would
+// either panic or silently truncate the file it is about to overwrite.
+func TestOptdocReplaceBlock_RejectsMalformedMarkers(t *testing.T) {
+	cases := []struct {
+		name    string
+		doc     string
+		wantSub string
+	}{
+		{"no markers at all", "# Heading\n\njust prose\n", "BEGIN marker"},
+		{"BEGIN only", "# Heading\n" + optdocBeginMarker + "\n", "END marker"},
+		{"END only", "# Heading\n" + optdocEndMarker + "\n", "BEGIN marker"},
+		{"markers reversed", "# Heading\n" + optdocEndMarker + "\nbody\n" + optdocBeginMarker + "\n", "precedes"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := optdocReplaceBlock([]byte(tc.doc), "NEW")
+			if err == nil {
+				t.Fatalf("optdocReplaceBlock returned no error; want one (got %q)", got)
+			}
+			if got != nil {
+				t.Errorf("optdocReplaceBlock returned %q alongside an error; want nil so a caller cannot write a corrupted doc", got)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error = %q; want it to mention %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestOptdocRenderMinVersion pins the special case its own comment calls out:
+// the AlwaysAvailable zero floor must read "none", because a literal "0.0"
+// in the published table would tell an operator there is a version
+// requirement to check when there is none.
+func TestOptdocRenderMinVersion(t *testing.T) {
+	if got := optdocRenderMinVersion(chopt.AlwaysAvailable); got != "none" {
+		t.Errorf("optdocRenderMinVersion(AlwaysAvailable) = %q; want %q", got, "none")
+	}
+	v := chopt.Version{Major: 25, Minor: 8}
+	if got, want := optdocRenderMinVersion(v), v.String(); got != want {
+		t.Errorf("optdocRenderMinVersion(%v) = %q; want %q", v, got, want)
+	}
+	if got := optdocRenderMinVersion(chopt.Version{Major: 25, Minor: 8}); got == "none" {
+		t.Errorf("a real version floor rendered as %q; want the version, not the no-floor sentinel", "none")
+	}
+}
+
+// TestOptdocRenderStabilityAndAutoSelect pins the two display vocabularies.
+// Both are read by operators deciding whether to enable a feature, and both
+// are booleans-in-disguise where an inverted mapping is invisible to
+// everything except a test that names the expected word.
+func TestOptdocRenderStabilityAndAutoSelect(t *testing.T) {
+	if got := optdocRenderStability(chopt.Stable); got != "stable" {
+		t.Errorf("optdocRenderStability(Stable) = %q; want %q", got, "stable")
+	}
+	if got := optdocRenderStability(chopt.Experimental); got != "experimental" {
+		t.Errorf("optdocRenderStability(Experimental) = %q; want %q", got, "experimental")
+	}
+	if got := optdocRenderAutoSelect(true); got != "yes" {
+		t.Errorf("optdocRenderAutoSelect(true) = %q; want %q", got, "yes")
+	}
+	if got := optdocRenderAutoSelect(false); got != "no" {
+		t.Errorf("optdocRenderAutoSelect(false) = %q; want %q", got, "no")
+	}
+}
+
+// TestOptdocWidthsFor pins the column sizing that keeps the emitted table
+// MD060-aligned: each width is the max of the header label and every cell in
+// that column, and the columns are sized independently. A width taken from
+// the wrong column, or one that ignored the header, emits a table markdownlint
+// rejects — which fails a lint gate rather than this generator, a long way
+// from the cause.
+func TestOptdocWidthsFor(t *testing.T) {
+	t.Run("headers floor the widths", func(t *testing.T) {
+		w := optdocWidthsFor(nil)
+		if w.ID != len("id") || w.MinVersion != len("minVersion") ||
+			w.Stability != len("stability") || w.AutoSelect != len("autoSelect") {
+			t.Errorf("optdocWidthsFor(nil) = %+v; want each column at its header's length", w)
+		}
+	})
+
+	t.Run("longest cell wins, per column", func(t *testing.T) {
+		// Each cell is longer than its own header and a DIFFERENT length from
+		// every other cell, so a width copied from the wrong column is visible.
+		rows := []optdocRow{
+			{ID: "aaaaa", MinVersion: "bbbbbbbbbbbb", Stability: "ccccccccccccc", AutoSelect: "dddddddddddddd"},
+			{ID: "aa", MinVersion: "bb", Stability: "cc", AutoSelect: "dd"},
+		}
+		w := optdocWidthsFor(rows)
+		if w.ID != 5 {
+			t.Errorf("ID width = %d; want 5", w.ID)
+		}
+		if w.MinVersion != 12 {
+			t.Errorf("MinVersion width = %d; want 12", w.MinVersion)
+		}
+		if w.Stability != 13 {
+			t.Errorf("Stability width = %d; want 13", w.Stability)
+		}
+		if w.AutoSelect != 14 {
+			t.Errorf("AutoSelect width = %d; want 14", w.AutoSelect)
+		}
+	})
+}
+
+// TestOptdocSpacesAndDashes pins the two padding primitives, and in
+// particular their disagreement at n <= 0: spaces collapse to the empty
+// string (a cell already at or past the column width needs no padding),
+// while dashes floor at ONE, because a markdown separator row with a
+// zero-width cell is not a table at all and the whole block would stop
+// rendering.
+func TestOptdocSpacesAndDashes(t *testing.T) {
+	if got := optdocSpaces(3); got != "   " {
+		t.Errorf("optdocSpaces(3) = %q; want three spaces", got)
+	}
+	if got := optdocSpaces(0); got != "" {
+		t.Errorf("optdocSpaces(0) = %q; want the empty string", got)
+	}
+	if got := optdocSpaces(-2); got != "" {
+		t.Errorf("optdocSpaces(-2) = %q; want the empty string", got)
+	}
+	if got := optdocDashes(3); got != "---" {
+		t.Errorf("optdocDashes(3) = %q; want three dashes", got)
+	}
+	if got := optdocDashes(0); got != "-" {
+		t.Errorf("optdocDashes(0) = %q; want a single dash — a zero-width separator cell breaks the table", got)
+	}
+	if got := optdocDashes(-2); got != "-" {
+		t.Errorf("optdocDashes(-2) = %q; want a single dash", got)
+	}
+}
+
+// TestOptdocRenderBlock_ShapeAndRegistryCoverage pins the generated block
+// against the registry it is derived from: every registered feature gets a
+// row, the block is marker-delimited, and the separator row is present. The
+// per-feature check is what makes `-check` drift detection meaningful — a
+// generator that silently dropped features would keep the doc "current"
+// while the table under-reports what cerberus supports.
+func TestOptdocRenderBlock_ShapeAndRegistryCoverage(t *testing.T) {
+	block, err := optdocRenderBlock()
+	if err != nil {
+		t.Fatalf("optdocRenderBlock: %v", err)
+	}
+	if !strings.HasPrefix(block, optdocBeginMarker) {
+		t.Errorf("block does not start with the BEGIN marker")
+	}
+	if !strings.HasSuffix(block, optdocEndMarker) {
+		t.Errorf("block does not end with the END marker")
+	}
+	if !strings.Contains(block, "| id ") {
+		t.Errorf("block has no header row:\n%s", block)
+	}
+
+	features := chopt.Registry()
+	if len(features) == 0 {
+		t.Fatal("chopt.Registry() is empty; this test's premise no longer holds")
+	}
+	for _, f := range features {
+		if !strings.Contains(block, "`"+f.ID+"`") {
+			t.Errorf("feature %q has no row in the generated block", f.ID)
+		}
+	}
+	// Every table line begins a new line with `|`: the header row, the
+	// separator row, and exactly one data row per registered feature. A
+	// generator that emitted a feature twice, or skipped one, lands a
+	// different count here even if every id still appears somewhere.
+	if got, want := strings.Count(block, "\n|"), len(features)+2; got != want {
+		t.Errorf("block has %d table lines; want %d (header + separator + %d features)", got, want, len(features))
+	}
+}
+
+// TestOptdocsGenerate_WritesCheckAndDriftDetection pins the three outcomes
+// `optdocsGenerate` produces, which together are the CI doc-drift gate:
+// a stale doc is rewritten in write mode, an up-to-date doc is left byte-
+// identical, and `-check` reports drift WITHOUT touching the file. The last
+// is the one that matters most: a -check that wrote would make the gate
+// self-healing on the runner and it would never fail, so the file's bytes
+// are compared before and after.
+func TestOptdocsGenerate_WritesCheckAndDriftDetection(t *testing.T) {
+	block, err := optdocRenderBlock()
+	if err != nil {
+		t.Fatalf("optdocRenderBlock: %v", err)
+	}
+	stale := optdocFixture(optdocBeginMarker + "\n| stale | table |\n" + optdocEndMarker)
+	current := optdocFixture(block)
+
+	t.Run("check reports drift and does not write", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "doc.md")
+		if err := os.WriteFile(path, stale, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		err := optdocsGenerate(path, true)
+		if err == nil {
+			t.Fatal("optdocsGenerate(check) on a stale doc = nil; want a drift error")
+		}
+		if !strings.Contains(err.Error(), "stale") {
+			t.Errorf("drift error = %q; want it to say the doc is stale", err)
+		}
+		after, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !bytes.Equal(after, stale) {
+			t.Errorf("-check rewrote the doc; want it left untouched so the gate can actually fail")
+		}
+	})
+
+	t.Run("write mode refreshes a stale doc", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "doc.md")
+		if err := os.WriteFile(path, stale, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := optdocsGenerate(path, false); err != nil {
+			t.Fatalf("optdocsGenerate(write): %v", err)
+		}
+		after, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !bytes.Equal(after, current) {
+			t.Errorf("write mode produced a doc that does not match the rendered block")
+		}
+		// Regenerating a fresh doc must be a no-op, and -check must now pass:
+		// a generator whose output is not a fixed point would make the gate
+		// fail forever no matter how often it is run.
+		if err := optdocsGenerate(path, true); err != nil {
+			t.Errorf("-check on a just-generated doc = %v; want nil (the generator is not idempotent)", err)
+		}
+	})
+
+	t.Run("missing file is an error, not a silent create", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "absent.md")
+		if err := optdocsGenerate(path, false); err == nil {
+			t.Error("optdocsGenerate on a missing doc = nil; want a read error rather than a doc invented from nothing")
+		}
+	})
+}
+
+// TestOptdocsRun_FlagParsing pins the single-dash flag surface the
+// `go:generate` directive in internal/chopt/registry.go and `just
+// gen-opt-docs` invoke. Cobra's flag parsing is disabled for this command
+// precisely so those historical spellings keep working, which means nothing
+// else in the CLI test suite exercises them.
+func TestOptdocsRun_FlagParsing(t *testing.T) {
+	block, err := optdocRenderBlock()
+	if err != nil {
+		t.Fatalf("optdocRenderBlock: %v", err)
+	}
+
+	t.Run("-doc and -check are honoured", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "doc.md")
+		if err := os.WriteFile(path, optdocFixture(block), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stderr bytes.Buffer
+		if err := optdocsRun([]string{"-doc", path, "-check"}, &stderr); err != nil {
+			t.Errorf("optdocsRun on a current doc = %v; want nil", err)
+		}
+	})
+
+	t.Run("drift is reported under the optdocs prefix", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "doc.md")
+		staleDoc := optdocFixture(optdocBeginMarker + "\n| stale |\n" + optdocEndMarker)
+		if err := os.WriteFile(path, staleDoc, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stderr bytes.Buffer
+		err := optdocsRun([]string{"-doc", path, "-check"}, &stderr)
+		if err == nil {
+			t.Fatal("optdocsRun on a stale doc = nil; want a drift error")
+		}
+		if !strings.HasPrefix(err.Error(), "optdocs: ") {
+			t.Errorf("error = %q; want the legacy `optdocs: ` prefix the go:generate caller reports under", err)
+		}
+	})
+
+	t.Run("an unknown flag is refused", func(t *testing.T) {
+		var stderr bytes.Buffer
+		if err := optdocsRun([]string{"-nope"}, &stderr); err == nil {
+			t.Error("optdocsRun with an unknown flag = nil; want a parse error rather than a silent regeneration of the default doc")
+		}
+	})
+}

--- a/internal/api/info/info_test.go
+++ b/internal/api/info/info_test.go
@@ -347,3 +347,128 @@ func TestInfo_OptimizationsAreLive(t *testing.T) {
 		t.Errorf("enabled after upgrade = %v; want [aggregation_in_order ts_grid_range]", got.Optimizations.Enabled)
 	}
 }
+
+// TestInfo_CatalogViewRefreshConfigured (cerberus issue #2991) confirms a
+// wired loki label-catalog resolver and a wired Tempo tag-catalog resolver
+// each surface verbatim under their OWN nested object, field for field.
+//
+// Both resolvers return the same Go type (ViewRefreshState) and each is
+// rendered into a per-head JSON type whose field set is identical bar the
+// tags. Two mistakes in that arrangement compile silently: crossing the two
+// heads' resolvers in snapshotResponse, and — should either conversion ever
+// be spelled out as a field-by-field literal — mis-pairing two of the four
+// consecutive string fields ViewRefreshState carries. Every string field
+// therefore gets a value distinct across BOTH heads, so either mistake
+// lands a recognisably wrong value rather than a coincidentally equal one.
+func TestInfo_CatalogViewRefreshConfigured(t *testing.T) {
+	lokiState := ViewRefreshState{
+		Configured:      true,
+		Status:          "loki-status",
+		Exception:       "loki-exception",
+		LastSuccessTime: "loki-success",
+		LastRefreshTime: "loki-refresh",
+		Retry:           7,
+	}
+	tempoState := ViewRefreshState{
+		Configured:      true,
+		Status:          "tempo-status",
+		Exception:       "tempo-exception",
+		LastSuccessTime: "tempo-success",
+		LastRefreshTime: "tempo-refresh",
+		Retry:           9,
+	}
+	h := New(Options{
+		Snapshot:                   baseSnapshot(),
+		Optimizations:              staticOpts(baseOptState()),
+		LokiCatalogViewRefresh:     func(context.Context) ViewRefreshState { return lokiState },
+		TempoTagCatalogViewRefresh: func(context.Context) ViewRefreshState { return tempoState },
+	})
+	got, _ := decodeInfo(t, h)
+
+	wantLoki := lokiCatalogViewRefreshInfo{
+		Configured:      true,
+		Status:          "loki-status",
+		Exception:       "loki-exception",
+		LastSuccessTime: "loki-success",
+		LastRefreshTime: "loki-refresh",
+		Retry:           7,
+	}
+	if got.LokiCatalogViewRefresh != wantLoki {
+		t.Errorf("lokiCatalogViewRefresh = %+v; want %+v", got.LokiCatalogViewRefresh, wantLoki)
+	}
+
+	wantTempo := tempoTagCatalogViewRefreshInfo{
+		Configured:      true,
+		Status:          "tempo-status",
+		Exception:       "tempo-exception",
+		LastSuccessTime: "tempo-success",
+		LastRefreshTime: "tempo-refresh",
+		Retry:           9,
+	}
+	if got.TempoTagCatalogViewRefresh != wantTempo {
+		t.Errorf("tempoTagCatalogViewRefresh = %+v; want %+v", got.TempoTagCatalogViewRefresh, wantTempo)
+	}
+}
+
+// TestInfo_CatalogViewRefreshFailingRefreshReadsVerbatim pins the failure
+// posture both catalog objects exist to make visible: cerberus layers no
+// "healthy"/"unhealthy" verdict over system.view_refreshes, so a view that
+// is serving a stale-but-real previous snapshot reports a non-empty
+// exception WITH a LastSuccessTime still populated and a LastRefreshTime
+// that has advanced past it. A resolver result rewritten into a verdict, or
+// one that blanked LastSuccessTime on a failed attempt, would lose exactly
+// the signal an operator reads to tell "stale but serving" from "never
+// worked", and this test fails on either.
+func TestInfo_CatalogViewRefreshFailingRefreshReadsVerbatim(t *testing.T) {
+	failing := ViewRefreshState{
+		Configured:      true,
+		Status:          "Scheduled",
+		Exception:       "Code: 60. DB::Exception: Table otel.logs does not exist",
+		LastSuccessTime: "2026-09-02 10:00:00",
+		LastRefreshTime: "2026-09-02 10:05:00",
+		Retry:           3,
+	}
+	h := New(Options{
+		Snapshot:               baseSnapshot(),
+		Optimizations:          staticOpts(baseOptState()),
+		LokiCatalogViewRefresh: func(context.Context) ViewRefreshState { return failing },
+	})
+	got, _ := decodeInfo(t, h)
+
+	if got.LokiCatalogViewRefresh.Status != "Scheduled" {
+		t.Errorf("lokiCatalogViewRefresh.status = %q; want %q (verbatim, not an Error verdict)",
+			got.LokiCatalogViewRefresh.Status, "Scheduled")
+	}
+	if got.LokiCatalogViewRefresh.Exception != failing.Exception {
+		t.Errorf("lokiCatalogViewRefresh.exception = %q; want %q", got.LokiCatalogViewRefresh.Exception, failing.Exception)
+	}
+	if got.LokiCatalogViewRefresh.LastSuccessTime != failing.LastSuccessTime {
+		t.Errorf("lokiCatalogViewRefresh.lastSuccessTime = %q; want %q — a failed attempt must not erase the snapshot still being served",
+			got.LokiCatalogViewRefresh.LastSuccessTime, failing.LastSuccessTime)
+	}
+	if got.LokiCatalogViewRefresh.LastRefreshTime <= got.LokiCatalogViewRefresh.LastSuccessTime {
+		t.Errorf("lokiCatalogViewRefresh.lastRefreshTime = %q, lastSuccessTime = %q; want the attempt to read as later than the last success",
+			got.LokiCatalogViewRefresh.LastRefreshTime, got.LokiCatalogViewRefresh.LastSuccessTime)
+	}
+	if got.LokiCatalogViewRefresh.Retry != 3 {
+		t.Errorf("lokiCatalogViewRefresh.retry = %d; want 3", got.LokiCatalogViewRefresh.Retry)
+	}
+}
+
+// TestInfo_CatalogViewRefreshNilFuncDefaultsToZero confirms a handler wired
+// without either catalog resolver reports both objects at their zero value
+// (configured=false) rather than omitting them — the honest answer for a
+// handler wired without chclient.QueryViewRefreshState, and the same
+// posture TestInfo_FilesystemCacheNilFuncDefaultsToZero pins for its
+// sibling object.
+func TestInfo_CatalogViewRefreshNilFuncDefaultsToZero(t *testing.T) {
+	h := New(Options{Snapshot: baseSnapshot()})
+	got, _ := decodeInfo(t, h)
+
+	if got.LokiCatalogViewRefresh != (lokiCatalogViewRefreshInfo{}) {
+		t.Errorf("lokiCatalogViewRefresh with no resolver = %+v; want zero", got.LokiCatalogViewRefresh)
+	}
+	if got.TempoTagCatalogViewRefresh != (tempoTagCatalogViewRefreshInfo{}) {
+		t.Errorf("tempoTagCatalogViewRefresh with no resolver = %+v; want zero", got.TempoTagCatalogViewRefresh)
+	}
+}

--- a/internal/chclient/columnar_bind_test.go
+++ b/internal/chclient/columnar_bind_test.go
@@ -1,0 +1,282 @@
+package chclient
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// TestFormatArg_SupportedTypes pins the closed set of Go types the columnar
+// binder renders into ClickHouse SQL literals (cerberus issue #2991).
+//
+// formatArg exists because the columnar path binds arguments ITSELF rather
+// than handing them to clickhouse-go's binder, so its rendering has to agree
+// with clickhouse-go's format() for every type the matrix path emits. A
+// disagreement is not a crash: it is a query that runs and returns the wrong
+// rows, on the optimised path only, while the row path stays right — the
+// hardest possible shape to notice. Each supported type is therefore pinned
+// to its exact literal.
+func TestFormatArg_SupportedTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"string", "abc", `'abc'`},
+		{"empty string", "", `''`},
+		{"bool true renders as 1", true, "1"},
+		{"bool false renders as 0", false, "0"},
+		{"int", int(-7), "-7"},
+		{"int32", int32(-7), "-7"},
+		{"int64", int64(-9007199254740993), "-9007199254740993"},
+		{"uint64", uint64(18446744073709551615), "18446744073709551615"},
+		{"float32", float32(1.5), "1.5"},
+		{"float64", float64(-0.25), "-0.25"},
+		{"nil renders as NULL", nil, "NULL"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := formatArg(tc.in)
+			if !ok {
+				t.Fatalf("formatArg(%#v) declined; want the literal %s", tc.in, tc.want)
+			}
+			if got != tc.want {
+				t.Errorf("formatArg(%#v) = %s; want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatArg_EscapesStringLiterals pins the escaping that keeps a string
+// argument INSIDE its literal. A single quote that reaches the SQL unescaped
+// closes the literal early and the remainder of the value is parsed as SQL —
+// the columnar path builds its statement by concatenation, so this is the
+// one place where an unescaped byte turns a value into syntax.
+//
+// Both characters clickhouse-go's stringQuoteReplacer handles are checked,
+// including the case that a naive single-pass escaper gets wrong: a
+// backslash immediately before a quote, where escaping the quote without
+// also escaping the backslash leaves `\\'` and re-opens the hole.
+func TestFormatArg_EscapesStringLiterals(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"single quote", `a'b`, `'a\'b'`},
+		{"backslash", `a\b`, `'a\\b'`},
+		{"backslash before quote", `a\'b`, `'a\\\'b'`},
+		{"quote terminator attempt", `x' OR 1=1 --`, `'x\' OR 1=1 --'`},
+		{"trailing backslash", `x\`, `'x\\'`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := formatArg(tc.in)
+			if !ok {
+				t.Fatalf("formatArg(%q) declined; want %s", tc.in, tc.want)
+			}
+			if got != tc.want {
+				t.Errorf("formatArg(%q) = %s; want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatArg_DeclinesUnhandledTypes pins the fail-closed half of the
+// contract formatArg's doc states: any type outside the closed set returns
+// false so queryCursorColumnar falls back to the row path. The failure mode
+// this prevents is a default arm that stringified an unknown value into
+// something that happens to parse — the columnar decode is an optimisation
+// and must never be a correctness gamble, so declining is the only allowed
+// answer.
+func TestFormatArg_DeclinesUnhandledTypes(t *testing.T) {
+	type custom struct{ A int }
+	unhandled := []any{
+		uint(1), uint8(1), uint16(1), uint32(1), int8(1), int16(1),
+		[]string{"a"},
+		[]byte("a"),
+		map[string]string{"a": "b"},
+		custom{A: 1},
+		&custom{A: 1},
+		[]any{1, 2},
+	}
+	for _, v := range unhandled {
+		got, ok := formatArg(v)
+		if ok {
+			t.Errorf("formatArg(%#v) = %s, true; want it declined so the caller falls back to the row path", v, got)
+		}
+		if got != "" {
+			t.Errorf("formatArg(%#v) returned literal %q alongside false; want the empty string", v, got)
+		}
+	}
+}
+
+// TestBindArgs_Positional pins the substitution itself: each `?` takes the
+// NEXT argument, in order, and nothing else in the statement moves. Argument
+// values are deliberately distinguishable from one another so a binder that
+// bound them out of order, or bound one argument twice, lands a visibly
+// wrong statement rather than a plausible one.
+func TestBindArgs_Positional(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		args []any
+		want string
+	}{
+		{
+			name: "no placeholders and no args passes through",
+			sql:  "SELECT 1",
+			args: nil,
+			want: "SELECT 1",
+		},
+		{
+			name: "single placeholder",
+			sql:  "SELECT * FROM t WHERE a = ?",
+			args: []any{int64(1)},
+			want: "SELECT * FROM t WHERE a = 1",
+		},
+		{
+			name: "arguments bind in order",
+			sql:  "SELECT * FROM t WHERE a = ? AND b = ? AND c = ?",
+			args: []any{int64(11), int64(22), int64(33)},
+			want: "SELECT * FROM t WHERE a = 11 AND b = 22 AND c = 33",
+		},
+		{
+			name: "mixed types",
+			sql:  "SELECT ?, ?, ?, ?",
+			args: []any{"s", true, float64(2.5), nil},
+			want: "SELECT 's', 1, 2.5, NULL",
+		},
+		{
+			name: "escaped question mark is a literal, not a placeholder",
+			sql:  `SELECT 'a\?b', ?`,
+			args: []any{int64(5)},
+			want: `SELECT 'a?b', 5`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := bindArgs(tc.sql, tc.args)
+			if !ok {
+				t.Fatalf("bindArgs(%q, %#v) declined; want %q", tc.sql, tc.args, tc.want)
+			}
+			if got != tc.want {
+				t.Errorf("bindArgs(%q, %#v) = %q; want %q", tc.sql, tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBindArgs_DeclinesOnMismatch pins every way bindArgs refuses. A binder
+// that guessed instead of declining would emit a statement whose placeholder
+// count and argument count disagree — either a stray literal `?` reaching
+// ClickHouse, or a silently dropped predicate that WIDENS the result set.
+// The second is the dangerous one: it returns rows, just the wrong ones, so
+// it is asserted rather than left to the server to reject.
+func TestBindArgs_DeclinesOnMismatch(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		args []any
+	}{
+		{"more placeholders than args", "SELECT ?, ?", []any{int64(1)}},
+		{"more args than placeholders", "SELECT ?", []any{int64(1), int64(2)}},
+		{"placeholder with no args at all", "SELECT ?", nil},
+		{"unhandled arg type", "SELECT ?", []any{uint8(1)}},
+		{"unhandled arg among handled ones", "SELECT ?, ?", []any{int64(1), []string{"x"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := bindArgs(tc.sql, tc.args)
+			if ok {
+				t.Errorf("bindArgs(%q, %#v) = %q, true; want it declined so queryCursorColumnar falls back to the row path", tc.sql, tc.args, got)
+			}
+			if got != "" {
+				t.Errorf("bindArgs(%q, %#v) returned %q alongside false; want the empty string", tc.sql, tc.args, got)
+			}
+		})
+	}
+}
+
+// TestBindArgs_EscapedArgumentCannotOpenAPlaceholder is the composition of
+// the two halves above, and the reason they belong in one file: a string
+// argument is escaped as it is written, and the writer does not re-scan what
+// it has already emitted. So a value containing `?` cannot consume the NEXT
+// argument, and a value containing `'` cannot swallow the rest of the
+// statement. Both are checked against a following placeholder, because that
+// is the only arrangement in which either failure is observable.
+func TestBindArgs_EscapedArgumentCannotOpenAPlaceholder(t *testing.T) {
+	got, ok := bindArgs("SELECT ?, ?", []any{`why? ' OR 1=1 --`, int64(42)})
+	if !ok {
+		t.Fatalf("bindArgs declined a pair of handled args")
+	}
+	want := `SELECT 'why? \' OR 1=1 --', 42`
+	if got != want {
+		t.Errorf("bindArgs = %q; want %q — the value's own `?` must not consume the next argument and its quote must stay escaped", got, want)
+	}
+}
+
+// TestCHSettings pins the translation of the per-query clickhouse-go
+// Settings map onto ch-go's []ch.Setting, which is what makes the columnar
+// dial run under the SAME server settings as the row path. Two properties
+// carry that guarantee: every key survives with its value stringified (a
+// dropped key means the columnar path silently runs without a memory or
+// execution-time bound the row path enforces), and every setting is marked
+// Important — ch-go's flag for "the server must reject a setting it does not
+// know" rather than ignore it, which is the difference between a failed
+// query and a query that quietly ran unbounded.
+func TestCHSettings(t *testing.T) {
+	in := clickhouse.Settings{
+		"max_memory_usage":       int64(1 << 30),
+		"max_execution_time":     30,
+		"timeout_overflow_mode":  "throw",
+		"optimize_read_in_order": true,
+	}
+	got := chSettings(in)
+	if len(got) != len(in) {
+		t.Fatalf("chSettings returned %d settings; want %d (%+v)", len(got), len(in), got)
+	}
+
+	byKey := map[string]string{}
+	for _, s := range got {
+		if !s.Important {
+			t.Errorf("chSettings key %q: Important = false; want true so the server rejects a setting it does not recognise instead of ignoring it", s.Key)
+		}
+		if _, dup := byKey[s.Key]; dup {
+			t.Errorf("chSettings emitted key %q twice", s.Key)
+		}
+		byKey[s.Key] = s.Value
+	}
+
+	want := map[string]string{
+		"max_memory_usage":       "1073741824",
+		"max_execution_time":     "30",
+		"timeout_overflow_mode":  "throw",
+		"optimize_read_in_order": "true",
+	}
+	keys := make([]string, 0, len(want))
+	for k := range want {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if byKey[k] != want[k] {
+			t.Errorf("chSettings[%q] = %q; want %q", k, byKey[k], want[k])
+		}
+	}
+}
+
+// TestCHSettings_EmptyYieldsNil pins the nil return an empty map produces.
+// ch-go treats a nil settings slice as "send none"; an empty non-nil slice
+// would be equivalent here, but the distinction is asserted because
+// chSettings' doc promises nil and a caller comparing against nil to decide
+// whether to take a settings-free dial path would silently change behaviour.
+func TestCHSettings_EmptyYieldsNil(t *testing.T) {
+	if got := chSettings(nil); got != nil {
+		t.Errorf("chSettings(nil) = %+v; want nil", got)
+	}
+	if got := chSettings(clickhouse.Settings{}); got != nil {
+		t.Errorf("chSettings(empty) = %+v; want nil", got)
+	}
+}

--- a/internal/chclient/columnar_cursor_protocol_test.go
+++ b/internal/chclient/columnar_cursor_protocol_test.go
@@ -119,23 +119,43 @@ func TestColumnarCursor_BudgetLimitPrecedence(t *testing.T) {
 // one row past the cap on every request that reaches the columnar path.
 func TestColumnarCursor_ChargePrecedence(t *testing.T) {
 	t.Run("per-cursor max", func(t *testing.T) {
-		d := &columnarCursor{maxSamples: 2}
-		if !d.charge() || !d.charge() {
-			t.Fatalf("charge() refused within the limit of 2")
+		const limit = 2
+		d := &columnarCursor{maxSamples: limit}
+		// charge() is side-effecting, so "two rows fit" is a claim about two
+		// DISTINCT calls. Each is charged and asserted on its own, and the
+		// consumed count is checked afterwards, so the claim rests on
+		// something observable rather than on the evaluation order of a
+		// compound condition.
+		for i := int64(1); i <= limit; i++ {
+			if !d.charge() {
+				t.Fatalf("charge() #%d refused within a maxSamples of %d", i, limit)
+			}
+		}
+		if d.seen != limit {
+			t.Fatalf("after %d successful charges, seen = %d; want %d", limit, d.seen, limit)
 		}
 		if d.charge() {
-			t.Errorf("charge() past a maxSamples of 2 = true; want false")
+			t.Errorf("charge() #%d past a maxSamples of %d = true; want false", limit+1, limit)
 		}
 	})
 	t.Run("shared budget wins", func(t *testing.T) {
 		// A generous per-cursor max with a tight shared budget: only if the
-		// shared budget takes precedence does the third charge fail.
-		d := &columnarCursor{maxSamples: 1000, budget: NewSampleBudget(2)}
-		if !d.charge() || !d.charge() {
-			t.Fatalf("charge() refused within the shared budget of 2")
+		// shared budget takes precedence does the third charge fail. Same
+		// per-call shape as above, for the same reason.
+		const sharedLimit = 2
+		const generousPerCursorMax = 1000
+		d := &columnarCursor{maxSamples: generousPerCursorMax, budget: NewSampleBudget(sharedLimit)}
+		for i := int64(1); i <= sharedLimit; i++ {
+			if !d.charge() {
+				t.Fatalf("charge() #%d refused within a shared budget of %d", i, sharedLimit)
+			}
+		}
+		if d.seen != sharedLimit {
+			t.Fatalf("after %d successful charges, seen = %d; want %d", sharedLimit, d.seen, sharedLimit)
 		}
 		if d.charge() {
-			t.Errorf("charge() past a shared budget of 2 = true; want false despite maxSamples=1000")
+			t.Errorf("charge() #%d past a shared budget of %d = true; want false despite maxSamples=%d",
+				sharedLimit+1, sharedLimit, generousPerCursorMax)
 		}
 	})
 	t.Run("unbounded when neither is set", func(t *testing.T) {

--- a/internal/chclient/columnar_cursor_protocol_test.go
+++ b/internal/chclient/columnar_cursor_protocol_test.go
@@ -1,0 +1,198 @@
+package chclient
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestColumnarCursor_IterationProtocol pins the Cursor contract the columnar
+// decoder must satisfy identically to the row path (cerberus issue #2991).
+// The columnar cursor is an optimisation that replaces rowsCursor for matrix
+// queries, so any divergence in the Next/Sample/Inspected protocol is a
+// silent, shape-dependent wrong answer rather than an error — and only on
+// the optimised path, where the row path stays correct and hides it.
+//
+// Four properties are asserted together because they constrain one another:
+// Next reports whether a row is available, Sample returns the row the LAST
+// successful Next landed on, Inspected counts exactly the Next calls that
+// returned true, and a drained cursor stays drained.
+func TestColumnarCursor_IterationProtocol(t *testing.T) {
+	samples := []Sample{
+		{MetricName: "a", Timestamp: time.Unix(1, 0).UTC(), Value: 1},
+		{MetricName: "b", Timestamp: time.Unix(2, 0).UTC(), Value: 2},
+		{MetricName: "c", Timestamp: time.Unix(3, 0).UTC(), Value: 3},
+	}
+	d := &columnarCursor{samples: samples}
+
+	// Before the first Next, Sample must not hand out a row: a consumer that
+	// reads before advancing gets the zero value, never samples[0].
+	if got := d.Sample(); !reflect.DeepEqual(got, Sample{}) {
+		t.Errorf("Sample() before Next = %+v; want the zero Sample", got)
+	}
+	if got := d.Inspected(); got != 0 {
+		t.Errorf("Inspected() before Next = %d; want 0", got)
+	}
+
+	for i, want := range samples {
+		if !d.Next() {
+			t.Fatalf("Next() at row %d = false; want true (%d rows buffered)", i, len(samples))
+		}
+		if got := d.Sample(); !reflect.DeepEqual(got, want) {
+			t.Errorf("Sample() at row %d = %+v; want %+v", i, got, want)
+		}
+		if got := d.Inspected(); got != int64(i+1) {
+			t.Errorf("Inspected() after %d rows = %d; want %d", i+1, got, i+1)
+		}
+	}
+
+	if d.Next() {
+		t.Errorf("Next() past the last row = true; want false")
+	}
+	// A drained cursor stays drained, and the final Sample is still the last
+	// row rather than the zero value — a consumer that calls Next once too
+	// often must not see the stream restart or the last row vanish.
+	if d.Next() {
+		t.Errorf("second Next() past the last row = true; want false")
+	}
+	if got := d.Sample(); !reflect.DeepEqual(got, samples[len(samples)-1]) {
+		t.Errorf("Sample() after the stream drained = %+v; want the last row %+v", got, samples[len(samples)-1])
+	}
+	if got := d.Inspected(); got != int64(len(samples)) {
+		t.Errorf("Inspected() after draining = %d; want %d — a Next that returned false must not be counted", got, len(samples))
+	}
+	if err := d.Err(); err != nil {
+		t.Errorf("Err() after a clean drain = %v; want nil", err)
+	}
+}
+
+// TestColumnarCursor_LatchedErrorStopsIteration pins the failure half of the
+// same protocol: once the decoder latches an error, Next reports false
+// immediately and Err surfaces that error. A cursor that kept handing out
+// buffered rows after an over-budget latch would serve a TRUNCATED result as
+// though it were complete, which is the exact shape the sample budget exists
+// to turn into a 422.
+func TestColumnarCursor_LatchedErrorStopsIteration(t *testing.T) {
+	sentinel := errors.New("columnar: budget exceeded")
+	d := &columnarCursor{
+		samples: []Sample{{MetricName: "a"}, {MetricName: "b"}},
+		err:     sentinel,
+	}
+	if d.Next() {
+		t.Errorf("Next() with a latched error = true; want false even though rows are buffered")
+	}
+	if got := d.Inspected(); got != 0 {
+		t.Errorf("Inspected() = %d; want 0 — a refused Next is not a consumed row", got)
+	}
+	if !errors.Is(d.Err(), sentinel) {
+		t.Errorf("Err() = %v; want the latched %v", d.Err(), sentinel)
+	}
+}
+
+// TestColumnarCursor_BudgetLimitPrecedence pins the precedence budgetLimit
+// documents: a per-request shared *SampleBudget wins over the per-cursor
+// maxSamples, matching rowsCursor. The number this returns is the limit the
+// over-budget error REPORTS to the client, so getting the precedence
+// backwards tells an operator to raise a knob that is not the binding one.
+func TestColumnarCursor_BudgetLimitPrecedence(t *testing.T) {
+	// The two limits are deliberately different, so "returned the shared
+	// budget's limit" is distinguishable from "returned the per-cursor max".
+	const perCursorMax = 111
+	const sharedLimit = 222
+
+	onlyCursor := &columnarCursor{maxSamples: perCursorMax}
+	if got := onlyCursor.budgetLimit(); got != perCursorMax {
+		t.Errorf("budgetLimit() with no shared budget = %d; want the per-cursor max %d", got, perCursorMax)
+	}
+
+	withShared := &columnarCursor{maxSamples: perCursorMax, budget: NewSampleBudget(sharedLimit)}
+	if got := withShared.budgetLimit(); got != sharedLimit {
+		t.Errorf("budgetLimit() with a shared budget = %d; want the shared limit %d (it takes precedence over the per-cursor max %d)",
+			got, sharedLimit, perCursorMax)
+	}
+}
+
+// TestColumnarCursor_ChargePrecedence pins the same precedence on the
+// consuming side, and the boundary itself. charge() must exhaust at exactly
+// the limit — an off-by-one here either rejects a result that fits or admits
+// one row past the cap on every request that reaches the columnar path.
+func TestColumnarCursor_ChargePrecedence(t *testing.T) {
+	t.Run("per-cursor max", func(t *testing.T) {
+		d := &columnarCursor{maxSamples: 2}
+		if !d.charge() || !d.charge() {
+			t.Fatalf("charge() refused within the limit of 2")
+		}
+		if d.charge() {
+			t.Errorf("charge() past a maxSamples of 2 = true; want false")
+		}
+	})
+	t.Run("shared budget wins", func(t *testing.T) {
+		// A generous per-cursor max with a tight shared budget: only if the
+		// shared budget takes precedence does the third charge fail.
+		d := &columnarCursor{maxSamples: 1000, budget: NewSampleBudget(2)}
+		if !d.charge() || !d.charge() {
+			t.Fatalf("charge() refused within the shared budget of 2")
+		}
+		if d.charge() {
+			t.Errorf("charge() past a shared budget of 2 = true; want false despite maxSamples=1000")
+		}
+	})
+	t.Run("unbounded when neither is set", func(t *testing.T) {
+		d := &columnarCursor{}
+		for i := range 5 {
+			if !d.charge() {
+				t.Fatalf("charge() #%d refused with no budget and no maxSamples; want unbounded", i+1)
+			}
+		}
+	})
+}
+
+// TestColumnarCursor_CloseIsIdempotent pins the once-only span end Close
+// documents. Close is called by both the handler's defer and the drain's
+// error path, so a second End() on an already-ended span is a real
+// possibility; the OpenTelemetry SDK treats it as a no-op but the closeErr
+// must stay stable across calls either way.
+func TestColumnarCursor_CloseIsIdempotent(t *testing.T) {
+	d := &columnarCursor{}
+	first := d.Close()
+	second := d.Close()
+	if first != nil {
+		t.Errorf("first Close() = %v; want nil", first)
+	}
+	if second != first {
+		t.Errorf("second Close() = %v; want the same result as the first (%v)", second, first)
+	}
+}
+
+// TestBreakerScopeString pins the scope vocabulary. breakerScope.String's own
+// doc calls the vocabulary stable because dashboards and runbooks key on
+// these exact strings: they reach operators as the trip metric's cause
+// attribute. Renaming one silently blanks a panel rather than failing
+// anything, so the strings are asserted literally, and the default arm is
+// pinned too — an unmapped scope must read as "unknown" rather than as a
+// number or an empty label.
+func TestBreakerScopeString(t *testing.T) {
+	cases := []struct {
+		scope breakerScope
+		want  string
+	}{
+		{breakerScopeServerHealth, "server-health"},
+		{breakerScopeStatement, "statement"},
+		{breakerScopeClient, "client"},
+		{breakerScope(99), "unknown"},
+	}
+	seen := map[string]bool{}
+	for _, tc := range cases {
+		if got := tc.scope.String(); got != tc.want {
+			t.Errorf("breakerScope(%d).String() = %q; want %q", int(tc.scope), got, tc.want)
+		}
+		// Two scopes sharing a label would make the trip metric's cause
+		// attribute unable to tell a statement rejection from a server-health
+		// failure — the exact distinction breaker_classify.go exists to draw.
+		if seen[tc.want] {
+			t.Errorf("scope label %q is used by more than one breakerScope", tc.want)
+		}
+		seen[tc.want] = true
+	}
+}

--- a/internal/chclienttest/label_cardinality_test.go
+++ b/internal/chclienttest/label_cardinality_test.go
@@ -1,0 +1,125 @@
+//go:build chdb
+
+package chclienttest
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// labelCardinalitySeedDDL stands in for the loki label-cardinality catalog
+// the /detected_labels read path queries (cerberus issue #2770): one row per
+// distinct label key, carrying that key's cardinality as an unsigned count.
+//
+// The seeded counts are deliberately unequal and NOT in the same order as
+// the label keys sort, so a decoder that paired the two columns by position
+// across rows — or that returned rows in insertion rather than query order —
+// produces a visibly wrong pairing rather than a plausible one.
+const labelCardinalitySeedDDL = `CREATE TABLE label_cardinality_probe (
+    LabelKey String,
+    Cardinality UInt64
+) ENGINE = Memory;
+INSERT INTO label_cardinality_probe VALUES ('service', 12), ('level', 3), ('pod', 4096);`
+
+const labelCardinalityQuery = `SELECT LabelKey, Cardinality FROM label_cardinality_probe ORDER BY LabelKey`
+
+// TestQueryLabelCardinalities is the chDB-backed decode test for the
+// Querier method the loki /detected_labels handler tests run against
+// (cerberus issue #2991). It was added with the catalog read path and had
+// no caller in any test, so the (String, UInt64) decode below had never
+// executed.
+//
+// That gap matters more than an ordinary uncovered method: this Client is
+// the SUBSTRATE the api/loki handler assertions stand on. If it decoded the
+// two columns wrongly, every handler test built on it would agree with the
+// handler about a wrong answer and still pass.
+func TestQueryLabelCardinalities(t *testing.T) {
+	c := NewChDB(t)
+	ctx := context.Background()
+	c.Seed(t, labelCardinalitySeedDDL)
+
+	got, err := c.QueryLabelCardinalities(ctx, labelCardinalityQuery)
+	if err != nil {
+		t.Fatalf("QueryLabelCardinalities: %v", err)
+	}
+
+	// ORDER BY LabelKey: level, pod, service.
+	want := []struct {
+		key         string
+		cardinality uint64
+	}{
+		{"level", 3},
+		{"pod", 4096},
+		{"service", 12},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("QueryLabelCardinalities returned %d rows (%+v); want %d", len(got), got, len(want))
+	}
+	for i, w := range want {
+		if got[i].LabelKey != w.key {
+			t.Errorf("row %d: LabelKey = %q; want %q", i, got[i].LabelKey, w.key)
+		}
+		if got[i].Cardinality != w.cardinality {
+			t.Errorf("row %d (%q): Cardinality = %d; want %d", i, w.key, got[i].Cardinality, w.cardinality)
+		}
+	}
+}
+
+// TestQueryLabelCardinalities_EmptyResult pins the empty-catalog answer.
+// /detected_labels asks this for a stream selector that may match nothing,
+// so "no rows" is an ordinary outcome and must come back as an empty result
+// with a nil error — not as an error the handler would render as a 500, and
+// not as a single zero-valued row.
+func TestQueryLabelCardinalities_EmptyResult(t *testing.T) {
+	c := NewChDB(t)
+	ctx := context.Background()
+	c.Seed(t, labelCardinalitySeedDDL)
+
+	got, err := c.QueryLabelCardinalities(ctx,
+		`SELECT LabelKey, Cardinality FROM label_cardinality_probe WHERE LabelKey = 'absent' ORDER BY LabelKey`)
+	if err != nil {
+		t.Fatalf("QueryLabelCardinalities on an empty result: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("QueryLabelCardinalities on an empty result = %+v; want no rows", got)
+	}
+}
+
+// TestQueryLabelCardinalities_QueryErrorSurfaces pins that a ClickHouse
+// exception reaches the caller as an error rather than as a silently empty
+// catalog. An empty catalog and a failed catalog query are different
+// answers: the first legitimately means "no labels", while the second means
+// the handler must not report that.
+func TestQueryLabelCardinalities_QueryErrorSurfaces(t *testing.T) {
+	c := NewChDB(t)
+	ctx := context.Background()
+	c.Seed(t, labelCardinalitySeedDDL)
+
+	got, err := c.QueryLabelCardinalities(ctx, `SELECT LabelKey, Cardinality FROM no_such_catalog_table`)
+	if err == nil {
+		t.Fatalf("QueryLabelCardinalities against a missing table = %+v, nil error; want an error", got)
+	}
+	if got != nil {
+		t.Errorf("QueryLabelCardinalities returned %+v alongside an error; want nil rows", got)
+	}
+}
+
+// TestQueryLabelCardinalities_InjectedClientError pins the error-only
+// Client's short circuit. NewChDBWithError builds a Querier that fails every
+// call, which is how a handler test drives its ClickHouse-unreachable path;
+// the injected error must be returned as-is so the test can match on it,
+// rather than being wrapped into the query-failure vocabulary and made
+// indistinguishable from a real ClickHouse exception.
+func TestQueryLabelCardinalities_InjectedClientError(t *testing.T) {
+	injected := errors.New("chclienttest: clickhouse unreachable")
+	c := NewChDBWithError(t, injected)
+
+	got, err := c.QueryLabelCardinalities(context.Background(), labelCardinalityQuery)
+	if !errors.Is(err, injected) {
+		t.Errorf("QueryLabelCardinalities on an error-only client = %v; want the injected %v", err, injected)
+	}
+	if got != nil {
+		t.Errorf("QueryLabelCardinalities returned %+v alongside the injected error; want nil rows", got)
+	}
+}

--- a/internal/chopt/resolve_test.go
+++ b/internal/chopt/resolve_test.go
@@ -1125,3 +1125,97 @@ func TestModeString(t *testing.T) {
 		t.Errorf("Permissive.String() = %q; want %q", got, "permissive")
 	}
 }
+
+// TestExplicitlyRequested pins the offline selection read `migrate schema`
+// depends on (cerberus issue #2991). cmd/cerberus's preview has no live
+// ClickHouse to Resolve against, so it decides seven DDL-shaping opt-ins
+// straight off the raw CERBERUS_CH_OPTIMIZATIONS string. A false positive
+// emits DDL for a feature nobody asked for; a false negative silently drops
+// one the operator did ask for. Neither is recoverable by re-running the
+// preview, so the discrimination is asserted rather than assumed:
+//
+//   - one listed id among several must not make its unlisted siblings read
+//     as requested;
+//   - "auto" must NOT stand in for "everything", because every feature this
+//     function is consulted for carries AutoSelect=false and so is reachable
+//     only by being named;
+//   - matching is per whole comma token, never a substring. No two
+//     registered ids contain one another today, so the case that makes this
+//     bite is an UNREGISTERED token that extends or embeds a real id — a
+//     typo, or a future versioned spelling. ExplicitlyRequested deliberately
+//     does not validate tokens against the registry (Resolve does that), so
+//     such a token does reach it, and a substring test would read it as a
+//     request for the id it happens to contain.
+func TestExplicitlyRequested(t *testing.T) {
+	cases := []struct {
+		name      string
+		selection string
+		id        string
+		want      bool
+	}{
+		{"listed id", "map_bucketed_serialization", FeatureMapBucketedSerialization, true},
+		{"listed among siblings", "column_statistics,map_bucketed_serialization,trace_id_projection", FeatureMapBucketedSerialization, true},
+		{"sibling not listed", "column_statistics,trace_id_projection", FeatureMapBucketedSerialization, false},
+		{"auto is not everything", "auto", FeatureMapBucketedSerialization, false},
+		{"off is not everything", "off", FeatureMapBucketedSerialization, false},
+		{"empty selection", "", FeatureMapBucketedSerialization, false},
+		{"whitespace only", "   ", FeatureMapBucketedSerialization, false},
+		{"upper-case selection", "MAP_BUCKETED_SERIALIZATION", FeatureMapBucketedSerialization, true},
+		{"upper-case id", "map_bucketed_serialization", "MAP_BUCKETED_SERIALIZATION", true},
+		{"padded tokens", " column_statistics , map_bucketed_serialization ", FeatureMapBucketedSerialization, true},
+		{"padded id", "map_bucketed_serialization", "  map_bucketed_serialization  ", true},
+		{"empty tokens tolerated", "column_statistics,,,map_bucketed_serialization", FeatureMapBucketedSerialization, true},
+		{"token that extends a real id does not match", "map_bucketed_serialization_v2", FeatureMapBucketedSerialization, false},
+		{"token that prefixes a real id does not match", "map_bucketed", FeatureMapBucketedSerialization, false},
+		{"id embedded mid-token does not match", "no_map_bucketed_serialization", FeatureMapBucketedSerialization, false},
+		{"auto listed alongside an id still finds the id", "auto,downsample_tier", FeatureDownsampleTier, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExplicitlyRequested(tc.selection, tc.id); got != tc.want {
+				t.Errorf("ExplicitlyRequested(%q, %q) = %v; want %v", tc.selection, tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExplicitlyRequested_IgnoresServerVersionAndAutoSelect pins the
+// documented difference from Resolve: ExplicitlyRequested consults neither
+// the server version floor nor Feature.AutoSelect, so its answer is a pure
+// reading of what the operator typed. That is the whole reason the offline
+// preview can use it, and it is why its doc comment warns callers with a
+// live connection off it. The two halves are checked against each other:
+// an id whose feature auto-selects still reads false when unlisted (so the
+// function is not quietly consulting the registry), and a listed id reads
+// true even against a server far below its floor (so the function is not
+// quietly consulting a version).
+func TestExplicitlyRequested_IgnoresServerVersionAndAutoSelect(t *testing.T) {
+	var autoSelected string
+	for _, f := range registry {
+		if f.AutoSelect {
+			autoSelected = f.ID
+			break
+		}
+	}
+	if autoSelected == "" {
+		t.Fatal("registry has no AutoSelect feature; this test's premise no longer holds")
+	}
+	if ExplicitlyRequested("auto", autoSelected) {
+		t.Errorf("ExplicitlyRequested(%q, %q) = true; want false — an auto-selected feature is still not an explicitly requested one",
+			"auto", autoSelected)
+	}
+
+	// Resolve on a server below every floor enables nothing; the same
+	// selection still reads as requested here.
+	enabled, _, err := Resolve(Config{Optimizations: FeatureMapBucketedSerialization, Mode: Permissive}, v(1, 1))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if enabled.Has(FeatureMapBucketedSerialization) {
+		t.Fatalf("Resolve enabled %q on server 1.1; this test's premise no longer holds", FeatureMapBucketedSerialization)
+	}
+	if !ExplicitlyRequested(FeatureMapBucketedSerialization, FeatureMapBucketedSerialization) {
+		t.Errorf("ExplicitlyRequested(%q, %q) = false; want true — the version floor must not reach this function",
+			FeatureMapBucketedSerialization, FeatureMapBucketedSerialization)
+	}
+}

--- a/internal/chplan/equal_invariants_test.go
+++ b/internal/chplan/equal_invariants_test.go
@@ -2530,3 +2530,230 @@ func TestHistogramProjection_Equal_InputNilBoth(t *testing.T) {
 		t.Errorf("both Input nil with equal sibling fields should be Equal")
 	}
 }
+
+// -----------------------------------------------------------------------
+// Lambda / BareIdent / Subscript / LabelJoin — the higher-order-function
+// Expr kinds. This file's header claims exhaustive Equal coverage of the
+// IR; these four kinds were added after it was written and were never
+// enrolled, so their Equal methods reached cerberus issue #2991 with the
+// nil-handling branches below entirely unexercised.
+//
+// Equal is what the optimizer's fixpoint driver uses to decide a rewrite
+// changed nothing and it may stop. An Equal that reports two structurally
+// different trees as equal therefore does not fail — it silently drops the
+// rewrite, and the query is emitted from the pre-rewrite plan.
+// -----------------------------------------------------------------------
+
+func TestLambda_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	a := &chplan.Lambda{Params: []string{"k", "v"}, Body: &chplan.BareIdent{Name: "v"}}
+	b := &chplan.Lambda{Params: []string{"k", "v"}, Body: &chplan.BareIdent{Name: "v"}}
+	if !a.Equal(b) {
+		t.Fatalf("identical Lambda trees should be Equal")
+	}
+	if !b.Equal(a) {
+		t.Fatalf("Equal must be symmetric")
+	}
+}
+
+func TestLambda_Equal_Negative(t *testing.T) {
+	t.Parallel()
+	base := func() *chplan.Lambda {
+		return &chplan.Lambda{Params: []string{"k", "v"}, Body: &chplan.BareIdent{Name: "v"}}
+	}
+	cases := []struct {
+		name  string
+		other chplan.Expr
+	}{
+		{"different param count", &chplan.Lambda{Params: []string{"k"}, Body: &chplan.BareIdent{Name: "v"}}},
+		{"different param name", &chplan.Lambda{Params: []string{"k", "w"}, Body: &chplan.BareIdent{Name: "v"}}},
+		// Param ORDER is load-bearing: `(k, v) -> v` and `(v, k) -> v`
+		// bind the lambda's argument to different columns.
+		{"swapped param order", &chplan.Lambda{Params: []string{"v", "k"}, Body: &chplan.BareIdent{Name: "v"}}},
+		{"different body", &chplan.Lambda{Params: []string{"k", "v"}, Body: &chplan.BareIdent{Name: "k"}}},
+		{"other kind entirely", &chplan.BareIdent{Name: "v"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if base().Equal(tc.other) {
+				t.Errorf("%s should not be Equal", tc.name)
+			}
+			if tc.other.Equal(base()) {
+				t.Errorf("%s should not be Equal (reverse)", tc.name)
+			}
+		})
+	}
+}
+
+// TestLambda_Equal_BodyNil pins the `l.Body == nil || o.Body == nil`
+// branch. Mutating `||` to `&&` makes the one-sided case fall through to
+// `l.Body.Equal(o.Body)` and dereference a nil Expr.
+func TestLambda_Equal_BodyNil(t *testing.T) {
+	t.Parallel()
+	nilBody := &chplan.Lambda{Params: []string{"v"}}
+	withBody := &chplan.Lambda{Params: []string{"v"}, Body: &chplan.BareIdent{Name: "v"}}
+	if nilBody.Equal(withBody) {
+		t.Errorf("nil vs non-nil Body should not be Equal")
+	}
+	if withBody.Equal(nilBody) {
+		t.Errorf("nil vs non-nil Body should not be Equal (reverse)")
+	}
+	if !nilBody.Equal(&chplan.Lambda{Params: []string{"v"}}) {
+		t.Errorf("both Body nil with equal Params should be Equal")
+	}
+}
+
+func TestBareIdent_Equal(t *testing.T) {
+	t.Parallel()
+	a := &chplan.BareIdent{Name: "v"}
+	if !a.Equal(&chplan.BareIdent{Name: "v"}) {
+		t.Errorf("identical BareIdent should be Equal")
+	}
+	if a.Equal(&chplan.BareIdent{Name: "k"}) {
+		t.Errorf("different Name should not be Equal")
+	}
+	// A BareIdent renders unquoted while a ColumnRef renders backticked, so
+	// the two are different SQL even for the same spelling — that
+	// distinction is the whole reason BareIdent exists (see its doc
+	// comment), and Equal must not conflate them.
+	if a.Equal(&chplan.ColumnRef{Name: "v"}) {
+		t.Errorf("BareIdent should not Equal a ColumnRef with the same Name")
+	}
+}
+
+func TestSubscript_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	a := &chplan.Subscript{Container: &chplan.BareIdent{Name: "arr"}, Key: &chplan.BareIdent{Name: "i"}}
+	b := &chplan.Subscript{Container: &chplan.BareIdent{Name: "arr"}, Key: &chplan.BareIdent{Name: "i"}}
+	if !a.Equal(b) {
+		t.Fatalf("identical Subscript trees should be Equal")
+	}
+	if !b.Equal(a) {
+		t.Fatalf("Equal must be symmetric")
+	}
+}
+
+func TestSubscript_Equal_Negative(t *testing.T) {
+	t.Parallel()
+	base := func() *chplan.Subscript {
+		return &chplan.Subscript{Container: &chplan.BareIdent{Name: "arr"}, Key: &chplan.BareIdent{Name: "i"}}
+	}
+	cases := []struct {
+		name  string
+		other chplan.Expr
+	}{
+		{"different Container", &chplan.Subscript{Container: &chplan.BareIdent{Name: "other"}, Key: &chplan.BareIdent{Name: "i"}}},
+		{"different Key", &chplan.Subscript{Container: &chplan.BareIdent{Name: "arr"}, Key: &chplan.BareIdent{Name: "j"}}},
+		// Container and Key are both arbitrary Exprs, so a comparison that
+		// checked the pair as an unordered set would call these equal —
+		// `arr[i]` and `i[arr]` are not the same read.
+		{"Container and Key swapped", &chplan.Subscript{Container: &chplan.BareIdent{Name: "i"}, Key: &chplan.BareIdent{Name: "arr"}}},
+		{"other kind entirely", &chplan.BareIdent{Name: "arr"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if base().Equal(tc.other) {
+				t.Errorf("%s should not be Equal", tc.name)
+			}
+			if tc.other.Equal(base()) {
+				t.Errorf("%s should not be Equal (reverse)", tc.name)
+			}
+		})
+	}
+}
+
+// TestSubscript_Equal_NilBranches pins both nil guards independently.
+// Subscript carries TWO optional child Exprs, so each guard has its own
+// one-sided-nil and both-nil case, and the Key guard is only reachable
+// once the Container comparison has passed.
+func TestSubscript_Equal_NilBranches(t *testing.T) {
+	t.Parallel()
+	container := &chplan.BareIdent{Name: "arr"}
+	key := &chplan.BareIdent{Name: "i"}
+
+	t.Run("one-sided nil Container", func(t *testing.T) {
+		t.Parallel()
+		a := &chplan.Subscript{Key: key}
+		b := &chplan.Subscript{Container: container, Key: key}
+		if a.Equal(b) || b.Equal(a) {
+			t.Errorf("nil vs non-nil Container should not be Equal")
+		}
+	})
+	t.Run("both Containers nil compares the Keys", func(t *testing.T) {
+		t.Parallel()
+		if !(&chplan.Subscript{Key: key}).Equal(&chplan.Subscript{Key: &chplan.BareIdent{Name: "i"}}) {
+			t.Errorf("both Container nil with equal Keys should be Equal")
+		}
+		if (&chplan.Subscript{Key: key}).Equal(&chplan.Subscript{Key: &chplan.BareIdent{Name: "j"}}) {
+			t.Errorf("both Container nil with DIFFERENT Keys should not be Equal — the nil guard must not short-circuit past the Key check")
+		}
+	})
+	t.Run("one-sided nil Key", func(t *testing.T) {
+		t.Parallel()
+		a := &chplan.Subscript{Container: container}
+		b := &chplan.Subscript{Container: container, Key: key}
+		if a.Equal(b) || b.Equal(a) {
+			t.Errorf("nil vs non-nil Key should not be Equal")
+		}
+	})
+	t.Run("both Keys nil", func(t *testing.T) {
+		t.Parallel()
+		if !(&chplan.Subscript{Container: container}).Equal(&chplan.Subscript{Container: &chplan.BareIdent{Name: "arr"}}) {
+			t.Errorf("both Key nil with equal Containers should be Equal")
+		}
+	})
+}
+
+func TestLabelJoin_Equal_Positive(t *testing.T) {
+	t.Parallel()
+	mk := func() *chplan.LabelJoin {
+		return &chplan.LabelJoin{
+			Map:       &chplan.ColumnRef{Name: "Attributes"},
+			Dst:       "dst",
+			Separator: "-",
+			Srcs:      []string{"a", "b"},
+		}
+	}
+	if !mk().Equal(mk()) {
+		t.Fatalf("identical LabelJoin trees should be Equal")
+	}
+}
+
+func TestLabelJoin_Equal_Negative(t *testing.T) {
+	t.Parallel()
+	base := func() *chplan.LabelJoin {
+		return &chplan.LabelJoin{
+			Map:       &chplan.ColumnRef{Name: "Attributes"},
+			Dst:       "dst",
+			Separator: "-",
+			Srcs:      []string{"a", "b"},
+		}
+	}
+	cases := []struct {
+		name  string
+		other chplan.Expr
+	}{
+		{"different Dst", &chplan.LabelJoin{Map: &chplan.ColumnRef{Name: "Attributes"}, Dst: "other", Separator: "-", Srcs: []string{"a", "b"}}},
+		{"different Separator", &chplan.LabelJoin{Map: &chplan.ColumnRef{Name: "Attributes"}, Dst: "dst", Separator: "_", Srcs: []string{"a", "b"}}},
+		{"different Srcs length", &chplan.LabelJoin{Map: &chplan.ColumnRef{Name: "Attributes"}, Dst: "dst", Separator: "-", Srcs: []string{"a"}}},
+		{"different Srcs content", &chplan.LabelJoin{Map: &chplan.ColumnRef{Name: "Attributes"}, Dst: "dst", Separator: "-", Srcs: []string{"a", "c"}}},
+		// label_join concatenates src values IN ORDER, so reordering Srcs
+		// produces a different joined value for the same input series.
+		{"reordered Srcs", &chplan.LabelJoin{Map: &chplan.ColumnRef{Name: "Attributes"}, Dst: "dst", Separator: "-", Srcs: []string{"b", "a"}}},
+		{"different Map", &chplan.LabelJoin{Map: &chplan.ColumnRef{Name: "ResourceAttributes"}, Dst: "dst", Separator: "-", Srcs: []string{"a", "b"}}},
+		{"other kind entirely", &chplan.ColumnRef{Name: "Attributes"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if base().Equal(tc.other) {
+				t.Errorf("%s should not be Equal", tc.name)
+			}
+			if tc.other.Equal(base()) {
+				t.Errorf("%s should not be Equal (reverse)", tc.name)
+			}
+		})
+	}
+}

--- a/internal/solver/config_env_test.go
+++ b/internal/solver/config_env_test.go
@@ -253,3 +253,123 @@ func TestConfigFromEnv_RouteMemoReValidationFractionExplicitSet(t *testing.T) {
 		t.Fatalf("explicit route-memo-revalidation-fraction config failed Validate: %v", err)
 	}
 }
+
+// TestConfigFromEnv_EveryKnobReachesItsOwnField (cerberus issue #2991) pins
+// the whole env-to-field ladder at once. ConfigFromEnv threads thirteen
+// knobs through a repetitive `if cfg.X, err = envT(EnvX, cfg.X); err != nil`
+// chain, and every line of it is one copy-paste away from being silently
+// wrong in a way the compiler cannot see: the knobs share only four
+// underlying types (int, int64, bool, time.Duration), so pairing EnvMaxK
+// with cfg.MaxKWithEstimate — or reading one knob into two fields and
+// leaving a third at its default — builds and runs.
+//
+// Every var is therefore set to a value distinct from every other AND from
+// its own default, and every field is checked. A crossed pair lands another
+// knob's distinct value; a dropped knob leaves the default. Both read as a
+// named mismatch rather than as a coincidence.
+func TestConfigFromEnv_EveryKnobReachesItsOwnField(t *testing.T) {
+	t.Setenv(EnvRoute, ModeSharded)
+	t.Setenv(EnvMinFanout, "11")
+	t.Setenv(EnvMinAnchorPairs, "12")
+	t.Setenv(EnvMaxK, "13")
+	t.Setenv(EnvMinAnchorsPerSlice, "14")
+	t.Setenv(EnvParallel, "15")
+	t.Setenv(EnvTimeout, "16s")
+	t.Setenv(EnvMaxOutputRows, "17")
+	t.Setenv(EnvAdaptiveEnabled, "false")
+	t.Setenv(EnvRouteMemoEntryTTL, "18m")
+	t.Setenv(EnvRouteMemoRevalFrac, "19")
+	t.Setenv(EnvEstimateNearEmptyRowFloor, "20")
+	t.Setenv(EnvMaxKWithEstimate, "21")
+	t.Setenv(EnvEstimateMinRowsPerAdditionalShard, "22")
+
+	cfg, err := ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("ConfigFromEnv() error = %v", err)
+	}
+
+	def := DefaultConfig()
+	checks := []struct {
+		env  string
+		got  any
+		want any
+		def  any
+	}{
+		{EnvRoute, cfg.Mode, ModeSharded, def.Mode},
+		{EnvMinFanout, cfg.MinFanout, 11, def.MinFanout},
+		{EnvMinAnchorPairs, cfg.MinAnchorPairs, 12, def.MinAnchorPairs},
+		{EnvMaxK, cfg.MaxK, 13, def.MaxK},
+		{EnvMinAnchorsPerSlice, cfg.MinAnchorsPerSlice, 14, def.MinAnchorsPerSlice},
+		{EnvParallel, cfg.Parallel, 15, def.Parallel},
+		{EnvTimeout, cfg.Timeout, 16 * time.Second, def.Timeout},
+		{EnvMaxOutputRows, cfg.MaxOutputRows, int64(17), def.MaxOutputRows},
+		{EnvAdaptiveEnabled, cfg.AdaptiveEnabled, false, def.AdaptiveEnabled},
+		{EnvRouteMemoEntryTTL, cfg.RouteMemoEntryTTL, 18 * time.Minute, def.RouteMemoEntryTTL},
+		{EnvRouteMemoRevalFrac, cfg.RouteMemoReValidationFraction, 19, def.RouteMemoReValidationFraction},
+		{EnvEstimateNearEmptyRowFloor, cfg.EstimateNearEmptyRowFloor, int64(20), def.EstimateNearEmptyRowFloor},
+		{EnvMaxKWithEstimate, cfg.MaxKWithEstimate, 21, def.MaxKWithEstimate},
+		{EnvEstimateMinRowsPerAdditionalShard, cfg.EstimateMinRowsPerAdditionalShard, int64(22), def.EstimateMinRowsPerAdditionalShard},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: field = %v; want %v", c.env, c.got, c.want)
+		}
+		// The whole design of this test is that "still at the default" is
+		// distinguishable from "took the env value". Assert that premise
+		// rather than trusting it: a knob whose chosen value happens to
+		// equal its own default proves nothing about the wiring.
+		if c.want == c.def {
+			t.Errorf("%s: chosen value %v equals the default; pick a different one so this test can discriminate", c.env, c.want)
+		}
+	}
+}
+
+// TestConfigFromEnv_MalformedKnobFailsFast pins the parse-vs-silent-default
+// contract ConfigFromEnv's doc states: "A parse failure on any knob is
+// returned so a typo never silently routes (or never silently disables
+// routing)." A knob that swallowed its parse error would boot the gateway on
+// a threshold the operator never chose — a wrong routing decision on every
+// subsequent query, with nothing in the logs. Each knob is checked
+// separately, because the ladder returns on the FIRST error and a knob whose
+// error arm was dropped would otherwise be masked by an earlier one.
+//
+// The returned error must name the offending variable: startup failure text
+// is the only thing the operator has to go on.
+func TestConfigFromEnv_MalformedKnobFailsFast(t *testing.T) {
+	// Values are malformed for the knob's own type, not merely out of range
+	// — range is Validate's job, which ConfigFromEnv deliberately does not run.
+	cases := []struct{ env, bad string }{
+		{EnvMinFanout, "three"},
+		{EnvMinAnchorPairs, "3.5"},
+		{EnvMaxK, "0x10"},
+		{EnvMinAnchorsPerSlice, "1,2"},
+		{EnvParallel, "many"},
+		{EnvTimeout, "16 seconds"},
+		{EnvMaxOutputRows, "1e6"},
+		{EnvAdaptiveEnabled, "yes-please"},
+		{EnvLegacyRouteMemoEnabled, "sometimes"},
+		{EnvRouteMemoEntryTTL, "18 minutes"},
+		{EnvRouteMemoRevalFrac, "half"},
+		{EnvEstimateNearEmptyRowFloor, "lots"},
+		{EnvMaxKWithEstimate, "some"},
+		{EnvEstimateMinRowsPerAdditionalShard, "9_000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv(tc.env, tc.bad)
+			cfg, err := ConfigFromEnv()
+			if err == nil {
+				t.Fatalf("ConfigFromEnv() with %s=%q: error = nil, want a parse failure (got cfg %+v)", tc.env, tc.bad, cfg)
+			}
+			if !strings.Contains(err.Error(), tc.env) {
+				t.Errorf("ConfigFromEnv() error = %q; want it to name %s so the operator can find the typo", err, tc.env)
+			}
+			if !strings.Contains(err.Error(), tc.bad) {
+				t.Errorf("ConfigFromEnv() error = %q; want it to quote the rejected value %q", err, tc.bad)
+			}
+			if cfg != (Config{}) {
+				t.Errorf("ConfigFromEnv() returned %+v alongside an error; want the zero Config so a caller that ignores err cannot boot on a half-parsed one", cfg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Seven of the eight packages sitting below their committed coverage floors are back above them,
with real tests. No floor was lowered, no package excluded, and **no production file changed** —
`git diff --name-only origin/main | grep -v _test.go` is empty.

Refs #2991 (that issue also needs the gate-honesty fix, which is not in this PR).

## The floors were lost to untested new code, not to retired tests

This is the headline finding, and it contradicts the obvious suspicion. This milestone deleted a
lot of code (#2961, #2963, #2977, #2980) and retired a lot of tests (#2966, #2968, #2975, #2986,
#2990), so the natural reading is that a retired test took its coverage with it.

**It did not. Not one of the seven drops is a deleted or narrowed test.** Every single one is
production code that merged after the 2026-08-24/28 ratchet without the tests to go with it —
traced per package to the PR that added it, below. **None of the five test-retiring PRs is
implicated in any of the seven.** A reader coming to this later should not assume otherwise;
the fix for this class is test discipline on incoming features, not caution about retiring
dead tests.

## Measured before/after

The default-tag lane run under `-coverpkg` restricted to these packages reproduces CI's ledger
**exactly**, package for package, so the numbers below are directly comparable to the ones
#2991 quotes.

| package | before | after | floor | lane |
| --- | --- | --- | --- | --- |
| `cmd/cerberus` | 53.56% | **57.87%** | 55.7% | default |
| `internal/api/info` | 95.56% | **100.00%** | 99% | default |
| `internal/chclient` | 64.85% | **69.08%** | 67.9% | default |
| `internal/chclienttest` | 72.21% | **76.02%** | 74.4% | chdb |
| `internal/chopt` | 96.34% | **97.56%** | 96.9% | default |
| `internal/chplan` | 94.19% | **94.85%** | 94.3% | default |
| `internal/solver` | 88.05% | **90.61%** | 88.4% | default |

`internal/chclienttest` is `//go:build chdb` throughout, so it was measured over the chdb-tagged
binaries that link it (`internal/api/{loki,prom,tempo,tempo/grpc}`, `test/integration/*`,
`test/consumer-corpus`, and its own). That subset's before-figure is 72.21% (265/367) — CI's
number to the digit — which is what makes its after-figure trustworthy.

## What actually caused each drop

- **`internal/api/info`** — #2846 and #2851 added the loki and Tempo catalog view-refresh
  resolvers and their `/info` rendering. No test ever wired either closure, so only the nil
  branch of `info.go`'s `lokiCatalogViewRefreshInfoNow` and its Tempo sibling ran.
- **`internal/chopt`** — #2799 (2026-08-31) added the exported `resolve.go`'s
  `ExplicitlyRequested` with no test at all. `cmd_migrate.go` decides seven DDL-shaping opt-ins
  with it in the offline `migrate schema` preview, which has no live server to `Resolve` against.
- **`internal/solver`** — #2836 extended `ConfigFromEnv`'s knob ladder to thirteen entries. Ten
  were never set by any test, and neither were the fail-fast arms of `envInt` / `envInt64` /
  `envBool` / `envDuration`.
- **`internal/chclient`** — the columnar path's own SQL binder (`columnar_support.go`'s
  `bindArgs`, `formatArg`, `chSettings`) and the `columnar.go`'s `columnarCursor` iteration
  protocol had no tests; `bindArgs` was at 10.7% and `formatArg` at 0%.
- **`cmd/cerberus`** — `cmd_optdocs.go`, the generator behind the
  `docs/clickhouse-optimizations.md` drift gate, was uncovered end to end.
- **`internal/chplan`** — `equal_invariants_test.go`'s header claims exhaustive `Equal` coverage
  of the IR, but `Lambda`, `BareIdent`, `Subscript` and `LabelJoin` were added after it was
  written and never enrolled, leaving their nil-handling branches unexercised.
- **`internal/chclienttest`** — #2846 added `client.go`'s `QueryLabelCardinalities`, the
  chDB-backed half of the loki `/detected_labels` catalog read path, and nothing called it.

## Every test was checked against a broken production tree

Each non-trivial test was verified by mutating the code it covers and confirming it goes red,
then reverting. Twenty-two mutants, all killed:

| # | mutation | caught by |
| --- | --- | --- |
| A | cross the loki and Tempo catalog resolvers in `snapshotResponse` | `TestInfo_CatalogViewRefreshConfigured` |
| B | mis-pair two of the four consecutive string fields in the catalog conversion | both catalog tests |
| C | `ExplicitlyRequested` matches substrings instead of whole tokens | `TestExplicitlyRequested` |
| D | `ExplicitlyRequested` treats `auto` as a request for auto-selected features | `..._IgnoresServerVersionAndAutoSelect` |
| E | `EnvMaxKWithEstimate` read into `Config.MaxK` | `TestConfigFromEnv_EveryKnobReachesItsOwnField` |
| F | `envInt64` swallows its parse error and returns the default | `TestConfigFromEnv_MalformedKnobFailsFast` |
| G | `sqlStringEscaper` stops escaping backslashes | `TestFormatArg_EscapesStringLiterals` |
| H | `bindArgs` accepts an argument/placeholder count mismatch | `TestBindArgs_DeclinesOnMismatch` |
| I | `formatArg` stringifies unknown types instead of declining | `TestFormatArg_DeclinesUnhandledTypes` |
| J | `columnarCursor.Inspected` reports charged rows, not consumed rows | `TestColumnarCursor_IterationProtocol` |
| K | `columnarCursor.Sample` off by one | `TestColumnarCursor_IterationProtocol` |
| L | `budgetLimit` precedence inverted (per-cursor max over shared budget) | `TestColumnarCursor_BudgetLimitPrecedence` |
| M | `charge` boundary `>` to `>=` | `TestColumnarCursor_ChargePrecedence/per-cursor_max` |
| N | `charge` drops the shared-budget branch so the per-cursor max governs | `..._ChargePrecedence/shared_budget_wins` |
| O | `charge` stops incrementing the consumed-row counter | both `..._ChargePrecedence` subtests |
| P | `optdocReplaceBlock` stops at the END marker instead of past it | `TestOptdocReplaceBlock_PreservesSurroundingProse` |
| Q | reversed markers no longer rejected | `..._RejectsMalformedMarkers` |
| R | `optdocDashes` no longer floors at 1 | `TestOptdocSpacesAndDashes` |
| S | `-check` writes instead of reporting drift | `TestOptdocsGenerate_...` |
| T | the `AlwaysAvailable` floor renders as `0.0` instead of `none` | `TestOptdocRenderMinVersion` |
| U | `Subscript.Equal` / `Lambda.Equal` nil guards `\|\|` to `&&` (three mutants) | `TestSubscript_Equal_NilBranches`, `TestLambda_Equal_BodyNil` |
| V | `LabelJoin.Equal` ignores `Srcs` | `TestLabelJoin_Equal_Negative` |
| W | `QueryLabelCardinalities` decodes every cardinality as zero | `TestQueryLabelCardinalities` |
| X | a failed catalog query returns an empty catalog and a nil error | `..._QueryErrorSurfaces` |

Three first attempts were caught by that discipline and rewritten rather than kept:

- The `ExplicitlyRequested` substring cases originally named two feature ids that do **not**
  contain one another, so mutant C survived. No two registered ids contain one another today,
  so the cases now use an unregistered token that extends or embeds a real id — a typo or a
  future versioned spelling, which does reach the function because it deliberately does not
  validate against the registry.
- A first `LabelJoin.Equal` mutant removed `slices.Equal` and left the `slices` import unused,
  so it did not compile. An uncompilable mutant is not a survivor and is not a kill either; it
  was replaced with one that compiles.
- `TestColumnarCursor_ChargePrecedence` first spelled its two consumptions as
  `!d.charge() || !d.charge()`, which staticcheck rejects under SA4000. Because `charge()` is
  side-effecting, those operands were two distinct calls and both ran on every path that
  continued, so the assertion was not in fact vacuous — but the form showed neither a reader
  nor an analyser that two charges happen, and would have turned vacuous without a sound had
  `charge()` ever been made pure. Each consumption is now charged and asserted on its own call,
  and the consumed count is asserted afterwards, so "both calls ran" is observed rather than
  inferred from short-circuit order. Mutants M, N and O are the re-verification.

## Not fixed here

`internal/qlcommon` (98.17% against a 99% floor) is filed as #2995. Its drop is a different
shape: #2977 planted five progress-invariant guard statements that are unreachable by
construction, and the shortfall is exactly their size. Restoring the floor means reaching five
genuine capture-probe declines in `capture_probe.go` and lands at 99.08% — a 0.08pp margin. That
needs real regex-planner reasoning rather than a line-touching test, so it was filed with the
arithmetic instead of rushed.
