### PR TITLE
ci(coverage): raise twenty package floors from the profile fifteen-run evidence selects

### DIFF
--- a/test/coverage-floor/cmd__cerberus.json
+++ b/test/coverage-floor/cmd__cerberus.json
@@ -1,3 +1,3 @@
 {
-  "cmd/cerberus": 55.7
+  "cmd/cerberus": 56.9
 }

--- a/test/coverage-floor/internal__api__loki.json
+++ b/test/coverage-floor/internal__api__loki.json
@@ -1,3 +1,3 @@
 {
-  "internal/api/loki": 86.1
+  "internal/api/loki": 86.2
 }

--- a/test/coverage-floor/internal__chaudit.json
+++ b/test/coverage-floor/internal__chaudit.json
@@ -1,3 +1,3 @@
 {
-  "internal/chaudit": 79.9
+  "internal/chaudit": 83.2
 }

--- a/test/coverage-floor/internal__chclient.json
+++ b/test/coverage-floor/internal__chclient.json
@@ -1,3 +1,3 @@
 {
-  "internal/chclient": 67.9
+  "internal/chclient": 68
 }

--- a/test/coverage-floor/internal__chclienttest.json
+++ b/test/coverage-floor/internal__chclienttest.json
@@ -1,3 +1,3 @@
 {
-  "internal/chclienttest": 74.4
+  "internal/chclienttest": 75
 }

--- a/test/coverage-floor/internal__downsampletier.json
+++ b/test/coverage-floor/internal__downsampletier.json
@@ -1,3 +1,3 @@
 {
-  "internal/downsampletier": 95.8
+  "internal/downsampletier": 98.3
 }

--- a/test/coverage-floor/internal__logql.json
+++ b/test/coverage-floor/internal__logql.json
@@ -1,3 +1,3 @@
 {
-  "internal/logql": 90.3
+  "internal/logql": 90.8
 }

--- a/test/coverage-floor/internal__logql__lsyntax.json
+++ b/test/coverage-floor/internal__logql__lsyntax.json
@@ -1,3 +1,3 @@
 {
-  "internal/logql/lsyntax": 92.6
+  "internal/logql/lsyntax": 93.4
 }

--- a/test/coverage-floor/internal__preflight.json
+++ b/test/coverage-floor/internal__preflight.json
@@ -1,3 +1,3 @@
 {
-  "internal/preflight": 94.1
+  "internal/preflight": 94.9
 }

--- a/test/coverage-floor/internal__promql.json
+++ b/test/coverage-floor/internal__promql.json
@@ -1,3 +1,3 @@
 {
-  "internal/promql": 89.3
+  "internal/promql": 89.6
 }

--- a/test/coverage-floor/internal__routememo.json
+++ b/test/coverage-floor/internal__routememo.json
@@ -1,3 +1,3 @@
 {
-  "internal/routememo": 91.6
+  "internal/routememo": 92.1
 }

--- a/test/coverage-floor/internal__schema.json
+++ b/test/coverage-floor/internal__schema.json
@@ -1,3 +1,3 @@
 {
-  "internal/schema": 97.6
+  "internal/schema": 97.7
 }

--- a/test/coverage-floor/internal__schema__ddl.json
+++ b/test/coverage-floor/internal__schema__ddl.json
@@ -1,3 +1,3 @@
 {
-  "internal/schema/ddl": 93.9
+  "internal/schema/ddl": 95.5
 }

--- a/test/coverage-floor/internal__solver.json
+++ b/test/coverage-floor/internal__solver.json
@@ -1,3 +1,3 @@
 {
-  "internal/solver": 88.4
+  "internal/solver": 89.6
 }

--- a/test/coverage-floor/internal__testsql.json
+++ b/test/coverage-floor/internal__testsql.json
@@ -1,3 +1,3 @@
 {
-  "internal/testsql": 89.2
+  "internal/testsql": 89.3
 }

--- a/test/coverage-floor/internal__traceql__ast.json
+++ b/test/coverage-floor/internal__traceql__ast.json
@@ -1,3 +1,3 @@
 {
-  "internal/traceql/ast": 86.1
+  "internal/traceql/ast": 86.5
 }

--- a/test/coverage-floor/test__e2e__migration__steps.json
+++ b/test/coverage-floor/test__e2e__migration__steps.json
@@ -1,3 +1,3 @@
 {
-  "test/e2e/migration/steps": 11.9
+  "test/e2e/migration/steps": 12
 }

--- a/test/coverage-floor/test__perf__nightly.json
+++ b/test/coverage-floor/test__perf__nightly.json
@@ -1,3 +1,3 @@
 {
-  "test/perf/nightly": 50.9
+  "test/perf/nightly": 51
 }

--- a/test/coverage-floor/test__property__oracle__traceql.json
+++ b/test/coverage-floor/test__property__oracle__traceql.json
@@ -1,3 +1,3 @@
 {
-  "test/property/oracle/traceql": 87
+  "test/property/oracle/traceql": 88.3
 }

--- a/test/coverage-floor/test__spec__parityoracle__logql.json
+++ b/test/coverage-floor/test__spec__parityoracle__logql.json
@@ -1,3 +1,3 @@
 {
-  "test/spec/parityoracle/logql": 70.1
+  "test/spec/parityoracle/logql": 74.5
 }


### PR DESCRIPTION
Takes the raises #2999 identified. Every value is `just update-coverage-floor`'s own output against a
full `default+chdb` CI profile whose digest-bound lane record the update path verified before writing;
nothing here is hand-written. Against `origin/main`: **20 raised, 0 lowered, 0 dropped, 0 added.**

## The measurement

Source: CI run
[33736940218](https://github.com/tsouza/cerberus/actions/runs/33736940218), lane record
`{"lanes":"default+chdb","profileSha256":"1492bca0…"}`, matching the profile bytes. Its tree differs
from this branch's base by exactly one file — `test/coverage-floor/internal__promql__promparse.json`,
a ledger entry, not code — so it measures precisely the tree these floors govern, and it carries all
97 packages.

## Why that run, and not `main`'s own

Fifteen full-lane profiles were compared. **87 of 97 packages measure bit-identically** run to run,
and eight of the ten movers step exactly once, at the commit that touched them — seven of those at
`5a93fd34e` (#2996), which restored exactly those seven packages. Two packages move with no code
change anywhere in range:

| package | draws observed | statements |
| --- | --- | --- |
| `test/property/oracle/traceql` | 242, 243, 244, 245 | of 272 |
| `internal/solver` | 743, 747 | of 820 |

The clean proof is commit `baa2455d6`, measured twice with zero commits between: run
[33736852105](https://github.com/tsouza/cerberus/actions/runs/33736852105) (push) drew 245 and 747;
run [33741638810](https://github.com/tsouza/cerberus/actions/runs/33741638810) (schedule) drew 243 and
743. Same tree, different measurement.

The mechanism is not a guess. `TestTraceQL_Property` reaches both packages through
`pgregory.net/rapid`, whose `-rapid.seed` is documented as defaulting to "0 to use a random one", and
no lane pins a seed.

This matters because `main`'s green run and this branch's own base run **both drew the peak on both
packages simultaneously**. Enrolling from either would set `test/property/oracle/traceql` to `89.0` —
which requires 243 covered statements, a bar the already-observed 242 misses. That is exactly the
shape #2991 produced: met once, recorded, then quietly missed for three days. Run 33736940218 drew
the mode on both, giving `88.3` and `89.6`. **Those two entries are the only difference between this
ledger and the one this branch's own base commit would have produced** — the other 95 shards are
identical either way.

## Reproducibility, per package

Against the seven profiles that measure current code, every raised floor sits at or below the lowest
value observed. Nineteen of twenty retain the ledger's full 1.0-point slack:

| package | new floor | min observed (n=7) | margin | in statements |
| --- | --- | --- | --- | --- |
| `internal/chaudit` | 83.2 | 84.29 (59/70, **identical in all 15 profiles**) | 1.09 | 0.8 |
| `internal/downsampletier` | 98.3 | 99.37 (158/159, **identical in all 15**) | 1.07 | 1.7 |
| `internal/solver` | 89.6 | 90.61 | 1.01 | 8.3 |
| `test/property/oracle/traceql` | 88.3 | 88.97 | 0.67 | 1.8 |
| the other sixteen | — | — | 1.01–1.09 | 2.2–82.8 |

**The two large movers are the safest raises in the set.** `internal/chaudit` (+3.3) and
`internal/downsampletier` (+2.5) have not moved by a single statement across all fifteen profiles,
spanning 26 hours and a dozen commits. Their jump size measures how stale the floors were, not how
volatile the packages are, so 1.0 is the right slack for both.

`test/property/oracle/traceql` is the one raise carrying real risk. At 88.3 it requires 241
statements, one below a fifteen-run minimum of 242. The fully safe value is 87.9, and no profile
available produces it without also regressing `internal/qlcommon` below its committed floor, so the
recipe cannot emit it; #3000 records what would have to change.

Three small packages — `internal/chaudit`, `test/perf/nightly`, `test/spec/parityoracle/logql` —
land with under one statement of margin, because at 70, 73 and 49 statements the 1.0-point slack is
sub-statement. All three are deterministic across all fifteen profiles, so this is a true-red trigger
on a genuine coverage drop rather than a flake risk. #3000 covers the sizing.

## Confidence that `main` stays green

- **Sixteen packages: very high.** Bit-identical across every profile, full slack retained.
- **`internal/chaudit`, `internal/downsampletier`: very high.** Zero variance in fifteen profiles.
- **`internal/solver`: high.** Floor taken from the mode (743), not the once-seen 747 peak; 8.3
  statements of margin against an observed wobble of 4.
- **`test/property/oracle/traceql`: moderate, and the only one I would flag.** Seed-dependent by
  construction. 88.3 survives every draw seen in fifteen runs, but it is one statement below the
  observed minimum, so an unluckier draw can red it.

Filed: #3000 (the ledger's single global point-slack fits neither seed-dependent nor small packages —
including `test/property/oracle/promql`, already sitting under one statement of margin on `main`) and
#3001 (the update path drops the floor of a package the profile does not measure, silently). Both are
sub-issues of #2891 in milestone M1.

Closes #2999
