### PR TITLE
feat(logql): push Loki's limit into SQL for pipelines proven Go-filter-free

### DIFF
--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -402,7 +402,7 @@ func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	// uses). Threading [ts - InstantLookback, ts] keeps the Scan
 	// filtered to that envelope so the SQL doesn't return every
 	// matching log in the table.
-	res, err := h.Engine.Query(ctx, h.langForRequest(ts.Add(-qlcommon.InstantLookback), ts), q)
+	res, err := h.Engine.Query(ctx, h.langForRequest(ts.Add(-qlcommon.InstantLookback), ts, limit, dir), q)
 	if err != nil {
 		h.respondError(w, classifyEngineErr(err))
 		return
@@ -488,7 +488,7 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 	}
 	defer cancel()
 
-	res, err := h.Engine.Query(ctx, h.langForRangeRequest(start, end, step), q)
+	res, err := h.Engine.Query(ctx, h.langForRangeRequest(start, end, step, limit, dir), q)
 	if err != nil {
 		h.respondError(w, classifyEngineErr(err))
 		return
@@ -516,28 +516,48 @@ func (h *Handler) handleQueryRange(w http.ResponseWriter, r *http.Request) {
 }
 
 // langForRequest builds a per-request *logql.Lang carrying the request's
-// [start, end] window. The engine threads Start / End down through
+// [start, end] window plus the parsed `limit` / `direction` (see
+// [logql.Lang.LogLineLimit]). The engine threads Start / End down through
 // logql.LowerAt so every Scan(LogsTable) gains a
 // `Timestamp BETWEEN start AND end` predicate at the SQL layer. Without
 // it, /query and /query_range would return every matching log row
 // regardless of the requested window, violating the wire-format
-// contract.
-func (h *Handler) langForRequest(start, end time.Time) *logql.Lang {
-	return &logql.Lang{Schema: h.Schema, Start: start, End: end, TextIndexLineFilter: h.TextIndexLineFilter}
+// contract. limit/dir are threaded unconditionally — including for a
+// metric query, which the handler doesn't know it's building until the
+// lowering classifies the parsed expression — since
+// maybePushLogLineLimit only ever engages for a genuine log-line plan.
+func (h *Handler) langForRequest(start, end time.Time, limit int, dir logDirection) *logql.Lang {
+	return &logql.Lang{
+		Schema:              h.Schema,
+		Start:               start,
+		End:                 end,
+		TextIndexLineFilter: h.TextIndexLineFilter,
+		LogLineLimit:        int64(limit),
+		LogLineBackward:     dir == directionBackward,
+	}
 }
 
 // langForRangeRequest builds a per-request *logql.Lang carrying the
-// request's [start, end, step] for metric queries. The engine threads
-// Step alongside Start / End so range-aggregation lowerings switch to
-// the matrix RangeWindow shape (one row per anchor across [start, end]
-// spaced by step). Without this, metric queries whose seeded data
-// lies outside the last 5 minutes of wall-clock return an empty matrix
-// because the windowed-array filter anchors at `now64(9)`. Log queries
-// also use this entry point — Step is harmless on the non-metric path
-// since lowerCtx.rangeMode() only fires inside the range-aggregation
-// lowering.
-func (h *Handler) langForRangeRequest(start, end time.Time, step time.Duration) *logql.Lang {
-	return &logql.Lang{Schema: h.Schema, Start: start, End: end, Step: step, TextIndexLineFilter: h.TextIndexLineFilter}
+// request's [start, end, step] for metric queries, plus the parsed
+// `limit` / `direction` for the log-line case — see [langForRequest].
+// The engine threads Step alongside Start / End so range-aggregation
+// lowerings switch to the matrix RangeWindow shape (one row per anchor
+// across [start, end] spaced by step). Without this, metric queries
+// whose seeded data lies outside the last 5 minutes of wall-clock
+// return an empty matrix because the windowed-array filter anchors at
+// `now64(9)`. Log queries also use this entry point — Step is harmless
+// on the non-metric path since lowerCtx.rangeMode() only fires inside
+// the range-aggregation lowering.
+func (h *Handler) langForRangeRequest(start, end time.Time, step time.Duration, limit int, dir logDirection) *logql.Lang {
+	return &logql.Lang{
+		Schema:              h.Schema,
+		Start:               start,
+		End:                 end,
+		Step:                step,
+		TextIndexLineFilter: h.TextIndexLineFilter,
+		LogLineLimit:        int64(limit),
+		LogLineBackward:     dir == directionBackward,
+	}
 }
 
 // classifyEngineErr maps the error chains engine.Engine returns onto

--- a/internal/api/loki/limit_pushdown_chdb_test.go
+++ b/internal/api/loki/limit_pushdown_chdb_test.go
@@ -1,0 +1,354 @@
+//go:build chdb
+
+// chDB-backed correctness proof for cerberus issue #2829 (Loki's `limit`
+// pushed into a real SQL `ORDER BY Timestamp {DESC|ASC} LIMIT N`).
+//
+// Two claims need proving, not asserting, per the issue's own correctness
+// bar:
+//
+//  1. For a pipeline shape [pipelineCanDropRowsInGo] classifies SAFE, SQL
+//     truncating the result set is IDENTICAL to today's decode-everything-
+//     then-Go-clamp path — see TestLimitPushdown_SafeShapes_IdenticalToGoOnlyClamp_ChDB,
+//     which runs the SAME query through the SAME buildRangeData post-
+//     processing pipeline twice — once against a plan with no SQL Limit
+//     (today's shape) and once against the pushed-down plan — and asserts
+//     the two *QueryData results are deeply equal.
+//  2. For the ONE shape it classifies UNSAFE (`| pattern` followed by a
+//     `__error__` / `__error_details__` label filter), naively pushing the
+//     SQL Limit ahead of that stage's Go-only re-filter (see
+//     internal/api/loki/post_process.go's newLabelFilterStep) WOULD have
+//     produced a wrong answer — see
+//     TestLimitPushdown_UnsafeShape_NaivePushdownWouldBeWrong_ChDB, which
+//     builds the naive (unguarded) plan by hand, alongside the actual
+//     shipped plan, and shows they diverge (10 correct streams vs 0).
+package loki
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// limitPushdownLogsDDL is the otel_logs projection the log-line
+// wrap-projection (internal/logql/lang.go's ProjectSamples) always
+// selects — Body, LogAttributes, ResourceAttributes, SeverityText,
+// Timestamp — regardless of which columns the query itself touches, so
+// every column has to exist even for the bare-selector case. `__error__`
+// rides as an ordinary ResourceAttributes key in the unsafe-shape test —
+// see its doc comment for why that is a faithful, not contrived, way to
+// exercise [FiltersErrorLabel]'s SQL-fallback path.
+const limitPushdownLogsDDL = `CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    SeverityText LowCardinality(String) DEFAULT '',
+    ResourceAttributes Map(String, String),
+    LogAttributes Map(String, String)
+) ENGINE = Memory;`
+
+// newLimitPushdownEngine seeds ddl into a fresh chDB instance and returns
+// an engine.Engine wired exactly like [New] wires Handler.Engine, so the
+// plan lifecycle (wrap-projection, optimize, emit, execute) this test
+// drives is the same one production traffic runs.
+func newLimitPushdownEngine(t *testing.T, ddl string) *engine.Engine {
+	t.Helper()
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, ddl)
+	h := New(c, schema.DefaultOTelLogs(), nil)
+	return h.Engine
+}
+
+// insertRows renders n INSERT rows (one per second starting at start,
+// each row's timestamp unique — sidestepping the tie-break
+// non-determinism [clampLogRows]'s doc comment already flags as
+// pre-existing, CH's natural row order for equal sort keys being
+// unspecified, which would otherwise confound a byte-identical-output
+// assertion with a question this change does not touch) and returns the
+// full DDL+INSERT statement seedable via chclienttest.
+func insertRows(n int, start time.Time, attrs func(i int) map[string]string, body func(i int) string) string {
+	const tsFmt = "2006-01-02 15:04:05.000000000"
+	stmt := limitPushdownLogsDDL + "\nINSERT INTO otel_logs (Timestamp, Body, ResourceAttributes) VALUES\n"
+	for i := 0; i < n; i++ {
+		ts := start.Add(time.Duration(i) * time.Second).Format(tsFmt)
+		m := "map("
+		first := true
+		for k, v := range attrs(i) {
+			if !first {
+				m += ", "
+			}
+			first = false
+			m += fmt.Sprintf("'%s', '%s'", k, v)
+		}
+		m += ")"
+		if i > 0 {
+			stmt += ",\n"
+		}
+		stmt += fmt.Sprintf("    (toDateTime64('%s', 9), '%s', %s)", ts, body(i), m)
+	}
+	return stmt + ";"
+}
+
+// TestLimitPushdown_SafeShapes_IdenticalToGoOnlyClamp_ChDB is the primary
+// correctness proof for the shapes this PR pushes a SQL Limit for: for
+// each of a bare stream selector and a pipeline whose only stages lower
+// to real SQL predicates, decoding the FULL matching window and
+// Go-clamping (the [logql.Lang.LogLineLimit] == 0 plan) produces the
+// EXACT SAME [QueryData] as letting SQL truncate to the request's limit
+// first (LogLineLimit == N) and then running the identical
+// [buildRangeData] post-processing on the smaller row set.
+//
+// Falsifiability: if [pipelineCanDropRowsInGo] under-classified a shape
+// as safe (missed a Go-side row-dropping stage), the two paths would
+// disagree whenever a dropped-and-not-yet-decoded row would have
+// displaced a kept one inside the requested limit — this test's window
+// (200 rows, limit 10) gives that scenario ample room to manifest.
+func TestLimitPushdown_SafeShapes_IdenticalToGoOnlyClamp_ChDB(t *testing.T) {
+	const (
+		seedRows = 200
+		limit    = 10
+	)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Duration(seedRows) * time.Second)
+	s := schema.DefaultOTelLogs()
+
+	cases := []struct {
+		name  string
+		query string
+		body  func(i int) string
+		attrs func(i int) map[string]string
+	}{
+		{
+			name:  "bare stream selector",
+			query: `{app="x"}`,
+			body:  func(i int) string { return fmt.Sprintf("line %d", i) },
+			attrs: func(i int) map[string]string { return map[string]string{"app": "x"} },
+		},
+		{
+			name:  "line filter",
+			query: `{app="x"} |= "even"`,
+			body: func(i int) string {
+				if i%2 == 0 {
+					return fmt.Sprintf("line %d even", i)
+				}
+				return fmt.Sprintf("line %d odd", i)
+			},
+			attrs: func(i int) map[string]string { return map[string]string{"app": "x"} },
+		},
+		{
+			name:  "json parser + label filter on an extracted key",
+			query: `{app="x"} | json | status="200"`,
+			body: func(i int) string {
+				status := "500"
+				if i%3 == 0 {
+					status = "200"
+				}
+				return fmt.Sprintf(`{"status":"%s"}`, status)
+			},
+			attrs: func(i int) map[string]string { return map[string]string{"app": "x"} },
+		},
+		{
+			name:  "pattern parser, no downstream error filter",
+			query: `{app="x"} | pattern "<lvl> <_>"`,
+			body:  func(i int) string { return fmt.Sprintf("info line-%d", i) },
+			attrs: func(i int) map[string]string { return map[string]string{"app": "x"} },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ddl := insertRows(seedRows, start, tc.attrs, tc.body)
+			eng := newLimitPushdownEngine(t, ddl)
+
+			expr, err := logql.ParseExprPermissive(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExprPermissive(%q): %v", tc.query, err)
+			}
+
+			ctx := context.Background()
+			langFull := &logql.Lang{Schema: s, Start: start, End: end}
+			langPushed := &logql.Lang{Schema: s, Start: start, End: end, LogLineLimit: limit, LogLineBackward: true}
+
+			resFull, err := eng.Query(ctx, langFull, tc.query)
+			if err != nil {
+				t.Fatalf("Query (no limit pushed): %v", err)
+			}
+			resPushed, err := eng.Query(ctx, langPushed, tc.query)
+			if err != nil {
+				t.Fatalf("Query (limit pushed): %v", err)
+			}
+
+			// Anti-vacuous: the pushed plan must actually have asked
+			// ClickHouse to truncate — otherwise a byte-identical result
+			// would be trivially true regardless of whether the pushdown
+			// logic works at all.
+			if len(resFull.Samples) <= limit {
+				t.Fatalf("fixture too small to be a meaningful check: full window returned %d rows, want > %d", len(resFull.Samples), limit)
+			}
+			if len(resPushed.Samples) != limit {
+				t.Errorf("SQL-pushed query returned %d rows, want exactly %d (SQL should have truncated) — pushdown did not actually engage", len(resPushed.Samples), limit)
+			}
+
+			dataFull, err := buildRangeData(expr, resFull.Samples, start, end, time.Minute, s, limit, directionBackward, false)
+			if err != nil {
+				t.Fatalf("buildRangeData (full decode + Go clamp): %v", err)
+			}
+			dataPushed, err := buildRangeData(expr, resPushed.Samples, start, end, time.Minute, s, limit, directionBackward, false)
+			if err != nil {
+				t.Fatalf("buildRangeData (SQL-pushed + Go clamp): %v", err)
+			}
+
+			if !reflect.DeepEqual(dataFull, dataPushed) {
+				t.Errorf("shape %q: SQL-pushed result diverges from the decode-everything-then-Go-clamp result\nfull:   %#v\npushed: %#v", tc.name, dataFull, dataPushed)
+			}
+		})
+	}
+}
+
+// TestLimitPushdown_UnsafeShape_NaivePushdownWouldBeWrong_ChDB is the
+// negative-side proof: it demonstrates that if the `| pattern` +
+// `__error__`-filter shape were NOT excluded from pushdown, cerberus
+// would silently return the wrong log lines.
+//
+// `| pattern` never changes labelsExpr in the lowering (it extracts
+// purely in Go — see internal/logql/lower.go's isDynamicLabelStage /
+// lowerStage's OpParserTypePattern case), so for
+// `{app="x"} | pattern "<lvl> <_>" | __error__=""` the SQL Filter this
+// PR would wrap a naive Limit(OrderBy(...)) around carries ONLY
+// `app="x"` plus the request window — the `__error__=""` predicate is
+// entirely absent from SQL (internal/logql/lower.go's
+// lowerPipelineWithLabels `continue`-skips it), so the row's real
+// ResourceAttributes `__error__` value (a legitimate Map key like any
+// other — nothing in the OTel-CH schema or the lowering's `Map(String,
+// String)` access reserves it) is the ONLY place that predicate is ever
+// evaluated: internal/api/loki/post_process.go's newLabelFilterStep,
+// Go-side, AFTER SQL has already returned rows.
+//
+// Seed: the 60 most-recent rows carry `__error__="boom"` (should be
+// excluded); the 50 rows before them carry no `__error__` key (absent
+// reads as "", so they pass `__error__=""` and should be kept).
+// direction=backward (Loki's default, most-recent-first), limit=10.
+//
+//   - Correct answer (what the shipped code returns, because
+//     [pipelineCanDropRowsInGo] excludes this shape from pushdown): SQL
+//     returns the full 110-row candidate set, the Go filter drops the 60
+//     "boom" rows, and the clamp takes the top 10 of the remaining 50 —
+//     10 streams.
+//   - Naive answer (what an UNGUARDED pushdown would have returned): SQL
+//     truncates to the 10 most-recent rows BEFORE the Go filter ever
+//     runs — all 10 are "boom" rows — and the Go filter then drops all
+//     10, leaving ZERO. limit=10 in the request, 0 in the naive
+//     response: a silently wrong answer, not merely a perf regression.
+func TestLimitPushdown_UnsafeShape_NaivePushdownWouldBeWrong_ChDB(t *testing.T) {
+	const (
+		errorRows = 60
+		cleanRows = 50
+		limit     = 10
+	)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Duration(errorRows+cleanRows) * time.Second)
+	s := schema.DefaultOTelLogs()
+
+	attrs := func(i int) map[string]string {
+		// i indexes rows in seed (insertion/timestamp) order, oldest
+		// first: the first cleanRows rows are clean, the last errorRows
+		// (most recent) carry __error__.
+		if i < cleanRows {
+			return map[string]string{"app": "x"}
+		}
+		return map[string]string{"app": "x", "__error__": "boom"}
+	}
+	body := func(i int) string { return fmt.Sprintf("info line-%d", i) }
+
+	ddl := insertRows(errorRows+cleanRows, start, attrs, body)
+	eng := newLimitPushdownEngine(t, ddl)
+
+	const query = `{app="x"} | pattern "<lvl> <_>" | __error__=""`
+	expr, err := logql.ParseExprPermissive(query)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive: %v", err)
+	}
+
+	ctx := context.Background()
+	lang := &logql.Lang{Schema: s, Start: start, End: end, LogLineLimit: limit, LogLineBackward: true}
+
+	// The correct (shipped) path: Lang.Parse itself, exactly as
+	// production runs it. Because this shape is UNSAFE,
+	// maybePushLogLineLimit leaves the plan un-pushed regardless of
+	// LogLineLimit being set — confirmed structurally by
+	// TestLogLineLimitPushdown_ShapeAndGating in internal/logql; this
+	// assertion is the end-to-end behavioral half of that same claim.
+	resShipped, err := eng.Query(ctx, lang, query)
+	if err != nil {
+		t.Fatalf("Query (shipped path): %v", err)
+	}
+	if len(resShipped.Samples) != errorRows+cleanRows {
+		t.Fatalf("shipped path returned %d rows, want all %d (SQL must NOT have truncated this unsafe shape)", len(resShipped.Samples), errorRows+cleanRows)
+	}
+	dataShipped, err := buildRangeData(expr, resShipped.Samples, start, end, time.Minute, s, limit, directionBackward, false)
+	if err != nil {
+		t.Fatalf("buildRangeData (shipped): %v", err)
+	}
+	gotShipped := countStreamEntries(t, dataShipped)
+	if gotShipped != limit {
+		t.Fatalf("shipped path returned %d entries, want %d (the %d clean rows immediately preceding the %d error rows)", gotShipped, limit, cleanRows, errorRows)
+	}
+
+	// The naive counterexample: build Limit(OrderBy(<the SAME base
+	// Filter LowerAt produces>)) by hand — simulating what this PR would
+	// have shipped WITHOUT the pipelineCanDropRowsInGo guard.
+	basePlan, err := logql.LowerAt(ctx, expr, s, start, end)
+	if err != nil {
+		t.Fatalf("LowerAt (base plan): %v", err)
+	}
+	naivePlan := &chplan.Limit{
+		Count: limit,
+		Input: &chplan.OrderBy{
+			Input: basePlan,
+			Keys: []chplan.OrderKey{
+				{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Desc: true},
+			},
+		},
+	}
+	meta := engine.Meta{IsMetric: false, ResponseShape: "loki-streams", Extra: map[string]any{"expr": expr}}
+	resNaive, err := eng.QueryPlan(ctx, lang, naivePlan, meta)
+	if err != nil {
+		t.Fatalf("QueryPlan (naive counterexample): %v", err)
+	}
+	if len(resNaive.Samples) != limit {
+		t.Fatalf("naive plan returned %d rows from SQL, want exactly %d (it must have truncated BEFORE the Go filter runs, or this counterexample doesn't demonstrate anything)", len(resNaive.Samples), limit)
+	}
+	dataNaive, err := buildRangeData(expr, resNaive.Samples, start, end, time.Minute, s, limit, directionBackward, false)
+	if err != nil {
+		t.Fatalf("buildRangeData (naive): %v", err)
+	}
+	gotNaive := countStreamEntries(t, dataNaive)
+
+	if gotNaive != 0 {
+		t.Fatalf("counterexample construction failed to reproduce the bug: naive pushdown returned %d entries, want 0 (all 10 SQL-selected rows should have been __error__=\"boom\" and dropped Go-side)", gotNaive)
+	}
+
+	t.Logf("shipped (correct, gated off): %d entries; naive (unguarded pushdown): %d entries — request limit was %d", gotShipped, gotNaive, limit)
+}
+
+// countStreamEntries sums the entry count across every stream in a
+// streams-shaped *QueryData, so the two paths above can be compared by a
+// single scalar without caring about incidental stream grouping.
+func countStreamEntries(t *testing.T, data *QueryData) int {
+	t.Helper()
+	streams, ok := data.Result.([]Stream)
+	if !ok {
+		t.Fatalf("QueryData.Result = %T, want []Stream", data.Result)
+	}
+	n := 0
+	for _, s := range streams {
+		n += len(s.Values)
+	}
+	return n
+}

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -2217,7 +2217,8 @@ var registry = []Feature{
 		MinVersion: Version{Major: 25, Minor: 11},
 		Stability:  Experimental,
 		AutoSelect: true,
-		Doc:        "stamp query_plan_optimize_lazy_materialization=1 + query_plan_max_limit_for_lazy_materialization=<request LIMIT> on any Limit(OrderBy(...)) plan shape — Tempo's search paths and Loki's log-line limit pushdown (server >= 25.11, auto-enabled — result-equivalent, chDB-verified)",
+		Doc: "stamp query_plan_optimize_lazy_materialization=1 + query_plan_max_limit_for_lazy_materialization=<request LIMIT> on any Limit(OrderBy(...)) plan shape — Tempo's search " +
+			"paths and Loki's log-line limit pushdown (server >= 25.11, auto-enabled — result-equivalent, chDB-verified)",
 	},
 	{
 		ID:         FeatureExplainEstimate,

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1567,9 +1567,15 @@ const (
 
 	// FeatureLazyMaterialization stamps query_plan_optimize_lazy_materialization=1
 	// + query_plan_max_limit_for_lazy_materialization=<the query's own LIMIT> on
-	// a Tempo `ORDER BY Timestamp DESC LIMIT N` search shape (internal/api/tempo
-	// handler.go's /search/recent and boundNewestTraces, structural_two_phase.go's
-	// phase-A ranking) — see internal/engine.eligibleForLazyMaterialization.
+	// any plan carrying an `ORDER BY Timestamp DESC LIMIT N` (or ASC) shape — see
+	// internal/engine.eligibleForLazyMaterialization, which is head-agnostic (it
+	// matches the chplan shape, not the query language). Tempo's handler.go
+	// builds it directly for /search/recent, boundNewestTraces, and
+	// structural_two_phase.go's phase-A ranking; since cerberus issue #2829,
+	// Loki's LogQL lowering (internal/logql/lower.go's maybePushLogLineLimit)
+	// also emits it for the request `limit`, for every log-line pipeline shape
+	// proven incapable of dropping a row in Go after SQL executes
+	// (pipelineCanDropRowsInGo).
 	// ClickHouse defers fetching every non-sort-key column (SpanAttributes,
 	// ResourceAttributes, Events, Links — the wide OTel span payload) until
 	// AFTER the ORDER BY + LIMIT has picked the surviving rows, instead of
@@ -2211,7 +2217,7 @@ var registry = []Feature{
 		MinVersion: Version{Major: 25, Minor: 11},
 		Stability:  Experimental,
 		AutoSelect: true,
-		Doc:        "stamp query_plan_optimize_lazy_materialization=1 + query_plan_max_limit_for_lazy_materialization=<request LIMIT> on Tempo's ORDER BY Timestamp DESC LIMIT N search shapes (server >= 25.11, auto-enabled — result-equivalent, chDB-verified)",
+		Doc:        "stamp query_plan_optimize_lazy_materialization=1 + query_plan_max_limit_for_lazy_materialization=<request LIMIT> on any Limit(OrderBy(...)) plan shape — Tempo's search paths and Loki's log-line limit pushdown (server >= 25.11, auto-enabled — result-equivalent, chDB-verified)",
 	},
 	{
 		ID:         FeatureExplainEstimate,

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -223,15 +223,21 @@ type SettingsRules struct {
 	// query_plan_optimize_lazy_materialization=1 +
 	// query_plan_max_limit_for_lazy_materialization=<the query's own LIMIT>
 	// on a plan carrying exactly one Limit(OrderBy(...)) shape (see
-	// eligibleForLazyMaterialization) — the Tempo `ORDER BY Timestamp DESC
-	// LIMIT N` search shapes (/search/recent, boundNewestTraces, structural
-	// two-phase's phase-A ranking). Driven by the lazy_materialization
-	// registry feature, which only resolves in on server >= 25.11; below
-	// that the feature is absent from the resolved set, so this flag is
-	// false and nothing is stamped (a no-op on every older server). The
-	// setting is result-equivalent (IO order only), so the eligibility
-	// check exists purely to size the max-limit knob to the request's own
-	// LIMIT rather than to guard correctness — see chopt.FeatureLazyMaterialization.
+	// eligibleForLazyMaterialization) — the head-agnostic check applies to
+	// whichever head's plan happens to carry the shape: the Tempo
+	// `ORDER BY Timestamp DESC LIMIT N` search shapes (/search/recent,
+	// boundNewestTraces, structural two-phase's phase-A ranking), and,
+	// since cerberus issue #2829, Loki log-line queries whose pipeline
+	// stages [internal/logql.pipelineCanDropRowsInGo] proves cannot still
+	// drop a row in Go after SQL executes — see
+	// internal/logql/lower.go's maybePushLogLineLimit. Driven by the
+	// lazy_materialization registry feature, which only resolves in on
+	// server >= 25.11; below that the feature is absent from the resolved
+	// set, so this flag is false and nothing is stamped (a no-op on every
+	// older server). The setting is result-equivalent (IO order only), so
+	// the eligibility check exists purely to size the max-limit knob to
+	// the request's own LIMIT rather than to guard correctness — see
+	// chopt.FeatureLazyMaterialization.
 	LazyMaterialization bool
 
 	// Metrics / Traces / Logs are the schema instances whose SortingKeyPrefix

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -60,6 +60,18 @@ type Lang struct {
 	// see [LowerOpts.TextIndexLineFilter]. false (the zero value) renders
 	// byte-identical to today.
 	TextIndexLineFilter bool
+
+	// LogLineLimit and LogLineBackward carry Loki's request `limit` /
+	// `direction` for a log-line query, threaded into [LowerAtRangeOpts] —
+	// see [LowerOpts.LogLineLimit]. LogLineLimit <= 0 (the zero value)
+	// renders byte-identical to today: no SQL Limit pushdown, the
+	// Go-side clamp in internal/api/loki/handler.go stays authoritative.
+	// Metric queries thread these fields too (the handler doesn't know
+	// in advance whether a query is metric or log form), but
+	// [maybePushLogLineLimit] only ever wraps a genuine log-line plan —
+	// see its doc comment.
+	LogLineLimit    int64
+	LogLineBackward bool
 }
 
 // errorTypes mirrors the Loki errorType vocabulary the handler emits.
@@ -93,7 +105,11 @@ func (l *Lang) Parse(ctx context.Context, query string) (chplan.Node, engine.Met
 	}
 
 	lowerT := telemetry.ObserveStage(telemetry.StageLower, l.Name())
-	plan, err := LowerAtRangeOpts(ctx, expr, l.Schema, l.Start, l.End, l.Step, LowerOpts{TextIndexLineFilter: l.TextIndexLineFilter})
+	plan, err := LowerAtRangeOpts(ctx, expr, l.Schema, l.Start, l.End, l.Step, LowerOpts{
+		TextIndexLineFilter: l.TextIndexLineFilter,
+		LogLineLimit:        l.LogLineLimit,
+		LogLineBackward:     l.LogLineBackward,
+	})
 	lowerT.Done(ctx)
 	if err != nil {
 		return nil, engine.Meta{}, &httperr.Error{

--- a/internal/logql/limit_pushdown_test.go
+++ b/internal/logql/limit_pushdown_test.go
@@ -1,0 +1,260 @@
+package logql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLogLineLimitPushdown_ShapeAndGating is the pipeline-shape
+// characterization proof for cerberus issue #2829: for every LogQL
+// pipeline shape the lowering supports, a positive LogLineLimit either
+// pushes a real `Limit(OrderBy(Timestamp))` on top of the EXACT plan
+// [logql.Lower] would otherwise build (proven via chplan.Node.Equal, not
+// merely "a plan came back" — the wrap must be purely additive, changing
+// no existing node), or leaves the plan byte-identical to the
+// LogLineLimit==0 case.
+//
+// The unsafe cases (a `| pattern` stage followed by a `__error__` /
+// `__error_details__` label filter) are the ONLY shapes gated off — see
+// internal/logql/lower.go's pipelineCanDropRowsInGo doc comment for why:
+// internal/api/loki/post_process.go's newLabelFilterStep is the one
+// lineTransform step that can still drop a row in Go, and it only runs
+// for exactly that gate. Every other stage kind this package supports
+// (line filters, ordinary label filters, every parser family — json,
+// logfmt, regexp, unpack, and pattern itself absent a downstream
+// error-family filter — line_format, decolorize, label_format, drop,
+// keep) either lowers to a real SQL predicate or is a post-fetch
+// transform that never drops a row, so pushing a SQL LIMIT on top of the
+// unchanged Filter is result-identical to today's decode-everything-then-
+// Go-clamp path.
+func TestLogLineLimitPushdown_ShapeAndGating(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	const pushLimit = 50
+
+	cases := []struct {
+		name       string
+		query      string
+		wantPushed bool
+	}{
+		{name: "bare stream selector", query: `{app="x"}`, wantPushed: true},
+		{name: "line filter |=", query: `{app="x"} |= "boom"`, wantPushed: true},
+		{name: "line filter !~", query: `{app="x"} !~ "boom.*"`, wantPushed: true},
+		{name: "ordinary label filter (pre-parser)", query: `{app="x"} | level="error"`, wantPushed: true},
+		{name: "bare json + label filter on extracted key", query: `{app="x"} | json | status="500"`, wantPushed: true},
+		{name: "typed json + label filter", query: `{app="x"} | json code="response.code" | code="500"`, wantPushed: true},
+		{name: "bare logfmt + label filter", query: `{app="x"} | logfmt | level="error"`, wantPushed: true},
+		{name: "regexp parser + label filter", query: `{app="x"} | regexp "(?P<lvl>[a-z]+)" | lvl="error"`, wantPushed: true},
+		{name: "unpack + ordinary label filter", query: `{app="x"} | unpack | level="error"`, wantPushed: true},
+		{name: "line_format post-fetch stage", query: `{app="x"} | line_format "{{.msg}}"`, wantPushed: true},
+		{name: "decolorize post-fetch stage", query: `{app="x"} | decolorize`, wantPushed: true},
+		{name: "label_format post-fetch stage", query: `{app="x"} | label_format renamed=level`, wantPushed: true},
+		{name: "drop labels post-fetch stage", query: `{app="x"} | drop level`, wantPushed: true},
+		{name: "keep labels post-fetch stage", query: `{app="x"} | keep app`, wantPushed: true},
+		{
+			name:       "pattern alone, no downstream error filter",
+			query:      `{app="x"} | pattern "<lvl> <_>"`,
+			wantPushed: true,
+		},
+		{
+			name:       "pattern + ordinary label filter downstream",
+			query:      `{app="x"} | pattern "<lvl> <_>" | lvl="error"`,
+			wantPushed: true,
+		},
+		{
+			name:       "unpack + __error__ filter (unpack's __error__ IS SQL-lowered, not Go-only)",
+			query:      `{app="x"} | unpack | __error__=""`,
+			wantPushed: true,
+		},
+
+		// The one unsafe shape: pattern's own extraction runs entirely in Go
+		// (see internal/logql/lower.go's isDynamicLabelStage — only `| pattern`
+		// sets dynamicLabels), so a downstream __error__/__error_details__
+		// filter is evaluated ONLY in Go
+		// (internal/api/loki/post_process.go's newLabelFilterStep) — the SQL
+		// Filter never encodes it, so pushing a SQL LIMIT ahead of that Go
+		// filter could truncate away rows the filter would have kept while
+		// admitting rows it would have dropped. See
+		// internal/api/loki/limit_pushdown_chdb_test.go for the concrete
+		// wrong-result counterexample.
+		{
+			name:       "pattern + __error__ filter downstream: UNSAFE, not pushed",
+			query:      `{app="x"} | pattern "<lvl> <_>" | __error__=""`,
+			wantPushed: false,
+		},
+		{
+			name:       "pattern + __error_details__ filter downstream: UNSAFE, not pushed",
+			query:      `{app="x"} | pattern "<lvl> <_>" | __error_details__=""`,
+			wantPushed: false,
+		},
+		{
+			name:       "pattern + error filter buried in an AND: UNSAFE, not pushed",
+			query:      `{app="x"} | pattern "<lvl> <_>" | lvl="error" and __error__=""`,
+			wantPushed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := logql.ParseExprPermissive(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExprPermissive(%q): %v", tc.query, err)
+			}
+
+			basePlan, err := logql.LowerAt(context.Background(), expr, s, start, end)
+			if err != nil {
+				t.Fatalf("LowerAt (no opts): %v", err)
+			}
+
+			pushedPlan, err := logql.LowerAtRangeOpts(context.Background(), expr, s, start, end, 0, logql.LowerOpts{
+				LogLineLimit:    pushLimit,
+				LogLineBackward: true,
+			})
+			if err != nil {
+				t.Fatalf("LowerAtRangeOpts (with limit): %v", err)
+			}
+
+			if !tc.wantPushed {
+				if !pushedPlan.Equal(basePlan) {
+					t.Fatalf("shape %q: expected LogLineLimit to be a no-op (unsafe shape), but the plan changed:\nbase:   %#v\npushed: %#v", tc.name, basePlan, pushedPlan)
+				}
+				return
+			}
+
+			lim, ok := pushedPlan.(*chplan.Limit)
+			if !ok {
+				t.Fatalf("shape %q: top node = %T, want *chplan.Limit", tc.name, pushedPlan)
+			}
+			if lim.Count != pushLimit {
+				t.Errorf("shape %q: Limit.Count = %d, want %d", tc.name, lim.Count, pushLimit)
+			}
+			ob, ok := lim.Input.(*chplan.OrderBy)
+			if !ok {
+				t.Fatalf("shape %q: Limit.Input = %T, want *chplan.OrderBy", tc.name, lim.Input)
+			}
+			if len(ob.Keys) != 1 {
+				t.Fatalf("shape %q: OrderBy.Keys has %d entries, want 1", tc.name, len(ob.Keys))
+			}
+			if !ob.Keys[0].Desc {
+				t.Errorf("shape %q: OrderBy.Keys[0].Desc = false, want true (LogLineBackward)", tc.name)
+			}
+			col, ok := ob.Keys[0].Expr.(*chplan.ColumnRef)
+			if !ok || col.Name != s.TimestampColumn {
+				t.Errorf("shape %q: OrderBy.Keys[0].Expr = %#v, want ColumnRef{Name: %q}", tc.name, ob.Keys[0].Expr, s.TimestampColumn)
+			}
+
+			// The wrap must be PURELY additive: peeling off Limit(OrderBy(...))
+			// must land on the exact plan Lower() builds without the option —
+			// same Scan, same Filter predicate, nothing rewritten underneath.
+			if !ob.Input.Equal(basePlan) {
+				t.Errorf("shape %q: Limit(OrderBy(...)).Input is not the unmodified base plan:\nbase:  %#v\ninner: %#v", tc.name, basePlan, ob.Input)
+			}
+		})
+	}
+}
+
+// TestLogLineLimitPushdown_DirectionMapsToOrderDirection confirms
+// LogLineBackward (Loki's default "backward" = most-recent-first
+// direction) maps to ORDER BY Timestamp DESC, and false ("forward") maps
+// to ASC — the direction convention [parseLogDirection] /
+// [clampLogRows] already establish in internal/api/loki/handler.go.
+func TestLogLineLimitPushdown_DirectionMapsToOrderDirection(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	expr, err := logql.ParseExprPermissive(`{app="x"}`)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		backward bool
+		wantDesc bool
+	}{
+		{name: "backward (default) -> DESC", backward: true, wantDesc: true},
+		{name: "forward -> ASC", backward: false, wantDesc: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := logql.LowerAtRangeOpts(context.Background(), expr, s, start, end, 0, logql.LowerOpts{
+				LogLineLimit:    10,
+				LogLineBackward: tc.backward,
+			})
+			if err != nil {
+				t.Fatalf("LowerAtRangeOpts: %v", err)
+			}
+			lim, ok := plan.(*chplan.Limit)
+			if !ok {
+				t.Fatalf("top node = %T, want *chplan.Limit", plan)
+			}
+			ob := lim.Input.(*chplan.OrderBy)
+			if ob.Keys[0].Desc != tc.wantDesc {
+				t.Errorf("Desc = %v, want %v", ob.Keys[0].Desc, tc.wantDesc)
+			}
+		})
+	}
+}
+
+// TestLogLineLimitPushdown_NoOpWhenLimitZeroOrMetricQuery confirms two
+// more no-op cases beyond the unsafe-pipeline gate:
+//
+//   - LogLineLimit<=0 (every non-Opts entry point, and every caller that
+//     hasn't parsed a request `limit`) never pushes.
+//   - A metric query (RangeAggregationExpr et al.) never pushes even
+//     when LogLineLimit is positive — [maybePushLogLineLimit] only fires
+//     when the TOP-level parsed expr is itself a syntax.LogSelectorExpr,
+//     which a metric query's top-level expr never is (see
+//     logql.IsMetricQuery). This is what keeps a metric query's inner
+//     selector (reached recursively while lowering the range
+//     aggregation) from ever being wrapped.
+func TestLogLineLimitPushdown_NoOpWhenLimitZeroOrMetricQuery(t *testing.T) {
+	s := schema.DefaultOTelLogs()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	t.Run("LogLineLimit<=0 no-ops", func(t *testing.T) {
+		expr, err := logql.ParseExprPermissive(`{app="x"}`)
+		if err != nil {
+			t.Fatalf("ParseExprPermissive: %v", err)
+		}
+		base, err := logql.LowerAt(context.Background(), expr, s, start, end)
+		if err != nil {
+			t.Fatalf("LowerAt: %v", err)
+		}
+		zero, err := logql.LowerAtRangeOpts(context.Background(), expr, s, start, end, 0, logql.LowerOpts{LogLineLimit: 0, LogLineBackward: true})
+		if err != nil {
+			t.Fatalf("LowerAtRangeOpts: %v", err)
+		}
+		if !zero.Equal(base) {
+			t.Errorf("LogLineLimit=0 changed the plan; want byte-identical to Lower without opts")
+		}
+	})
+
+	t.Run("metric query is never wrapped", func(t *testing.T) {
+		expr, err := logql.ParseExprPermissive(`count_over_time({app="x"}[5m])`)
+		if err != nil {
+			t.Fatalf("ParseExprPermissive: %v", err)
+		}
+		base, err := logql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+		if err != nil {
+			t.Fatalf("LowerAtRange: %v", err)
+		}
+		pushed, err := logql.LowerAtRangeOpts(context.Background(), expr, s, start, end, time.Minute, logql.LowerOpts{LogLineLimit: 50, LogLineBackward: true})
+		if err != nil {
+			t.Fatalf("LowerAtRangeOpts: %v", err)
+		}
+		if !pushed.Equal(base) {
+			t.Errorf("a metric query's plan changed when LogLineLimit was set; want byte-identical — the limit must never reach a metric query's plan")
+		}
+		if _, ok := pushed.(*chplan.Limit); ok {
+			t.Errorf("metric query plan's top node is *chplan.Limit; must never be wrapped")
+		}
+	})
+}

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -77,6 +77,18 @@ type lowerCtx struct {
 	// chplan.LineContent.TextIndexPrefilter's doc comment for the full
 	// rewrite and its eligibility shape.
 	TextIndexLineFilter bool
+
+	// LogLineLimit and LogLineBackward carry Loki's request `limit` /
+	// `direction` down to [lowerWithCtx]'s top-level SQL-LIMIT-pushdown
+	// decision (cerberus issue #2829). LogLineLimit <= 0 means "do not
+	// push a SQL Limit" — the zero value every non-Opts entry point
+	// leaves unset, and every caller of [Lower] / [LowerAt] /
+	// [LowerAtRange] besides [LowerAtRangeOpts] renders byte-identical
+	// to today. See [maybePushLogLineLimit]'s doc comment for the full
+	// eligibility rule and why it can only ever fire once per query,
+	// at the top level.
+	LogLineLimit    int64
+	LogLineBackward bool
 }
 
 // withOuterByLabels returns a copy of c with OuterByLabels set to
@@ -170,6 +182,11 @@ type LowerOpts struct {
 	// doc comment for what it does and its default-off, byte-identical
 	// posture.
 	TextIndexLineFilter bool
+
+	// LogLineLimit and LogLineBackward carry Loki's request `limit` /
+	// `direction` — see lowerCtx.LogLineLimit's doc comment.
+	LogLineLimit    int64
+	LogLineBackward bool
 }
 
 // LowerAtRangeOpts is the options-carrying variant of [LowerAtRange]. The
@@ -178,7 +195,14 @@ type LowerOpts struct {
 // uses [Lower] / [LowerAt] / [LowerAtRange] and gets the zero-options
 // (default, byte-identical) behaviour.
 func LowerAtRangeOpts(ctx context.Context, expr syntax.Expr, s schema.Logs, start, end time.Time, step time.Duration, opts LowerOpts) (chplan.Node, error) {
-	return lowerWithCtx(ctx, expr, s, lowerCtx{Start: start, End: end, Step: step, TextIndexLineFilter: opts.TextIndexLineFilter})
+	return lowerWithCtx(ctx, expr, s, lowerCtx{
+		Start:               start,
+		End:                 end,
+		Step:                step,
+		TextIndexLineFilter: opts.TextIndexLineFilter,
+		LogLineLimit:        opts.LogLineLimit,
+		LogLineBackward:     opts.LogLineBackward,
+	})
 }
 
 func lowerWithCtx(ctx context.Context, expr syntax.Expr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {
@@ -189,8 +213,100 @@ func lowerWithCtx(ctx context.Context, expr syntax.Expr, s schema.Logs, lc lower
 		span.RecordError(err)
 		return nil, err
 	}
+	plan = maybePushLogLineLimit(expr, plan, s, lc)
 	span.SetAttributes(cerbtrace.AttrPlanNodeCount.Int(cerbtrace.CountNodes(plan)))
 	return plan, nil
+}
+
+// maybePushLogLineLimit wraps plan in `Limit(OrderBy(plan))` — a real SQL
+// `ORDER BY Timestamp {DESC|ASC} LIMIT N` — when expr is a Loki log-LINE
+// query (a bare stream selector or a pipeline) whose pipeline stages are
+// proven incapable of dropping a row in Go after the SQL executes (see
+// [pipelineCanDropRowsInGo]), letting ClickHouse itself truncate the
+// result set instead of cerberus decoding and discarding every row in the
+// window. This is what makes the shape eligible for
+// query_plan_optimize_lazy_materialization (internal/engine's
+// eligibleForLazyMaterialization walks for exactly this Limit(OrderBy(...))
+// shape) — cerberus issue #2829.
+//
+// It is called exactly once per top-level [lowerWithCtx] call — never from
+// inside [lower]'s recursive dispatch — so a metric query's inner selector
+// (RangeAggregationExpr.Left, reached via lowerRangeAggregation calling
+// lowerMatchers/lowerPipelineWithLabels directly, never through this
+// function) can never be wrapped: [syntax.LogSelectorExpr] is only ever the
+// TOP-level expr for a genuine log-line query (see logql.IsMetricQuery's
+// type list — every metric-query expr type is a SampleExpr, not a
+// LogSelectorExpr), and lc.LogLineLimit is threaded only by
+// internal/api/loki's Lang.Parse for the request it is actually building a
+// response for.
+//
+// This is a strictly ADDITIVE fast path: internal/api/loki/handler.go's
+// clampLogRows keeps sorting + truncating every decoded row exactly as it
+// always has, on whatever rows come back (the whole window for an unsafe
+// or LogLineLimit<=0 shape, or the SQL-truncated top-N for an eligible
+// one) — so an unproven or unsafe pipeline shape simply renders
+// byte-identical to before this change, never wrong.
+func maybePushLogLineLimit(expr syntax.Expr, plan chplan.Node, s schema.Logs, lc lowerCtx) chplan.Node {
+	if lc.LogLineLimit <= 0 {
+		return plan
+	}
+	sel, ok := expr.(syntax.LogSelectorExpr)
+	if !ok {
+		return plan
+	}
+	if pe, ok := sel.(*syntax.PipelineExpr); ok && pipelineCanDropRowsInGo(pe.MultiStages) {
+		return plan
+	}
+	ordered := &chplan.OrderBy{
+		Input: plan,
+		Keys: []chplan.OrderKey{
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Desc: lc.LogLineBackward},
+		},
+	}
+	return &chplan.Limit{Input: ordered, Count: lc.LogLineLimit}
+}
+
+// pipelineCanDropRowsInGo reports whether stages contains the ONE shape
+// internal/api/loki/post_process.go's postProcessExtract can still drop a
+// row for, Go-side, after the SQL executes: a `| pattern` stage (which
+// extracts labels from the line in Go — the emitted SQL cannot see its
+// keys) followed later in the same pipeline by a `__error__` /
+// `__error_details__` label filter (postProcessExtract's newLabelFilterStep
+// — the ONLY lineTransform step in that file that ever returns keep ==
+// false).
+//
+// This mirrors [lowerPipelineWithLabels]'s own dynamicLabels gate
+// stage-for-stage, built off the SAME two exported primitives both that
+// gate and postProcessExtract's own dynamicLabels gate use —
+// [isDynamicLabelStage] and [FiltersErrorLabel] — so all three call sites
+// derive from one shared answer to "does this pipeline shape need a
+// Go-side re-filter" rather than three that could drift apart. See
+// unpackParseDetailStep's doc comment in post_process.go for why a second
+// answer to the same question is exactly how cerberus's SQL side and Go
+// side have drifted before.
+//
+// Every other stage kind (line filters, ordinary label filters, every
+// parser — `| json`, `| logfmt`, `| regexp`, `| unpack`, and `| pattern`
+// itself absent a downstream error-family filter — `| line_format`,
+// `| decolorize`, `| label_format`, `| drop`, `| keep`) either lowers to a
+// real SQL predicate or is a post-fetch transform that
+// internal/api/loki/post_process.go never lets drop a row (only rename,
+// reformat, or narrow the label MAP — never the row set). A pipeline with
+// none of them, or any number of them, is SQL-complete: the emitted
+// Filter already computes exactly the surviving row set, so truncating it
+// with a SQL LIMIT on top is identical to decoding every row and
+// truncating in Go.
+func pipelineCanDropRowsInGo(stages syntax.MultiStageExpr) bool {
+	dynamicLabels := false
+	for _, stage := range stages {
+		if lf, ok := stage.(*syntax.LabelFilterExpr); ok && dynamicLabels && FiltersErrorLabel(lf.LabelFilterer) {
+			return true
+		}
+		if isDynamicLabelStage(stage) {
+			dynamicLabels = true
+		}
+	}
+	return false
 }
 
 func lower(expr syntax.Expr, s schema.Logs, lc lowerCtx) (chplan.Node, error) {

--- a/test/e2e/seed/cmd/seed/main.go
+++ b/test/e2e/seed/cmd/seed/main.go
@@ -467,7 +467,7 @@ FROM numbers(600)`
 	// 15 s cadence across 3 services. The rolling re-seeder re-runs
 	// this INSERT every 30 s, so every Loki `/query` instant request
 	// (5 m staleness lookback, see
-	// internal/api/loki/handler.go:`h.langForRequest(ts.Add(-qlcommon.InstantLookback), ts)`)
+	// internal/api/loki/handler.go:`h.langForRequest(ts.Add(-qlcommon.InstantLookback), ts, limit, dir)`)
 	// finds ≥1 row inside the lookback regardless of suite drift.
 	//
 	// `service_name="api"` rows (number % 3 = 0, ~14 of the 40) are


### PR DESCRIPTION
## Problem

`internal/api/loki/handler.go`'s `buildRangeData` / `buildInstantData` applied Loki's request
`limit` Go-side, in `clampLogRows`, after `chclient.DecodeLogRows` had already decoded every row
ClickHouse returned for the request window. `internal/logql/lower.go`'s `Lower` built no
`chplan.Limit` node at all, so the emitted SQL drained the whole window unconditionally and the
log-line path was structurally ineligible for `query_plan_optimize_lazy_materialization` — the win
#2782 landed for Tempo's search paths but explicitly scoped out for Loki, for exactly this reason.

## Characterization (the substance of this issue)

Every LogQL pipeline stage this codebase supports (11 total — enumerated exhaustively against
`internal/logql/lsyntax/ast.go`'s `stageBase` implementers) either lowers to a real SQL predicate,
or is a Go-side post-fetch transform. Cross-referencing `internal/logql/lower.go`'s
`lowerPipelineWithLabels` against `internal/api/loki/post_process.go`'s `postProcessExtract` shows
there is exactly **one** place a row can still be dropped in Go, after SQL has already executed:
`postProcessExtract`'s `newLabelFilterStep` — the only `lineTransform` step in that file that ever
returns `keep == false` — which only runs when a `| pattern` stage (the one parser stage that
extracts entirely in Go, never touching `labelsExpr`) is followed later in the same pipeline by a
`__error__` / `__error_details__` label filter.

**Safe (SQL-LIMIT-pushdown eligible):** a bare stream selector, or any pipeline whose stages are
line filters, ordinary label filters, any parser family (`| json`, `| logfmt`, `| regexp`,
`| unpack`, and `| pattern` itself absent a downstream error-family filter), `| line_format`,
`| decolorize`, `| label_format`, `| drop`, `| keep` — in any number or combination. This is a much
larger safe set than the issue's own speculative framing (`| json` isn't actually unsafe — its
label filters are already SQL-lowered), verified against the real parser/lowering, not asserted.

**Unsafe:** `| pattern` followed later by a `__error__` / `__error_details__` label filter. This is
the only shape excluded from pushdown; the existing Go-side `clampLogRows` path is untouched for it.

## Proof

- `internal/logql/limit_pushdown_test.go` — pure, table-driven, exercises every stage kind above
  through the real parser + lowering (`logql.ParseExprPermissive` + `logql.LowerAtRangeOpts`),
  asserting via `chplan.Node.Equal` that the wrap is purely additive (peeling `Limit(OrderBy(...))`
  off lands on the byte-identical plan `Lower` builds without the option) for every safe shape, and
  a byte-identical no-op for the one unsafe shape, `LogLineLimit<=0`, and metric queries.
- `internal/api/loki/limit_pushdown_chdb_test.go` (chdb-tagged, real chDB roundtrip):
  - `TestLimitPushdown_SafeShapes_IdenticalToGoOnlyClamp_ChDB` runs a bare selector, a line filter,
    a `| json` + label-filter pipeline, and a bare `| pattern` pipeline through the SAME
    `buildRangeData` post-processing twice — once against a plan with no SQL Limit (today's shape)
    and once against the pushed-down plan — and asserts the two `*QueryData` results are deeply
    equal, with an anti-vacuous check that SQL actually truncated (200-row seed, limit 10).
  - `TestLimitPushdown_UnsafeShape_NaivePushdownWouldBeWrong_ChDB` is the negative-side proof:
    it hand-builds the naive (unguarded) `Limit(OrderBy(...))` plan for the one unsafe shape and
    shows a concrete wrong answer — 60 most-recent rows carry `__error__="boom"`, 50 older rows
    don't; limit=10. The shipped code (pushdown correctly gated off) returns the correct 10 clean
    entries; the naive plan returns **0**, because SQL truncates to the 10 most-recent (all
    "boom") rows before the Go-side error filter ever runs.

## Direction semantics

`LogLineBackward` (Loki's default "backward" = most-recent-first) maps to `ORDER BY Timestamp DESC`;
`false` ("forward") maps to `ASC` — matches `parseLogDirection` / `clampLogRows`'s existing
convention, pinned by `TestLogLineLimitPushdown_DirectionMapsToOrderDirection`.
`limit` is always positive by the time it reaches the lowering (`parseLogLimit` clamps into
`[1, maxLogQueryLimit]` and 400s on `<= 0`); `LogLineLimit<=0` is the pushdown's own "off" sentinel,
matching every non-Opts `Lower*` entry point's zero value.

## lazy_materialization

`internal/engine`'s `eligibleForLazyMaterialization` / `SettingsRules.apply` are shape-based, not
head-based — `e.Settings` is one engine-wide `SettingsRules`, applied uniformly in `engine.go`'s
`QueryPlan`. Once Loki's lowering emits `Limit(OrderBy(...))`, the existing (unmodified) mechanism
picks it up automatically — verified by cross-referencing `internal/logql/limit_pushdown_test.go`'s
proof that Loki emits exactly this shape against `internal/engine/lazy_materialization_test.go`'s
existing shape-only eligibility table (`TestEligibleForLazyMaterialization`), which already covers
`Limit(OrderBy(Filter(Scan)))` regardless of table name. Updated the now-incomplete "Tempo-only"
doc comments in `internal/chopt/registry.go` and `internal/engine/query_settings_rules.go` to say so.

## What's shipped vs Go-side

Shipped (SQL Limit pushdown, additive, gated by `pipelineCanDropRowsInGo`): every pipeline shape
above except the one unsafe case. Left on the Go-side `clampLogRows` path, unchanged: the
`| pattern` + `__error__`/`__error_details__`-filter shape. No follow-up issue is filed — this is
not a "we ran out of time" gap, it's the correct, provably-necessary permanent exclusion (that
shape's `__error__` value genuinely only exists after a Go-side step runs).

Closes #2829
