### PR TITLE
fix(routememo): recognize five more join kinds in HasJoin fingerprint

### DIFF
--- a/internal/routememo/key.go
+++ b/internal/routememo/key.go
@@ -243,7 +243,40 @@ func (w *keyWalker) walk(n chplan.Node) {
 			// cannot route a plan the solver rejects or slip a query past the
 			// bound. The blast radius of a wrong hit is a wasted route-B attempt
 			// that falls back to route A, never a wrong answer.
+		// VectorJoin, HistogramVectorJoin, HistogramFloatVectorJoin,
+		// MixedVectorJoin and CrossJoin are the step-aligned combinators
+		// PromQL lowers binary vector expressions and absent() into
+		// (internal/promql). Only VectorJoin is registered slice-invariant
+		// (internal/chplan/sliceinvariant.go), so only it can itself route
+		// B; the other four are permanently ineligible under
+		// Planner.classify's "(1) Slice-invariance: any unmarked node
+		// anywhere -> route A" gate and so are never memo-hit-routed. Their
+		// Key is still computed and Observed on every route-A resource
+		// failure regardless (deriveRouteMemoDispatch computes Key before
+		// checking Eligible, and retryOnRouteAResourceFailure's
+		// !d.eligible branch still Observes under it) — an unmarked
+		// HasJoin here would let a failure on one of these plans collide
+		// into, and pollute, an unrelated joinless plan's memo entry that
+		// happens to share every other Key field. StructuralJoin is
+		// TraceQL-only (internal/traceql/lower.go) and cannot reach this
+		// walker at all today: solver.Classify/Eligible gate on
+		// RequestMeta.Lang == LangPromQL (internal/solver/solver.go), so a
+		// TraceQL plan never produces the non-nil seedDecision every
+		// routememo.KeyFor call site in internal/engine requires. Marked
+		// here anyway — it costs nothing, and solver.go's own doc frames
+		// the PromQL-only gate as a foundation choice the other two heads
+		// deferred, not a permanent one.
 		case *chplan.VectorJoin:
+			w.hasJoin = true
+		case *chplan.HistogramVectorJoin:
+			w.hasJoin = true
+		case *chplan.HistogramFloatVectorJoin:
+			w.hasJoin = true
+		case *chplan.MixedVectorJoin:
+			w.hasJoin = true
+		case *chplan.CrossJoin:
+			w.hasJoin = true
+		case *chplan.StructuralJoin:
 			w.hasJoin = true
 		case *chplan.UnionAll:
 			w.hasUnion = true

--- a/internal/routememo/key_test.go
+++ b/internal/routememo/key_test.go
@@ -102,9 +102,10 @@ func TestKeyForGridGeometryBucketsDiffer(t *testing.T) {
 // kind keyWalker.walk switches on beyond the RangeWindow-based fixtures
 // above — one per range-window sibling (RangeBucketFanout,
 // RangeBucketGridNative, RangeLWR, RangeWindowGridNative,
-// RangeWindowStaleResample) and one per combinator (VectorJoin, UnionAll,
-// SetOperation, NaryVectorSetOp, Limit) — so a new case arm added to walk is
-// never silently unexercised again.
+// RangeWindowStaleResample) and one per combinator (VectorJoin,
+// HistogramVectorJoin, HistogramFloatVectorJoin, MixedVectorJoin, CrossJoin,
+// StructuralJoin, UnionAll, SetOperation, NaryVectorSetOp, Limit) — so a new
+// case arm added to walk is never silently unexercised again.
 func TestKeyForWalksEveryRangeAndCombinatorNodeKind(t *testing.T) {
 	const (
 		nAnchors = 241
@@ -157,6 +158,26 @@ func TestKeyForWalksEveryRangeAndCombinatorNodeKind(t *testing.T) {
 		kJoin := KeyFor(&chplan.VectorJoin{Left: scan, Right: scan, Op: chplan.OpAdd}, nAnchors, fanout, step)
 		if !kJoin.HasJoin {
 			t.Fatalf("VectorJoin must set HasJoin")
+		}
+		kHistogramJoin := KeyFor(&chplan.HistogramVectorJoin{Left: scan, Right: scan}, nAnchors, fanout, step)
+		if !kHistogramJoin.HasJoin {
+			t.Fatalf("HistogramVectorJoin must set HasJoin")
+		}
+		kHistogramFloatJoin := KeyFor(&chplan.HistogramFloatVectorJoin{Left: scan, Right: scan}, nAnchors, fanout, step)
+		if !kHistogramFloatJoin.HasJoin {
+			t.Fatalf("HistogramFloatVectorJoin must set HasJoin")
+		}
+		kMixedJoin := KeyFor(&chplan.MixedVectorJoin{Left: scan, Right: scan}, nAnchors, fanout, step)
+		if !kMixedJoin.HasJoin {
+			t.Fatalf("MixedVectorJoin must set HasJoin")
+		}
+		kCrossJoin := KeyFor(&chplan.CrossJoin{Left: scan, Right: scan}, nAnchors, fanout, step)
+		if !kCrossJoin.HasJoin {
+			t.Fatalf("CrossJoin must set HasJoin")
+		}
+		kStructuralJoin := KeyFor(&chplan.StructuralJoin{Left: scan, Right: scan, Op: chplan.StructuralChild}, nAnchors, fanout, step)
+		if !kStructuralJoin.HasJoin {
+			t.Fatalf("StructuralJoin must set HasJoin")
 		}
 		kUnion := KeyFor(&chplan.UnionAll{Inputs: []chplan.Node{scan, scan}}, nAnchors, fanout, step)
 		if !kUnion.HasUnion {


### PR DESCRIPTION
## Problem

`internal/routememo/key.go`'s `keyWalker.walk` set `HasJoin` from exactly one
case, `*chplan.VectorJoin`, missing five other real, production join-family
`chplan.Node` types this codebase lowers into today.

## Reachability trace

Traced every `routememo.KeyFor` call site in `internal/engine` back to its
gate, plus `internal/solver`'s slice-invariance registry:

- **HistogramVectorJoin, HistogramFloatVectorJoin, MixedVectorJoin,
  CrossJoin** — all PromQL-only (`internal/promql/*.go`). None is registered
  in `internal/chplan/sliceinvariant.go`'s `sliceInvariantKinds`, so
  `Planner.classify`'s "(1) Slice-invariance: any unmarked node anywhere ->
  route A" gate makes a plan containing one of these **permanently
  ineligible** — it can never itself be memo-hit-routed to B. But
  `deriveRouteMemoDispatch` computes `routememo.Key` **before** checking
  `Eligible`, and `retryOnRouteAResourceFailure`'s `!d.eligible` branch still
  calls `RouteMemo.Observe(d.key, ...)` on every route-A resource failure. So
  the (previously wrong) Key for these plans was still written into the
  memo store — with `HasJoin=false` it could collide with, and pollute, an
  unrelated genuinely-joinless-and-eligible plan's memo entry that happened
  to share every other Key field. This is real, live impact today, not a
  future concern.
- **StructuralJoin** — TraceQL-only (`internal/traceql/lower.go`). Every
  `routememo.KeyFor` call site in `internal/engine` requires a non-nil
  `seedDecision`/`baseline`, which requires `solver.Solver.Classify` (or
  `.Eligible`) to succeed — both gate on `RequestMeta.Lang == LangPromQL`
  (`internal/solver/solver.go`). A TraceQL request's `Lang` is `"traceql"`,
  so this gate is unconditional and `routememo.KeyFor` is **never invoked**
  for a TraceQL plan today. Adding this case is provably dead code right
  now. Registered it anyway — it costs nothing, and `solver.go`'s own doc
  frames the PromQL-only gate as a foundation choice "deferred" to the other
  two heads, not a permanent restriction.
- **LabelJoin** — excluded. Despite the name, `chplan.LabelJoin` is an
  `Expr` (`func (*LabelJoin) exprNode() {}`), not a `Node` — it's a per-row
  `label_join()` string-concatenation over a Map column, not a join in the
  relational/cost-shape sense `HasJoin` exists to track. It cannot appear in
  a type switch over `chplan.Node` at all (missing the `planNode()` marker),
  and today it isn't walked by `keyWalker` in any form (it would only ever
  appear inside a `Project`'s output expressions, which the walker doesn't
  descend into). The issue's suggested fix listed it conditionally ("if it
  lowers to a join shape") — it doesn't, so it's out.

## Fix

Added switch cases for `HistogramVectorJoin`, `HistogramFloatVectorJoin`,
`MixedVectorJoin`, `CrossJoin` and `StructuralJoin`, each setting `HasJoin`,
with a comment recording the reachability finding above so a future reader
doesn't have to re-derive it.

## Tests

Extended `TestKeyForWalksEveryRangeAndCombinatorNodeKind` in
`internal/routememo/key_test.go` with one assertion per new join kind.
Proved each assertion isn't vacuous by temporarily reverting its switch arm
and confirming the corresponding assertion fails (`... must set HasJoin`),
then restoring and confirming green again, for all five kinds individually.

## Scope

No out-of-scope findings during the trace — the ineligibility of the four
PromQL join kinds and the TraceQL gate are both working as designed
elsewhere in the codebase; this PR is purely the pinning fix `HasJoin`
itself needed. `internal/routememo` is an existing package (no
`.go-arch-lint.yml` or coverage-floor changes needed).

Closes #2886
