### PR TITLE
fix(ci): refuse a floor the profile never measured, and pin the seed the ledger measures with

### DIFF
--- a/.github/scripts/coverage-summary.mjs
+++ b/.github/scripts/coverage-summary.mjs
@@ -29,6 +29,10 @@
 // The floors are a ratchet: `just update-coverage-floor` raises them to what
 // the tree actually achieves and REFUSES to lower one. Lowering a floor is a
 // hand-edited, reviewable line in a pull request, never a tool's silent output.
+// DELETING a floor is a lowering too — it is the deepest one available, since
+// the ratchet only moves up and so has no mechanism that ever restores a
+// vanished entry — so the update path refuses that as well, unless the package's
+// own directory is gone from the tree (tsouza/cerberus#3001).
 //
 // Usage:
 //   node .github/scripts/coverage-summary.mjs
@@ -51,6 +55,12 @@
 //                           downgrading to the skip above, so a chdb install
 //                           that silently no-ops cannot turn the gate off.
 //   COVERAGE_UPDATE_FLOORS  `1` rewrites the ledger instead of comparing.
+//   COVERAGE_TREE_ROOT      module root the update path resolves a floored
+//                           package's directory against, to tell a package
+//                           DELETED from the tree apart from one the profile
+//                           merely failed to measure (default: the working
+//                           directory, which is the module root every recipe
+//                           invokes this from).
 //   GITHUB_STEP_SUMMARY     appended to when present (set by Actions).
 //
 // The lane record (`<profile>.lanes.json`):
@@ -81,10 +91,13 @@
 // Exit codes:
 //   0  every package clears its floor (or the ledger was rewritten).
 //   1  unreadable input, a COVERAGE_REQUIRE_LANES mismatch, a lane set the
-//      update path cannot prove is `default+chdb`, or a floor violation.
+//      update path cannot prove is `default+chdb`, a floored package the
+//      profile did not measure while the tree still carries it, or a floor
+//      violation.
 
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { appendStepSummary, error, log, notice } from './lib/gh.mjs';
@@ -102,6 +115,24 @@ export const FULL_LANES = 'default+chdb';
 // sits this far below the measurement that produced it. Wide enough to absorb
 // the jitter, narrow enough that a deleted test still trips it.
 const FLOOR_SLACK_PCT = 1.0;
+
+// ...but a percentage point is not a unit of jitter. The jitter above moves
+// whole STATEMENTS, and what a point is worth in statements is decided entirely
+// by the package's size, which a point-only slack never consults: 1.0 point of
+// a 70-statement package is 0.70 statements, so its floor tolerates no jitter at
+// all, while 1.0 point of a 4600-statement package is 46 of them.
+//
+// One statement is the quantum of the measurement itself — a package cannot
+// lose less — so a margin narrower than one statement is not a margin, it is a
+// floor pinned to the exact draw that produced it. This is the lower bound in
+// the unit the jitter actually moves in. It binds only below 100 statements,
+// which is precisely where a point is worth less than one statement; above that
+// FLOOR_SLACK_PCT is the wider of the two and nothing changes.
+//
+// Widening the slack can only ever LOWER the floor a fresh measurement
+// justifies, and nextFloors keeps the greater of that and the committed value,
+// so this cannot lower an entry already in the ledger.
+const FLOOR_SLACK_STATEMENTS = 1;
 
 // Floors are recorded to this many decimals; the profile itself is integer
 // statement counts, so more precision would be noise.
@@ -188,12 +219,22 @@ export function pct(covered, total) {
   return total > 0 ? (100 * covered) / total : 0;
 }
 
-// floorFor rounds a measurement down to the floor it justifies. A measurement
-// too thin to clear the slack justifies no floor at all, and says so with 0 —
-// callers must treat that as "this package needs a test", never as a floor.
-export function floorFor(measured) {
+// floorSlackPct is the margin a package of this size gets, in percentage
+// points: the wider of the flat point slack and FLOOR_SLACK_STATEMENTS
+// statements expressed as a percentage of the package. A package with no
+// statements gets the flat value, which is moot — nothing floors it.
+export function floorSlackPct(total) {
+  if (!(total > 0)) return FLOOR_SLACK_PCT;
+  return Math.max(FLOOR_SLACK_PCT, (100 * FLOOR_SLACK_STATEMENTS) / total);
+}
+
+// floorFor rounds a measurement down to the floor it justifies, given the size
+// of the package it measured. A measurement too thin to clear the slack
+// justifies no floor at all, and says so with 0 — callers must treat that as
+// "this package needs a test", never as a floor.
+export function floorFor(measured, total) {
   const scale = 10 ** FLOOR_DECIMALS;
-  return Math.max(0, Math.floor((measured - FLOOR_SLACK_PCT) * scale) / scale);
+  return Math.max(0, Math.floor((measured - floorSlackPct(total)) * scale) / scale);
 }
 
 // rows renders the per-package table, widest coverage first — the same shape,
@@ -246,6 +287,29 @@ export function compare(packages, floors) {
   };
 }
 
+// packageStillInTree answers the one question that separates a floored package
+// the profile DELIBERATELY no longer measures from one it silently failed to.
+//
+// A package that was removed from the module has no directory carrying
+// non-test Go files any more, and that is a fact about the tree the updater can
+// read for itself — no marker file, no exemption list, nothing a human has to
+// remember to keep in step. A package whose directory is still sitting there is
+// a package the profile SHOULD have measured, and its absence is evidence about
+// the profile, not about the tree.
+//
+// `_test.go` files are excluded deliberately: they carry no instrumented
+// statements, so a directory holding only tests can never contribute to a
+// profile and is, for the ledger's purposes, exactly as gone as an empty one.
+export function packageStillInTree(pkg, root = process.env.COVERAGE_TREE_ROOT || '.') {
+  let entries;
+  try {
+    entries = readdirSync(path.join(root, ...packageKeySegments(pkg)), { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  return entries.some((e) => e.isFile() && e.name.endsWith('.go') && !e.name.endsWith('_test.go'));
+}
+
 // nextFloors ratchets the ledger up to what the tree achieves. It never lowers
 // one: a package that no longer clears its floor is returned as a regression so
 // the caller can refuse, because a tool that rewrites the floor to match a drop
@@ -254,10 +318,21 @@ export function compare(packages, floors) {
 // Nor does it record a zero. A package whose measurement cannot justify a floor
 // above 0 is returned as unfloorable rather than written out, so the ledger
 // never gains an entry that no future run can fail.
-export function nextFloors(packages, floors) {
+//
+// Nor does it drop one. The returned map is the ENTIRE next ledger, so a
+// floored package that never appears in the profile silently loses its entry —
+// a third way out of the ledger, and the worst of the three, because the
+// ratchet only moves up and so has nothing that ever puts a vanished floor
+// back. Such packages come back as `unmeasured` (the directory is still in the
+// tree, so the profile is incomplete and the caller must refuse) or `removed`
+// (the directory is gone, so the drop is what the tree says should happen and
+// the caller reports it). Nothing is written on the strength of an absence.
+export function nextFloors(packages, floors, inTree = packageStillInTree) {
   const next = {};
   const regressions = [];
   const unfloorable = [];
+  const removed = [];
+  const unmeasured = [];
 
   for (const [pkg, { total, covered }] of [...packages.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
     if (total === 0) continue;
@@ -266,17 +341,31 @@ export function nextFloors(packages, floors) {
     if (existing !== undefined && value < existing) {
       regressions.push({ pkg, value, floor: existing });
     }
-    const floor = Math.max(existing ?? 0, floorFor(value));
+    const floor = Math.max(existing ?? 0, floorFor(value, total));
     if (!(floor > 0)) {
       unfloorable.push({ pkg, value, total });
       continue;
     }
     next[pkg] = floor;
   }
+
+  // `next` is the WHOLE ledger the caller is about to write, so every floored
+  // package the loop above did not reach loses its entry. Sort them into the
+  // two cases that look identical from inside the profile and demand opposite
+  // answers.
+  for (const pkg of Object.keys(floors).sort()) {
+    const measured = packages.get(pkg);
+    if (measured && measured.total > 0) continue;
+    if (inTree(pkg)) unmeasured.push(pkg);
+    else removed.push(pkg);
+  }
+
   return {
     next,
     regressions: regressions.sort((a, b) => a.pkg.localeCompare(b.pkg)),
     unfloorable: unfloorable.sort((a, b) => a.pkg.localeCompare(b.pkg)),
+    removed,
+    unmeasured,
   };
 }
 
@@ -484,7 +573,19 @@ function main() {
     const update = resolveUpdateLanes(recordText, text, recordPath);
     if (update.err) fail(update.err);
 
-    const { next, regressions, unfloorable } = nextFloors(packages, floors);
+    const { next, regressions, unfloorable, removed, unmeasured } = nextFloors(packages, floors);
+    if (unmeasured.length) {
+      fail(
+        `${unmeasured.length} package(s) carry a committed floor that this profile did not measure, ` +
+          `and their directories are still in the tree. Rewriting the ledger from this profile would ` +
+          `DELETE those floors — the one weakening the ratchet cannot undo, since it only ever moves ` +
+          `up and nothing restores an entry that is gone. Either the profile is older than the ` +
+          `package (enrolling from a downloaded artifact measured at some earlier commit) or a lane ` +
+          `failed to build it; from inside the profile those look identical, so neither is guessed ` +
+          `at. Re-measure the tree in hand and enroll from THAT profile:\n` +
+          unmeasured.map((p) => `  - ${p}`).join('\n'),
+      );
+    }
     if (regressions.length) {
       fail(
         `${regressions.length} package(s) sit below a committed floor, and raising the ledger ` +
@@ -502,6 +603,19 @@ function main() {
           `\`-coverpkg\` over the whole module, so a test in ANY package counts: give each one a ` +
           `test that reaches it, or delete the code that nothing reaches:\n` +
           unfloorable.map((r) => `  - ${r.pkg}: ${r.value.toFixed(2)}% of ${r.total} statements`).join('\n'),
+      );
+    }
+    if (removed.length) {
+      // Reported, not refused: the package's directory is gone from the tree,
+      // so dropping its floor is the ledger following the module rather than a
+      // measurement gap being laundered. It is still a floor leaving the
+      // ledger, so it says so out loud and lands as a deletion in the diff.
+      notice(
+        `${removed.length} floor(s) dropped: the package no longer exists in the tree, so nothing ` +
+          `can measure it. The deletion is in the ledger diff — check each one is a package you ` +
+          `meant to remove:\n` +
+          removed.map((p) => `  - ${p}`).join('\n'),
+        { title: 'coverage floor' },
       );
     }
     writeFloors(floorsDir, next);

--- a/.github/scripts/coverage-summary.test.mjs
+++ b/.github/scripts/coverage-summary.test.mjs
@@ -19,10 +19,12 @@ import {
   compare,
   DEFAULT_PROFILE,
   floorFor,
+  floorSlackPct,
   laneRecordPath,
   nextFloors,
   packageKeySegments,
   packageOf,
+  packageStillInTree,
   parseProfile,
   profileDigest,
   resolveLanes,
@@ -152,10 +154,32 @@ test('the table is widest coverage first, in the column shape the summary has al
   ]);
 });
 
-test('a floor sits a fixed slack below the measurement and never goes negative', () => {
-  assert.equal(floorFor(82.55), 81.5);
-  assert.equal(floorFor(100), 99);
-  assert.equal(floorFor(0.4), 0);
+test('a floor sits a slack below the measurement and never goes negative', () => {
+  // A package big enough that a point is worth more than a statement gets the
+  // flat point slack, unchanged.
+  assert.equal(floorFor(82.55, 1000), 81.5);
+  assert.equal(floorFor(100, 1000), 99);
+  assert.equal(floorFor(0.4, 1000), 0);
+});
+
+test('the slack is at least one statement wide, whatever a point is worth in this package', () => {
+  // The defect: a point-only slack means whatever the package's size makes it
+  // mean. On a 70-statement package 1.0 point is 0.70 statements, so the floor
+  // it justifies tolerates NO jitter — one statement flipping reds the gate.
+  assert.equal(floorSlackPct(1000), 1.0, 'a point is worth 10 statements here — the point wins');
+  assert.equal(floorSlackPct(100), 1.0, 'exactly the crossover: a point IS one statement');
+  assert.ok(floorSlackPct(70) > 1.0, 'below the crossover the statement wins');
+  assert.equal(floorSlackPct(70).toFixed(4), (100 / 70).toFixed(4));
+
+  // 59/70 statements. The old flat slack put the floor at 83.2, which 58/70
+  // (82.86%) fails — a one-statement swing on a package nothing has changed.
+  const measured = (100 * 59) / 70;
+  assert.ok(floorFor(measured, 70) < (100 * 58) / 70, 'one statement of margin is now inside the floor');
+  assert.ok(floorFor(measured, 70) > (100 * 57) / 70, 'and no more than that — two statements still red');
+
+  // A package with no statements is never floored, so the value is moot; it
+  // must still be a number rather than an Infinity that poisons floorFor.
+  assert.equal(floorSlackPct(0), 1.0);
 });
 
 test('comparison reports drops, unfloored packages and vanished floors', () => {
@@ -195,8 +219,12 @@ test('the update ratchets floors up and refuses to lower one', () => {
       ['internal/down/a.go', 10, 0],
     ]),
   );
-  const { next, regressions } = nextFloors(packages, { 'internal/up': 40, 'internal/down': 70 });
-  assert.equal(next['internal/up'], 99, 'a package that improved raises its floor');
+  const { next, regressions } = nextFloors(packages, { 'internal/up': 40, 'internal/down': 70 }, () => false);
+  assert.equal(
+    next['internal/up'],
+    90,
+    'a package that improved raises its floor — to 100% less one statement, this package being 10 wide',
+  );
   assert.equal(next['internal/down'], 70, 'a package that dropped keeps the floor it failed');
   assert.deepEqual(
     regressions.map((r) => r.pkg),
@@ -213,7 +241,7 @@ test('the update returns an unfloorable package instead of writing a 0 into the 
       ['internal/real/a.go', 10, 1],
     ]),
   );
-  const { next, unfloorable } = nextFloors(packages, {});
+  const { next, unfloorable } = nextFloors(packages, {}, () => false);
   assert.deepEqual(
     unfloorable.map((r) => r.pkg),
     // 0% justifies nothing; 0.5% is inside the slack, so it justifies nothing
@@ -383,7 +411,9 @@ test('end to end: the update accepts the both-lane profile and enrolls the packa
   try {
     const { status, out } = run(profilePath, floorsDir, { COVERAGE_UPDATE_FLOORS: '1' });
     assert.equal(status, 0, `expected acceptance; output was:\n${out}`);
-    assert.equal(loadShardedMap(floorsDir)['internal/new'], 99);
+    // 10 statements, all covered: 100% less the one-statement slack this
+    // package's size makes worth 10 points.
+    assert.equal(loadShardedMap(floorsDir)['internal/new'], 90);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -510,5 +540,158 @@ test('a lane record that cannot be written fails the gate with an explanation, n
     assert.doesNotMatch(out, /at file:\/\//, 'the failure escaped as a stack trace');
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// treeRoot lays out a fake module root holding one directory per package, each
+// carrying the kind of file named: 'go' for an instrumented source file,
+// 'test' for a file that carries no instrumented statements at all.
+function treeRoot(packages) {
+  const root = mkdtempSync(path.join(tmpdir(), 'coverage-tree-'));
+  for (const [pkg, kind] of Object.entries(packages)) {
+    const dir = path.join(root, ...pkg.split('/'));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, kind === 'test' ? 'a_test.go' : 'a.go'), 'package a\n');
+  }
+  return root;
+}
+
+test('a package is still in the tree only while a directory of non-test Go files says so', () => {
+  const root = treeRoot({ 'internal/live': 'go', 'internal/testsonly': 'test' });
+  try {
+    assert.equal(packageStillInTree('internal/live', root), true);
+    assert.equal(
+      packageStillInTree('internal/testsonly', root),
+      false,
+      'test files carry no instrumented statements, so such a directory can never be measured',
+    );
+    assert.equal(packageStillInTree('internal/gone', root), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a floored package the profile never measured is classified, never silently dropped', () => {
+  const { packages } = parseProfile(profile([['internal/measured/a.go', 200, 1]]));
+  const floors = { 'internal/measured': 90, 'internal/absent': 80, 'internal/deleted': 70 };
+  const { next, unmeasured, removed } = nextFloors(packages, floors, (pkg) => pkg === 'internal/absent');
+
+  assert.deepEqual(unmeasured, ['internal/absent'], 'still in the tree: the PROFILE is incomplete');
+  assert.deepEqual(removed, ['internal/deleted'], 'gone from the tree: the ledger follows the module');
+  assert.deepEqual(
+    Object.keys(next),
+    ['internal/measured'],
+    'the returned map is the whole next ledger, which is exactly why an absence cannot be written blind',
+  );
+});
+
+test('end to end: an update that would delete a floor whose package is still there exits 1', () => {
+  // tsouza/cerberus#3001, reproduced: the profile is complete, both lanes,
+  // digest-stamped — it simply predates the package. Rewriting the ledger from
+  // it deletes the floor, and the ratchet has nothing that puts one back.
+  const { dir, profilePath, floorsDir } = fixture([['internal/measured/a.go', 200, 1]], {
+    'internal/measured': 40,
+    'internal/promql/promparse': 99,
+  });
+  const root = treeRoot({ 'internal/measured': 'go', 'internal/promql/promparse': 'go' });
+  const before = loadShardedMap(floorsDir);
+  try {
+    const { status, out } = run(profilePath, floorsDir, {
+      COVERAGE_UPDATE_FLOORS: '1',
+      COVERAGE_TREE_ROOT: root,
+    });
+    assert.equal(status, 1, `expected a refusal; output was:\n${out}`);
+    assert.match(out, /internal\/promql\/promparse/);
+    assert.match(out, /did not measure/);
+    assert.deepEqual(loadShardedMap(floorsDir), before, 'the ledger is untouched — nothing was written');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('end to end: the same profile against a tree without the package drops the floor and says so', () => {
+  // The positive control for the refusal above, and the answer to "a deliberate
+  // package removal stays expressible without hand-editing the ledger": delete
+  // the package, re-run, and the entry goes with it — reported, and visible in
+  // the ledger diff.
+  const { dir, profilePath, floorsDir } = fixture([['internal/measured/a.go', 200, 1]], {
+    'internal/measured': 40,
+    'internal/promql/promparse': 99,
+  });
+  const root = treeRoot({ 'internal/measured': 'go' });
+  try {
+    const { status, out } = run(profilePath, floorsDir, {
+      COVERAGE_UPDATE_FLOORS: '1',
+      COVERAGE_TREE_ROOT: root,
+    });
+    assert.equal(status, 0, `expected acceptance; output was:\n${out}`);
+    assert.match(out, /no longer exists in the tree/);
+    assert.match(out, /internal\/promql\/promparse/);
+    assert.deepEqual(Object.keys(loadShardedMap(floorsDir)), ['internal/measured']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('end to end: a profile that measures every floored package still enrolls normally', () => {
+  // The second positive control: nothing about the guard fires on a complete
+  // profile, so a green run is a statement about the profile rather than about
+  // the guard being asleep.
+  const { dir, profilePath, floorsDir } = fixture(
+    [
+      ['internal/measured/a.go', 200, 1],
+      ['internal/promql/promparse/a.go', 200, 1],
+    ],
+    { 'internal/measured': 40, 'internal/promql/promparse': 40 },
+  );
+  const root = treeRoot({ 'internal/measured': 'go', 'internal/promql/promparse': 'go' });
+  try {
+    const { status, out } = run(profilePath, floorsDir, {
+      COVERAGE_UPDATE_FLOORS: '1',
+      COVERAGE_TREE_ROOT: root,
+    });
+    assert.equal(status, 0, `expected acceptance; output was:\n${out}`);
+    assert.doesNotMatch(out, /no longer exists in the tree/);
+    assert.deepEqual(loadShardedMap(floorsDir), {
+      'internal/measured': 99,
+      'internal/promql/promparse': 99,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('end to end: every refusal is decided before the ledger is written, and none of them writes', () => {
+  // The fail-closed property this change must PRESERVE, stated over a profile
+  // that carries a raise (internal/measured, floored at 40 and measuring 100%),
+  // a regression and a measurement gap at once: whichever refusal fires, the
+  // raise must not land. writeFloors rewrites the whole ledger, so a refusal
+  // that ran after it would have already replaced every entry.
+  const { dir, profilePath, floorsDir } = fixture(
+    [
+      ['internal/dropped/a.go', 200, 0],
+      ['internal/measured/a.go', 200, 1],
+    ],
+    { 'internal/dropped': 90, 'internal/measured': 40, 'internal/promql/promparse': 99 },
+  );
+  const root = treeRoot({
+    'internal/dropped': 'go',
+    'internal/measured': 'go',
+    'internal/promql/promparse': 'go',
+  });
+  const before = loadShardedMap(floorsDir);
+  try {
+    const { status, out } = run(profilePath, floorsDir, {
+      COVERAGE_UPDATE_FLOORS: '1',
+      COVERAGE_TREE_ROOT: root,
+    });
+    assert.equal(status, 1, `expected a refusal; output was:\n${out}`);
+    assert.deepEqual(loadShardedMap(floorsDir), before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
   }
 });

--- a/Justfile
+++ b/Justfile
@@ -671,6 +671,29 @@ bench:
 # lane keeps the measured set identical to the tested set, with no exclusion
 # list to maintain or forget.
 
+# The pgregory.net/rapid PRNG seed both coverage lanes measure with.
+#
+# rapid's own default is 0, which it documents as "use a random one", and a
+# ratchet cannot be fed a measurement that moves: test/coverage-floor/ only
+# raises a floor, so one enrolled from a lucky draw is never corrected by the
+# unlucky draw that follows it. Measured on tsouza/cerberus#3000,
+# test/property/oracle/traceql drew 242, 243, 244 and 245 of its 272 statements
+# across fifteen full-lane profiles of an unchanged tree — a 1.10-point spread
+# against a 1.0-point slack.
+#
+# Exported to the two `go test` sweeps below, and read by the per-binary init
+# each rapid-linked test package carries (see internal/chplan/rapid_seed_test.go
+# for the canonical copy and test/regression/rapid_seed_pin_test.go for the
+# scan that keeps the set complete). It is deliberately NOT set by `just
+# property`: that lane's job is to SEARCH for counterexamples, which needs a
+# fresh sample every run. This lane's job is to MEASURE, which needs the same
+# one.
+#
+# The value is arbitrary but permanent. Changing it re-rolls every rapid-driven
+# package's coverage in one step, against floors derived from the old draw, so
+# treat it as fixed unless a floor is being deliberately re-derived.
+COVERAGE_RAPID_SEED := "20260903"
+
 # Fold a raw -coverpkg profile in place. -coverpkg makes EVERY test binary
 # emit a row for every block it linked, so a raw lane profile is ~200 MB of
 # repeats where the useful content is ~2 MB. One row per block, keeping the
@@ -705,7 +728,7 @@ coverage-default:
     # everything on stderr pass through untouched. `fflush()` keeps the pipe
     # line-buffered — a block-buffered filter would show nothing at all until
     # a 4 KiB chunk fills, which on a lane this long reads as a hung job.
-    go test -timeout 40m -coverpkg="$(go list ./... | paste -sd, -)" -coverprofile=cover.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'
+    CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} go test -timeout 40m -coverpkg="$(go list ./... | paste -sd, -)" -coverprofile=cover.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'
     @test -s cover.out
     @just _coverage-fold cover.out
 
@@ -724,9 +747,9 @@ coverage-chdb:
     @if [ -e "{{CHDB_INSTALL_PATH}}" ]; then \
         echo "==> chdb-tagged coverage"; \
         COVERPKG="$(go list -tags chdb,agpl_oracle,chdb_agpl_oracle ./... | paste -sd, -)"; \
-        PERF_SHARD_INDEX=1 PERF_SHARD_COUNT=3 go test -timeout 60m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$COVERPKG" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'; \
+        CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} PERF_SHARD_INDEX=1 PERF_SHARD_COUNT=3 go test -timeout 60m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$COVERPKG" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'; \
         if [ "${SKIP_RATCHET_FANOUT:-}" != "1" ]; then \
-            TAGS=chdb,agpl_oracle,chdb_agpl_oracle COVERPKG="$COVERPKG" node .github/scripts/perf-coverage-fanout.mjs; \
+            CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} TAGS=chdb,agpl_oracle,chdb_agpl_oracle COVERPKG="$COVERPKG" node .github/scripts/perf-coverage-fanout.mjs; \
         else \
             echo "==> SKIP_RATCHET_FANOUT=1: shards 2..PERF_SHARD_COUNT run on their own coverage-chdb-ratchet CI matrix legs, not here"; \
         fi; \

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -64,7 +64,43 @@ produces no record naming both lanes, so the recipe declines it rather than rely
 have checked.
 
 `just update-coverage-floor` only ratchets up. It refuses to lower a floor to match a coverage drop
-and never records a `0`, so both of those stay hand-edited, reviewable lines in a diff.
+and never records a `0`, so both of those stay hand-edited, reviewable lines in a diff. It also
+refuses to DELETE one. The recipe rewrites the whole ledger from the profile in hand, so a floored
+package the profile never measured would simply lose its entry — the deepest lowering available,
+since a ratchet has nothing that ever restores a floor that is gone. The two ways that happens look
+identical from inside the profile, so the recipe reads the tree instead: a package whose directory
+still holds non-test Go files should have been measured, and its absence is a refusal naming it,
+while a package whose directory is gone is one the module no longer has and its floor is dropped
+with a notice. Removing a package therefore stays a plain `just update-coverage-floor` away, and
+enrolling from an artifact older than a package in the tree fails loudly instead of quietly undoing
+that package's gate.
+
+The margin a floor grants — the slack between the measurement and the floor it justifies — is the
+wider of one percentage point and one statement. A point alone means whatever the package's size
+makes it mean: on a 70-statement package it is 0.70 statements, so the floor tolerates no jitter at
+all and a single statement flipping reds a required check, while on a 4600-statement package the
+same point is 46 statements. One statement is the quantum the measurement moves in, so it is the
+narrowest honest margin; the statement term binds only below 100 statements, which is exactly where
+a point is worth less than one. Widening a slack can only lower the floor a fresh measurement
+justifies, and the ratchet keeps the greater of that and the committed value, so this never moves an
+entry already in the ledger.
+
+Slack absorbs jitter; it cannot absorb a random variable, so the coverage lanes remove the largest
+source of one. Property tests draw through `pgregory.net/rapid`, whose `-rapid.seed` defaults to a
+random value, and which branches of a generator-driven test execute moves a package by whole
+statements between two runs of an identical tree: `test/property/oracle/traceql` drew 242, 243, 244
+and 245 of its 272 statements across fifteen full-lane profiles (tsouza/cerberus#3000). No slack
+narrow enough to catch a real regression is wide enough to cover that, and a ratchet fed a lucky
+draw never corrects itself. So both lanes export `CERBERUS_RAPID_SEED` from the Justfile's
+`COVERAGE_RAPID_SEED`, and every test binary that links rapid honours it in an `init` that pins the
+flag before `flag.Parse` — per binary, because rapid registers that flag from its own `init`, so a
+lane-wide `go test -rapid.seed=N ./...` would abort every package that does not link it.
+`test/regression/rapid_seed_pin_test.go` derives the set of packages owing a pin from the import
+graph, so a new rapid-driven package cannot rejoin the unpinned set. `just property` and
+`property.yml` deliberately leave the variable unset: that lane SEARCHES for counterexamples and
+needs a fresh sample every run, where the coverage lane MEASURES and needs the same one. The seed's
+value is arbitrary but permanent — changing it re-rolls every rapid-driven package's coverage
+against floors derived from the old draw.
 
 `actionlint` (`just lint-actions`) validates the workflow files. GitHub rejects an invalid workflow
 file server-side as a zero-job failure run, which prevents required `pull_request` checks from ever

--- a/internal/chplan/rapid_seed_test.go
+++ b/internal/chplan/rapid_seed_test.go
@@ -1,0 +1,124 @@
+package chplan_test
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// rapidSeedEnv names the PRNG seed the coverage lanes pin for
+// pgregory.net/rapid. Only those lanes set it: `just property`, property.yml
+// and a bare `go test` leave it unset and keep drawing a fresh random sample,
+// which is where new counterexamples are actually found.
+//
+// The coverage ledger is a ratchet — it raises floors and never lowers one — so
+// it cannot be fed a measurement that moves. rapid's seed defaults to random,
+// and which branches of a generator-driven test execute moves the profile by
+// whole statements between runs on an identical tree, so a floor enrolled from
+// a lucky draw is never corrected by the unlucky one that follows.
+//
+// The pin is per test binary because `-rapid.seed` is registered by rapid's
+// own init, so only a binary that links rapid carries the flag at all: a
+// lane-wide `go test -rapid.seed=N ./...` would abort every package that does
+// not. test/regression/rapid_seed_pin_test.go derives the set of packages that
+// owe this pin from the import graph, so a new rapid-driven test cannot quietly
+// rejoin the unpinned set. See docs/toolchain.md.
+const rapidSeedEnv = "CERBERUS_RAPID_SEED"
+
+// init runs before flag.Parse, so an explicit `-rapid.seed` on the command line
+// still wins: parsing assigns only the flags actually present in the arguments.
+func init() {
+	seed, ok := os.LookupEnv(rapidSeedEnv)
+	if !ok || seed == "" {
+		return
+	}
+	f := flag.Lookup("rapid.seed")
+	if f == nil {
+		// This binary does not link rapid under the tags it was built with.
+		// The coverage lanes export the variable to every package in the
+		// sweep, so that is the ordinary case, not an error.
+		return
+	}
+	if err := f.Value.Set(seed); err != nil {
+		fmt.Fprintf(os.Stderr, "%s=%q is not a seed rapid accepts: %v\n", rapidSeedEnv, seed, err)
+		os.Exit(1)
+	}
+}
+
+// pinChildEnv marks the re-executed copy of this test binary that reports what
+// the init above did to the flag.
+const pinChildEnv = "CERBERUS_RAPID_SEED_PIN_CHILD"
+
+// TestRapidSeedPinAppliesTheEnvironmentSeed proves the init is load-bearing.
+//
+// It cannot be asserted in-process: init has already run by the time any test
+// body executes, with whatever environment the whole binary was started in. So
+// the test re-executes THIS binary — the same one, so rapid is linked and the
+// flag exists — once per case and reads back the seed the child ended up with.
+//
+// The negative control is the point. Without it, a test that passes because
+// rapid's default happens to equal the value under test would look identical to
+// one that passes because the pin worked.
+func TestRapidSeedPinAppliesTheEnvironmentSeed(t *testing.T) {
+	if os.Getenv(pinChildEnv) == "1" {
+		fmt.Printf("PINNED-SEED=%s\n", flag.Lookup("rapid.seed").Value.String())
+		return
+	}
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		seed     string
+		wantSeed string
+		wantExit int
+	}{
+		{name: "pinned", seed: "4242", wantSeed: "4242"},
+		{name: "pinned to a different value", seed: "17", wantSeed: "17"},
+		// rapid's own default: 0, which it reads as "draw a random one".
+		{name: "unset", seed: "", wantSeed: "0"},
+		{name: "not a seed", seed: "twelve", wantExit: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := exec.Command(os.Args[0], "-test.run=^TestRapidSeedPinAppliesTheEnvironmentSeed$")
+			env := []string{pinChildEnv + "=1"}
+			for _, kv := range os.Environ() {
+				// The coverage lanes export this to the whole sweep, so the
+				// "unset" case has to strip it rather than merely not add it.
+				if !strings.HasPrefix(kv, rapidSeedEnv+"=") && !strings.HasPrefix(kv, pinChildEnv+"=") {
+					env = append(env, kv)
+				}
+			}
+			if tc.seed != "" {
+				env = append(env, rapidSeedEnv+"="+tc.seed)
+			}
+			cmd.Env = env
+
+			out, err := cmd.CombinedOutput()
+			exit := 0
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				exit = exitErr.ExitCode()
+			} else if err != nil {
+				t.Fatalf("re-executing the test binary: %v\n%s", err, out)
+			}
+			if exit != tc.wantExit {
+				t.Fatalf("child exited %d, want %d\n%s", exit, tc.wantExit, out)
+			}
+			if tc.wantExit != 0 {
+				if !strings.Contains(string(out), rapidSeedEnv) {
+					t.Fatalf("a rejected seed must name the variable it came from; got:\n%s", out)
+				}
+				return
+			}
+			if want := "PINNED-SEED=" + tc.wantSeed + "\n"; !strings.Contains(string(out), want) {
+				t.Fatalf("child reported the wrong seed, want %q in:\n%s", want, out)
+			}
+		})
+	}
+}

--- a/internal/optimizer/rapid_seed_test.go
+++ b/internal/optimizer/rapid_seed_test.go
@@ -1,0 +1,46 @@
+package optimizer
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// rapidSeedEnv names the PRNG seed the coverage lanes pin for
+// pgregory.net/rapid. Only those lanes set it: `just property`, property.yml
+// and a bare `go test` leave it unset and keep drawing a fresh random sample,
+// which is where new counterexamples are actually found.
+//
+// The coverage ledger is a ratchet — it raises floors and never lowers one — so
+// it cannot be fed a measurement that moves. rapid's seed defaults to random,
+// and which branches of a generator-driven test execute moves the profile by
+// whole statements between runs on an identical tree, so a floor enrolled from
+// a lucky draw is never corrected by the unlucky one that follows.
+//
+// The pin is per test binary because `-rapid.seed` is registered by rapid's
+// own init, so only a binary that links rapid carries the flag at all: a
+// lane-wide `go test -rapid.seed=N ./...` would abort every package that does
+// not. test/regression/rapid_seed_pin_test.go derives the set of packages that
+// owe this pin from the import graph, so a new rapid-driven test cannot quietly
+// rejoin the unpinned set. See docs/toolchain.md.
+const rapidSeedEnv = "CERBERUS_RAPID_SEED"
+
+// init runs before flag.Parse, so an explicit `-rapid.seed` on the command line
+// still wins: parsing assigns only the flags actually present in the arguments.
+func init() {
+	seed, ok := os.LookupEnv(rapidSeedEnv)
+	if !ok || seed == "" {
+		return
+	}
+	f := flag.Lookup("rapid.seed")
+	if f == nil {
+		// This binary does not link rapid under the tags it was built with.
+		// The coverage lanes export the variable to every package in the
+		// sweep, so that is the ordinary case, not an error.
+		return
+	}
+	if err := f.Value.Set(seed); err != nil {
+		fmt.Fprintf(os.Stderr, "%s=%q is not a seed rapid accepts: %v\n", rapidSeedEnv, seed, err)
+		os.Exit(1)
+	}
+}

--- a/internal/solver/rapid_seed_test.go
+++ b/internal/solver/rapid_seed_test.go
@@ -1,0 +1,46 @@
+package solver
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// rapidSeedEnv names the PRNG seed the coverage lanes pin for
+// pgregory.net/rapid. Only those lanes set it: `just property`, property.yml
+// and a bare `go test` leave it unset and keep drawing a fresh random sample,
+// which is where new counterexamples are actually found.
+//
+// The coverage ledger is a ratchet — it raises floors and never lowers one — so
+// it cannot be fed a measurement that moves. rapid's seed defaults to random,
+// and which branches of a generator-driven test execute moves the profile by
+// whole statements between runs on an identical tree, so a floor enrolled from
+// a lucky draw is never corrected by the unlucky one that follows.
+//
+// The pin is per test binary because `-rapid.seed` is registered by rapid's
+// own init, so only a binary that links rapid carries the flag at all: a
+// lane-wide `go test -rapid.seed=N ./...` would abort every package that does
+// not. test/regression/rapid_seed_pin_test.go derives the set of packages that
+// owe this pin from the import graph, so a new rapid-driven test cannot quietly
+// rejoin the unpinned set. See docs/toolchain.md.
+const rapidSeedEnv = "CERBERUS_RAPID_SEED"
+
+// init runs before flag.Parse, so an explicit `-rapid.seed` on the command line
+// still wins: parsing assigns only the flags actually present in the arguments.
+func init() {
+	seed, ok := os.LookupEnv(rapidSeedEnv)
+	if !ok || seed == "" {
+		return
+	}
+	f := flag.Lookup("rapid.seed")
+	if f == nil {
+		// This binary does not link rapid under the tags it was built with.
+		// The coverage lanes export the variable to every package in the
+		// sweep, so that is the ordinary case, not an error.
+		return
+	}
+	if err := f.Value.Set(seed); err != nil {
+		fmt.Fprintf(os.Stderr, "%s=%q is not a seed rapid accepts: %v\n", rapidSeedEnv, seed, err)
+		os.Exit(1)
+	}
+}

--- a/test/property/gen/rapid_seed_test.go
+++ b/test/property/gen/rapid_seed_test.go
@@ -1,0 +1,46 @@
+package gen
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// rapidSeedEnv names the PRNG seed the coverage lanes pin for
+// pgregory.net/rapid. Only those lanes set it: `just property`, property.yml
+// and a bare `go test` leave it unset and keep drawing a fresh random sample,
+// which is where new counterexamples are actually found.
+//
+// The coverage ledger is a ratchet — it raises floors and never lowers one — so
+// it cannot be fed a measurement that moves. rapid's seed defaults to random,
+// and which branches of a generator-driven test execute moves the profile by
+// whole statements between runs on an identical tree, so a floor enrolled from
+// a lucky draw is never corrected by the unlucky one that follows.
+//
+// The pin is per test binary because `-rapid.seed` is registered by rapid's
+// own init, so only a binary that links rapid carries the flag at all: a
+// lane-wide `go test -rapid.seed=N ./...` would abort every package that does
+// not. test/regression/rapid_seed_pin_test.go derives the set of packages that
+// owe this pin from the import graph, so a new rapid-driven test cannot quietly
+// rejoin the unpinned set. See docs/toolchain.md.
+const rapidSeedEnv = "CERBERUS_RAPID_SEED"
+
+// init runs before flag.Parse, so an explicit `-rapid.seed` on the command line
+// still wins: parsing assigns only the flags actually present in the arguments.
+func init() {
+	seed, ok := os.LookupEnv(rapidSeedEnv)
+	if !ok || seed == "" {
+		return
+	}
+	f := flag.Lookup("rapid.seed")
+	if f == nil {
+		// This binary does not link rapid under the tags it was built with.
+		// The coverage lanes export the variable to every package in the
+		// sweep, so that is the ordinary case, not an error.
+		return
+	}
+	if err := f.Value.Set(seed); err != nil {
+		fmt.Fprintf(os.Stderr, "%s=%q is not a seed rapid accepts: %v\n", rapidSeedEnv, seed, err)
+		os.Exit(1)
+	}
+}

--- a/test/property/rapid_seed_test.go
+++ b/test/property/rapid_seed_test.go
@@ -1,0 +1,46 @@
+package property_test
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// rapidSeedEnv names the PRNG seed the coverage lanes pin for
+// pgregory.net/rapid. Only those lanes set it: `just property`, property.yml
+// and a bare `go test` leave it unset and keep drawing a fresh random sample,
+// which is where new counterexamples are actually found.
+//
+// The coverage ledger is a ratchet — it raises floors and never lowers one — so
+// it cannot be fed a measurement that moves. rapid's seed defaults to random,
+// and which branches of a generator-driven test execute moves the profile by
+// whole statements between runs on an identical tree, so a floor enrolled from
+// a lucky draw is never corrected by the unlucky one that follows.
+//
+// The pin is per test binary because `-rapid.seed` is registered by rapid's
+// own init, so only a binary that links rapid carries the flag at all: a
+// lane-wide `go test -rapid.seed=N ./...` would abort every package that does
+// not. test/regression/rapid_seed_pin_test.go derives the set of packages that
+// owe this pin from the import graph, so a new rapid-driven test cannot quietly
+// rejoin the unpinned set. See docs/toolchain.md.
+const rapidSeedEnv = "CERBERUS_RAPID_SEED"
+
+// init runs before flag.Parse, so an explicit `-rapid.seed` on the command line
+// still wins: parsing assigns only the flags actually present in the arguments.
+func init() {
+	seed, ok := os.LookupEnv(rapidSeedEnv)
+	if !ok || seed == "" {
+		return
+	}
+	f := flag.Lookup("rapid.seed")
+	if f == nil {
+		// This binary does not link rapid under the tags it was built with.
+		// The coverage lanes export the variable to every package in the
+		// sweep, so that is the ordinary case, not an error.
+		return
+	}
+	if err := f.Value.Set(seed); err != nil {
+		fmt.Fprintf(os.Stderr, "%s=%q is not a seed rapid accepts: %v\n", rapidSeedEnv, seed, err)
+		os.Exit(1)
+	}
+}

--- a/test/regression/rapid_seed_pin_test.go
+++ b/test/regression/rapid_seed_pin_test.go
@@ -1,0 +1,198 @@
+package regression
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The coverage ledger (test/coverage-floor/) is a ratchet: it raises a
+// package's floor to what a run measured and never lowers one. That only holds
+// together while the measurement is reproducible. pgregory.net/rapid defaults
+// its PRNG seed to a random value, and which branches of a generator-driven
+// test execute moves a package's coverage by whole statements between two runs
+// of an identical tree — measured on tsouza/cerberus#3000, where
+// test/property/oracle/traceql drew 242, 243, 244 and 245 of its 272
+// statements across fifteen full-lane profiles. A floor enrolled from the 245
+// draw is one the 242 draw fails, and nothing in a ratchet ever corrects it.
+//
+// The coverage lanes therefore export CERBERUS_RAPID_SEED, and every test
+// binary that links rapid honours it in an init that pins `-rapid.seed`. The
+// pin has to be per binary: rapid registers that flag from its own init, so
+// only a binary linking rapid has it, and a lane-wide
+// `go test -rapid.seed=N ./...` would abort every package that does not.
+//
+// Per-binary means repeated, and repeated means it can be forgotten. This test
+// derives the set that owes a pin from the IMPORT GRAPH rather than from a
+// list somebody maintains, so a new rapid-driven test package cannot quietly
+// rejoin the unpinned set: it either carries the pin or it fails here.
+const (
+	rapidImportPath = "pgregory.net/rapid"
+	rapidSeedEnvVar = "CERBERUS_RAPID_SEED"
+	rapidSeedFlag   = "rapid.seed"
+	rapidTreeRoot   = "../.."
+)
+
+// rapidSeedSkippedDirs are directories the walk never descends into: build
+// output, VCS metadata, agent worktrees (which are whole checkouts of this
+// same repository and would double every finding), and node_modules.
+var rapidSeedSkippedDirs = map[string]bool{
+	".git":         true,
+	".claude":      true,
+	"bin":          true,
+	"node_modules": true,
+	"vendor":       true,
+}
+
+// rapidLinkingPackageDirs returns every directory holding a Go file that
+// imports rapid — the exact set of test binaries whose draws move.
+//
+// Imports are read with go/parser rather than matched as text, so the import
+// path spelled in this file's own constants does not count itself, and a
+// mention inside a comment or a string literal never inflates the set.
+// Build tags are deliberately NOT applied: a file excluded from today's tag
+// set still ships a rapid-driven test, and the pin has to be there when a lane
+// does build it.
+func rapidLinkingPackageDirs(t *testing.T) []string {
+	t.Helper()
+
+	dirs := map[string]bool{}
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(rapidTreeRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if rapidSeedSkippedDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if perr != nil {
+			return perr
+		}
+		for _, imp := range file.Imports {
+			if strings.Trim(imp.Path.Value, `"`) == rapidImportPath {
+				dirs[filepath.Dir(path)] = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s for rapid importers: %v", rapidTreeRoot, err)
+	}
+	if len(dirs) == 0 {
+		t.Fatalf("no package imports %s — this test can no longer see the thing it guards", rapidImportPath)
+	}
+
+	out := make([]string, 0, len(dirs))
+	for dir := range dirs {
+		out = append(out, dir)
+	}
+	return out
+}
+
+// dirPinsRapidSeed reports whether some file in dir installs the pin: it must
+// name the environment variable the lanes export AND the flag rapid registers,
+// in the same file, because either one alone pins nothing.
+func dirPinsRapidSeed(t *testing.T, dir string) bool {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("reading %s: %v", filepath.Join(dir, e.Name()), err)
+		}
+		text := string(src)
+		if strings.Contains(text, `"`+rapidSeedEnvVar+`"`) && strings.Contains(text, `"`+rapidSeedFlag+`"`) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRapidSeedPinCoversEveryRapidBinary fails when a package that draws
+// through rapid does not honour the coverage lanes' pinned seed.
+func TestRapidSeedPinCoversEveryRapidBinary(t *testing.T) {
+	t.Parallel()
+
+	var unpinned []string
+	for _, dir := range rapidLinkingPackageDirs(t) {
+		if !dirPinsRapidSeed(t, dir) {
+			unpinned = append(unpinned, dir)
+		}
+	}
+	if len(unpinned) > 0 {
+		t.Fatalf("these packages import %s but do not pin its seed, so their coverage moves run to "+
+			"run and the floor ledger's ratchet can enrol a floor from a lucky draw: %v\n"+
+			"Copy the init from internal/chplan/rapid_seed_test.go into each. See docs/toolchain.md.",
+			rapidImportPath, unpinned)
+	}
+}
+
+// TestRapidSeedPinIsWiredIntoTheCoverageLanes pins the other half: an init
+// nothing sets the variable for is an init that never runs. Both coverage
+// lanes must export it, and they must export the SAME value — two lanes drawing
+// different samples would merge into a profile neither of them measured.
+func TestRapidSeedPinIsWiredIntoTheCoverageLanes(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile(filepath.Join(rapidTreeRoot, "Justfile"))
+	if err != nil {
+		t.Fatalf("reading Justfile: %v", err)
+	}
+	text := string(src)
+
+	if !strings.Contains(text, "COVERAGE_RAPID_SEED := ") {
+		t.Fatal("the Justfile no longer defines COVERAGE_RAPID_SEED, so nothing pins the seed the " +
+			"coverage lanes measure with")
+	}
+	for _, recipe := range []string{"coverage-default:", "coverage-chdb:"} {
+		body := recipeBody(t, text, recipe)
+		if !strings.Contains(body, rapidSeedEnvVar+"={{COVERAGE_RAPID_SEED}}") {
+			t.Errorf("recipe %s does not export %s={{COVERAGE_RAPID_SEED}}, so its half of the "+
+				"merged profile is still drawn from a random seed", recipe, rapidSeedEnvVar)
+		}
+	}
+}
+
+// recipeBody returns the lines of a Justfile recipe: everything from its
+// header to the next line that starts in column zero.
+func recipeBody(t *testing.T, justfile, header string) string {
+	t.Helper()
+
+	lines := strings.Split(justfile, "\n")
+	start := -1
+	for i, line := range lines {
+		if line == header {
+			start = i + 1
+			break
+		}
+	}
+	if start == -1 {
+		t.Fatalf("recipe %q not found in the Justfile", header)
+	}
+	var body []string
+	for _, line := range lines[start:] {
+		if line != "" && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			break
+		}
+		body = append(body, line)
+	}
+	return strings.Join(body, "\n")
+}


### PR DESCRIPTION
## What

Two defects in the coverage floor ledger's own machinery, both reached while taking the raises in
#2999, both fixed here because they are the same mechanism.

## #3001 — the ledger could lose a floor silently

`nextFloors` built its output map from the packages present in the profile, and `writeFloors`
rewrites the whole ledger from that map. A package carrying a committed floor that the profile did
not measure lost its entry: exit `0`, no notice, no refusal, no diff line explaining why. The
function's own header documents two ways it refuses to weaken the ledger — never lower a floor,
never record a zero. Deletion was an undocumented third, and strictly worse than either: the ratchet
only moves up, so nothing ever restores a vanished floor and the package rejoins the unfloored set.

### Refuse, and how the two cases are told apart

The update path now refuses, rather than merely reporting, because a report on a path whose whole
purpose is to rewrite the ledger is a report nobody reads until the floor is already gone. A refusal
costs a re-measurement; a report costs a package its gate, indefinitely.

Refusing outright would block the legitimate case — a package deliberately deleted from the tree —
so the guard does not decide from the profile at all. It reads the tree:

- the package's directory still holds non-test Go files → it **should** have been measured, so its
  absence is evidence about the profile. Refuse, naming it.
- the directory is gone → the module no longer has the package, so the floor goes with it. Dropped,
  with a `::notice::` listing every entry that left.

That keeps a deliberate removal a plain `just update-coverage-floor` away with no hand-edit, and no
marker file, exemption list or tolerance file to drift. `_test.go` files do not count: they carry no
instrumented statements, so a directory holding only tests can never contribute to a profile and is,
for the ledger's purposes, exactly as gone as an empty one.

The compare path already failed on a floor whose package contributed nothing. The update path now
mirrors it, which is what closes the asymmetry that let one path enforce what the other silently
undid.

## #3000 — one global slack fit neither extreme

Two independent causes, and the numbers say neither fix substitutes for the other.

### The small-package end: give the slack a unit

A percentage point means whatever the package's size makes it mean. 1.0 point of a 70-statement
package is 0.70 statements, so its floor tolerates **no** jitter — one statement flipping reds a
required check. The same point on a 4600-statement package is 46 statements.

The slack is now the wider of one point and one statement. One statement is the quantum the
measurement moves in, so a margin narrower than that is not a margin — it is a floor pinned to the
exact draw that produced it. The statement term binds only below 100 statements, which is precisely
where a point is worth less than one; above that nothing changes.

This cannot lower a committed floor. A wider slack only lowers the floor a **fresh** measurement
justifies, and `nextFloors` keeps the greater of that and the committed value, so regenerating the
ledger against it is a no-op for every existing entry. `test/coverage-floor/` is unchanged in this
PR for exactly that reason.

### The random-draw end: pin the seed, because slack cannot absorb a random variable

This is the half worth arguing. `test/property/oracle/traceql` drew 242, 243, 244 and 245 of its 272
statements across fifteen full-lane profiles of an unchanged tree — a 1.10-point spread. Proportional
slack does not rescue it: on 272 statements 1.0 point is 2.72 statements, and covering a 3-4
statement swing needs ~4. Setting the statement term to 4 to reach it would hand a 70-statement
package 5.7 points of slack, which is no floor at all. **No single size-based slack rule covers both
ends**, which is why both fixes are here and neither is the other's substitute.

Sampling cannot bound a random variable either — deriving a floor from the minimum of N profiles
still enrols the peak whenever N draws happen to agree — so the fix is determinism. Both coverage
lanes now export `CERBERUS_RAPID_SEED` from the Justfile's `COVERAGE_RAPID_SEED`, and every test
binary that links rapid pins the flag in an `init` that runs before `flag.Parse` (so an explicit
`-rapid.seed` on the command line still wins).

**Trade-off accepted:** the coverage lane's property runs stop being an incidental extra random
search. That is the right side to give up — the coverage lane's job is to MEASURE, and `just
property` / `property.yml` still run unseeded at `-rapid.checks=500`, which is where counterexamples
are actually found. The seed's value is arbitrary but permanent: changing it re-rolls every
rapid-driven package's coverage against floors derived from the old draw.

**Why per binary, and why that stays complete.** rapid registers `-rapid.seed` from its own `init`,
so only a binary linking rapid has the flag at all — a lane-wide `go test -rapid.seed=N ./...` would
abort every package that does not. Per binary means repeated, so
`test/regression/rapid_seed_pin_test.go` derives the set owing a pin from the **import graph** (via
`go/parser`, tag-agnostic, no maintained list) and fails on any package that draws through rapid
without honouring the variable. It also asserts both lanes export it, and export the same value —
two lanes on different draws would merge into a profile neither measured.

## Evidence that every guard fires

Each guard was broken and watched go red, not merely watched go green.

| mutation | result |
| --- | --- |
| tree probe always answers "gone" (the pre-fix silent-drop behaviour) | 2 node tests red, including the `internal/promql/promparse` reproduction |
| slack reverted to a flat point value | 3 node tests red |
| one of the five pin files deleted | `TestRapidSeedPinCoversEveryRapidBinary` red, naming `test/property/gen` |
| `CERBERUS_RAPID_SEED` export dropped from `coverage-default` | `TestRapidSeedPinIsWiredIntoTheCoverageLanes` red, naming the recipe |
| the pin's `init` neutered | `TestRapidSeedPinAppliesTheEnvironmentSeed` red on both the pinned and the rejected-seed case |

The pin's behavioural test re-executes the test binary once per case and reads back the seed the
child ended up with, so it carries its own negative control: unset must report rapid's default `0`,
not the value under test.

Measured on this branch, `./test/property/...` under `-tags chdb,agpl_oracle,chdb_agpl_oracle`:

| run | property | gen | oracle/logql | oracle/promql | oracle/traceql |
| --- | --- | --- | --- | --- | --- |
| pinned, `-rapid.seed` | 303 | 727 | 175 | 1254 | 244 |
| pinned, same seed again | 303 | 727 | 175 | 1254 | 244 |
| pinned via `CERBERUS_RAPID_SEED` (the wired path) | 303 | 727 | 175 | 1254 | 244 |
| unpinned | 304 | 727 | 175 | 1255 | 244 |

The three pinned runs agree statement for statement across all five packages, including the run
driven by the environment variable rather than the flag; the unpinned run moves two of them. On the
narrower `TestTraceQL_Property`-only measurement the same seed reported 220/272 twice while two
unpinned runs reported 218 and 221 — a 3-statement swing against a 2.72-statement slack.

The pinned traceql draw is 244/272 = 89.71% against a committed floor of 88.3, clearing it by 1.41
points (3.8 statements), so the pin does not walk any measured package into its floor.

## Fail-closed property preserved

Every refusal is still decided before `writeFloors` runs. The new guard is placed with the existing
two, and a test states the property over a profile that carries a raise, a regression and a
measurement gap at once: whichever refusal fires, the raise must not land — `writeFloors` rewrites
the whole ledger, so a refusal running after it would have already replaced every entry. Both
refusal tests assert the ledger is byte-identical to what they found.

## Not changed

`test/coverage-floor/` carries no diff: the slack change cannot move an existing entry, and the seed
pin changes future measurements rather than committed floors. Nothing here is hand-edited.

Closes #3000
Closes #3001
