### PR TITLE
ci(markdownlint): run one pinned engine locally and in CI so MD060 reproduces

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -803,6 +803,50 @@ what actually runs.
     commit still fails the gate even beside a skipped empty one, and a
     non-empty commit whose subject merely reads "Initial plan" is still
     linted — proving the filter is diff-based, not text-based.
+- **`markdownlint-run.mjs`** — the ONLY markdownlint-cli2 invocation in the
+  repository, shared by three callers: `ci.yml`'s `lint` job, the `lint-md` /
+  `fmt-md` recipes, and lefthook's `markdownlint` pre-commit hook. It exists
+  because those three each resolved to a DIFFERENT engine — the Justfile pinned
+  markdownlint-cli2 0.18.1 (markdownlint 0.38.0), the CI action bundled 0.23.2
+  (markdownlint 0.41.1), and the hook ran whatever was on `$PATH`. markdownlint
+  ignores a config key naming a rule it does not implement, so
+  `.markdownlint.yaml`'s `MD060` — a rule that arrived in markdownlint 0.40 —
+  configured nothing under the local pin. `just lint-md` reported `0 error(s)`
+  on a table CI then failed on, which made CLAUDE.md invariant 5's "reproduce
+  the red check locally" unsatisfiable for every rule newer than that pin
+  (tsouza/cerberus#2997).
+  - Modes: no args lints the tree; `--fix` auto-fixes it; `--staged FILE...`
+    fixes the named files for the hook; `--print-version` feeds
+    `just install-tools`.
+  - Env: `GITHUB_ACTIONS` (when set, each finding is ALSO emitted as an
+    `::error file=,line=,col=,title=::` annotation — the one thing the action
+    added over running cli2 directly; the raw `file:line:col RULE …` line is
+    printed either way, because that text is what a developer reproduces);
+    `PATH` (searched for a binary in `--staged` mode).
+  - Exit: markdownlint-cli2's own — `0` clean, non-zero on any finding.
+  - **No drift gate, deliberately.** The usual shape here would be a checker
+    comparing the Justfile pin, the hook's pin and the workflow's pin. There is
+    nothing left for it to compare: `PINNED_CLI2_VERSION` is the only
+    markdownlint-cli2 version literal in the tree and `GLOBS` the only file
+    set, so agreement is structural rather than asserted, and a gate over one
+    declaration asserts a tautology. The one edge that is NOT structural is the
+    hook's `$PATH` binary, which cannot use `npm exec` — npm's startup alone is
+    ~4s, five times the budget CLAUDE.md sets for `pre-commit`. That edge is
+    closed in `chooseEngine`, which accepts a `$PATH` binary ONLY at exactly
+    the pinned version and otherwise falls back to the pinned `npm exec`, so
+    the hook is slow-but-correct in the worst case and never runs a different
+    engine. A reviewer checking this should look for a version literal
+    reappearing anywhere else — a hardcoded `markdownlint-cli2@x.y.z`, or a
+    workflow going back to the action — rather than for a red gate.
+  - Tests: `markdownlint-run.test.mjs` (run in `ci.yml` immediately before the
+    `markdownlint` step). Its load-bearing case is anti-vacuity: a version
+    comparison cannot see a rule that is *configured but not implemented*,
+    which is the whole defect, so the suite runs the pinned engine against a
+    deliberately misaligned table and requires MD060 to fire, then requires an
+    aligned one to pass. Lowering the pin below markdownlint 0.40 or dropping
+    the `MD060` key turns the suite red instead of turning `just lint-md`
+    quietly green — verified by re-pinning to the old 0.18.1 and watching both
+    that case and the `chooseEngine` refusal case fail.
 - **`doc-counts.mjs`** — `ci.yml`, the `forbid-skip` job step "Assert
   doc-stated counts match source". The assert-from-source gate that stops
   doc-stated integer counts from drifting away from the source structures

--- a/.github/scripts/markdownlint-run.mjs
+++ b/.github/scripts/markdownlint-run.mjs
@@ -1,0 +1,279 @@
+// markdownlint-run.mjs — the ONE markdownlint-cli2 invocation in the repo.
+//
+// WHY THIS MODULE EXISTS
+//
+// markdownlint was invoked from three places, and each resolved to a DIFFERENT
+// engine. The divergence was silent, and it was in the dangerous direction:
+//
+//   `just lint-md` / `just fmt-md`  markdownlint-cli2@v0.18.1 -> markdownlint 0.38.0
+//   lefthook `pre-commit`           a bare binary from $PATH   -> whatever is installed
+//   `ci.yml`'s `lint` job           markdownlint-cli2-action   -> markdownlint 0.41.1
+//
+// markdownlint IGNORES a config key that names a rule it does not implement
+// rather than rejecting it. `.markdownlint.yaml` pins `MD060: {style: aligned}`,
+// and MD060 arrived in markdownlint 0.40 — so under the local pin that key
+// configured nothing and the rule could not fire. `just lint-md` reported
+// `0 error(s)` on a file whose table CI then failed on (tsouza/cerberus#2997,
+// observed on tsouza/cerberus#2993 against a docs/test-strategy.md table).
+//
+// The cost is not one rule. CLAUDE.md invariant 5 requires a red CI check to be
+// reproduced locally, narrowed, before the next push. For every rule newer than
+// the local pin that is impossible: the local run cannot see the failure, so the
+// author either pushes speculatively — the guess-and-wait loop invariant 5 exists
+// to forbid — or concludes CI is flaky.
+//
+// THE FIX IS STRUCTURAL, NOT ASSERTED. `PINNED_CLI2_VERSION` below is the only
+// markdownlint-cli2 version literal in the repository, and every caller routes
+// through this module: the `lint-md` / `fmt-md` recipes, the lefthook
+// `pre-commit` hook, and `ci.yml`'s `lint` job. There is no second declaration
+// for a drift gate to compare against, and no glob set that can disagree with
+// another glob set — `GLOBS` is likewise single. See `.github/scripts/README.md`
+// for why that made a drift gate the wrong shape here.
+//
+// MD060 HAS NO AUTO-FIXER. `--fix` cannot repair a misaligned table; only
+// `scripts/align-md-tables.py` can, which is why lefthook runs that as its own
+// `md-table-align` hook BEFORE this one, and why `--fix` here prints where the
+// padding pass lives when MD060 survives the fix.
+//
+// Modes:
+//   (no args)             lint the whole tree. `just lint-md`, and ci.yml.
+//   --fix                 lint and auto-fix the whole tree. `just fmt-md`.
+//   --staged FILE...      auto-fix the named files. lefthook `pre-commit`.
+//   --print-version       print PINNED_CLI2_VERSION. `just install-tools`.
+//
+// Engine selection differs between the whole-tree modes and `--staged`, and the
+// reason is measured, not stylistic. `npm exec` costs 2.6-4.5 s per invocation
+// even with the package already in the npx cache and even with `--offline`; the
+// cost is npm's own startup, not the download. That is fine for a CI step and
+// for a deliberate `just lint-md`, and it is 5x over the budget CLAUDE.md sets
+// for `pre-commit` ("sub-second formatters on staged files"). So `--staged`
+// prefers a $PATH binary — but ONLY when that binary's own package.json reports
+// exactly PINNED_CLI2_VERSION. Anything else (absent, or any other version)
+// falls back to the pinned `npm exec` and prints how to get the fast path. The
+// hook is therefore slow-but-correct in the worst case and never, in any case,
+// runs an engine other than the pinned one. Running the wrong engine is the
+// defect; being slow is not.
+//
+// Env:
+//   GITHUB_ACTIONS  when set, each markdownlint error is ALSO emitted as an
+//                   `::error file=,line=,col=,title=::` annotation, so the
+//                   finding lands on the offending line in the PR diff. The
+//                   raw `file:line:col RULE …` line is printed either way —
+//                   that text is what a developer greps and reproduces, so
+//                   annotating must not replace it.
+//   PATH            searched for `markdownlint-cli2` in `--staged` mode.
+//
+// Exit: the markdownlint-cli2 exit code — 0 clean, non-zero on any finding.
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { delimiter, dirname, join } from 'node:path';
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+import { error, log } from './lib/gh.mjs';
+
+// The markdownlint-cli2 release the repository lints with, everywhere.
+//
+// It is the release `DavidAnson/markdownlint-cli2-action@v24.2.0` bundled —
+// that action's package.json pins `markdownlint-cli2: 0.23.2` — because CI was
+// the side enforcing the config the repo actually wrote, and the fix is for the
+// local runs to see what CI sees rather than for CI to stop seeing it.
+//
+// Bumping it: change this literal, then run `just lint-md` and fix whatever the
+// newer engine surfaces IN THE SAME CHANGE. A backlog left behind here is a
+// backlog every later author inherits as a mystery red check.
+export const PINNED_CLI2_VERSION = '0.23.2';
+
+// The markdownlint release PINNED_CLI2_VERSION resolves to. Recorded so a
+// reader can tell which rules are in play without resolving an npm dependency;
+// nothing derives behaviour from it.
+export const PINNED_MARKDOWNLINT_VERSION = '0.41.1';
+
+// The file set, single-sourced for the same reason as the version. The three
+// `compatibility/*/upstream` trees are vendored reference backends whose
+// Markdown is not ours to reformat; `.markdownlintignore` names them too, and
+// both are kept because the glob set is what a `--staged` run has instead of
+// the ignore file's directory walk.
+export const GLOBS = [
+  '**/*.md',
+  '!compatibility/prometheus/upstream/**',
+  '!compatibility/tempo/upstream/**',
+  '!compatibility/loki/upstream/**',
+  '!**/node_modules/**',
+];
+
+// markdownlint-cli2 writes findings to stderr, one per line, as
+//   <file>:<line>[:<col>] error <RULE>[/<alias>] <description> [<detail>]
+// The `error` token and the optional column are both version-dependent shapes,
+// which is exactly why the version is pinned: this parser is written against
+// PINNED_CLI2_VERSION's output and nothing else.
+const ERROR_LINE = /^(?<file>[^\s:][^:]*):(?<line>\d+)(?::(?<column>\d+))?\s+(?:error\s+)?(?<rule>MD\d{3}\S*)\s+(?<message>.+)$/;
+
+// parseErrorLine — one stderr line to a finding, or null when the line is not
+// one (cli2 also writes blank lines and, on a crash, a stack trace).
+export function parseErrorLine(line) {
+  const m = ERROR_LINE.exec(line);
+  if (!m) return null;
+  const { file, line: lineNumber, column, rule, message } = m.groups;
+  return {
+    file,
+    line: Number(lineNumber),
+    column: column === undefined ? undefined : Number(column),
+    rule,
+    message,
+  };
+}
+
+// chooseEngine — which markdownlint-cli2 a `--staged` run may use.
+//
+// `pathVersion` is the version the $PATH binary reports, or null when there is
+// no usable binary on $PATH. The pinned engine is the answer to everything that
+// is not an exact match, so a wrong version can never be the one that runs.
+export function chooseEngine(pathVersion) {
+  if (pathVersion === PINNED_CLI2_VERSION) {
+    return { kind: 'path', reason: `$PATH markdownlint-cli2 is ${pathVersion}` };
+  }
+  const found = pathVersion === null
+    ? 'no markdownlint-cli2 on $PATH'
+    : `$PATH markdownlint-cli2 is ${pathVersion}`;
+  return {
+    kind: 'pinned',
+    reason: `${found}, not the pinned ${PINNED_CLI2_VERSION}`,
+  };
+}
+
+// whichBinary — first executable named `name` on $PATH, or null.
+function whichBinary(name, env = process.env) {
+  for (const dir of (env.PATH || '').split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+// pathBinaryVersion — the version of the $PATH markdownlint-cli2, or null.
+//
+// Read from the package's own package.json rather than by running the binary
+// with `--version`: a spawn costs ~0.7 s, which is the entire `pre-commit`
+// budget spent on finding out whether we may spend it.
+export function pathBinaryVersion(env = process.env) {
+  const bin = whichBinary('markdownlint-cli2', env);
+  if (!bin) return null;
+  let real;
+  try {
+    real = realpathSync(bin);
+  } catch {
+    return null;
+  }
+  // A global install resolves to
+  // <prefix>/lib/node_modules/markdownlint-cli2/markdownlint-cli2-bin.mjs, so
+  // the package root is the first ancestor carrying a package.json. Walk a
+  // bounded number of levels; an unbounded walk would happily read some
+  // unrelated ancestor's manifest.
+  const maxAncestors = 4;
+  let dir = dirname(real);
+  for (let i = 0; i < maxAncestors; i += 1) {
+    const manifest = join(dir, 'package.json');
+    if (existsSync(manifest)) {
+      try {
+        const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+        if (pkg.name === 'markdownlint-cli2' && typeof pkg.version === 'string') {
+          return pkg.version;
+        }
+      } catch {
+        return null;
+      }
+      return null;
+    }
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+// report — print findings, annotating them when running under Actions.
+//
+// The raw line is printed unconditionally and FIRST: it is the text a developer
+// greps for and re-runs against, and CLAUDE.md invariant 5 turns on being able
+// to reproduce that exact string locally. The annotation is additive.
+export function report(stderrText, env = process.env) {
+  let findings = 0;
+  for (const line of stderrText.split('\n')) {
+    const trimmed = line.replace(/\r$/, '');
+    if (trimmed.trim() === '') continue;
+    log(trimmed);
+    const finding = parseErrorLine(trimmed);
+    if (!finding) continue;
+    findings += 1;
+    if (!env.GITHUB_ACTIONS) continue;
+    error(finding.message, {
+      title: finding.rule,
+      file: finding.file,
+      line: finding.line,
+      col: finding.column,
+    });
+  }
+  return findings;
+}
+
+// runEngine — spawn the selected markdownlint-cli2 over `args`.
+function runEngine(engine, args) {
+  const [command, prefix] = engine.kind === 'path'
+    ? ['markdownlint-cli2', []]
+    : ['npm', ['exec', '--yes', '--', `markdownlint-cli2@${PINNED_CLI2_VERSION}`]];
+  const result = spawnSync(command, [...prefix, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'inherit', 'pipe'],
+  });
+  if (result.error) {
+    error(`could not run markdownlint-cli2: ${result.error.message}`);
+    return { status: 1, stderr: '' };
+  }
+  return { status: result.status ?? 1, stderr: result.stderr ?? '' };
+}
+
+const MD060_HINT =
+  'MD060 (table-column-style) has no auto-fixer. Realign tables with '
+  + '`python3 scripts/align-md-tables.py <file>...` — lefthook runs that as its '
+  + 'own `md-table-align` pre-commit hook, before the fixer.';
+
+function main(argv, env = process.env) {
+  if (argv.includes('--print-version')) {
+    log(PINNED_CLI2_VERSION);
+    return 0;
+  }
+
+  const staged = argv.indexOf('--staged');
+  const fix = argv.includes('--fix') || staged !== -1;
+
+  let engine;
+  let targets;
+  if (staged === -1) {
+    engine = { kind: 'pinned', reason: 'whole-tree run' };
+    targets = GLOBS;
+  } else {
+    targets = argv.slice(staged + 1);
+    // lefthook passes {staged_files}, which is empty when nothing matched the
+    // glob. Linting nothing is success, and it must not pay for an engine.
+    if (targets.length === 0) return 0;
+    engine = chooseEngine(pathBinaryVersion(env));
+    if (engine.kind === 'pinned') {
+      log(
+        `markdownlint: ${engine.reason}; falling back to the pinned engine `
+        + '(slower). `just install-tools` installs the matching binary.',
+      );
+    }
+  }
+
+  const { status, stderr } = runEngine(engine, fix ? ['--fix', ...targets] : targets);
+  const findings = report(stderr, env);
+  if (findings > 0 && fix && stderr.includes('MD060')) log(MD060_HINT);
+  return status;
+}
+
+const invokedDirectly = process.argv[1]
+  && import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+if (invokedDirectly) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/.github/scripts/markdownlint-run.test.mjs
+++ b/.github/scripts/markdownlint-run.test.mjs
@@ -1,0 +1,186 @@
+// markdownlint-run.test.mjs — guards for the single markdownlint invocation.
+//
+// Two things are pinned here, and they fail for different reasons.
+//
+// The unit tests pin the pieces that decide WHICH engine runs and how its
+// output is reported. `chooseEngine` is the one place a wrong-version binary
+// can be let through, so it is exercised against the exact versions the repo
+// has actually had on a developer's $PATH and in the old Justfile pin.
+//
+// `the pinned engine enforces MD060` is the load-bearing one, and it is what
+// makes this suite more than a restatement of the code. tsouza/cerberus#2997
+// was not a wrong comparison — it was a pin whose engine did not implement a
+// rule `.markdownlint.yaml` configures, so the config key applied to nothing
+// and a clean local run meant nothing. That defect is invisible to any check
+// that only compares version strings to each other. This one runs the pinned
+// engine against a deliberately misaligned table and requires MD060 to fire,
+// so lowering PINNED_CLI2_VERSION back below markdownlint 0.40 — or deleting
+// the MD060 key — turns this suite red instead of turning `just lint-md`
+// quietly green.
+//
+// That test spawns `npm exec`, which is the same fetch the markdownlint step
+// itself performs moments later; it adds no failure mode the lint job did not
+// already have.
+
+import { strict as assert } from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, copyFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import process from 'node:process';
+
+import {
+  GLOBS,
+  PINNED_CLI2_VERSION,
+  PINNED_MARKDOWNLINT_VERSION,
+  chooseEngine,
+  parseErrorLine,
+  report,
+} from './markdownlint-run.mjs';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+// A real markdownlint-cli2 0.23.2 stderr line, copied verbatim from a run.
+const REAL_LINE =
+  'docs/test-strategy.md:169:4812 error MD060/table-column-style Table column '
+  + 'style [Table pipe does not align with header for style "aligned"]';
+
+test('parseErrorLine reads a real cli2 finding', () => {
+  const finding = parseErrorLine(REAL_LINE);
+  assert.ok(finding, 'a real finding line must parse');
+  assert.equal(finding.file, 'docs/test-strategy.md');
+  assert.equal(finding.line, 169);
+  assert.equal(finding.column, 4812);
+  assert.equal(finding.rule, 'MD060/table-column-style');
+  assert.match(finding.message, /^Table column style/);
+});
+
+test('parseErrorLine reads a finding with no column', () => {
+  const finding = parseErrorLine('README.md:12 error MD047/single-trailing-newline Files should end with a single newline character');
+  assert.ok(finding);
+  assert.equal(finding.line, 12);
+  assert.equal(finding.column, undefined);
+});
+
+test('parseErrorLine rejects cli2 progress output', () => {
+  for (const line of [
+    `markdownlint-cli2 v${PINNED_CLI2_VERSION} (markdownlint v${PINNED_MARKDOWNLINT_VERSION})`,
+    'Finding: **/*.md',
+    'Linting: 53 files',
+    'Summary: 0 issues in 0 files',
+    '',
+    '    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)',
+  ]) {
+    assert.equal(parseErrorLine(line), null, `must not parse as a finding: ${line}`);
+  }
+});
+
+test('chooseEngine takes the $PATH binary only at the pinned version', () => {
+  assert.equal(chooseEngine(PINNED_CLI2_VERSION).kind, 'path');
+});
+
+test('chooseEngine refuses every version that is not the pin', () => {
+  // 0.18.1 is the version the Justfile pinned while CI ran a newer one;
+  // 0.22.1 is what a developer's global install actually was. Both predate
+  // the pin and both must be refused, or #2997 comes back on the hook path.
+  for (const skewed of ['0.18.1', '0.20.0', '0.22.1', '0.24.0', 'not-a-version']) {
+    const engine = chooseEngine(skewed);
+    assert.equal(engine.kind, 'pinned', `${skewed} must not be allowed to run`);
+    assert.match(engine.reason, new RegExp(PINNED_CLI2_VERSION.replace(/\./g, '\\.')));
+  }
+});
+
+test('chooseEngine refuses an absent binary', () => {
+  assert.equal(chooseEngine(null).kind, 'pinned');
+});
+
+test('GLOBS excludes every vendored upstream corpus', () => {
+  for (const head of ['prometheus', 'tempo', 'loki']) {
+    assert.ok(
+      GLOBS.includes(`!compatibility/${head}/upstream/**`),
+      `${head}'s vendored upstream Markdown must stay out of the lint set`,
+    );
+  }
+  assert.ok(GLOBS.includes('**/*.md'));
+});
+
+// captureStdout — run `fn` with process.stdout.write collected.
+function captureStdout(fn) {
+  const written = [];
+  const original = process.stdout.write;
+  process.stdout.write = (chunk) => {
+    written.push(String(chunk));
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stdout.write = original;
+  }
+  return written.join('');
+}
+
+test('report prints the raw finding whether or not it annotates', () => {
+  const plain = captureStdout(() => report(REAL_LINE, {}));
+  assert.ok(plain.includes(REAL_LINE), 'the greppable line must survive');
+  assert.ok(!plain.includes('::error'), 'no workflow command outside Actions');
+});
+
+test('report annotates the offending line under Actions', () => {
+  const annotated = captureStdout(() => report(REAL_LINE, { GITHUB_ACTIONS: 'true' }));
+  assert.ok(annotated.includes(REAL_LINE), 'the raw line is additive, not replaced');
+  assert.match(annotated, /::error [^:]*file=docs\/test-strategy\.md/);
+  assert.match(annotated, /line=169/);
+  assert.match(annotated, /col=4812/);
+});
+
+test('report counts only findings', () => {
+  const text = ['Linting: 2 files', REAL_LINE, '', 'Summary: 1 issue in 1 file'].join('\n');
+  let count;
+  captureStdout(() => {
+    count = report(text, {});
+  });
+  assert.equal(count, 1);
+});
+
+// The anti-vacuity test. See the header: a version comparison cannot see a
+// rule that is configured but not implemented, and that is the defect.
+test('the pinned engine enforces MD060 as .markdownlint.yaml configures it', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'cerberus-md060-'));
+  try {
+    copyFileSync(join(REPO_ROOT, '.markdownlint.yaml'), join(dir, '.markdownlint.yaml'));
+
+    const misaligned = ['# Probe', '', '| left | right |', '| --- | --- |', '| a | b |', ''].join('\n');
+    writeFileSync(join(dir, 'probe.md'), misaligned);
+
+    const run = () => {
+      try {
+        execFileSync(
+          'npm',
+          ['exec', '--yes', '--', `markdownlint-cli2@${PINNED_CLI2_VERSION}`, 'probe.md'],
+          { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+        );
+        return '';
+      } catch (err) {
+        return String(err.stderr ?? '');
+      }
+    };
+
+    const stderr = run();
+    const findings = stderr.split('\n').map(parseErrorLine).filter(Boolean);
+    assert.ok(
+      findings.some((f) => f.rule.startsWith('MD060')),
+      'the pinned engine must implement MD060 — a pin that does not makes '
+      + '.markdownlint.yaml\'s MD060 key configure nothing, which is #2997. '
+      + `Engine reported:\n${stderr}`,
+    );
+
+    const aligned = ['# Probe', '', '| left | right |', '| ---- | ----- |', '| a    | b     |', ''].join('\n');
+    writeFileSync(join(dir, 'probe.md'), aligned);
+    assert.equal(run().trim(), '', 'an aligned table must satisfy MD060');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/markdownlint-run.test.mjs
+++ b/.github/scripts/markdownlint-run.test.mjs
@@ -88,7 +88,13 @@ test('chooseEngine refuses every version that is not the pin', () => {
   for (const skewed of ['0.18.1', '0.20.0', '0.22.1', '0.24.0', 'not-a-version']) {
     const engine = chooseEngine(skewed);
     assert.equal(engine.kind, 'pinned', `${skewed} must not be allowed to run`);
-    assert.match(engine.reason, new RegExp(PINNED_CLI2_VERSION.replace(/\./g, '\\.')));
+    // Substring, not a constructed RegExp: hand-escaping `.` while leaving `\`
+    // unescaped is CodeQL's js/incomplete-sanitization, and the assertion never
+    // needed pattern semantics — it only needs the pin's version to be named.
+    assert.ok(
+      engine.reason.includes(PINNED_CLI2_VERSION),
+      `reason must name the pinned version ${PINNED_CLI2_VERSION}, got: ${engine.reason}`,
+    );
   }
 });
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,15 +404,24 @@ jobs:
           npm install --no-save @commitlint/cli@19 @commitlint/config-conventional@19
           node .github/scripts/commitlint-range.mjs
 
+      # Markdown lint. This ran DavidAnson/markdownlint-cli2-action, which
+      # bundles its own markdownlint-cli2 (v24.2.0 -> 0.23.2 -> markdownlint
+      # 0.41.1). Nothing local could reach that engine: `just lint-md` pinned
+      # 0.18.1 (markdownlint 0.38.0) and lefthook called a bare $PATH binary,
+      # so `.markdownlint.yaml`'s MD060 key — a rule that arrived in 0.40 —
+      # configured nothing locally while CI enforced it. `just lint-md`
+      # reported `0 error(s)` on a table CI then failed on, and invariant 5's
+      # "reproduce the red check locally" was unsatisfiable by construction
+      # (tsouza/cerberus#2997). The step now runs the same module the recipe
+      # and the hook do, so there is ONE version literal in the repo and no
+      # second declaration to drift from. The module re-emits each finding as
+      # an `::error file=,line=,col=::` annotation, which is the only thing
+      # the action added over running cli2 directly.
+      - name: markdownlint self-test (engine pin + finding parser)
+        run: node --test .github/scripts/markdownlint-run.test.mjs
+
       - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff  # v24.2.0
-        with:
-          globs: |
-            **/*.md
-            !compatibility/prometheus/upstream/**
-            !compatibility/tempo/upstream/**
-            !compatibility/loki/upstream/**
-            !**/node_modules/**
+        run: node .github/scripts/markdownlint-run.mjs
 
       # doc-to-code reference integrity. Greps docs/**/*.md for inline
       # `(internal|cmd|test|deploy)/<path>.go[:line]` (+ dir) citations and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,13 @@ just ci                                               # lint + test + build
 ```
 
 Hooks are lightweight: `pre-commit` runs `gofumpt -w` / `goimports -w` /
-`markdownlint-cli2 --fix` on staged files (auto-fixes; restages), and
-`commit-msg` runs `commitlint` so a malformed subject is caught locally
-instead of in CI. Heavy validation (`go test`, `golangci-lint run`,
+`scripts/align-md-tables.py` / `markdownlint-cli2 --fix` on staged files
+(auto-fixes; restages), and `commit-msg` runs `commitlint` so a malformed
+subject is caught locally instead of in CI. The table-padding pass is separate
+because `MD060` has no auto-fixer; `markdownlint --fix` cannot realign a table.
+The markdownlint engine is pinned once, in
+`.github/scripts/markdownlint-run.mjs`, and CI runs that same module — so
+`just lint-md` reproduces a red `lint` job rather than disagreeing with it. Heavy validation (`go test`, `golangci-lint run`,
 `go build`) deliberately is **not** in the hook — CI owns that. Don't
 pre-flight manually.
 

--- a/Justfile
+++ b/Justfile
@@ -7,7 +7,6 @@ GOLANGCI_LINT_VERSION := "v2.12.2"
 GOFUMPT_VERSION := "v0.7.0"
 GOIMPORTS_VERSION := "latest"
 GREMLINS_VERSION := "v0.6.0"
-MARKDOWNLINT_VERSION := "v0.18.1"
 ACTIONLINT_VERSION := "v1.7.12"
 MODULE := "github.com/tsouza/cerberus"
 
@@ -54,6 +53,16 @@ install-tools:
     go install golang.org/x/tools/cmd/goimports@{{GOIMPORTS_VERSION}}
     go install github.com/go-gremlins/gremlins/cmd/gremlins@{{GREMLINS_VERSION}}
     go install github.com/rhysd/actionlint/cmd/actionlint@{{ACTIONLINT_VERSION}}
+    # The `pre-commit` hook's Markdown fixer. The hook runs a $PATH binary
+    # rather than `npm exec` because npm's own startup is ~4s, five times the
+    # budget CLAUDE.md sets for that stage — but it accepts one ONLY at the
+    # pinned version, and falls back to the (slow) pinned `npm exec` otherwise.
+    # The version is read from the script so this stays a single declaration.
+    #
+    # Leading `-`: a global npm install needs a writable npm prefix, which not
+    # every environment has. The hook is correct without it — just slower — so
+    # a failure here must not block the rest of the toolchain.
+    -npm install -g markdownlint-cli2@"$(node .github/scripts/markdownlint-run.mjs --print-version)"
 
 # Install lefthook + activate git hooks. Idempotent; run once after clone.
 # Hooks defined in lefthook.yml run gofumpt / goimports / markdownlint-cli2 --fix
@@ -1212,13 +1221,27 @@ lint:
 lint-actions:
     actionlint
 
-# Lint all Markdown files (run via npm exec; no global Node deps).
-lint-md:
-    npm exec --yes -- markdownlint-cli2@{{MARKDOWNLINT_VERSION}} "**/*.md" "!compatibility/prometheus/upstream/**" "!**/node_modules/**"
+# The engine version and the glob set both live in
+# `.github/scripts/markdownlint-run.mjs`, which is also what ci.yml's `lint`
+# job and lefthook's `pre-commit` hook run. That is the point: this recipe used
+# to pin its own older markdownlint, so a rule `.markdownlint.yaml` configures
+# (MD060) was enforced in CI and invisible here, and `just lint-md` reported
+# success on a file CI then failed (tsouza/cerberus#2997).
+#
+# NOT everything `lint-md` reports is auto-fixable by `fmt-md`. MD060
+# (table-column-style) has no fixer in markdownlint at all — realign tables
+# with `python3 scripts/align-md-tables.py <file>...`, which lefthook runs as
+# its own `md-table-align` pre-commit hook. `fmt-md` says so when MD060
+# survives the fix pass, rather than leaving a clean-looking run that still
+# fails `lint-md`.
 
-# Auto-fix Markdown lint issues where possible.
+# Lint all Markdown files, with the same pinned engine CI runs.
+lint-md:
+    node .github/scripts/markdownlint-run.mjs
+
+# Auto-fix Markdown lint issues where possible (MD060 needs align-md-tables.py).
 fmt-md:
-    npm exec --yes -- markdownlint-cli2@{{MARKDOWNLINT_VERSION}} --fix "**/*.md" "!compatibility/prometheus/upstream/**" "!**/node_modules/**"
+    node .github/scripts/markdownlint-run.mjs --fix
 
 # Format Go code.
 fmt:

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -72,7 +72,26 @@ being scheduled — a PR then sits blocked on contexts that can never report.
 
 `markdownlint-cli2` with `.markdownlint.yaml`. `MD060` pins table-column-style to `aligned`; the
 `pre-commit` hook pads cell widths with `scripts/align-md-tables.py` before the auto-fixer runs,
-because that rule has no auto-fixer of its own.
+because that rule has no auto-fixer of its own. `just fmt-md` therefore does not fix everything
+`just lint-md` reports — when MD060 survives the fix pass it names the padding script rather than
+leaving a clean-looking run that still fails the lint.
+
+The engine version is declared exactly once, as `PINNED_CLI2_VERSION` in
+`.github/scripts/markdownlint-run.mjs`, and all three callers route through that module: the
+`lint-md` / `fmt-md` recipes, lefthook's `markdownlint` hook, and the `lint` job. They used to
+resolve to three different engines — a Justfile pin, a bundled action, and whatever binary was on a
+developer's `$PATH`. Because markdownlint IGNORES a config key naming a rule it does not implement
+rather than rejecting it, the `MD060` key configured nothing under the older local pin: `just
+lint-md` reported success on a table CI then failed on. The failure mode is silent and in the
+dangerous direction, and it generalises past MD060 — any rule the repo configures ahead of the
+local pin is enforced in CI and invisible locally, so invariant 5's "reproduce the red check
+locally" cannot be satisfied for it.
+
+Bumping the engine is one literal, and the bump belongs in the same change as whatever the newer
+engine surfaces. The hook is the one caller that cannot use `npm exec` — npm's startup alone is
+~4s against a sub-second `pre-commit` budget — so it prefers a `$PATH` binary, but only at exactly
+the pinned version, and otherwise falls back to the pinned `npm exec`. `just install-tools`
+installs the matching binary so that fast path is the default.
 
 ## Mutation testing — the gremlins fork
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -52,10 +52,16 @@ pre-commit:
       run: |
         python3 scripts/align-md-tables.py {staged_files}
     markdownlint:
+      # Routed through the script rather than calling `markdownlint-cli2`
+      # straight off $PATH. A bare call ran whatever version happened to be
+      # installed — a THIRD engine, matching neither the Justfile pin nor CI,
+      # so the fixer could rewrite a file in ways CI then rejected
+      # (tsouza/cerberus#2997). `--staged` still prefers a $PATH binary for
+      # speed, but only when its version is exactly the pinned one.
       glob: "*.md"
       stage_fixed: true
       run: |
-        markdownlint-cli2 --fix {staged_files}
+        node .github/scripts/markdownlint-run.mjs --staged {staged_files}
 
 # pre-push runs once per `git push`. It carries the forbid-skip and
 # repo-hygiene gates — grep and Node scans that finish in about a second


### PR DESCRIPTION
## The defect

markdownlint was invoked from three places, and each resolved to a **different**
engine. The divergence was silent and in the dangerous direction.

| where | invocation | markdownlint-cli2 | markdownlint |
| ---------------------------- | ------------------------------------ | ----------------- | ------------ |
| `just lint-md` / `just fmt-md` | `markdownlint-cli2@v0.18.1`          | 0.18.1            | **0.38.0**   |
| lefthook `pre-commit`          | a bare binary from `$PATH`           | unpinned          | **unpinned** |
| `ci.yml`'s `lint` job          | `markdownlint-cli2-action@v24.2.0`   | 0.23.2            | **0.41.1**   |

The action's own `package.json` at the pinned SHA declares
`markdownlint-cli2: 0.23.2`, which depends on `markdownlint@0.41.1` — so CI was
a minor version further ahead than #2997 estimated, and the `$PATH` binary on
the machine this was reproduced on was a third engine again (0.22.1).

markdownlint **ignores** a config key naming a rule it does not implement rather
than rejecting it. `.markdownlint.yaml` pins `MD060: {style: aligned}`, and
MD060 arrived in markdownlint 0.40 — so under the local pin that key configured
nothing and the rule could not fire. Reproduced directly, same file, same
config:

```text
cli2 0.18.1  ->  Summary: 0 error(s)
cli2 0.23.2  ->  4 x MD060/table-column-style  Table pipe does not align with header
```

The cost is not one rule. CLAUDE.md invariant 5 requires a red check to be
reproduced locally before the next push; for every rule newer than the local
pin that was impossible by construction, leaving exactly the guess-and-wait push
loop the invariant exists to forbid.

## The fix — structural, not asserted

`.github/scripts/markdownlint-run.mjs` is now the only markdownlint-cli2
invocation in the repository. All three callers route through it, so
`PINNED_CLI2_VERSION` is the only version literal in the tree and `GLOBS` the
only file set. Agreement is a property of the structure, not something a checker
has to re-establish.

That also closed a second skew axis nobody had noticed: the Justfile's glob set
excluded only `compatibility/prometheus/upstream/**`, while CI's also excluded
the tempo and loki upstream corpora. `.markdownlintignore` happened to cover the
difference, so the two file sets agreed by luck rather than by construction.

CI's step drops the action in favour of the shared module. The module re-emits
each finding as an `::error file=,line=,col=,title=::` annotation, which is the
only thing the action added over running cli2 directly — inline PR annotations
are preserved. The `lint` job already reaches the npm registry one step earlier
(`commitlint` does `npm install --no-save`), so this adds no new failure class.

### The hook is the one edge that is not structural

lefthook cannot use `npm exec`: measured at 2.6-4.5s per invocation with the
package already in the npx cache and even with `--offline` — the cost is npm's
own startup — against the sub-second budget CLAUDE.md sets for `pre-commit`. So
`--staged` prefers a `$PATH` binary, but `chooseEngine` accepts one **only** at
exactly the pinned version and otherwise falls back to the pinned `npm exec`.
The hook is slow-but-correct in the worst case and never, in any case, runs a
different engine. Running the wrong engine is the defect; being slow is not.
`just install-tools` installs the matching binary so the fast path is the
default, and it is non-fatal because a global npm install needs a writable
prefix that not every environment has.

## The bump is clean on current `main`

`markdownlint-cli2@0.23.2` (markdownlint 0.41.1) over all 53 linted files:
`Summary: 0 issues in 0 files`. No backlog, so nothing was carried.

## Why no drift gate

The usual shape here would be a checker comparing the Justfile pin, the hook's
pin and the workflow's pin. After this change there is nothing left to compare —
one literal, one invoker — and a gate over a single declaration asserts a
tautology. The genuinely unguarded edge is the hook's `$PATH` binary, and that
is closed in `chooseEngine` rather than in a gate.

What is gated instead is the thing a version comparison structurally cannot see.
A checker comparing version strings would have been **green throughout the
original defect**: the versions were each internally consistent, and the failure
was a rule *configured but not implemented*. So
`markdownlint-run.test.mjs` runs the pinned engine against a deliberately
misaligned table and requires MD060 to fire, then requires an aligned one to
pass.

**Proof it can go red.** Re-pinning `PINNED_CLI2_VERSION` to the old `0.18.1`
and running the suite:

```text
✖ chooseEngine refuses every version that is not the pin
✖ the pinned engine enforces MD060 as .markdownlint.yaml configures it
  AssertionError: the pinned engine must implement MD060 — a pin that does not
  makes .markdownlint.yaml's MD060 key configure nothing, which is #2997.
ℹ pass 9   ℹ fail 2
```

Lowering the pin below markdownlint 0.40, or dropping the `MD060` key, turns the
suite red instead of turning `just lint-md` quietly green.

## `fmt-md` cannot fix MD060, and now says so

markdownlint has no fixer for MD060; `scripts/align-md-tables.py` is what
realigns a table, which is why lefthook carries `md-table-align` as its own hook
ahead of the fixer. That hook is untouched. The distinction is now discoverable
rather than folklore: `just fmt-md` prints where the padding pass lives when
MD060 survives the fix, and the Justfile, `CONTRIBUTING.md` and
`docs/toolchain.md` each say that `fmt-md` does not fix everything `lint-md`
reports.

## Verification

- `just lint-md` — `markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)`, 53 files, 0 issues.
- `just lint-actions` — clean (a workflow changed).
- `node --test .github/scripts/markdownlint-run.test.mjs` — 11/11.
- `assert-gate-suites-wired` — 80 suites, all invoked by a workflow.
- `verify-code-citations`, `forbid-contradicted-mutants`, `repo-hygiene`
  (`binary` + `root-allowlist`), `doc-refs`, `doc-counts`, `ci-lane-contract`,
  `main-coalescing` — all clean.
- End-to-end: a misaligned table added to the tree now fails `just lint-md`
  locally with the same `file:line:col MD060/table-column-style` text CI prints,
  and `scripts/align-md-tables.py` clears it.

## Notes for the reviewer

**No required context changes.** The `lint` job keeps its name and its contexts;
only steps inside it moved.

`ci.yml` is also being edited by the change for tsouza/cerberus#2994, in the
workflow-level `concurrency` block. This change touches only the `lint` job's
markdownlint steps, a distant region of the same file.

A reviewer guarding against a recurrence should look for a version literal
reappearing anywhere else — a hardcoded `markdownlint-cli2@x.y.z`, or a workflow
returning to the action — rather than for a red gate.

Found and filed while here: tsouza/cerberus#3003, `just --list` renders a
rationale fragment instead of a description for 75 recipes, because `just` shows
only the last line of a recipe's contiguous comment block. The two recipes this
change touches are fixed; the sweep belongs with that issue rather than inside a
CI-correctness change.

Closes #2997
