### PR TITLE
ci: stop killing nine main-push lanes mid-flight, and make the tier a partition

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -287,7 +287,10 @@ what actually runs.
   editing one line. `CANCEL_COALESCED_WORKFLOWS` is its reasoned complement
   (tsouza/cerberus#2994) — the enrolled workflows for which mid-flight
   cancellation is still correct, each carrying the measurement behind that
-  answer. The two tiers must partition the enrollment exactly, so a newly
+  answer. A lane is queue-coalesced when the trunk would permanently lose a
+  record the successor will not restore AND the measured loss is material;
+  determinism alone does not excuse a kill, since a deterministic verdict still
+  posts a per-commit check-run. The two tiers must partition the enrollment exactly, so a newly
   enrolled workflow cannot inherit cancellation as an unexamined default, and
   the pin is two-sided: a member of either tier that carries the other tier's
   `cancel-in-progress` value fails the audit.

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -284,7 +284,13 @@ what actually runs.
   left 71 of its last 120 push runs killed a median 27 minutes in, against 6
   successes; that is not coalescing, it is starvation. Opting out is a
   declared enrollment here, never something a workflow can do to itself by
-  editing one line.
+  editing one line. `CANCEL_COALESCED_WORKFLOWS` is its reasoned complement
+  (tsouza/cerberus#2994) — the enrolled workflows for which mid-flight
+  cancellation is still correct, each carrying the measurement behind that
+  answer. The two tiers must partition the enrollment exactly, so a newly
+  enrolled workflow cannot inherit cancellation as an unexamined default, and
+  the pin is two-sided: a member of either tier that carries the other tier's
+  `cancel-in-progress` value fails the audit.
   - Env: `CI_LANE_REGISTRY` (optional; default `.github/ci-lanes.json`).
   - Exit: `0` only when enrollment, registry posture, exclusions, and workflow
     expressions agree; `1` on any drift. `main-coalescing.test.mjs` carries the

--- a/.github/scripts/main-coalescing.mjs
+++ b/.github/scripts/main-coalescing.mjs
@@ -84,65 +84,75 @@ export const COALESCED_WORKFLOWS = Object.freeze([
 // # The decision rule (tsouza/cerberus#2994)
 //
 // Cancellation is not uniformly wrong, so enrollment is not uniform. Every
-// enrolled workflow is classified by ONE ordered question, and the answer is
-// recorded next to the name:
+// enrolled workflow answers ONE ordered pair of questions, and its answer is
+// recorded beside its name.
 //
-//   1. Does a superseded run still carry information its successor will not
-//      reproduce? A lane whose output is a deterministic function of the tree
-//      answers NO — the newer tree's verdict is a strict replacement, and the
-//      older run's result is genuinely redundant. A lane that emits a
-//      per-commit measurement, publishes a score, or explores randomly-seeded
-//      input answers YES.
+//   1. Does the trunk permanently lose a record the successor will not
+//      restore? A main-push run measures a commit that is now permanently on
+//      `main`, and the successor measures its OWN commit, never the killed
+//      one — so an unfinished run is a gap in the trunk's record, and the
+//      default answer for a push-triggered lane is YES. A lane answers NO only
+//      when it keeps no durable per-commit record to lose. Determinism alone
+//      is NOT that reason: a deterministic verdict still posts a per-commit
+//      check-run that a release preflight and a bisect both read.
 //   2. If YES, is the measured loss material? Cancellation that lands in the
-//      first quarter of a run and throws away single-digit runner minutes per
-//      day is not worth trading latency-to-HEAD for.
+//      first quarter of a run and discards single-digit minutes per day is not
+//      worth trading latency-to-HEAD for.
 //
 // Only a workflow answering YES to both is queue-coalesced. The rest stay in
 // CANCEL_COALESCED_WORKFLOWS below, and the audit requires the two tiers to
 // partition COALESCED_WORKFLOWS exactly, so a fourteenth enrollment cannot
 // land without an explicit tier and a reason.
 //
-// Figures below are the last ~99 push-on-main runs per workflow over
-// 2026-08-31T06:35Z - 2026-09-03T09:05Z (74.5 h), against a median main-push
-// gap of 38.5 min. A run duration is the median of that workflow's SUCCESSFUL
-// runs, so a lane's fast failures cannot flatter it; a kill point is the
-// median cancelled-run lifetime, expressed against that same duration.
+// The trade this buys is latency, and nothing else. `false` costs no runner
+// minutes: a superseded run is still dropped while PENDING, and a pending run
+// holds no runner. What it can cost is time-to-verdict on HEAD, bounded by one
+// run duration, since GitHub keeps at most one in-progress plus one pending
+// run per group. Suppressing the schedule branch of the expression is part of
+// the same trade: a nightly now queues behind a slow predecessor rather than
+// replacing it, which is immaterial for every enrolled lane here (all are
+// daily crons against runs well under a day).
+//
+// Each member's measured figures live in its own workflow's concurrency
+// comment, at the point where someone would be tempted to flip the line back;
+// the one decisive figure is repeated here so this roster justifies itself.
+// Window: the last ~99 push-on-main runs per workflow over
+// 2026-08-31T06:35Z - 2026-09-03T09:05Z (74.5 h), median main-push gap
+// 38.5 min. A run duration is the median of that workflow's SUCCESSFUL runs,
+// so fast failures cannot flatter a lane.
 export const QUEUE_COALESCED_WORKFLOWS = Object.freeze([
-  // 48% cancelled, 35% of runner minutes (991 min) discarded, 12 of 48 kills
-  // past 90% of a full run. A 34.5-min run against a 38.5-min gap is on the
-  // knife edge. It also carried 30 real failures: cancelling this lane hides
-  // red on the trunk as well as wasting the runner that found it.
+  // Q2 decisive: a 34.5-min run against the 38.5-min gap clears only 57% of
+  // gaps, and 48% of its main-push runs were cancelled.
   '.github/workflows/chdb.yml',
-  // 29% cancelled, 18% of minutes (297 min). Publishes a per-head parity SCORE
-  // to the badges branch and runs the parity ratchet, so a killed run is a
-  // missing datum in the public compatibility record, not a redundant verdict.
+  // Q1 decisive: a main-push run is the only one that publishes the per-head
+  // parity SCORE and runs the parity ratchet, so a kill is a missing datum in
+  // the published record. 29% cancelled.
   '.github/workflows/compatibility.yml',
+  // The founding member (tsouza/cerberus#2991): 66% cancelled against a single
+  // success, 50% of its run-minutes discarded.
   '.github/workflows/coverage.yml',
-  // 36% cancelled, 25% of minutes (517 min), 8 of 36 kills past 90%. Uploads
-  // per-tier run reports that are the evidence half of its coverage ratchet.
+  // Q1 decisive: the tier jobs upload the per-tier reports that are the
+  // evidence half of its coverage ratchet. 36% cancelled.
   '.github/workflows/migration-e2e.yml',
-  // The worst of the set and the closest sibling of the coverage failure: 60%
-  // cancelled, 45% of minutes (1413 min) discarded, 19 of 59 kills past 90% of
-  // a full run, and only 10 successes in 74.5 h. Its 38.6-min run is level with
-  // the 38.5-min median push gap — only 50% of gaps are long enough for a run
-  // to finish — so cancellation coalesced nothing; it starved the lane. Its
-  // output is a per-commit mutation score held to an efficacy threshold, which
-  // its successor does not reproduce for the killed commit.
+  // The worst of the set and the closest sibling of the coverage failure: its
+  // 38.6-min run is level with the 38.5-min median push gap, so only 50% of
+  // gaps are long enough to finish, and it managed 10 successes in 74.5 h
+  // against 60% cancelled.
   '.github/workflows/mutation.yml',
-  // 40% cancelled, 31% of minutes (677 min), 13 of 40 kills past 90%. Merges
-  // shard profiles into one per-commit profile artifact — a measurement.
+  // Q1 decisive: `profile` merges the shard profiles into ONE per-commit
+  // profile artifact. 40% cancelled, 13 of 40 kills past 90% of a full run.
   '.github/workflows/perf-profile.yml',
-  // Enrolled on question 1, not on volume: 19% cancelled and 9% of minutes
-  // (93 min), but `property` runs rapid with an unpinned seed, so every run
-  // explores a DIFFERENT region of the input space. A cancelled run's draws
-  // are never re-drawn by its successor, which makes the loss irreplaceable
-  // rather than merely repeated.
+  // Q1 decisive and unusual: rapid runs with an unpinned seed, so each run
+  // explores a DIFFERENT region of the input space and a cancelled run's draws
+  // are never re-drawn. Enrolled on that, not on its 19% cancellation rate.
   '.github/workflows/property.yml',
-  // Enrolled on kill efficiency: only 21% cancelled, but the median kill lands
-  // at 86% of a completed run — the latest in the whole set — and 8 of 21 kills
-  // land past 90%. Cancelling this lane almost never saves work; it discards
-  // an all-but-finished real-ClickHouse DDL differential.
+  // Q2 decisive: the median kill lands at 85% of a completed run, the latest
+  // point of any enrolled workflow, so cancelling it saves almost nothing.
   '.github/workflows/schema-integration.yml',
+  // Q1 is YES for the same reason as its real-ClickHouse siblings — its
+  // per-commit check-run is read by name by release.yml's preflight — and Q2
+  // follows at 22% cancelled, kills a median 50% into a 13.6-min run.
+  '.github/workflows/strict-scan.yml',
 ]);
 
 // The reasoned complement of QUEUE_COALESCED_WORKFLOWS: enrolled workflows for
@@ -152,33 +162,29 @@ export const QUEUE_COALESCED_WORKFLOWS = Object.freeze([
 // workflow here that carries `cancel-in-progress: false` is as much a failure
 // as a queue-coalesced one that regains the cancel expression.
 export const CANCEL_COALESCED_WORKFLOWS = Object.freeze([
-  // Question 1 is NO: a deterministic licence-boundary differential over the
-  // tree, so the newer tree's verdict strictly replaces the older one.
-  // Question 2 is NO as well: 12% cancelled, 8% of minutes (47 min over
-  // 74.5 h), and the median kill lands 23% into a 4.7-min run.
+  // Q2 is NO: 12% cancelled, 8% of its run-minutes (47 min in 74.5 h), and the
+  // median kill lands 23% into a 4.7-min run — cancellation here is nearly
+  // free, which is the only condition under which it pays.
   '.github/workflows/agpl-oracle.yml',
-  // Question 1 is NO, and decisively so: code scanning surfaces only the
-  // LATEST analysis for a ref, so an older commit's SARIF is superseded by
-  // construction rather than merely by convention. The median kill does land
-  // late (64% of a 6.3-min run), but late kills of a redundant result are
-  // still redundant — 105 min over 74.5 h, and 83 of 99 pushes analysed.
+  // The one genuine Q1 NO in the enrollment. Code scanning surfaces only the
+  // LATEST analysis for a ref, so this lane keeps no durable per-commit record
+  // for a kill to lose — the successor's analysis does not merely supersede
+  // the older result, it is the only one the ref ever retains. Its kills DO
+  // land late (64% of a 6.4-min run, 7 of 16 past 90%), which is why Q1 has to
+  // carry this entry: on Q2 alone it would enroll.
   '.github/workflows/codeql.yml',
-  // No `push:` trigger at all, so the latest-main-push branch of the cancel
-  // expression is unreachable and no push-on-main run exists to cancel. See
-  // MAIN_COALESCED_OWNER_WORKFLOWS below for the registry half of this.
+  // No `push:` trigger, so the latest-main-push branch is unreachable and no
+  // push-on-main run exists to cancel; its registry main posture stays `never`
+  // (see MAIN_COALESCED_OWNER_WORKFLOWS below). The reachable branch is its
+  // weekly schedule, where a superseded run is a repeat of the same benchmark
+  // on a week-old tree and the cron cannot overlap its own short run.
   '.github/workflows/perf-benchmark.yml',
-  // Question 2 is NO: 11% cancelled, 5% of minutes (23 min over 74.5 h), one
-  // kill past 90% in eleven, and the median kill lands 22% into a 5.3-min run.
-  // Question 1 is weak too — it re-measures the same sentinel corpus against
-  // the same committed baseline every run, so a killed run's datum is
-  // substantially re-derived by its successor on a near-identical tree.
+  // Q2 is NO: 11% cancelled, 5% of its run-minutes (23 min in 74.5 h), one
+  // kill past 90% in eleven, median kill 22% into a 5.3-min run. Q1 is weak
+  // too — it re-measures the same sentinel corpus against the same committed
+  // baseline every run, so a killed run's datum is substantially re-derived by
+  // its successor on a near-identical tree.
   '.github/workflows/perf-nightly.yml',
-  // Question 1 is NO: 24 deterministic real-ClickHouse differentials over the
-  // tree, each a verdict the newer tree's run re-derives in full. 22%
-  // cancelled and 13% of minutes (144 min) is a larger loss than `property`'s,
-  // and it is still the right trade — the loss is repeated work, not lost
-  // evidence, which is exactly the distinction question 1 draws.
-  '.github/workflows/strict-scan.yml',
 ]);
 
 // perf-benchmark has no push-to-main trigger. Its weekly schedule is still

--- a/.github/scripts/main-coalescing.mjs
+++ b/.github/scripts/main-coalescing.mjs
@@ -80,8 +80,105 @@ export const COALESCED_WORKFLOWS = Object.freeze([
 // carries a literal `cancel-in-progress: false`. Its registry `main_posture`
 // stays `coalesced`, which remains the truth: a superseded run is still
 // replaced, just at queue time rather than mid-flight.
+//
+// # The decision rule (tsouza/cerberus#2994)
+//
+// Cancellation is not uniformly wrong, so enrollment is not uniform. Every
+// enrolled workflow is classified by ONE ordered question, and the answer is
+// recorded next to the name:
+//
+//   1. Does a superseded run still carry information its successor will not
+//      reproduce? A lane whose output is a deterministic function of the tree
+//      answers NO — the newer tree's verdict is a strict replacement, and the
+//      older run's result is genuinely redundant. A lane that emits a
+//      per-commit measurement, publishes a score, or explores randomly-seeded
+//      input answers YES.
+//   2. If YES, is the measured loss material? Cancellation that lands in the
+//      first quarter of a run and throws away single-digit runner minutes per
+//      day is not worth trading latency-to-HEAD for.
+//
+// Only a workflow answering YES to both is queue-coalesced. The rest stay in
+// CANCEL_COALESCED_WORKFLOWS below, and the audit requires the two tiers to
+// partition COALESCED_WORKFLOWS exactly, so a fourteenth enrollment cannot
+// land without an explicit tier and a reason.
+//
+// Figures below are the last ~99 push-on-main runs per workflow over
+// 2026-08-31T06:35Z - 2026-09-03T09:05Z (74.5 h), against a median main-push
+// gap of 38.5 min. A run duration is the median of that workflow's SUCCESSFUL
+// runs, so a lane's fast failures cannot flatter it; a kill point is the
+// median cancelled-run lifetime, expressed against that same duration.
 export const QUEUE_COALESCED_WORKFLOWS = Object.freeze([
+  // 48% cancelled, 35% of runner minutes (991 min) discarded, 12 of 48 kills
+  // past 90% of a full run. A 34.5-min run against a 38.5-min gap is on the
+  // knife edge. It also carried 30 real failures: cancelling this lane hides
+  // red on the trunk as well as wasting the runner that found it.
+  '.github/workflows/chdb.yml',
+  // 29% cancelled, 18% of minutes (297 min). Publishes a per-head parity SCORE
+  // to the badges branch and runs the parity ratchet, so a killed run is a
+  // missing datum in the public compatibility record, not a redundant verdict.
+  '.github/workflows/compatibility.yml',
   '.github/workflows/coverage.yml',
+  // 36% cancelled, 25% of minutes (517 min), 8 of 36 kills past 90%. Uploads
+  // per-tier run reports that are the evidence half of its coverage ratchet.
+  '.github/workflows/migration-e2e.yml',
+  // The worst of the set and the closest sibling of the coverage failure: 60%
+  // cancelled, 45% of minutes (1413 min) discarded, 19 of 59 kills past 90% of
+  // a full run, and only 10 successes in 74.5 h. Its 38.6-min run is level with
+  // the 38.5-min median push gap — only 50% of gaps are long enough for a run
+  // to finish — so cancellation coalesced nothing; it starved the lane. Its
+  // output is a per-commit mutation score held to an efficacy threshold, which
+  // its successor does not reproduce for the killed commit.
+  '.github/workflows/mutation.yml',
+  // 40% cancelled, 31% of minutes (677 min), 13 of 40 kills past 90%. Merges
+  // shard profiles into one per-commit profile artifact — a measurement.
+  '.github/workflows/perf-profile.yml',
+  // Enrolled on question 1, not on volume: 19% cancelled and 9% of minutes
+  // (93 min), but `property` runs rapid with an unpinned seed, so every run
+  // explores a DIFFERENT region of the input space. A cancelled run's draws
+  // are never re-drawn by its successor, which makes the loss irreplaceable
+  // rather than merely repeated.
+  '.github/workflows/property.yml',
+  // Enrolled on kill efficiency: only 21% cancelled, but the median kill lands
+  // at 86% of a completed run — the latest in the whole set — and 8 of 21 kills
+  // land past 90%. Cancelling this lane almost never saves work; it discards
+  // an all-but-finished real-ClickHouse DDL differential.
+  '.github/workflows/schema-integration.yml',
+]);
+
+// The reasoned complement of QUEUE_COALESCED_WORKFLOWS: enrolled workflows for
+// which mid-flight cancellation remains CORRECT. This is not an exemption list
+// — each entry answers the decision rule above with a NO, and the audit's
+// partition check makes the membership load-bearing in both directions: a
+// workflow here that carries `cancel-in-progress: false` is as much a failure
+// as a queue-coalesced one that regains the cancel expression.
+export const CANCEL_COALESCED_WORKFLOWS = Object.freeze([
+  // Question 1 is NO: a deterministic licence-boundary differential over the
+  // tree, so the newer tree's verdict strictly replaces the older one.
+  // Question 2 is NO as well: 12% cancelled, 8% of minutes (47 min over
+  // 74.5 h), and the median kill lands 23% into a 4.7-min run.
+  '.github/workflows/agpl-oracle.yml',
+  // Question 1 is NO, and decisively so: code scanning surfaces only the
+  // LATEST analysis for a ref, so an older commit's SARIF is superseded by
+  // construction rather than merely by convention. The median kill does land
+  // late (64% of a 6.3-min run), but late kills of a redundant result are
+  // still redundant — 105 min over 74.5 h, and 83 of 99 pushes analysed.
+  '.github/workflows/codeql.yml',
+  // No `push:` trigger at all, so the latest-main-push branch of the cancel
+  // expression is unreachable and no push-on-main run exists to cancel. See
+  // MAIN_COALESCED_OWNER_WORKFLOWS below for the registry half of this.
+  '.github/workflows/perf-benchmark.yml',
+  // Question 2 is NO: 11% cancelled, 5% of minutes (23 min over 74.5 h), one
+  // kill past 90% in eleven, and the median kill lands 22% into a 5.3-min run.
+  // Question 1 is weak too — it re-measures the same sentinel corpus against
+  // the same committed baseline every run, so a killed run's datum is
+  // substantially re-derived by its successor on a near-identical tree.
+  '.github/workflows/perf-nightly.yml',
+  // Question 1 is NO: 24 deterministic real-ClickHouse differentials over the
+  // tree, each a verdict the newer tree's run re-derives in full. 22%
+  // cancelled and 13% of minutes (144 min) is a larger loss than `property`'s,
+  // and it is still the right trade — the loss is repeated work, not lost
+  // evidence, which is exactly the distinction question 1 draws.
+  '.github/workflows/strict-scan.yml',
 ]);
 
 // perf-benchmark has no push-to-main trigger. Its weekly schedule is still
@@ -343,8 +440,42 @@ function sameMembers(left, right) {
   return a.length === b.length && a.every((item, index) => item === b[index]);
 }
 
-export function auditMainCoalescing(root = process.cwd()) {
+// Every enrolled workflow must sit in exactly one cancellation tier. Without
+// this, a fourteenth enrollment would silently inherit mid-flight cancellation
+// as a default, which is the shape tsouza/cerberus#2991 and #2994 both took.
+export function tierPartitionProblems({
+  enrolled: enrolledWorkflows = COALESCED_WORKFLOWS,
+  queued: queuedWorkflows = QUEUE_COALESCED_WORKFLOWS,
+  cancelling: cancellingWorkflows = CANCEL_COALESCED_WORKFLOWS,
+} = {}) {
   const problems = [];
+  const queued = new Set(queuedWorkflows);
+  const cancelling = new Set(cancellingWorkflows);
+  for (const workflow of enrolledWorkflows) {
+    const inQueued = queued.has(workflow);
+    const inCancelling = cancelling.has(workflow);
+    if (inQueued && inCancelling) {
+      problems.push(
+        `${workflow}: enrolled in both cancellation tiers; a workflow either keeps mid-flight cancellation or refuses it`,
+      );
+    } else if (!inQueued && !inCancelling) {
+      problems.push(
+        `${workflow}: latest-main enrolled but in neither cancellation tier — add it to QUEUE_COALESCED_WORKFLOWS or CANCEL_COALESCED_WORKFLOWS with the reason its superseded runs do or do not carry information`,
+      );
+    }
+  }
+  for (const workflow of [...queued, ...cancelling]) {
+    if (!enrolledWorkflows.includes(workflow)) {
+      problems.push(
+        `${workflow}: carries a cancellation tier but is absent from the canonical enrollment`,
+      );
+    }
+  }
+  return problems;
+}
+
+export function auditMainCoalescing(root = process.cwd()) {
+  const problems = [...tierPartitionProblems()];
   const enrolled = new Set(COALESCED_WORKFLOWS);
 
   for (const workflow of COALESCED_WORKFLOWS) {
@@ -460,7 +591,9 @@ export function main(root = process.cwd()) {
     return 1;
   }
   notice(
-    `latest-main cancellation is confined to ${COALESCED_WORKFLOWS.length} deep-test workflow(s); distinct events remain unique`,
+    `latest-main grouping covers ${COALESCED_WORKFLOWS.length} deep-test workflow(s): ` +
+      `${QUEUE_COALESCED_WORKFLOWS.length} queue-coalesced (grouped, never killed mid-flight), ` +
+      `${CANCEL_COALESCED_WORKFLOWS.length} still cancelling; distinct events remain unique`,
     { title: 'main coalescing' },
   );
   return 0;

--- a/.github/scripts/main-coalescing.test.mjs
+++ b/.github/scripts/main-coalescing.test.mjs
@@ -345,6 +345,11 @@ test('every queue-coalesced workflow reds if cancellation is restored to it', ()
     // false`, and a bare substring replace would be only accidentally safe
     // (it happens to sit later in the file). Rewriting the wrong line would
     // exercise the nested-concurrency check instead of the tier check.
+    assert.equal(
+      (body.match(/^ {2}cancel-in-progress: false$/gm) ?? []).length,
+      1,
+      `${workflow} must carry exactly one top-level cancel-in-progress line`,
+    );
     const flip = (value) => {
       const rewritten = body.replace(
         /^ {2}cancel-in-progress: false$/m,
@@ -398,7 +403,7 @@ test('every still-cancelling workflow reds if it is quietly opted out', () => {
     );
     assert.match(
       validateEnrolledWorkflow(workflow, optedOut).join('\n'),
-      /cancel-in-progress/,
+      /want the canonical main-push\/equivalent-schedule-only expression/,
       workflow,
     );
   }
@@ -418,14 +423,21 @@ test('the two cancellation tiers partition the enrollment exactly', () => {
   for (const workflow of CANCEL_COALESCED_WORKFLOWS) {
     assert.ok(COALESCED_WORKFLOWS.includes(workflow), workflow);
   }
-  // The two workflows the measurement explicitly ruled out stay cancelling,
-  // and the starved pair the issue named stays queue-coalesced.
-  assert.ok(
-    CANCEL_COALESCED_WORKFLOWS.includes('.github/workflows/perf-benchmark.yml'),
-  );
-  assert.ok(!COALESCED_WORKFLOWS.includes('.github/workflows/forbid-deferral.yml'));
+  // The starved pair the issue named is queue-coalesced, and the lanes the
+  // measurement found cancellation still pays for stay cancelling. Both halves
+  // are pinned: a sweep that moved everything would red here just as a
+  // reversion would.
   assert.ok(QUEUE_COALESCED_WORKFLOWS.includes('.github/workflows/mutation.yml'));
   assert.ok(QUEUE_COALESCED_WORKFLOWS.includes('.github/workflows/chdb.yml'));
+  for (const workflow of [
+    '.github/workflows/agpl-oracle.yml',
+    '.github/workflows/codeql.yml',
+    '.github/workflows/perf-benchmark.yml',
+    '.github/workflows/perf-nightly.yml',
+  ]) {
+    assert.ok(CANCEL_COALESCED_WORKFLOWS.includes(workflow), workflow);
+    assert.ok(!QUEUE_COALESCED_WORKFLOWS.includes(workflow), workflow);
+  }
 });
 
 test('a workflow in neither tier, or in both, is a policy failure', () => {

--- a/.github/scripts/main-coalescing.test.mjs
+++ b/.github/scripts/main-coalescing.test.mjs
@@ -1,11 +1,16 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
+  CANCEL_COALESCED_WORKFLOWS,
   CANCEL_EXPRESSION,
   COALESCED_WORKFLOWS,
   GROUP_EXPRESSION,
+  LATEST_MAIN_SUFFIX,
   MAIN_REF,
+  NEVER_COALESCED_WORKFLOWS,
   QUEUE_CANCEL_LITERAL,
   QUEUE_COALESCED_WORKFLOWS,
   QUICKSTART_CANCEL_EXPRESSION,
@@ -14,6 +19,7 @@ import {
   coalescingDecision,
   concurrencyGroupValues,
   parseTopLevelConcurrency,
+  tierPartitionProblems,
   validateE2EWorkflow,
   validateEnrolledWorkflow,
   validateQuickstartWorkflow,
@@ -312,4 +318,158 @@ jobs: {}
 
 test('the checked-in registry and every enrolled workflow match the policy', () => {
   assert.deepEqual(auditMainCoalescing(process.cwd()), []);
+});
+
+// ---------------------------------------------------------------------------
+// Non-vacuity of the tier policy (tsouza/cerberus#2994).
+//
+// The audit above passes on the checked-in tree. A green that a policy change
+// cannot turn red is not evidence, so these drive the REAL workflow text
+// through the validator with the one line under policy flipped, in BOTH
+// directions, and pin the tier partition itself.
+
+test('every queue-coalesced workflow reds if cancellation is restored to it', () => {
+  assert.ok(QUEUE_COALESCED_WORKFLOWS.length > 0);
+  for (const workflow of QUEUE_COALESCED_WORKFLOWS) {
+    const body = readFileSync(path.join(process.cwd(), workflow), 'utf8');
+    // The checked-in text is accepted, so the flip below is the only variable.
+    assert.deepEqual(validateEnrolledWorkflow(workflow, body), [], workflow);
+    assert.equal(
+      parseTopLevelConcurrency(body).cancelInProgress,
+      QUEUE_CANCEL_LITERAL,
+      workflow,
+    );
+
+    // Anchored to a line carrying EXACTLY the two-space top-level indent:
+    // migration-e2e.yml also holds a six-space JOB-level `cancel-in-progress:
+    // false`, and a bare substring replace would be only accidentally safe
+    // (it happens to sit later in the file). Rewriting the wrong line would
+    // exercise the nested-concurrency check instead of the tier check.
+    const flip = (value) => {
+      const rewritten = body.replace(
+        /^ {2}cancel-in-progress: false$/m,
+        `  cancel-in-progress: ${value}`,
+      );
+      assert.notEqual(rewritten, body, workflow);
+      assert.equal(
+        parseTopLevelConcurrency(rewritten).cancelInProgress,
+        value,
+        workflow,
+      );
+      return rewritten;
+    };
+
+    // Someone "optimises" the literal back into the cancel expression, or
+    // reaches for the cruder bare `true`. Both are refused by the tier check.
+    for (const value of [CANCEL_EXPRESSION, 'true']) {
+      assert.match(
+        validateEnrolledWorkflow(workflow, flip(value)).join('\n'),
+        /queue-coalesced/,
+        `${workflow} <- ${value}`,
+      );
+    }
+  }
+});
+
+test('every still-cancelling workflow reds if it is quietly opted out', () => {
+  assert.ok(CANCEL_COALESCED_WORKFLOWS.length > 0);
+  for (const workflow of CANCEL_COALESCED_WORKFLOWS) {
+    const body = readFileSync(path.join(process.cwd(), workflow), 'utf8');
+    assert.deepEqual(validateEnrolledWorkflow(workflow, body), [], workflow);
+    assert.equal(
+      parseTopLevelConcurrency(body).cancelInProgress,
+      CANCEL_EXPRESSION,
+      workflow,
+    );
+
+    // The pin is two-sided: a workflow the policy deliberately leaves
+    // cancelling cannot opt itself out by editing one line either. Moving it
+    // has to be a declared tier change with its reason, the same as moving one
+    // the other way.
+    const optedOut = body.replace(
+      /^ {2}cancel-in-progress: \$\{\{.*\}\}$/m,
+      `  cancel-in-progress: ${QUEUE_CANCEL_LITERAL}`,
+    );
+    assert.notEqual(optedOut, body, workflow);
+    assert.equal(
+      parseTopLevelConcurrency(optedOut).cancelInProgress,
+      QUEUE_CANCEL_LITERAL,
+      workflow,
+    );
+    assert.match(
+      validateEnrolledWorkflow(workflow, optedOut).join('\n'),
+      /cancel-in-progress/,
+      workflow,
+    );
+  }
+});
+
+test('the two cancellation tiers partition the enrollment exactly', () => {
+  assert.deepEqual(tierPartitionProblems(), []);
+  assert.equal(
+    QUEUE_COALESCED_WORKFLOWS.length + CANCEL_COALESCED_WORKFLOWS.length,
+    COALESCED_WORKFLOWS.length,
+  );
+  // The tiers are disjoint and neither is a superset of the enrollment.
+  for (const workflow of QUEUE_COALESCED_WORKFLOWS) {
+    assert.ok(!CANCEL_COALESCED_WORKFLOWS.includes(workflow), workflow);
+    assert.ok(COALESCED_WORKFLOWS.includes(workflow), workflow);
+  }
+  for (const workflow of CANCEL_COALESCED_WORKFLOWS) {
+    assert.ok(COALESCED_WORKFLOWS.includes(workflow), workflow);
+  }
+  // The two workflows the measurement explicitly ruled out stay cancelling,
+  // and the starved pair the issue named stays queue-coalesced.
+  assert.ok(
+    CANCEL_COALESCED_WORKFLOWS.includes('.github/workflows/perf-benchmark.yml'),
+  );
+  assert.ok(!COALESCED_WORKFLOWS.includes('.github/workflows/forbid-deferral.yml'));
+  assert.ok(QUEUE_COALESCED_WORKFLOWS.includes('.github/workflows/mutation.yml'));
+  assert.ok(QUEUE_COALESCED_WORKFLOWS.includes('.github/workflows/chdb.yml'));
+});
+
+test('a workflow in neither tier, or in both, is a policy failure', () => {
+  // The SAME function the audit calls, driven over injected rosters so the
+  // reachability of each branch is shown rather than restated.
+  const enrolled = ['a.yml', 'b.yml'];
+  assert.deepEqual(
+    tierPartitionProblems({ enrolled, queued: ['a.yml'], cancelling: ['b.yml'] }),
+    [],
+  );
+  assert.match(
+    tierPartitionProblems({ enrolled, queued: ['a.yml'], cancelling: [] }).join('\n'),
+    /b\.yml: latest-main enrolled but in neither cancellation tier/,
+  );
+  assert.match(
+    tierPartitionProblems({
+      enrolled,
+      queued: ['a.yml', 'b.yml'],
+      cancelling: ['b.yml'],
+    }).join('\n'),
+    /b\.yml: enrolled in both cancellation tiers/,
+  );
+  assert.match(
+    tierPartitionProblems({
+      enrolled,
+      queued: ['a.yml', 'stray.yml'],
+      cancelling: ['b.yml'],
+    }).join('\n'),
+    /stray\.yml: carries a cancellation tier but is absent/,
+  );
+});
+
+test('the never-coalesced workflows are untouched by the tier policy', () => {
+  // A negative control for the whole change: ci.yml must not acquire either
+  // tier, and its concurrency must stay outside the latest-main groups.
+  for (const workflow of NEVER_COALESCED_WORKFLOWS) {
+    assert.ok(!QUEUE_COALESCED_WORKFLOWS.includes(workflow), workflow);
+    assert.ok(!CANCEL_COALESCED_WORKFLOWS.includes(workflow), workflow);
+  }
+  const ci = readFileSync(
+    path.join(process.cwd(), '.github/workflows/ci.yml'),
+    'utf8',
+  );
+  assert.ok(
+    !concurrencyGroupValues(ci).some((group) => group.includes(LATEST_MAIN_SUFFIX)),
+  );
 });

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -102,7 +102,29 @@ concurrency:
   # Main pushes replace only older main pushes; matching cron schedules replace
   # only that scheduled mode. Every other event gets its own run-id group.
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
+  #
+  # The GROUP above is what makes deep-main work replaceable, and it keeps
+  # working: GitHub holds at most ONE pending run per group, so a burst of
+  # pushes is still superseded at QUEUE time, where a pending run holds no
+  # runner and costs nothing. Killing a run that is already EXECUTING is a
+  # separate act, and it only pays when the killed work was nearly worthless.
+  #
+  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
+  # `false` looks like the setting that wastes runners and the measurement says
+  # the opposite: cancellation SPENT the minutes below and threw the result
+  # away, then re-ran the same work on the next commit. The tier and the
+  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
+  # two halves ever disagree.
+  #
+  # Measured on this lane: 48% of its main-push runs CANCELLED, a 34.5-min
+  # median successful run against the 38.5-min median push gap — only 57% of
+  # gaps clear it — kills a median 18.0 min in, 12 of 48 past 90% of a run, and
+  # 35% of the lane's runner minutes (991 min in 74.5 h) discarded. The window
+  # also held 30 genuine failures, so cancelling this lane suppresses red on
+  # the trunk as well as wasting the runner that found it.
+  cancel-in-progress: false
 
 jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -104,26 +104,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
   # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
   #
-  # The GROUP above is what makes deep-main work replaceable, and it keeps
-  # working: GitHub holds at most ONE pending run per group, so a burst of
-  # pushes is still superseded at QUEUE time, where a pending run holds no
-  # runner and costs nothing. Killing a run that is already EXECUTING is a
-  # separate act, and it only pays when the killed work was nearly worthless.
-  #
-  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
-  # `false` looks like the setting that wastes runners and the measurement says
-  # the opposite: cancellation SPENT the minutes below and threw the result
-  # away, then re-ran the same work on the next commit. The tier and the
-  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # The GROUP above still coalesces: GitHub holds at most ONE pending run per
+  # group, so a burst of pushes is superseded at QUEUE time, where a pending run
+  # holds no runner and costs nothing. Killing a run already EXECUTING is a
+  # separate act, and it only pays when the killed work was near-worthless.
+  # Before "optimising" this line back into an expression, read the decision
+  # rule and this lane's recorded answer in QUEUE_COALESCED_WORKFLOWS in
   # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
-  # two halves ever disagree.
+  # two halves ever disagree. The figures below are run-minutes (wall clock per
+  # run, not billed runner minutes, which a fan-out multiplies).
   #
-  # Measured on this lane: 48% of its main-push runs CANCELLED, a 34.5-min
-  # median successful run against the 38.5-min median push gap — only 57% of
-  # gaps clear it — kills a median 18.0 min in, 12 of 48 past 90% of a run, and
-  # 35% of the lane's runner minutes (991 min in 74.5 h) discarded. The window
-  # also held 30 genuine failures, so cancelling this lane suppresses red on
-  # the trunk as well as wasting the runner that found it.
+  # Measured here: 48% of its main-push runs CANCELLED, a 34.5-min median
+  # successful run against the 38.5-min median push gap — only 57% of gaps
+  # clear it — kills a median 18.0 min in (52%) with 12 of 48 past the 90%
+  # mark, and 35% of this lane's run-minutes (991 min in 74.5 h) discarded. The
+  # window also held 30 genuine failures, so cancelling suppresses red on the
+  # trunk as well as wasting the runner that found it.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -109,7 +109,29 @@ concurrency:
   # Main pushes and matching cron schedules replace only their own modes.
   # Release-head PRs, queue, dispatch, and maintenance remain distinct.
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
+  #
+  # The GROUP above is what makes deep-main work replaceable, and it keeps
+  # working: GitHub holds at most ONE pending run per group, so a burst of
+  # pushes is still superseded at QUEUE time, where a pending run holds no
+  # runner and costs nothing. Killing a run that is already EXECUTING is a
+  # separate act, and it only pays when the killed work was nearly worthless.
+  #
+  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
+  # `false` looks like the setting that wastes runners and the measurement says
+  # the opposite: cancellation SPENT the minutes below and threw the result
+  # away, then re-ran the same work on the next commit. The tier and the
+  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
+  # two halves ever disagree.
+  #
+  # Measured on this lane: 29% of its main-push runs CANCELLED, kills a median
+  # 7.9 min into a 19.3-min run, and 18% of the lane's runner minutes (297 min
+  # in 74.5 h) discarded. A main-push run is the only one that reaches the
+  # badge publish step and the parity ratchet, so a cancelled run is a missing
+  # datum in the published compatibility record — the one thing a later run
+  # cannot backfill for the commit that was killed.
+  cancel-in-progress: false
 
 jobs:
   # See `.github/workflows/ci.yml` for the rationale + filter convention.

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -111,26 +111,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
   # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
   #
-  # The GROUP above is what makes deep-main work replaceable, and it keeps
-  # working: GitHub holds at most ONE pending run per group, so a burst of
-  # pushes is still superseded at QUEUE time, where a pending run holds no
-  # runner and costs nothing. Killing a run that is already EXECUTING is a
-  # separate act, and it only pays when the killed work was nearly worthless.
-  #
-  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
-  # `false` looks like the setting that wastes runners and the measurement says
-  # the opposite: cancellation SPENT the minutes below and threw the result
-  # away, then re-ran the same work on the next commit. The tier and the
-  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # The GROUP above still coalesces: GitHub holds at most ONE pending run per
+  # group, so a burst of pushes is superseded at QUEUE time, where a pending run
+  # holds no runner and costs nothing. Killing a run already EXECUTING is a
+  # separate act, and it only pays when the killed work was near-worthless.
+  # Before "optimising" this line back into an expression, read the decision
+  # rule and this lane's recorded answer in QUEUE_COALESCED_WORKFLOWS in
   # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
-  # two halves ever disagree.
+  # two halves ever disagree. The figures below are run-minutes (wall clock per
+  # run, not billed runner minutes, which a fan-out multiplies).
   #
-  # Measured on this lane: 29% of its main-push runs CANCELLED, kills a median
-  # 7.9 min into a 19.3-min run, and 18% of the lane's runner minutes (297 min
-  # in 74.5 h) discarded. A main-push run is the only one that reaches the
-  # badge publish step and the parity ratchet, so a cancelled run is a missing
-  # datum in the published compatibility record — the one thing a later run
-  # cannot backfill for the commit that was killed.
+  # Measured here: 29% of its main-push runs CANCELLED, kills a median 7.9 min
+  # into a 19.3-min run (41%), and 18% of this lane's run-minutes (297 min in
+  # 74.5 h) discarded. A main-push run is the only one that reaches the badge
+  # publish step and the parity ratchet, so a killed run is a missing datum in
+  # the published compatibility record.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -209,6 +209,15 @@ concurrency:
   # That gap is now REPORTED rather than silent: coverage-verdict.mjs states how
   # many commits have landed on the trunk since it was last measured, and warns
   # past its MAX_UNMEASURED_TRUNK_COMMITS.
+  #
+  # This lane is the founding member of QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs (tsouza/cerberus#2991), which
+  # tsouza/cerberus#2994 turned into a general policy with a recorded answer per
+  # workflow. Its answer is the account above: 66% of its main-push runs
+  # CANCELLED against a single success, kills a median 26.5 min in with 31 of 65
+  # past the 90% mark, and 50% of this lane's run-minutes (1790 min in 74.5 h)
+  # discarded. The audit fails this workflow if the enrollment and this line
+  # ever disagree.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -88,7 +88,28 @@ concurrency:
   # Artifact calls, dispatches, and maintenance qualification use a unique
   # run-id group and can neither queue behind nor cancel source work.
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
+  #
+  # The GROUP above is what makes deep-main work replaceable, and it keeps
+  # working: GitHub holds at most ONE pending run per group, so a burst of
+  # pushes is still superseded at QUEUE time, where a pending run holds no
+  # runner and costs nothing. Killing a run that is already EXECUTING is a
+  # separate act, and it only pays when the killed work was nearly worthless.
+  #
+  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
+  # `false` looks like the setting that wastes runners and the measurement says
+  # the opposite: cancellation SPENT the minutes below and threw the result
+  # away, then re-ran the same work on the next commit. The tier and the
+  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
+  # two halves ever disagree.
+  #
+  # Measured on this lane: 36% of its main-push runs CANCELLED, kills a median
+  # 11.3 min into a 22.8-min run (49%) with 8 of 36 past the 90% mark, and 25%
+  # of the lane's runner minutes (517 min in 74.5 h) discarded. The tier jobs
+  # upload the per-tier run reports that are the EVIDENCE half of this lane's
+  # coverage ratchet, so a killed run leaves that evidence unwritten.
+  cancel-in-progress: false
 
 jobs:
   # Enumerate the Gherkin features, hold them to the 26-story anchor, and

--- a/.github/workflows/migration-e2e.yml
+++ b/.github/workflows/migration-e2e.yml
@@ -90,25 +90,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
   # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
   #
-  # The GROUP above is what makes deep-main work replaceable, and it keeps
-  # working: GitHub holds at most ONE pending run per group, so a burst of
-  # pushes is still superseded at QUEUE time, where a pending run holds no
-  # runner and costs nothing. Killing a run that is already EXECUTING is a
-  # separate act, and it only pays when the killed work was nearly worthless.
-  #
-  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
-  # `false` looks like the setting that wastes runners and the measurement says
-  # the opposite: cancellation SPENT the minutes below and threw the result
-  # away, then re-ran the same work on the next commit. The tier and the
-  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # The GROUP above still coalesces: GitHub holds at most ONE pending run per
+  # group, so a burst of pushes is superseded at QUEUE time, where a pending run
+  # holds no runner and costs nothing. Killing a run already EXECUTING is a
+  # separate act, and it only pays when the killed work was near-worthless.
+  # Before "optimising" this line back into an expression, read the decision
+  # rule and this lane's recorded answer in QUEUE_COALESCED_WORKFLOWS in
   # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
-  # two halves ever disagree.
+  # two halves ever disagree. The figures below are run-minutes (wall clock per
+  # run, not billed runner minutes, which a fan-out multiplies).
   #
-  # Measured on this lane: 36% of its main-push runs CANCELLED, kills a median
-  # 11.3 min into a 22.8-min run (49%) with 8 of 36 past the 90% mark, and 25%
-  # of the lane's runner minutes (517 min in 74.5 h) discarded. The tier jobs
-  # upload the per-tier run reports that are the EVIDENCE half of this lane's
-  # coverage ratchet, so a killed run leaves that evidence unwritten.
+  # Measured here: 36% of its main-push runs CANCELLED, kills a median 11.3 min
+  # into a 22.8-min run (49%) with 8 of 36 past the 90% mark, and 25% of this
+  # lane's run-minutes (517 min in 74.5 h) discarded. The tier jobs upload the
+  # per-tier run reports that are the EVIDENCE half of this lane's coverage
+  # ratchet, so a killed run leaves that evidence unwritten.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -64,7 +64,31 @@ concurrency:
   # Main pushes and the exact nightly cron replace only their own modes. Scoped
   # PR/queue and manual or release-head qualification remain unique.
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
+  #
+  # The GROUP above is what makes deep-main work replaceable, and it keeps
+  # working: GitHub holds at most ONE pending run per group, so a burst of
+  # pushes is still superseded at QUEUE time, where a pending run holds no
+  # runner and costs nothing. Killing a run that is already EXECUTING is a
+  # separate act, and it only pays when the killed work was nearly worthless.
+  #
+  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
+  # `false` looks like the setting that wastes runners and the measurement says
+  # the opposite: cancellation SPENT the minutes below and threw the result
+  # away, then re-ran the same work on the next commit. The tier and the
+  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
+  # two halves ever disagree.
+  #
+  # Measured on this lane: 60% of its main-push runs CANCELLED against 10
+  # successes, a median 38.6-min successful run against a 38.5-min median push
+  # gap — only 50% of gaps are long enough for a run to finish — kills landing
+  # a median 24.3 min in (63% of a full run) with 19 of 59 past the 90% mark,
+  # and 45% of the lane's runner minutes (1413 min in 74.5 h) discarded. Cancellation coalesced nothing here; it
+  # starved the lane, exactly as it starved coverage. A killed run is also a
+  # missing per-commit mutation score, not a redundant verdict — the successor
+  # scores its own commit, never the one that was killed.
+  cancel-in-progress: false
 
 jobs:
   # select — decide WHICH phases this event runs, and emit them as the `mutate`

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -66,28 +66,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
   # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
   #
-  # The GROUP above is what makes deep-main work replaceable, and it keeps
-  # working: GitHub holds at most ONE pending run per group, so a burst of
-  # pushes is still superseded at QUEUE time, where a pending run holds no
-  # runner and costs nothing. Killing a run that is already EXECUTING is a
-  # separate act, and it only pays when the killed work was nearly worthless.
-  #
-  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
-  # `false` looks like the setting that wastes runners and the measurement says
-  # the opposite: cancellation SPENT the minutes below and threw the result
-  # away, then re-ran the same work on the next commit. The tier and the
-  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # The GROUP above still coalesces: GitHub holds at most ONE pending run per
+  # group, so a burst of pushes is superseded at QUEUE time, where a pending run
+  # holds no runner and costs nothing. Killing a run already EXECUTING is a
+  # separate act, and it only pays when the killed work was near-worthless.
+  # Before "optimising" this line back into an expression, read the decision
+  # rule and this lane's recorded answer in QUEUE_COALESCED_WORKFLOWS in
   # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
-  # two halves ever disagree.
+  # two halves ever disagree. The figures below are run-minutes (wall clock per
+  # run, not billed runner minutes, which a fan-out multiplies).
   #
-  # Measured on this lane: 60% of its main-push runs CANCELLED against 10
-  # successes, a median 38.6-min successful run against a 38.5-min median push
-  # gap — only 50% of gaps are long enough for a run to finish — kills landing
-  # a median 24.3 min in (63% of a full run) with 19 of 59 past the 90% mark,
-  # and 45% of the lane's runner minutes (1413 min in 74.5 h) discarded. Cancellation coalesced nothing here; it
-  # starved the lane, exactly as it starved coverage. A killed run is also a
-  # missing per-commit mutation score, not a redundant verdict — the successor
-  # scores its own commit, never the one that was killed.
+  # Measured here: 60% of its main-push runs CANCELLED against 10 successes, a
+  # median 38.6-min successful run against the 38.5-min median push gap — only
+  # 50% of gaps are long enough for a run to finish — kills landing a median
+  # 24.3 min in (63% of a full run) with 19 of 59 past the 90% mark, and 45% of
+  # this lane's run-minutes (1413 min in 74.5 h) discarded. Cancellation
+  # coalesced nothing here; it starved the lane, as it starved coverage.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -101,7 +101,29 @@ concurrency:
   # Main pushes and matching cron schedules replace only their own modes.
   # Release-head PRs, dispatches, and maintenance pushes remain distinct.
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
+  #
+  # The GROUP above is what makes deep-main work replaceable, and it keeps
+  # working: GitHub holds at most ONE pending run per group, so a burst of
+  # pushes is still superseded at QUEUE time, where a pending run holds no
+  # runner and costs nothing. Killing a run that is already EXECUTING is a
+  # separate act, and it only pays when the killed work was nearly worthless.
+  #
+  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
+  # `false` looks like the setting that wastes runners and the measurement says
+  # the opposite: cancellation SPENT the minutes below and threw the result
+  # away, then re-ran the same work on the next commit. The tier and the
+  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
+  # two halves ever disagree.
+  #
+  # Measured on this lane: 40% of its main-push runs CANCELLED, kills a median
+  # 13.0 min into a 23.6-min run (55%) with 13 of 40 past the 90% mark, and 31%
+  # of the lane's runner minutes (677 min in 74.5 h) discarded. The `profile`
+  # job merges the shard profiles into ONE per-commit profile artifact, so a
+  # killed run is a hole in the performance record rather than a repeat of work
+  # the next commit redoes.
+  cancel-in-progress: false
 
 jobs:
   # decide-run-heavy — computes the RUN_HEAVY decision ONCE, ahead of both

--- a/.github/workflows/perf-profile.yml
+++ b/.github/workflows/perf-profile.yml
@@ -103,26 +103,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
   # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
   #
-  # The GROUP above is what makes deep-main work replaceable, and it keeps
-  # working: GitHub holds at most ONE pending run per group, so a burst of
-  # pushes is still superseded at QUEUE time, where a pending run holds no
-  # runner and costs nothing. Killing a run that is already EXECUTING is a
-  # separate act, and it only pays when the killed work was nearly worthless.
-  #
-  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
-  # `false` looks like the setting that wastes runners and the measurement says
-  # the opposite: cancellation SPENT the minutes below and threw the result
-  # away, then re-ran the same work on the next commit. The tier and the
-  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # The GROUP above still coalesces: GitHub holds at most ONE pending run per
+  # group, so a burst of pushes is superseded at QUEUE time, where a pending run
+  # holds no runner and costs nothing. Killing a run already EXECUTING is a
+  # separate act, and it only pays when the killed work was near-worthless.
+  # Before "optimising" this line back into an expression, read the decision
+  # rule and this lane's recorded answer in QUEUE_COALESCED_WORKFLOWS in
   # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
-  # two halves ever disagree.
+  # two halves ever disagree. The figures below are run-minutes (wall clock per
+  # run, not billed runner minutes, which a fan-out multiplies).
   #
-  # Measured on this lane: 40% of its main-push runs CANCELLED, kills a median
-  # 13.0 min into a 23.6-min run (55%) with 13 of 40 past the 90% mark, and 31%
-  # of the lane's runner minutes (677 min in 74.5 h) discarded. The `profile`
-  # job merges the shard profiles into ONE per-commit profile artifact, so a
-  # killed run is a hole in the performance record rather than a repeat of work
-  # the next commit redoes.
+  # Measured here: 40% of its main-push runs CANCELLED, kills a median 13.0 min
+  # into a 23.6-min run (55%) with 13 of 40 past the 90% mark, and 31% of this
+  # lane's run-minutes (677 min in 74.5 h) discarded. The `profile` job merges
+  # the shard profiles into ONE per-commit artifact, so a killed run leaves a
+  # hole in the performance record rather than repeating work.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -96,7 +96,30 @@ concurrency:
   # Main pushes and matching cron schedules replace only their own modes. PR,
   # queue, dispatch, and maintenance evidence stays unique and uncancelled.
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
+  #
+  # The GROUP above is what makes deep-main work replaceable, and it keeps
+  # working: GitHub holds at most ONE pending run per group, so a burst of
+  # pushes is still superseded at QUEUE time, where a pending run holds no
+  # runner and costs nothing. Killing a run that is already EXECUTING is a
+  # separate act, and it only pays when the killed work was nearly worthless.
+  #
+  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
+  # `false` looks like the setting that wastes runners and the measurement says
+  # the opposite: cancellation SPENT the minutes below and threw the result
+  # away, then re-ran the same work on the next commit. The tier and the
+  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
+  # two halves ever disagree.
+  #
+  # Measured on this lane: 19% of its main-push runs CANCELLED and 9% of its
+  # runner minutes (93 min in 74.5 h) discarded — a smaller loss than some
+  # lanes that keep cancelling, and it is enrolled anyway because of WHAT is
+  # lost. property-fanout.mjs runs rapid with no pinned seed, so every run
+  # explores a different region of the input space. A cancelled run's draws are
+  # never re-drawn by its successor, which makes this loss irreplaceable rather
+  # than merely repeated.
+  cancel-in-progress: false
 
 jobs:
   property:

--- a/.github/workflows/property.yml
+++ b/.github/workflows/property.yml
@@ -98,27 +98,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
   # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
   #
-  # The GROUP above is what makes deep-main work replaceable, and it keeps
-  # working: GitHub holds at most ONE pending run per group, so a burst of
-  # pushes is still superseded at QUEUE time, where a pending run holds no
-  # runner and costs nothing. Killing a run that is already EXECUTING is a
-  # separate act, and it only pays when the killed work was nearly worthless.
-  #
-  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
-  # `false` looks like the setting that wastes runners and the measurement says
-  # the opposite: cancellation SPENT the minutes below and threw the result
-  # away, then re-ran the same work on the next commit. The tier and the
-  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # The GROUP above still coalesces: GitHub holds at most ONE pending run per
+  # group, so a burst of pushes is superseded at QUEUE time, where a pending run
+  # holds no runner and costs nothing. Killing a run already EXECUTING is a
+  # separate act, and it only pays when the killed work was near-worthless.
+  # Before "optimising" this line back into an expression, read the decision
+  # rule and this lane's recorded answer in QUEUE_COALESCED_WORKFLOWS in
   # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
-  # two halves ever disagree.
+  # two halves ever disagree. The figures below are run-minutes (wall clock per
+  # run, not billed runner minutes, which a fan-out multiplies).
   #
-  # Measured on this lane: 19% of its main-push runs CANCELLED and 9% of its
-  # runner minutes (93 min in 74.5 h) discarded — a smaller loss than some
-  # lanes that keep cancelling, and it is enrolled anyway because of WHAT is
-  # lost. property-fanout.mjs runs rapid with no pinned seed, so every run
-  # explores a different region of the input space. A cancelled run's draws are
-  # never re-drawn by its successor, which makes this loss irreplaceable rather
-  # than merely repeated.
+  # Measured here: 19% of its main-push runs CANCELLED and 9% of this lane's
+  # run-minutes (93 min in 74.5 h) discarded — a smaller loss than some lanes,
+  # and it is enrolled on WHAT is lost. property-fanout.mjs runs rapid with no
+  # pinned seed, so every run explores a different region of the input space; a
+  # cancelled run's draws are never re-drawn by its successor, which makes this
+  # loss irreplaceable rather than merely repeated.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -50,7 +50,29 @@ concurrency:
   # Main pushes and matching cron schedules replace only their own modes. PR
   # and manual qualification remain unique and cannot be cancelled.
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
+  #
+  # The GROUP above is what makes deep-main work replaceable, and it keeps
+  # working: GitHub holds at most ONE pending run per group, so a burst of
+  # pushes is still superseded at QUEUE time, where a pending run holds no
+  # runner and costs nothing. Killing a run that is already EXECUTING is a
+  # separate act, and it only pays when the killed work was nearly worthless.
+  #
+  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
+  # `false` looks like the setting that wastes runners and the measurement says
+  # the opposite: cancellation SPENT the minutes below and threw the result
+  # away, then re-ran the same work on the next commit. The tier and the
+  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
+  # two halves ever disagree.
+  #
+  # Measured on this lane: only 21% of its main-push runs CANCELLED, but the
+  # median kill lands at 86% of a completed run — the LATEST kill point of any
+  # enrolled workflow — with 8 of 21 past the 90% mark, so 17% of the lane's
+  # runner minutes (135 min in 74.5 h) buy nothing. Cancelling here almost
+  # never saves work: it discards an all-but-finished real-ClickHouse DDL
+  # differential a few seconds before it would have reported.
+  cancel-in-progress: false
 
 jobs:
   # Docs-only PRs short-circuit the Docker work. See ci.yml / chdb.yml for the

--- a/.github/workflows/schema-integration.yml
+++ b/.github/workflows/schema-integration.yml
@@ -52,26 +52,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
   # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
   #
-  # The GROUP above is what makes deep-main work replaceable, and it keeps
-  # working: GitHub holds at most ONE pending run per group, so a burst of
-  # pushes is still superseded at QUEUE time, where a pending run holds no
-  # runner and costs nothing. Killing a run that is already EXECUTING is a
-  # separate act, and it only pays when the killed work was nearly worthless.
-  #
-  # READ THAT DIRECTION BEFORE "OPTIMISING" THIS LINE BACK TO AN EXPRESSION.
-  # `false` looks like the setting that wastes runners and the measurement says
-  # the opposite: cancellation SPENT the minutes below and threw the result
-  # away, then re-ran the same work on the next commit. The tier and the
-  # decision rule behind it live in QUEUE_COALESCED_WORKFLOWS in
+  # The GROUP above still coalesces: GitHub holds at most ONE pending run per
+  # group, so a burst of pushes is superseded at QUEUE time, where a pending run
+  # holds no runner and costs nothing. Killing a run already EXECUTING is a
+  # separate act, and it only pays when the killed work was near-worthless.
+  # Before "optimising" this line back into an expression, read the decision
+  # rule and this lane's recorded answer in QUEUE_COALESCED_WORKFLOWS in
   # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
-  # two halves ever disagree.
+  # two halves ever disagree. The figures below are run-minutes (wall clock per
+  # run, not billed runner minutes, which a fan-out multiplies).
   #
-  # Measured on this lane: only 21% of its main-push runs CANCELLED, but the
-  # median kill lands at 86% of a completed run — the LATEST kill point of any
-  # enrolled workflow — with 8 of 21 past the 90% mark, so 17% of the lane's
-  # runner minutes (135 min in 74.5 h) buy nothing. Cancelling here almost
-  # never saves work: it discards an all-but-finished real-ClickHouse DDL
-  # differential a few seconds before it would have reported.
+  # Measured here: only 21% of its main-push runs CANCELLED, but the median kill
+  # lands at 85% of a completed run — the latest point of any enrolled workflow
+  # — with 8 of 21 past the 90% mark, so 17% of this lane's run-minutes (135 min
+  # in 74.5 h) buy nothing. Cancelling almost never saves work here: it discards
+  # an all-but-finished real-ClickHouse DDL differential about a minute before
+  # it would have reported.
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/strict-scan.yml
+++ b/.github/workflows/strict-scan.yml
@@ -52,7 +52,25 @@ concurrency:
   # Main pushes and matching cron schedules replace only their own modes. PR,
   # queue, dispatch, and maintenance evidence stays unique and uncancelled.
   group: ${{ github.workflow }}-${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'latest-main-push' || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') && format('latest-main-schedule-{0}', github.event.schedule) || github.run_id }}
-  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'schedule' && github.ref == 'refs/heads/main' && github.event.schedule != '') }}
+  # NEVER cancel a run that is already in progress (tsouza/cerberus#2994).
+  #
+  # The GROUP above still coalesces: GitHub holds at most ONE pending run per
+  # group, so a burst of pushes is superseded at QUEUE time, where a pending run
+  # holds no runner and costs nothing. Killing a run already EXECUTING is a
+  # separate act, and it only pays when the killed work was near-worthless.
+  # Before "optimising" this line back into an expression, read the decision
+  # rule and this lane's recorded answer in QUEUE_COALESCED_WORKFLOWS in
+  # .github/scripts/main-coalescing.mjs, whose audit fails this workflow if the
+  # two halves ever disagree. The figures below are run-minutes (wall clock per
+  # run, not billed runner minutes, which a fan-out multiplies).
+  #
+  # Measured here: 22% of its main-push runs CANCELLED, kills a median 6.8 min
+  # into a 13.6-min run (50%), and 13% of this lane's run-minutes (144 min in
+  # 74.5 h) discarded. Its 24 real-ClickHouse differentials are deterministic,
+  # but determinism is not the question: this lane posts a per-commit check-run
+  # that release.yml's preflight reads by name, so a killed run leaves the
+  # commit that is now permanently on the trunk with no verdict at all.
+  cancel-in-progress: false
 
 jobs:
   # Docs-only PRs short-circuit the Docker work. See ci.yml / chdb.yml for the

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -118,6 +118,17 @@ outlasts the median push gap needs — `coverage.yml` takes ~52 minutes against 
 38-minute median cadence, and cancelling it left 71 of 120 pushes measured by
 nothing at all.
 
+Enrollment in that tier is a per-workflow decision, not a default. Each enrolled
+workflow answers one ordered question, and the recorded answer is what puts it
+in `QUEUE_COALESCED_WORKFLOWS` or in `CANCEL_COALESCED_WORKFLOWS` beside it:
+does a superseded run still carry information its successor will not reproduce,
+and if so, is the measured loss material? A lane whose output is a deterministic
+function of the tree answers no — the newer tree's verdict strictly replaces the
+older one — and keeps cancelling. A lane that emits a per-commit measurement,
+publishes a score, or explores randomly-seeded input answers yes. The audit
+requires the two tiers to partition the enrollment exactly, so a new enrolled
+workflow cannot inherit mid-flight cancellation as an unexamined default.
+
 One subtlety on the three `compatibility/<head>` checks: each gates in two
 layers. The harness is *scored* — it accumulates per-case results into
 `compat-score.json` plus a per-case roster in `compat-cases.json`, and exits

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -119,15 +119,29 @@ outlasts the median push gap needs — `coverage.yml` takes ~52 minutes against 
 nothing at all.
 
 Enrollment in that tier is a per-workflow decision, not a default. Each enrolled
-workflow answers one ordered question, and the recorded answer is what puts it
-in `QUEUE_COALESCED_WORKFLOWS` or in `CANCEL_COALESCED_WORKFLOWS` beside it:
-does a superseded run still carry information its successor will not reproduce,
-and if so, is the measured loss material? A lane whose output is a deterministic
-function of the tree answers no — the newer tree's verdict strictly replaces the
-older one — and keeps cancelling. A lane that emits a per-commit measurement,
-publishes a score, or explores randomly-seeded input answers yes. The audit
-requires the two tiers to partition the enrollment exactly, so a new enrolled
-workflow cannot inherit mid-flight cancellation as an unexamined default.
+workflow answers one ordered pair of questions, and the recorded answer is what
+puts it in `QUEUE_COALESCED_WORKFLOWS` or in `CANCEL_COALESCED_WORKFLOWS`
+beside it. First: does the trunk permanently lose a record the successor will
+not restore? A main-push run measures a commit that is now permanently on
+`main`, and the successor measures its own commit rather than the killed one,
+so the default answer is yes; determinism alone is not a reason to answer no,
+because a deterministic verdict still posts a per-commit check-run that a
+release preflight and a bisect both read. A lane answers no only when it keeps
+no durable per-commit record to lose — `codeql` is the one such case, because
+code scanning surfaces only the latest analysis for a ref. Second: is the
+measured loss material? Cancellation that lands in the first quarter of a run
+and discards single-digit minutes per day is not worth trading latency for.
+Only a lane answering yes to both is queue-coalesced. The audit requires the
+two tiers to partition the enrollment exactly, so a new enrolled workflow
+cannot inherit mid-flight cancellation as an unexamined default.
+
+The trade is latency and nothing else: `false` costs no runner minutes, because
+a superseded run is still dropped while pending and a pending run holds no
+runner. What it can cost is time-to-verdict on `main`'s head, bounded by one
+run duration, since GitHub keeps at most one in-progress plus one pending run
+per group. The same flip suppresses the schedule branch, so a nightly queues
+behind a slow predecessor rather than replacing it — immaterial for every
+enrolled lane, which are daily crons against runs well under a day.
 
 One subtlety on the three `compatibility/<head>` checks: each gates in two
 layers. The harness is *scored* — it accumulates per-case results into


### PR DESCRIPTION
## Re-measured first

The issue's figures were hours old, so nothing was changed until they were taken
again. Window: the **last ~99 push-on-main runs per workflow**, all over
**2026-08-31T06:35Z → 2026-09-03T09:05Z (74.5 h)**, median main-push gap
**38.5 min** (p25 16.7, p75 60.5).

One correction to method: run duration is the median of each workflow's
**successful** runs, not of all completed ones. Several lanes fail fast, and
mixing those in flatters the lane — it made `perf-nightly` look like a 5.2-min
no-op when it is a genuine 5.3-min real-ClickHouse run with 26 separate
failures. The issue's open question about that lane resolves as "healthy and
cheap", not "scope-gated".

| workflow | cancelled | ok / fail | median OK run | kill lands at | kills past 90% | run-minutes discarded | verdict |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `mutation.yml` | **60%** | 10 / 30 | 38.6 min | 24.3 min (63%) | 19 / 59 | **45%** (1413 min) | queue |
| `chdb.yml` | **48%** | 21 / 30 | 34.5 min | 18.0 min (52%) | 12 / 48 | **35%** (991 min) | queue |
| `perf-profile.yml` | 40% | 58 / 1 | 23.6 min | 13.0 min (55%) | 13 / 40 | 31% (677 min) | queue |
| `migration-e2e.yml` | 36% | 62 / 1 | 22.8 min | 11.3 min (49%) | 8 / 36 | 25% (517 min) | queue |
| `compatibility.yml` | 29% | 41 / 29 | 19.3 min | 7.9 min (41%) | 5 / 29 | 18% (297 min) | queue |
| `strict-scan.yml` | 22% | 77 / 0 | 13.6 min | 6.8 min (50%) | 3 / 22 | 13% (144 min) | queue |
| `schema-integration.yml` | 21% | 78 / 0 | 7.8 min | 6.7 min (**85%**) | 8 / 21 | 17% (135 min) | queue |
| `property.yml` | 19% | 80 / 0 | 11.9 min | 4.6 min (39%) | 1 / 19 | 9% (93 min) | queue |
| `codeql.yml` | 16% | 83 / 0 | 6.4 min | 4.1 min (64%) | 7 / 16 | 13% (105 min) | **cancels** |
| `agpl-oracle.yml` | 12% | 88 / 0 | 4.7 min | 1.1 min (23%) | 3 / 12 | 8% (47 min) | **cancels** |
| `perf-nightly.yml` | 11% | 63 / 26 | 5.3 min | 1.2 min (22%) | 1 / 11 | 5% (23 min) | **cancels** |

"Kill lands at" is the median cancelled-run lifetime, in minutes and as a
fraction of that workflow's median successful run. Minutes are **run-minutes**
(wall clock per run), not billed runner minutes, which a fan-out multiplies —
so these understate the waste. `coverage` is absent because #2993 fixed it
mid-window; `perf-benchmark` because it has no `push:` trigger.

The issue's shape reproduces. `mutation` is the worst: its 38.6-min run is level
with the 38.5-min push gap, and **only 50% of gaps are long enough for a run to
finish**, which is why it managed 10 successes in 74.5 hours. `chdb` clears 57%
of gaps.

## The failure counts the issue left unclassified

#2994's body recorded high `failure` counts alongside the cancellations —
`coverage` 33, `chdb` 30, `mutation` 30, `compatibility` 29, `perf-nightly` 26 —
and explicitly did not classify them. Since that record disappears when this PR
closes the issue, the resolution belongs here: **all five are green on main as
of the latest completed runs, and every signature is already owned.** Each
workflow's failures collapse to one deterministic signature repeated verbatim
(the opposite of flake), not to a shared cause: `compatibility` was 871 hard
errors with zero diffs from circuit-breaker amplification (#2900, closed),
`perf-nightly` a parquet column-name mismatch (#2875, closed), `coverage` a
standing floor breach (#2991, closed; follow-ups #2999–#3001 open), `chdb` the
duplicate-timestamp divergence (#2914, closed) plus a five-hour stale
cardinality-baseline window, and `mutation` a converging efficacy shortfall
(#2949 and siblings, closed). No new issue is warranted — every one of these is
a leaf of a class epic #2891 already carries.

## The decision rule

Every enrolled workflow now answers one ordered pair of questions, recorded
beside its name in `main-coalescing.mjs`:

1. **Does the trunk permanently lose a record the successor will not restore?**
   A main-push run measures a commit that is now permanently on `main`, and the
   successor measures its *own* commit, never the killed one — so an unfinished
   run is a gap in the trunk's record, and the default answer is yes.
   **Determinism alone is not a reason to answer no**: a deterministic verdict
   still posts a per-commit check-run that a release preflight and a bisect both
   read. A lane answers no only when it keeps no durable per-commit record.
2. **If yes, is the measured loss material?** Cancellation landing in the first
   quarter of a run and discarding single-digit minutes per day is not worth
   trading latency for.

Only yes-to-both is queue-coalesced.

The trade this buys is **latency, and nothing else**. `false` costs no runner
minutes: a superseded run is still dropped while pending, and a pending run
holds no runner. What it can cost is time-to-verdict on head, bounded by one run
duration, because GitHub keeps at most one in-progress plus one pending run per
group. The flip also suppresses the *schedule* branch — a nightly now queues
behind a slow predecessor rather than replacing it — which is immaterial for
every enrolled lane (all daily crons against runs well under a day). That is
stated in the roster and in `docs/test-strategy.md` rather than left implicit.

### Moved into `QUEUE_COALESCED_WORKFLOWS` (8, joining `coverage`)

`mutation` (starved — 50% of gaps clear its run), `chdb` (57% of gaps, plus 30
genuine failures cancellation was suppressing), `perf-profile` (merges shard
profiles into one per-commit artifact), `migration-e2e` (per-tier reports are
the evidence half of its coverage ratchet), `compatibility` (a main-push run is
the only one reaching the badge publish step and parity ratchet),
`schema-integration` (median kill at **85%** of a completed run — the latest
point in the set, so cancelling saves almost nothing), `property` (rapid runs
with **no pinned seed**, so a cancelled run's draws are never re-drawn),
`strict-scan` (per-commit check-run read by name by release preflight).

### Deliberately left cancelling (4)

- **`codeql`** — the one genuine question-1 *no*. Code scanning surfaces only
  the **latest** analysis for a ref, so the lane keeps no durable per-commit
  record for a kill to lose. Its kills land late (64%, 7 of 16 past 90%), so on
  question 2 alone it would enroll — question 1 is doing real work here.
- **`agpl-oracle`** — question 2 *no*: 47 min lost in 74.5 h, median kill 23%
  into a 4.7-min run. Cancellation is nearly free, the only condition under
  which it pays.
- **`perf-nightly`** — question 2 *no*: 23 min in 74.5 h, one late kill in
  eleven. Question 1 is weak too — it re-measures the same sentinel corpus
  against the same committed baseline every run.
- **`perf-benchmark`** — no `push:` trigger. Its entry also answers for the
  *reachable* weekly-schedule branch, which the previous framing left unaddressed.

`forbid-deferral.yml` is untouched — it is not in `COALESCED_WORKFLOWS` at all.

## Extending the tier, not adding exemptions

- `CANCEL_COALESCED_WORKFLOWS` is the **reasoned complement**, not an exemption
  list — each entry carries the measurement behind its answer.
- `tierPartitionProblems` requires the two tiers to **partition**
  `COALESCED_WORKFLOWS` exactly. A fourteenth enrollment cannot inherit
  mid-flight cancellation as an unexamined default. Membership in neither tier,
  in both, or in a tier without enrollment are three distinct failures.
- The pin is **two-sided**: a workflow the policy leaves cancelling cannot opt
  itself out by editing one line either.
- `coverage.yml` — the #2993 founding member — now carries its own recorded
  answer and names the tier, so the policy is nine files sharing a rule rather
  than eight that happen to agree with a ninth.

No required context is added, renamed or removed; every job and workflow name is
unchanged, so the branch ruleset is untouched.

## The pin can fail

**A. cancellation restored on a moved workflow** (`mutation.yml` → `true`):

```
::error title=main coalescing::.github/workflows/mutation.yml: cancel-in-progress
is "true", want the literal "false" — this workflow is queue-coalesced, so it
shares the latest-main group but must never kill a run already in progress
exit=1
```

**B. a workflow deliberately left cancelling, quietly opted out**
(`codeql.yml` → `false`):

```
::error title=main coalescing::.github/workflows/codeql.yml: cancel-in-progress
is "false", want the canonical main-push/equivalent-schedule-only expression
exit=1
```

**C. negative control** — unmodified tree, including `ci.yml`, the workflow the
adversarial pass on #2993 flagged as the one a naive change reddens:

```
::notice title=main coalescing::latest-main grouping covers 13 deep-test
workflow(s): 9 queue-coalesced (grouped, never killed mid-flight), 4 still
cancelling; distinct events remain unique
exit=0
```

And the suite is non-vacuous by mutation, not merely green:

| mutation applied to the source | result |
| --- | --- |
| none (checked-in tree) | 19 pass / 0 fail |
| validator's `cancel-in-progress` comparison disabled | 15 pass / **4 fail** |
| `tierPartitionProblems` neutered to always return `[]` | 18 pass / **1 fail** |

The suite drives **every** queue-coalesced workflow's real file text through the
validator with the literal flipped to both the cancel expression and a bare
`true`, drives every still-cancelling workflow's real text flipped to `false`,
drives `tierPartitionProblems` over injected rosters so each branch is shown
reachable, and asserts the never-coalesced workflows acquire neither tier and
`ci.yml` stays out of the latest-main groups.

## Adversarial review

An independent pass re-derived every cited figure from the API (all reproduced)
and found one blocking defect, now fixed: the rule was **stated** as a
conjunction but **applied** as a disjunction. Question 1 originally read "a lane
whose output is a deterministic function of the tree answers no", which
`schema-integration` and `chdb` both contradicted — and it refused `strict-scan`
on exactly the ground `schema-integration` was admitted on. Rather than paper
over the asymmetry, question 1 is redefined around the durable per-commit
record, `strict-scan` moves to the queue tier where the corrected rule puts it,
and `codeql` is kept cancelling on a specific, checkable reason instead of a
generic determinism argument.

Also applied from that pass: `coverage.yml`'s missing recorded answer; anchoring
the tests' line replacement to the two-space top-level indent with an
exactly-one-match assertion (`migration-e2e.yml` has a six-space job-level
`cancel-in-progress: false` that a substring replace could reach if the file
were reordered); tightening the cancel-tier assertion from `/cancel-in-progress/`
— which the nested-concurrency message also matches — to the specific message;
replacing a near-tautological `forbid-deferral.yml` assertion with real
cancel-tier pins; relabelling "runner minutes" as run-minutes with the basis
stated once; correcting "a few seconds" to about a minute; answering the
decision rule for `perf-benchmark`'s reachable schedule branch; stating the
schedule-mode effect; and cutting the duplicated per-file preamble down to a
pointer plus each lane's own measurement.

## Verification

- `node --test .github/scripts/main-coalescing.test.mjs` — 19 pass, 0 fail (14
  before), plus the two mutation runs above.
- `node .github/scripts/main-coalescing.mjs` — exit 0.
- `just lint-actions` (actionlint) — clean; `yaml.safe_load` parses all thirteen
  enrolled workflows and reports the expected value for each tier.
- `go test -run 'TestMergeQueue|TestQuickstart|TestCoverage|TestRelease' ./test/regression/`
  — ok. The merge-queue guard requires every `cancel-in-progress` reachable from
  a merge-group run to be provably false; a literal `false` satisfies it
  strictly more than the expression did.
- `verify-code-citations.mjs`, `forbid-contradicted-mutants.mjs`,
  `forbid-deferral.mjs` (diff + commits + this body) — clean, 0 markers.
- `markdownlint-cli2@0.20.0` (CI's v0.40 rules) over both edited Markdown files
  — 0 errors.

Closes #2994
