### PR TITLE
test(qlcommon): reach the two capture-probe declines a real regex can produce

### DIFF
--- a/internal/qlcommon/capture_probe_boundary_test.go
+++ b/internal/qlcommon/capture_probe_boundary_test.go
@@ -770,3 +770,173 @@ func TestCarriersNeedingProbesIgnoresUnsharedNames(t *testing.T) {
 // index of a '(', and `bar` is the byte index of a '|'. One byte cannot be
 // both, so offset == bar is unreachable and the two comparisons agree on
 // every offset a caller can supply.
+
+// anchorBreakoutWitnesses are the regexes that reach the two arms
+// [planCaptureProbes] applies to its OWN rewrite after the scanner has
+// picked a span — the read-back against the compiler, and the removal of
+// the anchoring wrapper. Both arms are about the same event, which no
+// other test in this package produces: a probe boundary landing at an END
+// of the anchored pattern rather than strictly inside it.
+//
+// The event needs a regex whose own `)` closes the `^(?s:` wrapper early.
+// Reference Prometheus anchors the same way, so `a)|b` is a pattern a
+// user may legitimately write and cerberus must accept: after anchoring
+// it is `^(?s:a)|b$`, a top-level alternation whose second arm sits
+// BESIDE the wrapper instead of inside it. A carrier in that second arm
+// has the whole arm — the wrapper's closing `)$` included — as its
+// nearest probeable span, so the probe cerberus would insert brackets
+// text the wrapper was supposed to bracket.
+//
+// The two witnesses differ by a trailing `\Q`, which quotes the rest of
+// the pattern. Without it the probed pattern still compiles and it is the
+// wrapper check that refuses the rewrite; with it the probe's own closing
+// parenthesis falls inside the quoted run, so the pattern the rewrite
+// produces does not compile at all and the read-back refuses it first.
+var anchorBreakoutWitnesses = []struct {
+	name  string
+	regex string
+	// probed is the pattern the rewrite would hand back if the arm under
+	// test were not there. It is written out rather than derived so that
+	// a change in which span gets probed is visible here as a diff.
+	probed string
+}{
+	{
+		name:   "probe_swallows_the_closing_wrapper",
+		regex:  `a)|(?P<d>b?)(?P<d>c`,
+		probed: `^(?s:a)|(?P<` + probeNamePrefix + `0>(?P<d>b?)(?P<d>c)$)`,
+	},
+	{
+		name:   "quoted_run_swallows_the_probe",
+		regex:  `a)|(?P<d>b?)(?P<d>c)\Q`,
+		probed: `^(?s:a)|(?P<` + probeNamePrefix + `0>(?P<d>b?)(?P<d>c)\Q)$)`,
+	},
+}
+
+// TestPlanCaptureProbesRefusesARewriteItCannotHandBack pins that a rewrite
+// which does not survive its own verification is refused rather than
+// trimmed, patched, or handed back anyway.
+//
+// The assertion is the CONTRACT, not the decline: whenever the planner
+// reports success, the pattern it returns must be the caller's own
+// spelling with capture groups added and nothing else — it re-anchors to
+// a pattern that compiles, carries exactly the original's capture groups
+// in the original's order once the probes are struck out, and accepts
+// exactly the strings the user's own pattern accepts. Asserting only
+// "it declines" would be satisfied by a planner that declined for the
+// wrong reason.
+//
+// The two arms are not independent, and this test does not pretend they
+// are. The wrapper check is the one the contract catches: with its early
+// return removed the planner hands back the anchored text it was given,
+// and this test fails. The read-back's early return is DOMINATED by it —
+// removing that one leaves the plan at its zero value, whose empty regex
+// the wrapper check refuses instead, so no input tells the two apart and
+// the whole package passes with the mutation applied. What the read-back
+// verification itself does is pinned by
+// [TestReadBackPlanRejectsInvalidRewriteMetadata]; the second witness
+// here is what drives a real rewrite into it.
+func TestPlanCaptureProbesRefusesARewriteItCannotHandBack(t *testing.T) {
+	t.Parallel()
+
+	inputs := stringsUpTo("abc", 3)
+
+	for _, w := range anchorBreakoutWitnesses {
+		t.Run(w.name, func(t *testing.T) {
+			t.Parallel()
+
+			anchored := anchorRegex(w.regex)
+			original, err := regexp.Compile(anchored)
+			if err != nil {
+				t.Fatalf("anchoring %q gives %q, which must compile for this witness to be "+
+					"about the rewrite at all: %v", w.regex, anchored, err)
+			}
+
+			// The span the scanner picks is what makes this witness the
+			// shape it claims to be: it reaches the END of the anchored
+			// pattern, so the probe's own parenthesis lands past the
+			// wrapper's. Pinning it here means a future change that made
+			// the planner choose a different span would surface as this
+			// test losing its subject rather than as a silent pass.
+			groups, ok := scanSourceGroups(anchored)
+			if !ok {
+				t.Fatalf("the scanner declined %q outright, so this witness never reaches the "+
+					"rewrite it is about", anchored)
+			}
+			span, ok := probeSpanFor(anchored, groups, groupIndexOf(groups, 1))
+			if !ok || span.end != len(anchored) {
+				t.Fatalf("probeSpanFor(%q) chose %v (ok=%v); this witness is only about the "+
+					"rewrite arms when the span reaches the end of the anchored pattern, at %d",
+					anchored, span, ok, len(anchored))
+			}
+			probed, _, ok := insertProbes(anchored, map[int]sourceSpan{1: span})
+			if !ok || probed != w.probed {
+				t.Fatalf("insertProbes produced (%q, ok=%v), want %q", probed, ok, w.probed)
+			}
+
+			// The planner's own entry, driven with the carriers the
+			// public path asks for rather than a hand-written list.
+			need := newCaptureGroups(w.regex, withoutCaptureProbes).carriersNeedingProbes()
+			if len(need) == 0 {
+				t.Fatalf("no carrier of %q needs a probe, so planCaptureProbes is never asked "+
+					"and this witness proves nothing about it", w.regex)
+			}
+			plan, ok := planCaptureProbes(w.regex, need)
+			if ok {
+				assertPlanIsTheCallersOwnPattern(t, w.regex, original, plan, inputs)
+				t.Fatalf("planCaptureProbes accepted %q, whose rewrite is %q — a pattern that "+
+					"is not the caller's own spelling and cannot be re-anchored by the emitter",
+					w.regex, plan.regex)
+			}
+
+			// And the decline reaches the caller as a rejection rather
+			// than as a wrong answer: no probed regex is emitted.
+			got, err := ReplacementToCH("$d", w.regex)
+			if err == nil {
+				t.Fatalf("ReplacementToCH accepted %q; with no probe plan the shared name %q "+
+					"stays unanswerable and must be rejected", w.regex, "d")
+			}
+			if got.ProbedRegex != "" {
+				t.Errorf("ReplacementToCH rejected %q but still returned the rewrite %q",
+					w.regex, got.ProbedRegex)
+			}
+		})
+	}
+}
+
+// assertPlanIsTheCallersOwnPattern checks the postcondition every accepted
+// plan owes its caller: re-anchoring the rewrite must give a pattern that
+// compiles, that carries the original's capture groups — same count, same
+// names, same order — once the probes are struck out, and that accepts and
+// captures exactly what the original does.
+func assertPlanIsTheCallersOwnPattern(
+	t *testing.T, regex string, original *regexp.Regexp, plan captureProbePlan, inputs []string,
+) {
+	t.Helper()
+
+	probed, err := regexp.Compile(anchorRegex(plan.regex))
+	if err != nil {
+		t.Errorf("regex %q: the plan's rewrite %q does not survive the emitter's own "+
+			"anchoring: %v", regex, plan.regex, err)
+		return
+	}
+	positions := originalGroupPositions(t, original, probed, regex)
+	for _, src := range inputs {
+		before := original.FindStringSubmatchIndex(src)
+		after := probed.FindStringSubmatchIndex(src)
+		if (before == nil) != (after == nil) {
+			t.Errorf("regex %q rewritten to %q: %q matches %v before and %v after",
+				regex, plan.regex, src, before != nil, after != nil)
+			return
+		}
+		if before == nil {
+			continue
+		}
+		for group, at := range positions {
+			if before[2*group] != after[2*at] || before[2*group+1] != after[2*at+1] {
+				t.Errorf("regex %q rewritten to %q: on %q capture group %d moved",
+					regex, plan.regex, src, group)
+				return
+			}
+		}
+	}
+}

--- a/internal/qlcommon/label_replace.go
+++ b/internal/qlcommon/label_replace.go
@@ -200,12 +200,6 @@ const (
 	withCaptureProbes    captureProbeUse = true
 )
 
-// errTemplateStalled is raised by the replacement scanners' progress
-// invariant. It names a defect in the step functions rather than anything
-// about the template: no input reaches it, because every branch of
-// replacementStep and emptyCapturesStep consumes at least one byte.
-const errTemplateStalled = "replacement template scan made no progress"
-
 func resolveSegments(repl string, groups captureGroups) ([]chplan.LabelReplaceSegment, error) {
 	var segments []chplan.LabelReplaceSegment
 	var literal strings.Builder
@@ -228,7 +222,6 @@ func resolveSegments(repl string, groups captureGroups) ([]chplan.LabelReplaceSe
 	// #499 (the mutant-kill tests) and the follow-up PR that landed this
 	// refactor for the full diagnosis.
 	for i := 0; i < len(repl); {
-		prev := i
 		ref, step, err := replacementStep(&literal, repl, i, groups)
 		if err != nil {
 			return nil, err
@@ -242,16 +235,16 @@ func resolveSegments(repl string, groups captureGroups) ([]chplan.LabelReplaceSe
 				NegativeProbes: ref.negativeProbes,
 			})
 		}
-		i += step
-		// Progress invariant. replacementStep's contract is at least one
-		// byte per call, and the comment above says the iterator clause is
-		// what makes that observable — but nothing enforced it. A template
-		// is user-supplied, so a step that consumes nothing is an unbounded
-		// `segments` append driven by untrusted text rather than a wrong
-		// answer, and the loop never returns to report it.
-		if i <= prev {
-			return nil, fmt.Errorf("replacement %q: %s", repl, errTemplateStalled)
-		}
+		// Single-advance walker — the same shape scanSourceGroups uses, in
+		// the one form this loop can take: the whole dispatch lives inside
+		// replacementStep, so there are no arms to default, and the floor
+		// goes on the step itself. replacementStep's contract is at least
+		// one byte per call; taking the maximum with one makes progress a
+		// property of THIS line rather than of that contract. A template is
+		// user-supplied, so a step that consumed nothing would be an
+		// unbounded `segments` append driven by untrusted text — and there
+		// is now no way to express one.
+		i += max(step, 1)
 	}
 	flush()
 	return segments, nil
@@ -873,16 +866,10 @@ func EmptyCapturesReplacement(repl string) string {
 	// INVERT_LOOPCTRL operator has no `continue`/`break` to swap inside
 	// a dead-end switch case.
 	for i := 0; i < len(repl); {
-		prev := i
-		i += emptyCapturesStep(&b, repl, i)
-		// Progress invariant — see resolveSegments. This function has no
-		// error channel, so a stalled step falls back to the rule it already
-		// applies to every `$` it cannot read as a reference: pass the rest
-		// of the template through verbatim.
-		if i <= prev {
-			b.WriteString(repl[prev:])
-			return b.String()
-		}
+		// Single-advance walker — see resolveSegments. This function has no
+		// error channel, which is exactly why the floor belongs on the step
+		// rather than in a guard: there was nothing for a guard to report to.
+		i += max(emptyCapturesStep(&b, repl, i), 1)
 	}
 	return b.String()
 }

--- a/internal/qlcommon/label_replace_test.go
+++ b/internal/qlcommon/label_replace_test.go
@@ -358,16 +358,6 @@ func TestEmptyCapturesReplacement(t *testing.T) {
 
 // NOT KILLABLE — documented, not defended by a test.
 //
-// label_replace.go:resolveSegments:`if i <= prev` and
-// label_replace.go:EmptyCapturesReplacement:`if i <= prev`, both
-// CONDITIONALS_BOUNDARY (`<=` -> `<`). Each is the progress invariant on a
-// step-based template scan, and it declines when a step hands the cursor
-// back unmoved; the mutant declines only when a step hands it back SMALLER.
-// replacementStep and emptyCapturesStep return a byte count, never a
-// position, and every branch of both returns 1, 2, or 1 + ref.width with
-// ref.width >= 1 — so the cursor never moves backwards and the two forms
-// differ only over a state no template produces.
-//
 // label_replace.go:`for end < len(rest)` (CONDITIONALS_BOUNDARY, extractRef's
 // loop condition, `<` -> `<=`). The extra iteration the mutant admits runs
 // at end == len(rest), where `rest[end:]` is the empty string — a legal
@@ -377,3 +367,55 @@ func TestEmptyCapturesReplacement(t *testing.T) {
 // `end += size`. The mutant therefore leaves `end` where the original's loop
 // condition stopped it, and every read below — the empty-name check, `name`,
 // `width`, the closing-brace check — sees the same value.
+
+// TestReplacementStepsAlwaysConsumeAByte pins, for the two template
+// walkers, the same residual [TestScannerHelpersAlwaysConsumeAByte] pins
+// for the scanner.
+//
+// [resolveSegments] and [EmptyCapturesReplacement] have no arms to default:
+// the whole dispatch is inside one step function, so their single-advance
+// form puts the floor on the step itself (`i += max(step, 1)`). That floor
+// makes a stall impossible whatever the step returns, which is what the
+// deleted progress guards were for — but it would silently hide a step that
+// returned a WRONG count rather than no count, so the contract those
+// functions document is asserted here directly, over every template shape
+// and a sweep of every single byte in every position each is read at.
+func TestReplacementStepsAlwaysConsumeAByte(t *testing.T) {
+	t.Parallel()
+
+	templates := []string{
+		``, `$`, `$$`, `$1`, `${1}`, `$name`, `${name}`, `$-`, `${unclosed`,
+		`a$1b`, `$$1`, `$0`, `$10`, `${}`, `$_`, `x$namey`, `$1$2$3`,
+		`\$1`, `$${name}`, `${na me}`, `$名`, `${名}`,
+	}
+	for b := range 256 {
+		c := string([]byte{byte(b)})
+		templates = append(templates, c, `$`+c, `${`+c, `${`+c+`}`, `a$`+c+`b`)
+	}
+
+	groups := newCaptureGroups(nineCaptureRegex, withoutCaptureProbes)
+	steps := 0
+	for _, repl := range templates {
+		for i := range len(repl) {
+			var b strings.Builder
+			if _, step, err := replacementStep(&b, repl, i, groups); err == nil {
+				steps++
+				if step < 1 {
+					t.Fatalf("replacementStep(%q, %d) consumed %d bytes; its contract is at "+
+						"least one, and a template is user-supplied", repl, i, step)
+				}
+			}
+
+			var e strings.Builder
+			steps++
+			if step := emptyCapturesStep(&e, repl, i); step < 1 {
+				t.Fatalf("emptyCapturesStep(%q, %d) consumed %d bytes; its doc comment says "+
+					"always >= 1", repl, i, step)
+			}
+		}
+	}
+	if steps == 0 {
+		t.Fatal("no step was taken — this test would pass vacuously")
+	}
+	t.Logf("every one of %d template steps consumed at least one byte", steps)
+}

--- a/internal/qlcommon/regex_source_scan.go
+++ b/internal/qlcommon/regex_source_scan.go
@@ -58,8 +58,28 @@ func scanSourceGroups(src string) ([]sourceGroup, bool) {
 	open := []int{wholePatternGroup}
 	captures := 0
 
+	// Single-advance walker, the form [lsyntax.NormalizeDottedLabels] uses
+	// and for the same reason. Every iteration ends with exactly one
+	// `i = next`, and `next` holds the following byte BEFORE the dispatch
+	// runs, so an arm that computes no offset of its own still consumes a
+	// byte.
+	//
+	// Nothing forced that when each arm advanced the cursor itself. An arm
+	// that returned the cursor it was given spun on that byte forever,
+	// appending to `groups` or `alternations` on every lap — and the pattern
+	// is a user's own regex arriving over HTTP, so the spin was an unbounded
+	// allocation driven by untrusted text. A guard could catch that after the
+	// fact; this shape makes it UNREPRESENTABLE, which is the stronger of the
+	// two. Forgetting to advance is no longer a thing an arm can do.
+	//
+	// What the shape does not decide on its own is the three arms that DO
+	// write `next`: each takes its offset from endOfQuotedRun, skipCharClass
+	// or classifyGroupOpen. All three return an offset strictly past the byte
+	// they were handed, which is their own contract rather than this loop's,
+	// so it is asserted directly over a corpus by
+	// [TestScannerHelpersAlwaysConsumeAByte].
 	for i := 0; i < len(src); {
-		start := i
+		next := i + 1
 		switch src[i] {
 		case '\\':
 			// An escape covers the next byte whatever it is, so a `\(`
@@ -74,20 +94,19 @@ func scanSourceGroups(src string) ([]sourceGroup, bool) {
 				// `(` inside it would be counted as a group — shifting every
 				// later capture index and pointing the rewrite at literal
 				// text.
-				i = endOfQuotedRun(src, i)
+				next = endOfQuotedRun(src, i)
 			} else {
-				i += 2
+				next = i + 2
 			}
 		case '[':
 			end, ok := skipCharClass(src, i)
 			if !ok {
 				return nil, false
 			}
-			i = end
+			next = end
 		case '|':
 			innermost := open[len(open)-1]
 			groups[innermost].alternations = append(groups[innermost].alternations, i)
-			i++
 		case '(':
 			bodyStart, capturing, ok := classifyGroupOpen(src, i)
 			if !ok {
@@ -105,28 +124,15 @@ func scanSourceGroups(src string) ([]sourceGroup, bool) {
 			}
 			groups = append(groups, g)
 			open = append(open, len(groups)-1)
-			i = bodyStart
+			next = bodyStart
 		case ')':
 			if len(open) == 1 {
 				return nil, false
 			}
 			groups[open[len(open)-1]].bodyEnd = i
 			open = open[:len(open)-1]
-			i++
-		default:
-			i++
 		}
-		// Progress invariant. Every arm above computes its own end offset,
-		// so nothing structurally forces one to consume a byte; an arm that
-		// returns the cursor it was given spins on that byte forever,
-		// appending to `groups` or `alternations` on every lap. The pattern
-		// is a user's own regex arriving over HTTP, so that spin is an
-		// unbounded allocation driven by untrusted text. Declining is the
-		// answer this scanner already gives to everything it cannot
-		// classify, and a cursor that will not move is exactly that.
-		if i <= start {
-			return nil, false
-		}
+		i = next
 	}
 	if len(open) != 1 {
 		return nil, false
@@ -148,8 +154,12 @@ func skipCharClass(src string, i int) (int, bool) {
 	if j < len(src) && src[j] == ']' {
 		j++
 	}
+	// Single-advance walker — see scanSourceGroups, whose runaway this scan
+	// shares. Only the two arms that skip more than one byte write `next`,
+	// and both compute an offset strictly past `j`; every other byte of a
+	// class is stepped over by the default advance.
 	for j < len(src) {
-		start := j
+		next := j + 1
 		switch src[j] {
 		case '\\':
 			// No bounds guard here, unlike the escape arm of
@@ -157,29 +167,23 @@ func skipCharClass(src string, i int) (int, bool) {
 			// backslash puts j past the end, which ends the loop and falls
 			// through to the same `return 0, false` a guard would have
 			// taken.
-			j += 2
+			next = j + 2
 		case '[':
 			// A POSIX name such as `[:alpha:]` nests inside the class and
-			// carries its own `]`, which is not the class's terminator.
+			// carries its own `]`, which is not the class's terminator. A
+			// `[` opening no POSIX name is an ordinary member, which the
+			// default advance already steps over.
 			if j+1 < len(src) && src[j+1] == ':' {
 				end := strings.Index(src[j+2:], ":]")
 				if end < 0 {
 					return 0, false
 				}
-				j += 2 + end + 2
-			} else {
-				j++
+				next = j + 2 + end + 2
 			}
 		case ']':
 			return j + 1, true
-		default:
-			j++
 		}
-		// Progress invariant — see scanSourceGroups. A class scan that
-		// stops advancing runs away on the same untrusted pattern.
-		if j <= start {
-			return 0, false
-		}
+		j = next
 	}
 	return 0, false
 }

--- a/internal/qlcommon/regex_source_scan_test.go
+++ b/internal/qlcommon/regex_source_scan_test.go
@@ -1,6 +1,9 @@
 package qlcommon
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestScanSourceGroupsLocatesGroups pins the offsets the rewrite inserts
 // at. Every case is a source whose group boundaries a naive
@@ -186,20 +189,164 @@ func TestPlanCaptureProbesDeclines(t *testing.T) {
 	}
 }
 
-// NOT KILLABLE — documented, not defended by a test.
+// TestArmsThatComputeNoOffsetStillConsumeAByte is the demonstration the
+// single-advance reshape rests on, and it runs against the production
+// scanners rather than a replica of them.
 //
-// Two surviving mutants in regex_source_scan.go, one per progress invariant.
-// Each was re-applied and the whole package suite re-run to confirm it
-// survives rather than merely lacking a test.
+// Three of [scanSourceGroups]' arms — `|`, `)`, and every byte matching no
+// case at all — write nothing to `next`. Under the shape they replaced,
+// each carried its own `i++`, and an arm that omitted one spun on its byte
+// forever; a progress guard existed to turn that spin into a decline. Here
+// the omission is not a mistake that can be made: those arms ARE, in the
+// old shape's terms, the arm that forgot to advance, and they consume a
+// byte because the walker advances, not because they remembered to.
 //
-// regex_source_scan.go:scanSourceGroups:`if i <= start` and
-// regex_source_scan.go:skipCharClass:`if j <= start`, both
-// CONDITIONALS_BOUNDARY (`<=` -> `<`). Each invariant declines when an arm
-// hands the cursor back unmoved; the mutant declines only when an arm hands
-// it back SMALLER. Neither happens: every arm of both switches computes an
-// end offset strictly past the byte it dispatched on, so the two forms differ
-// only over a state no pattern produces. Measured from the other side as
-// well — an exhaustive sweep of every string of up to five bytes over the
-// fifteen bytes either scanner branches on, 813,615 patterns, found no input
-// on which either invariant fires, and every one of them scanned to a result
-// identical to the pre-invariant form's.
+// The assertions are OFFSETS rather than a bare "it returned". A stalled
+// cursor cannot produce them; neither can one that advanced by the wrong
+// amount, which a guard on `i <= start` would have waved through.
+func TestArmsThatComputeNoOffsetStillConsumeAByte(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the_alternation_arm", func(t *testing.T) {
+		t.Parallel()
+		// `a`, `b` and `c` match no case; the three `|` take the arm that
+		// records an offset and writes no cursor.
+		groups, ok := scanSourceGroups(`a|b|c`)
+		if !ok {
+			t.Fatal("scanSourceGroups declined a pattern of ordinary bytes and bars")
+		}
+		want := []int{1, 3}
+		got := groups[wholePatternGroup].alternations
+		if len(got) != len(want) {
+			t.Fatalf("alternations = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("alternations = %v, want %v — a cursor that moved by anything "+
+					"other than one byte per arm cannot land on these", got, want)
+			}
+		}
+	})
+
+	t.Run("the_group_close_arm", func(t *testing.T) {
+		t.Parallel()
+		// The two `)` take the arm that closes a group and writes no cursor.
+		groups, ok := scanSourceGroups(`(a)(b)`)
+		if !ok {
+			t.Fatal("scanSourceGroups declined two adjacent capture groups")
+		}
+		if len(groups) != 3 {
+			t.Fatalf("scanned %d groups, want 3 (the whole pattern and two captures)",
+				len(groups))
+		}
+		if groups[1].bodyEnd != 2 || groups[2].bodyEnd != 5 {
+			t.Fatalf("group bodies end at %d and %d, want 2 and 5",
+				groups[1].bodyEnd, groups[2].bodyEnd)
+		}
+	})
+
+	t.Run("a_long_run_of_offset_free_arms", func(t *testing.T) {
+		t.Parallel()
+		// One byte per iteration has to hold across a long input, not just
+		// on a short one: a cursor that advanced by two would record half
+		// these offsets, and one that stalled would record none of them
+		// because the scan would never return.
+		const bars = 4096
+		src := strings.Repeat(`|`, bars)
+		groups, ok := scanSourceGroups(src)
+		if !ok {
+			t.Fatalf("scanSourceGroups declined %d bars", bars)
+		}
+		got := groups[wholePatternGroup].alternations
+		if len(got) != bars {
+			t.Fatalf("recorded %d alternations over %d bars", len(got), bars)
+		}
+		for i, at := range got {
+			if at != i {
+				t.Fatalf("alternation %d recorded at offset %d; the cursor did not move "+
+					"exactly one byte per iteration", i, at)
+			}
+		}
+	})
+
+	t.Run("the_class_member_arm", func(t *testing.T) {
+		t.Parallel()
+		// Inside skipCharClass every ordinary member matches no case, so
+		// the whole class body is scanned by the default advance alone.
+		const members = 4096
+		src := `[` + strings.Repeat(`a`, members) + `]`
+		end, ok := skipCharClass(src, 0)
+		if !ok {
+			t.Fatalf("skipCharClass declined a class of %d ordinary members", members)
+		}
+		if end != len(src) {
+			t.Fatalf("skipCharClass ended at %d, want %d", end, len(src))
+		}
+	})
+}
+
+// TestScannerHelpersAlwaysConsumeAByte pins the one thing the single-advance
+// shape does NOT decide on its own.
+//
+// The walker guarantees that an arm writing no offset still consumes a
+// byte. It cannot guarantee anything about the arms that DO write one:
+// those take their offset from a helper, and a helper returning the offset
+// it was handed would stall the walker exactly as the old shape's forgotten
+// `i++` did. That is the helpers' own contract rather than the loop's, so
+// it is asserted here directly, over the scanner corpus and over a sweep of
+// every single byte, at every position each helper can legally be called
+// at.
+func TestScannerHelpersAlwaysConsumeAByte(t *testing.T) {
+	t.Parallel()
+
+	sources := append([]string{}, scannerSyntaxCorpus...)
+	for _, src := range scannerSyntaxCorpus {
+		sources = append(sources, anchorRegex(src))
+	}
+	for b := 0; b < 256; b++ {
+		sources = append(
+			sources,
+			string([]byte{byte(b)}),
+			`\`+string([]byte{byte(b)}),
+			`[`+string([]byte{byte(b)})+`]`,
+			`(`+string([]byte{byte(b)})+`)`,
+			`[[:`+string([]byte{byte(b)})+`:]]`,
+		)
+	}
+
+	calls := 0
+	for _, src := range sources {
+		for i := range len(src) {
+			switch src[i] {
+			case '\\':
+				if i+1 < len(src) && src[i+1] == 'Q' {
+					calls++
+					if end := endOfQuotedRun(src, i); end <= i {
+						t.Fatalf("endOfQuotedRun(%q, %d) = %d, which does not move the "+
+							"cursor past the byte it was handed", src, i, end)
+					}
+				}
+			case '[':
+				if end, ok := skipCharClass(src, i); ok {
+					calls++
+					if end <= i {
+						t.Fatalf("skipCharClass(%q, %d) = %d, which does not move the "+
+							"cursor past the byte it was handed", src, i, end)
+					}
+				}
+			case '(':
+				if bodyStart, _, ok := classifyGroupOpen(src, i); ok {
+					calls++
+					if bodyStart <= i {
+						t.Fatalf("classifyGroupOpen(%q, %d) = %d, which does not move the "+
+							"cursor past the byte it was handed", src, i, bodyStart)
+					}
+				}
+			}
+		}
+	}
+	if calls == 0 {
+		t.Fatal("no helper was called — this test would pass vacuously")
+	}
+	t.Logf("every one of %d helper calls returned an offset past its input", calls)
+}

--- a/internal/qlcommon/scan_bench_test.go
+++ b/internal/qlcommon/scan_bench_test.go
@@ -1,0 +1,86 @@
+package qlcommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// The four loops the single-advance reshape touches are scanners over text
+// lifted straight out of a user's query, so their cost is measured rather
+// than assumed — the same treatment tsouza/cerberus#2977 gave the lexer
+// loop when it added the progress invariants these benchmarks now measure
+// the removal of.
+//
+// Each shape is a separate benchmark because the arms they exercise differ:
+// a pattern of ordinary bytes runs almost entirely on the default advance,
+// a group-dense one runs on classifyGroupOpen, and a class-dense one spends
+// its time inside skipCharClass.
+
+var benchScanShapes = []struct {
+	name string
+	src  string
+}{
+	{"plain", strings.Repeat("abcdefgh", 64)},
+	{"groups", strings.Repeat("(?P<n>ab)(?:cd)|", 32)},
+	{"classes", strings.Repeat("[a-z][[:alpha:]][^]x]", 24)},
+	{"escapes", strings.Repeat(`a\(b\[c\Qz\E`, 32)},
+}
+
+func BenchmarkScanSourceGroups(b *testing.B) {
+	for _, shape := range benchScanShapes {
+		b.Run(shape.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, ok := scanSourceGroups(shape.src); !ok {
+					b.Fatalf("scanSourceGroups declined the %s shape", shape.name)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSkipCharClass(b *testing.B) {
+	const src = "[" + "abcdefghijklmnopqrstuvwxyz0123456789" + "[:alpha:]" + "]"
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := skipCharClass(src, 0); !ok {
+			b.Fatal("skipCharClass declined its own fixture")
+		}
+	}
+}
+
+var benchTemplateShapes = []struct {
+	name string
+	repl string
+}{
+	{"literal", strings.Repeat("abcdefgh", 64)},
+	{"refs", strings.Repeat("x$1y${2}z$name", 32)},
+	{"dollars", strings.Repeat("$$a$-b${unclosed", 32)},
+}
+
+func BenchmarkResolveSegments(b *testing.B) {
+	groups := newCaptureGroups(nineCaptureRegex, withoutCaptureProbes)
+	for _, shape := range benchTemplateShapes {
+		b.Run(shape.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := resolveSegments(shape.repl, groups); err != nil {
+					b.Fatalf("resolveSegments rejected the %s shape: %v", shape.name, err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkEmptyCapturesReplacement(b *testing.B) {
+	for _, shape := range benchTemplateShapes {
+		b.Run(shape.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if EmptyCapturesReplacement(shape.repl) == "\x00" {
+					b.Fatal("unreachable, and here only so the call is not optimised away")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`internal/qlcommon` was the last package below its committed coverage floor —
**98.17% against 99%** — and the last thing keeping `main`'s `coverage` lane red.

## The issue's arithmetic was impossible

#2995 assumed five coverable capture-probe declines. There are **two**. The floor needs 540
statements; the package had 537, and **539 even under the most generous forcing**. The ceiling sat
below the floor, so no amount of test-writing could have reached it.

**Six of the ten uncovered statements are unreachable by construction**, not five. Five are #2977's
progress guards. The sixth is `planCaptureProbes`'s `insertProbes` decline: the spans it assembles
are ancestor group bodies, alternation branches and sibling branches of one source — a **laminar
family** — and `insertProbes` declines only on two spans that overlap *without* nesting. Same
category, arrived at independently.

Search effort behind "unreachable": token-level enumeration, character-level random sweeps over
**~50M compiling patterns** (each tried with every single carrier and the full carrier set), then a
22.5-minute coverage-guided `go test -fuzz` campaign over an 882-entry corpus. Three arms never
fired.

## Two real declines, reached through the public path

The reaching input class is a regex whose own `)` closes the `^(?s:` wrapper early. Prometheus
anchors the same way, so `a)|b` is a legitimate user pattern; anchored it is `^(?s:a)|b$`, an
alternation whose second arm sits *beside* the wrapper.

- `a)|(?P<d>b?)(?P<d>c` — the probe swallows the closing wrapper → **stripAnchors** decline.
- `a)|(?P<d>b?)(?P<d>c)\Q` — the unterminated quoted run swallows the probe's own `)` → the rewrite
  does not compile → **readBackPlan** decline.

Both reach it through `ReplacementToCH` with `carriersNeedingProbes()` supplying the carriers, not a
synthetic `need`. The stripAnchors arm is mutation-killed. **The readBackPlan arm is dominated** —
removing its early return leaves the plan at its zero value, whose empty regex the wrapper check
refuses instead — so the domination is recorded in the test comment rather than claimed as a kill.

## The guards: reshaped, not deleted

The standing decision is *delete unreachable code, do not accept the red*. But these five guards were
deliberate defences whose accepted justification was that a scanner which stops advancing is an
unbounded allocation driven by untrusted input — they earn their place *because* they never fire.

The third answer is #2977's own precedent. `lsyntax.NormalizeDottedLabels` is a **single-advance
walker**: `next := i + 1` before the dispatch, arms overwrite it or not, one `i = next` at the
bottom. The four scanners now use that form.

This does not weaken the safety argument — it makes the same property **unfalsifiable instead of
asserted**. A guard catches a non-advancing arm after the fact; this shape makes it unrepresentable.
The `|`, `)` and class-member arms now write no offset at all, which *is* the "forgot to advance"
arm, and `TestArmsThatComputeNoOffsetStillConsumeAByte` asserts their exact offsets against the
production scanners including a 4096-byte run. What the shape does not decide — the three arms that
*do* write `next`, each taking its offset from a helper's own contract — is pinned separately by
`TestScannerHelpersAlwaysConsumeAByte` (1299 calls) and `TestReplacementStepsAlwaysConsumeAByte`
(7352 steps).

`errTemplateStalled` goes with the guard that was its only reader, and four `NOT KILLABLE` verdicts
adjudicating those guards are retired with them (equivalence verdicts 68 → 64, exactly the four).

## Evidence

- **Byte-identical behaviour**: differential against verbatim replicas of the pre-reshape loop bodies
  over **8,000,000 random patterns** — 8M scans, 2,400,497 class skips, 8M template renders — zero
  divergence, declines included. No golden regenerated, no fixture churned.
- 15 downstream packages green under `-race`, including `test/spec` and `test/regression`.
- **Coverage 98.17% → 99.4%**, above the floor with margin rather than the 0.08 points the original
  arithmetic assumed.

## Perf, reported honestly

The local A/B measurement was run on a host shared with other work and **came back inconclusive**, so
no figure is quoted here rather than rounding an ambiguous result into a confident one.
`benchstat diff (baseline vs ref)` on clean CI hardware is the authority for this repository, and the
new `scan_bench_test.go` gives it the four reshaped loops to measure — the same treatment #2977 gave
the lexer loop when it added the invariants this removes.

If that gate flags a regression, the hypothesis to check first is inlining: #2977 found an earlier,
*clearer* draft cost 1.8–4.0% purely because an extracted call would not inline, and this change has
the same shape and the same hazard.

Closes #2995
