### PR TITLE
feat(tempo): widen the tag catalog to event/link scopes

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1814,13 +1814,14 @@ refresh-count column (verified live against a 25.9 server) — a failed
 refresh reads as a non-empty `exception` plus `lastRefreshTime` having
 advanced past `lastSuccessTime`, not a distinct status value.
 
-### Tempo tag catalog (cerberus issue #2771)
+### Tempo tag catalog (cerberus issues #2771, #2850)
 
 `GET /api/v2/search/tags` and `GET /api/search/tag/{name}/values` normally
-answer every request with a live scan of the traces table's
-`SpanAttributes`/`ResourceAttributes` attribute maps — a full
-`arrayJoin(mapKeys(...))` explosion per Grafana Explore keystroke, since
-Tempo's tag/tag-value autocomplete fires as the user types a TraceQL query.
+answer every request with a live scan of the traces table's attribute
+families — a full `arrayJoin(mapKeys(...))` explosion (or, for the two
+Nested event/link families, an `arrayFlatten(arrayMap(...))` fan-out on top
+of that) per Grafana Explore keystroke, since Tempo's tag/tag-value
+autocomplete fires as the user types a TraceQL query.
 
 Auto-create can install a **refreshable materialized view**, the Tempo
 sibling of the Loki label-cardinality catalog above, gated behind
@@ -1844,6 +1845,16 @@ FROM (
     SELECT 'span' AS Scope, k AS TagKey, v AS TagValue FROM <db>.otel_traces
     ARRAY JOIN mapKeys(SpanAttributes) AS k, mapValues(SpanAttributes) AS v
     WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+    UNION ALL
+    SELECT 'event' AS Scope, k AS TagKey, v AS TagValue FROM <db>.otel_traces
+    ARRAY JOIN arrayFlatten(arrayMap(m -> mapKeys(m), Events.Attributes)) AS k,
+               arrayFlatten(arrayMap(m -> mapValues(m), Events.Attributes)) AS v
+    WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+    UNION ALL
+    SELECT 'link' AS Scope, k AS TagKey, v AS TagValue FROM <db>.otel_traces
+    ARRAY JOIN arrayFlatten(arrayMap(m -> mapKeys(m), Links.Attributes)) AS k,
+               arrayFlatten(arrayMap(m -> mapValues(m), Links.Attributes)) AS v
+    WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
 )
 GROUP BY Scope, TagKey
 ```
@@ -1862,10 +1873,14 @@ selector-less-only rule because this catalog answers with an actual key/value
 LIST rather than a cardinality count, so a window mismatch would silently
 omit real entries rather than merely reporting an approximate count), with
 **no `q=<TraceQL>` narrowing filter**, and, for `/search/tags`, only for the
-`resource`/`span`/unscoped `?scope=` values. Every other shape — a real
-window, a `q=` filter, or `event`/`link`/`instrumentation`/`intrinsic`/`trace`
-scope — stays on the existing live scan unconditionally; that path is
-untouched and permanent, not a transitional shim.
+`resource`/`span`/`event`/`link`/unscoped `?scope=` values — `?scope=none`
+additionally requires the schema to carry no instrumentation-scope column
+(`schema.Traces.ScopeAttributesColumn == ""`, true of every default-schema
+deployment), since the catalog cannot answer that one bucket and a
+catalog-served "none" must not silently omit it. Every other shape — a real
+window, a `q=` filter, or `instrumentation`/`intrinsic`/`trace` scope —
+stays on the existing live scan unconditionally; that path is untouched and
+permanent, not a transitional shim.
 
 Each key's top values carry a bounded top-50 sample (`topKState`/
 `topKMerge`, a Space-Saving sketch) rather than the exhaustive value set the
@@ -1879,15 +1894,33 @@ non-nil filter when `q` is present AND lowers to a real span-row predicate,
 so a filtered tag-values lookup provably never reaches the catalog — see
 `TestSearchTagValues_WithQFilter_StaysOnLivePath`.
 
-**Event/link scopes are intentionally out of scope for this feature.**
-`Events.Attributes`/`Links.Attributes` are `Array(Map(String, String))` — one
-map PER EVENT/PER LINK on a span row, not one map per row — so cataloging
-them costs an extra `arrayFlatten(arrayMap(...))` fan-out on top of the
-explosion the resource/span arms already pay twice, a materially costlier
-shape the "if cheap" qualifier in the originating issue was not written to
-cover. See cerberus issue
-[#2850](https://github.com/tsouza/cerberus/issues/2850) for tracking a
-dedicated design pass on that, independent of this feature.
+**Event/link scopes (cerberus issue #2850).** Issue #2771 originally scoped
+these out: `Events.Attributes`/`Links.Attributes` are
+`Array(Map(String, String))` — one map PER EVENT/PER LINK on a span row,
+not one map per row — so cataloging them costs an extra
+`arrayFlatten(arrayMap(...))` fan-out on top of the explosion the
+resource/span arms already pay twice, and issue #2771 was not written to
+assume that stayed "cheap". Issue #2850 measured it instead of guessing
+(see below) and found the extra cost small enough to include: the honest
+scope-down from issue #2771 is superseded here, not kept out of inertia.
+Instrumentation scope (`ScopeAttributes`) remains excluded — the upstream
+schema carries no such column by default, so a stock deployment has
+nothing to catalog there; a custom schema that populates it stays on the
+live path for that bucket, and `?scope=none` steps off the catalog fast
+path entirely on such a schema (see above) rather than silently omit it.
+Service-name keying (a third `(Scope, ServiceName, TagKey)` catalog
+dimension) was considered and not pursued: neither `/search/tags` nor
+`/search/tag/{name}/values` accepts a service-scoped narrowing parameter
+in any request shape this codebase or upstream Tempo's own API defines
+today, so a service-keyed catalog would pay service-cardinality× more
+rows for zero present read-side consumer — a decision the request shape
+itself, not this repository's schedule, would prompt reopening. A
+separate, narrower bug this investigation found — `resolveTagName`
+silently routing an explicit `instrumentation.x` tag-values lookup to the
+auto-scope (resource/span) union instead of the configured
+`ScopeAttributesColumn`, on schemas that configure one — is tracked as
+cerberus issue #3010; it does not block this feature (the catalog never
+served that bucket either way).
 
 **Measured before/after cost** (2,000,000 synthetic `otel_traces` rows
 spread across a trailing 1h window, 5 resource-attribute keys + 10
@@ -1901,6 +1934,20 @@ TagKey`) reads 15 rows (515 bytes) in 4.6ms — roughly 132,800x fewer rows
 and ~65.6x less wall-clock time, verified via `system.query_log`
 (`read_rows`/`read_bytes`), not client-side row counting. See
 `internal/schema/ddl.TestTempoTagCatalog_MeasuredCost`.
+
+**Event/link refresh cost** (same corpus and methodology, extended with
+Events/Links populated on the SAME 2,000,000 rows — 10% of spans carry >=1
+exception-shaped event, 3% carry a messaging link; see
+`TestTempoTagCatalog_EventsLinks_MeasuredCost` for the exact assumptions):
+adding the event+link arms to the refreshable view's own body cost only
+~1.08x the existing resource+span refresh's wall-clock time (923ms vs
+857ms), despite reading ~2x the rows — both Nested columns are empty for
+the large majority of rows, so the extra arms decode far fewer bytes (66MB +
+36MB) than the flat-Map arms do (799MB) even though ClickHouse's
+`read_rows` accounting counts a full base-table scan for each arm. A
+stress-test rerun with an unrealistically dense corpus (every span carries
+1-3 events AND 1-2 links) still stayed at 2.01x baseline (1.78s) — a small
+fraction of the 5-minute refresh period either way.
 
 `system.view_refreshes`' live status for this view is surfaced on `GET
 /info` under `tempoTagCatalogViewRefresh`, the exact same shape and posture

--- a/internal/api/tempo/export_test.go
+++ b/internal/api/tempo/export_test.go
@@ -57,6 +57,8 @@ const (
 	AttrMapScopeAnyForTest      = attrMapScopeAny
 	AttrMapScopeResourceForTest = attrMapScopeResource
 	AttrMapScopeSpanForTest     = attrMapScopeSpan
+	AttrMapScopeEventForTest    = attrMapScopeEvent
+	AttrMapScopeLinkForTest     = attrMapScopeLink
 )
 
 // BuildAttributeValuesSQLForTest re-exports buildAttributeValuesSQL

--- a/internal/api/tempo/grpc_exports.go
+++ b/internal/api/tempo/grpc_exports.go
@@ -104,10 +104,11 @@ type ResolvedTagName struct {
 	IntrinsicName string
 	Key           string
 	// MapScope encodes which attribute map(s) a dynamic-attribute
-	// lookup should consult: 0 (any), 1 (resource), 2 (span). The
-	// constants live as package-private values inside the tempo
-	// package; the grpc handler treats them as opaque and just
-	// passes the struct back into BuildTagValuesSQL.
+	// lookup should consult: any, resource, span, event, or link
+	// (cerberus issue #2850 added the latter two). The constants live
+	// as package-private values inside the tempo package; the grpc
+	// handler treats them as opaque and just passes the struct back
+	// into BuildTagValuesSQL.
 	mapScope attrMapScope
 }
 

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -273,7 +273,21 @@ func buildIntrinsicValuesSQL(s schema.Traces, col string, filter chsql.Frag, sta
 // back to the map subscript for the other side — see that function's doc
 // for the four routing cases. A key materialized in neither map keeps
 // today's single arrayJoin-over-both-maps shape, unchanged, below.
+//
+// attrMapScopeEvent / attrMapScopeLink (cerberus issue #2850) route
+// straight to buildNestedAttributeValuesSQL before any of the above: the
+// Nested Events.Attributes / Links.Attributes families are
+// Array(Map(String, String)), not a flat Map, so neither the materialized-
+// column short-circuit (#2776/#2870 only ever provision materialized
+// columns for SpanAttributes/ResourceAttributes keys) nor the scalar
+// mapAtFrag/mapContainsFrag shape below applies to them.
 func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, filter chsql.Frag, start, end time.Time) (string, []any) {
+	switch scope {
+	case attrMapScopeEvent:
+		return buildNestedAttributeValuesSQL(s, s.EventsColumn, name, filter, start, end)
+	case attrMapScopeLink:
+		return buildNestedAttributeValuesSQL(s, s.LinksColumn, name, filter, start, end)
+	}
 	switch scope {
 	case attrMapScopeResource:
 		if col, ok := s.MaterializedResourceAttributeColumns[name]; ok {
@@ -314,6 +328,55 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 		Select(selFrag).
 		From(chsql.Col(s.SpansTable)).
 		Where(whereFrag)
+	if !start.IsZero() {
+		inner.Where(tempoTimeGteFrag(s.TimestampColumn, start))
+	}
+	if !end.IsZero() {
+		inner.Where(tempoTimeLteFrag(s.TimestampColumn, end))
+	}
+	if filter != nil {
+		inner.Where(filter)
+	}
+
+	outer := chsql.NewQuery().
+		Select(chsql.Distinct(chsql.Col("v"))).
+		From(inner.Frag()).
+		Where(nonEmptyFrag("v"))
+	return outer.Build()
+}
+
+// buildNestedAttributeValuesSQL is buildAttributeValuesSQL's single-scope
+// branch one nesting level up (cerberus issue #2850): nestedCol names a
+// Nested event/link attribute family (Events / Links), whose Attributes
+// sub-column is Array(Map(String, String)) rather than a flat Map, so the
+// per-event/per-link key and value arrays are flattened
+// (nestedMapKeysFlatFrag / nestedMapValuesFlatFrag — same helpers
+// distinctNestedMapKeysFrag in search_tags.go builds on) and ARRAY JOINed
+// together to zip them into (k, v) pairs, filtered to the requested key:
+//
+//	SELECT DISTINCT v FROM (
+//	    SELECT v FROM `otel_traces`
+//	    ARRAY JOIN
+//	      arrayFlatten(arrayMap(m -> mapKeys(m), `<nestedCol>`.`Attributes`)) AS k,
+//	      arrayFlatten(arrayMap(m -> mapValues(m), `<nestedCol>`.`Attributes`)) AS v
+//	    WHERE k = ? [AND time bounds] [AND filter]
+//	)
+//	WHERE v != ''
+//
+// No materialized-column short-circuit applies here (see
+// buildAttributeValuesSQL's doc) and there is no "both nested maps at once"
+// auto-scope form — an event./link. prefix is always a single-scope
+// request (see resolveTagName) — so unlike its flat-Map sibling this
+// builder has no attrMapScopeAny-shaped union branch to consider.
+func buildNestedAttributeValuesSQL(s schema.Traces, nestedCol, name string, filter chsql.Frag, start, end time.Time) (string, []any) {
+	inner := chsql.NewQuery().
+		Select(chsql.Col("v")).
+		From(chsql.Col(s.SpansTable)).
+		ArrayJoin(
+			chsql.As(nestedMapKeysFlatFrag(nestedCol), "k"),
+			chsql.As(nestedMapValuesFlatFrag(nestedCol), "v"),
+		).
+		Where(chsql.Eq(chsql.Col("k"), chsql.Lit(name)))
 	if !start.IsZero() {
 		inner.Where(tempoTimeGteFrag(s.TimestampColumn, start))
 	}
@@ -510,7 +573,9 @@ type attrMapScope int
 const (
 	// attrMapScopeAny unions both SpanAttributes and ResourceAttributes
 	// (Tempo's auto-scope form: bare `service.name`, leading-dot
-	// `.service.name`).
+	// `.service.name`). Never event/link — those require an explicit
+	// event./link. prefix, so a bare/dotted identifier can only ever mean
+	// "resource or span" (see resolveTagName).
 	attrMapScopeAny attrMapScope = iota
 	// attrMapScopeResource consults only ResourceAttributes
 	// (Tempo's `resource.x` scoped form).
@@ -518,6 +583,14 @@ const (
 	// attrMapScopeSpan consults only SpanAttributes
 	// (Tempo's `span.x` scoped form).
 	attrMapScopeSpan
+	// attrMapScopeEvent consults only the Nested Events.Attributes family
+	// (Tempo's `event.x` scoped form) — cerberus issue #2850. Routed
+	// through buildNestedAttributeValuesSQL rather than the flat-Map
+	// mapAtFrag/mapContainsFrag shape attrMapScopeResource/Span use.
+	attrMapScopeEvent
+	// attrMapScopeLink is attrMapScopeEvent's sibling for the Nested
+	// Links.Attributes family (Tempo's `link.x` scoped form).
+	attrMapScopeLink
 )
 
 func (s attrMapScope) String() string {
@@ -526,6 +599,10 @@ func (s attrMapScope) String() string {
 		return "resource"
 	case attrMapScopeSpan:
 		return "span"
+	case attrMapScopeEvent:
+		return "event"
+	case attrMapScopeLink:
+		return "link"
 	default:
 		return "any"
 	}
@@ -596,6 +673,15 @@ func resolveTagName(name string, s schema.Traces) (resolvedTagName, error) {
 		ms = attrMapScopeResource
 	case traceql.AttributeScopeSpan:
 		ms = attrMapScopeSpan
+	case traceql.AttributeScopeEvent:
+		// cerberus issue #2850: previously fell to attrMapScopeAny, which
+		// silently searched SpanAttributes/ResourceAttributes only — an
+		// explicit `event.x` tag-values request could never find a value
+		// that only ever lives in Events.Attributes, and returned an
+		// empty (not an error) result forever.
+		ms = attrMapScopeEvent
+	case traceql.AttributeScopeLink:
+		ms = attrMapScopeLink // same fix, for Links.Attributes.
 	default:
 		ms = attrMapScopeAny
 	}

--- a/internal/api/tempo/search_tag_values_test.go
+++ b/internal/api/tempo/search_tag_values_test.go
@@ -363,6 +363,106 @@ func TestSearchTagValuesV2_SpanScope(t *testing.T) {
 	}
 }
 
+// TestSearchTagValuesV2_EventScope — `event.exception.message` (cerberus
+// issue #2850) narrows to the Nested Events.Attributes family, via an
+// ARRAY JOIN fan-out rather than a flat-Map subscript. Before this issue,
+// resolveTagName fell through to the auto-scope form for this input,
+// which never consults Events.Attributes at all and silently returned an
+// empty result regardless of what values existed.
+func TestSearchTagValuesV2_EventScope(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"card declined"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/event.exception.message/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if !strings.Contains(q.lastSQL, "`Events`.`Attributes`") {
+		t.Errorf("expected an Events.Attributes fan-out, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "`Links`.`Attributes`") {
+		t.Errorf("event scope should NOT touch Links.Attributes, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "`SpanAttributes`[") || strings.Contains(q.lastSQL, "`ResourceAttributes`[") {
+		t.Errorf("event scope should NOT touch the flat span/resource maps, got: %s", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "ARRAY JOIN") {
+		t.Errorf("expected an ARRAY JOIN fan-out, got: %s", q.lastSQL)
+	}
+	hits := 0
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "exception.message" {
+			hits++
+		}
+	}
+	if hits < 1 {
+		t.Errorf("expected key %q bound, got args %v", "exception.message", q.lastArgs)
+	}
+}
+
+// TestSearchTagValuesV2_LinkScope is TestSearchTagValuesV2_EventScope's
+// sibling for `link.x` / Links.Attributes.
+func TestSearchTagValuesV2_LinkScope(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"child_of"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/link.opentracing.ref_type/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if !strings.Contains(q.lastSQL, "`Links`.`Attributes`") {
+		t.Errorf("expected a Links.Attributes fan-out, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "`Events`.`Attributes`") {
+		t.Errorf("link scope should NOT touch Events.Attributes, got: %s", q.lastSQL)
+	}
+	hits := 0
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "opentracing.ref_type" {
+			hits++
+		}
+	}
+	if hits < 1 {
+		t.Errorf("expected key %q bound, got args %v", "opentracing.ref_type", q.lastArgs)
+	}
+}
+
+// TestSearchTagValues_AutoScope_NeverTouchesEventLink pins that the bare
+// / leading-dot auto-scope form stays "resource or span only" even after
+// cerberus issue #2850 added event/link routing — auto-scope has never
+// included event/link (they require an explicit prefix), and this guards
+// against a future change accidentally widening it.
+func TestSearchTagValues_AutoScope_NeverTouchesEventLink(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"frontend"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tag/service.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if strings.Contains(q.lastSQL, "`Events`.`Attributes`") || strings.Contains(q.lastSQL, "`Links`.`Attributes`") {
+		t.Errorf("auto-scope must never touch Events/Links.Attributes, got: %s", q.lastSQL)
+	}
+}
+
 // TestSearchTagValues_ScopedFormParityWithBare — the scoped
 // `.service.name` form (Tempo-acceptable) and the bare `service.name`
 // form (V1 backward-compat) MUST produce equivalent SQL: identical

--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -107,8 +107,8 @@ const (
 	// import — see that constant's doc comment.
 	tagScopeResource        = schema.TagCatalogScopeResource
 	tagScopeSpan            = schema.TagCatalogScopeSpan
-	tagScopeEvent           = "event"
-	tagScopeLink            = "link"
+	tagScopeEvent           = schema.TagCatalogScopeEvent
+	tagScopeLink            = schema.TagCatalogScopeLink
 	tagScopeInstrumentation = "instrumentation"
 	tagScopeIntrinsic       = "intrinsic"
 	tagScopeTrace           = "trace"
@@ -213,7 +213,7 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, route Tags
 	// through to the SAME per-request live scan every other request
 	// already takes — that path is untouched below.
 	scopes, ok := ([]TagScope)(nil), false
-	if h.TagCatalogEnabled && tagsCatalogEligible(scope, filter, windowless) {
+	if h.TagCatalogEnabled && tagsCatalogEligible(scope, filter, windowless, h.Schema.ScopeAttributesColumn != "") {
 		scopes, ok = h.tagsFromCatalog(ctx, scope)
 	}
 	if !ok {
@@ -396,32 +396,57 @@ func distinctMapKeysFrag(col string) chsql.Frag {
 	return chsql.Distinct(chsql.Call("arrayJoin", chsql.Qual(col, "keys")))
 }
 
-// distinctNestedMapKeysFrag is the same idea one nesting level up:
-// `Events.Attributes` / `Links.Attributes` are Array(Map(...)) — one
-// map per event / link on the span row — so the keys of every element
-// are collected with arrayMap+mapKeys, flattened into a single key
-// array, and then unrolled by arrayJoin.
+// nestedMapParam names the lambda-bound element the nested Array(Map)
+// attribute-family helpers below range over — one event / link on a
+// span row's Events.Attributes / Links.Attributes array.
+const nestedMapParam = "m"
+
+// nestedMapKeysFlatFrag / nestedMapValuesFlatFrag emit
+// "arrayFlatten(arrayMap(m -> mapKeys(m), `<col>`.`Attributes`))" and its
+// mapValues sibling: the per-row flattened key / value arrays across
+// EVERY element of a Nested event/link attribute family. The sub-column
+// is addressed with the same qualified-identifier spelling every other
+// Nested reference in the emitter uses (see Builder.exprNestedArrayExists).
 //
-// Emits "DISTINCT arrayJoin(arrayFlatten(arrayMap(m -> mapKeys(m),
-// `<col>`.`Attributes`)))". `nestedMapParam` is the lambda's bound
-// element. The sub-column is addressed with the same qualified-identifier
-// spelling every other Nested reference in the emitter uses (see
-// Builder.exprNestedArrayExists).
-func distinctNestedMapKeysFrag(col string) chsql.Frag {
-	const nestedMapParam = "m"
-	return chsql.Distinct(
+// Positionally aligned: mapKeys(m)/mapValues(m) of the same map element
+// are always the same length and order, and arrayMap/arrayFlatten
+// preserve element order deterministically, so an ARRAY JOIN of both
+// together (as buildNestedAttributeValuesSQL does) zips them into
+// correct (key, value) pairs — the same contract flat-Map
+// mapKeys(col)/mapValues(col) already has one nesting level down (see
+// internal/schema/ddl's tempoTagCatalogScopeArm, which relies on the
+// identical zipping property for the flat-Map arms).
+func nestedMapKeysFlatFrag(col string) chsql.Frag {
+	return chsql.Call(
+		"arrayFlatten",
 		chsql.Call(
-			"arrayJoin",
-			chsql.Call(
-				"arrayFlatten",
-				chsql.Call(
-					"arrayMap",
-					chsql.Lambda1(nestedMapParam, chsql.Call("mapKeys", chsql.BareIdent(nestedMapParam))),
-					chsql.Qual(col, nestedAttributesSubfield),
-				),
-			),
+			"arrayMap",
+			chsql.Lambda1(nestedMapParam, chsql.Call("mapKeys", chsql.BareIdent(nestedMapParam))),
+			chsql.Qual(col, nestedAttributesSubfield),
 		),
 	)
+}
+
+func nestedMapValuesFlatFrag(col string) chsql.Frag {
+	return chsql.Call(
+		"arrayFlatten",
+		chsql.Call(
+			"arrayMap",
+			chsql.Lambda1(nestedMapParam, chsql.Call("mapValues", chsql.BareIdent(nestedMapParam))),
+			chsql.Qual(col, nestedAttributesSubfield),
+		),
+	)
+}
+
+// distinctNestedMapKeysFrag is distinctMapKeysFrag one nesting level up:
+// `Events.Attributes` / `Links.Attributes` are Array(Map(...)) — one map
+// per event / link on the span row — so the keys of every element are
+// collected via nestedMapKeysFlatFrag, then unrolled by arrayJoin.
+//
+// Emits "DISTINCT arrayJoin(arrayFlatten(arrayMap(m -> mapKeys(m),
+// `<col>`.`Attributes`)))".
+func distinctNestedMapKeysFrag(col string) chsql.Frag {
+	return chsql.Distinct(chsql.Call("arrayJoin", nestedMapKeysFlatFrag(col)))
 }
 
 // tempoTimeGteFrag emits "`<col>` >= toDateTime64('...', 9)" — the

--- a/internal/api/tempo/tag_catalog.go
+++ b/internal/api/tempo/tag_catalog.go
@@ -48,10 +48,13 @@ import (
 //     historical window is left on the live path rather than silently
 //     answered from a narrower window than the caller asked for.
 //   - (tags only) the requested `?scope=` is one the catalog covers —
-//     "none" (both buckets), "resource", or "span". Every other scope
-//     value (event/link/instrumentation/intrinsic/trace) stays live
-//     unconditionally — see internal/schema/ddl's own SCOPE COVERAGE
-//     doc for why.
+//     "none" (every covered bucket), "resource", "span", "event", or
+//     "link" (cerberus issue #2850 widened the catalog to the latter
+//     two — see internal/schema/ddl's SCOPE COVERAGE doc for the
+//     measured cost that justified it). Every other scope value
+//     (instrumentation/intrinsic/trace) stays live unconditionally.
+//     "none" additionally requires scopeAttrsConfigured == false — see
+//     that parameter's doc below.
 //   - (tag values only) the resolved tag name is NOT an intrinsic —
 //     intrinsics read a dedicated column directly (cheap already, never
 //     an attribute-map explosion), so the catalog has nothing to offer
@@ -59,13 +62,29 @@ import (
 
 // tagsCatalogEligible reports whether a /search/tags (or
 // /api/v2/search/tags) request may be served from the catalog.
-func tagsCatalogEligible(scope string, filter chsql.Frag, windowless bool) bool {
+//
+// scopeAttrsConfigured is h.Schema.ScopeAttributesColumn != "": whether
+// this deployment's schema carries an instrumentation-scope attribute
+// map. The catalog never covers that bucket (see internal/schema/ddl's
+// SCOPE COVERAGE doc), so a `scope=none` catalog hit is a faithful
+// substitute for the live "none" answer (collectAttributeTagScopes /
+// attributeTagScopes) ONLY when the schema has no instrumentation bucket
+// for the live path to include either. On a custom schema that DOES
+// populate ScopeAttributesColumn, a catalog-served "none" would silently
+// omit that bucket, so "none" stays off the fast path there — every
+// default-schema deployment (scopeAttrsConfigured == false) is
+// unaffected. A scoped request ("resource"/"span"/"event"/"link") never
+// touches the instrumentation bucket in the first place, so this
+// parameter only gates "none".
+func tagsCatalogEligible(scope string, filter chsql.Frag, windowless, scopeAttrsConfigured bool) bool {
 	if filter != nil || !windowless {
 		return false
 	}
 	switch scope {
-	case tagScopeNone, tagScopeResource, tagScopeSpan:
+	case tagScopeResource, tagScopeSpan, tagScopeEvent, tagScopeLink:
 		return true
+	case tagScopeNone:
+		return !scopeAttrsConfigured
 	default:
 		return false
 	}
@@ -82,31 +101,45 @@ func tagValuesCatalogEligible(resolved resolvedTagName, filter chsql.Frag, windo
 }
 
 // catalogScopesFor maps the `?scope=` query parameter to the catalog
-// Scope value(s) a /search/tags catalog read should fetch: both buckets
-// for "none" (the default / unscoped request), one bucket for an
-// explicit "resource" or "span". Only called after tagsCatalogEligible
-// has already rejected every other scope value.
+// Scope value(s) a /search/tags catalog read should fetch: every covered
+// bucket for "none" (the default / unscoped request), one bucket for an
+// explicit "resource", "span", "event", or "link". Only called after
+// tagsCatalogEligible has already rejected every other scope value.
 func catalogScopesFor(scope string) []string {
 	switch scope {
 	case tagScopeResource:
 		return []string{schema.TagCatalogScopeResource}
 	case tagScopeSpan:
 		return []string{schema.TagCatalogScopeSpan}
+	case tagScopeEvent:
+		return []string{schema.TagCatalogScopeEvent}
+	case tagScopeLink:
+		return []string{schema.TagCatalogScopeLink}
 	default: // tagScopeNone
-		return []string{schema.TagCatalogScopeResource, schema.TagCatalogScopeSpan}
+		return []string{
+			schema.TagCatalogScopeResource, schema.TagCatalogScopeSpan,
+			schema.TagCatalogScopeEvent, schema.TagCatalogScopeLink,
+		}
 	}
 }
 
 // catalogScopeForMapScope maps a resolved tag-VALUES lookup's attrMapScope
 // to the single catalog Scope value to filter by, or ok=false for
-// attrMapScopeAny — the auto-scope form, which unions both maps and so
-// omits the Scope predicate entirely (see buildTagCatalogValuesSQL).
+// attrMapScopeAny — the auto-scope form, which unions the resource AND
+// span buckets ONLY (never event/link — those require an explicit
+// event./link. prefix, see resolveTagName) via the explicit
+// TagCatalogScopeResource/Span IN-list buildTagCatalogValuesSQL applies
+// when ok is false.
 func catalogScopeForMapScope(ms attrMapScope) (string, bool) {
 	switch ms {
 	case attrMapScopeResource:
 		return schema.TagCatalogScopeResource, true
 	case attrMapScopeSpan:
 		return schema.TagCatalogScopeSpan, true
+	case attrMapScopeEvent:
+		return schema.TagCatalogScopeEvent, true
+	case attrMapScopeLink:
+		return schema.TagCatalogScopeLink, true
 	default:
 		return "", false
 	}
@@ -185,12 +218,18 @@ func buildTagCatalogKeysSQL(scope string) (string, []any) {
 // one top-N array; arrayJoin unrolls that array into one row per value,
 // the shape chclient.QueryStrings (a single-string-column scan) expects.
 //
-// A single-scope mapScope (resource./span. forms) adds the Scope
-// predicate; the auto-scope "any" form (catalogScopeForMapScope's
-// ok=false) omits it, so topKMerge folds BOTH scope buckets' states into
-// one merged top-N array — the catalog's analogue of
+// A single-scope mapScope (resource./span./event./link. forms) adds an
+// exact Scope predicate; the auto-scope "any" form (catalogScopeForMapScope's
+// ok=false) adds an explicit `Scope IN ('resource', 'span')` predicate
+// instead of omitting the Scope filter — auto-scope has only ever meant
+// "resource or span" (see resolveTagName: event./link. require an
+// explicit prefix, so attr.Scope only resolves to attrMapScopeAny for a
+// bare or dotted identifier), and since cerberus issue #2850 the catalog
+// ALSO carries event/link rows, so an unfiltered read here would widen
+// auto-scope's merge to include them too — a genuine behaviour change
+// the explicit IN prevents. The result is the catalog's analogue of
 // attrValueArrayJoinFrag's live-path union of SpanAttributes and
-// ResourceAttributes, pre-aggregated instead of per-row.
+// ResourceAttributes ONLY, pre-aggregated instead of per-row.
 func buildTagCatalogValuesSQL(key string, mapScope attrMapScope) (string, []any) {
 	sb := chsql.NewQuery().
 		Select(chsql.As(chsql.Call("arrayJoin", tagCatalogTopValuesMergeFrag(chsql.Col(schema.TagCatalogTopValuesStateColumn))), "value")).
@@ -198,6 +237,11 @@ func buildTagCatalogValuesSQL(key string, mapScope attrMapScope) (string, []any)
 		Where(chsql.Eq(chsql.Col(schema.TagCatalogKeyColumn), chsql.Lit(key)))
 	if catScope, ok := catalogScopeForMapScope(mapScope); ok {
 		sb.Where(chsql.Eq(chsql.Col(schema.TagCatalogScopeColumn), chsql.Lit(catScope)))
+	} else {
+		sb.Where(chsql.In(
+			chsql.Col(schema.TagCatalogScopeColumn),
+			chsql.Lit(schema.TagCatalogScopeResource), chsql.Lit(schema.TagCatalogScopeSpan),
+		))
 	}
 	return sb.Build()
 }

--- a/internal/api/tempo/tag_catalog_test.go
+++ b/internal/api/tempo/tag_catalog_test.go
@@ -31,35 +31,42 @@ func nonNilFrag() chsql.Frag { return func(*chsql.Builder) {} }
 // --- Eligibility rule (pure function, no handler round-trip) ---
 
 // TestTagsCatalogEligible pins internal/api/tempo's tagsCatalogEligible
-// rule (cerberus issue #2771): eligible only for the catalog-covered
-// scopes (none/resource/span), a nil filter (no `q=` narrowing), and a
-// windowless request.
+// rule: eligible for the catalog-covered scopes
+// (none/resource/span/event/link — cerberus issue #2850 widened the
+// catalog to the latter two), a nil filter (no `q=` narrowing), and a
+// windowless request. "none" additionally requires the schema to carry
+// no instrumentation-scope column (scopeAttrsConfigured == false) — see
+// tagsCatalogEligible's doc comment for why.
 func TestTagsCatalogEligible(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
-		name       string
-		scope      string
-		filter     chsql.Frag
-		windowless bool
-		want       bool
+		name                 string
+		scope                string
+		filter               chsql.Frag
+		windowless           bool
+		scopeAttrsConfigured bool
+		want                 bool
 	}{
-		{"none scope, no filter, windowless", "none", nil, true, true},
-		{"resource scope, no filter, windowless", "resource", nil, true, true},
-		{"span scope, no filter, windowless", "span", nil, true, true},
-		{"event scope stays live", "event", nil, true, false},
-		{"link scope stays live", "link", nil, true, false},
-		{"instrumentation scope stays live", "instrumentation", nil, true, false},
-		{"intrinsic scope stays live", "intrinsic", nil, true, false},
-		{"trace scope stays live", "trace", nil, true, false},
-		{"filtered request stays live", "none", nonNilFrag(), true, false},
-		{"explicit window stays live", "none", nil, false, false},
-		{"filtered AND windowed stays live", "resource", nonNilFrag(), false, false},
+		{"none scope, no filter, windowless", "none", nil, true, false, true},
+		{"resource scope, no filter, windowless", "resource", nil, true, false, true},
+		{"span scope, no filter, windowless", "span", nil, true, false, true},
+		{"event scope, no filter, windowless", "event", nil, true, false, true},
+		{"link scope, no filter, windowless", "link", nil, true, false, true},
+		{"instrumentation scope stays live", "instrumentation", nil, true, false, false},
+		{"intrinsic scope stays live", "intrinsic", nil, true, false, false},
+		{"trace scope stays live", "trace", nil, true, false, false},
+		{"filtered request stays live", "none", nonNilFrag(), true, false, false},
+		{"explicit window stays live", "none", nil, false, false, false},
+		{"filtered AND windowed stays live", "resource", nonNilFrag(), false, false, false},
+		{"none scope with instrumentation-scope column configured stays live", "none", nil, true, true, false},
+		{"scoped resource request unaffected by instrumentation-scope column", "resource", nil, true, true, true},
+		{"scoped event request unaffected by instrumentation-scope column", "event", nil, true, true, true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := tempo.TagsCatalogEligibleForTest(tt.scope, tt.filter, tt.windowless); got != tt.want {
-				t.Errorf("tagsCatalogEligible(%q, filter=%v, windowless=%v) = %v, want %v",
-					tt.scope, tt.filter != nil, tt.windowless, got, tt.want)
+			if got := tempo.TagsCatalogEligibleForTest(tt.scope, tt.filter, tt.windowless, tt.scopeAttrsConfigured); got != tt.want {
+				t.Errorf("tagsCatalogEligible(%q, filter=%v, windowless=%v, scopeAttrsConfigured=%v) = %v, want %v",
+					tt.scope, tt.filter != nil, tt.windowless, tt.scopeAttrsConfigured, got, tt.want)
 			}
 		})
 	}
@@ -67,8 +74,9 @@ func TestTagsCatalogEligible(t *testing.T) {
 
 // TestTagValuesCatalogEligible pins tagValuesCatalogEligible: eligible
 // only for a non-intrinsic resolved name, a nil filter, and a windowless
-// request — MapScope (resource/span/any) never restricts eligibility, all
-// three are catalog-servable.
+// request — MapScope (resource/span/event/link/any) never restricts
+// eligibility, all five are catalog-servable (cerberus issue #2850 added
+// event/link).
 func TestTagValuesCatalogEligible(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
@@ -82,6 +90,8 @@ func TestTagValuesCatalogEligible(t *testing.T) {
 		{"dynamic attribute, any scope, no filter, windowless", false, tempo.AttrMapScopeAnyForTest, nil, true, true},
 		{"dynamic attribute, resource scope, no filter, windowless", false, tempo.AttrMapScopeResourceForTest, nil, true, true},
 		{"dynamic attribute, span scope, no filter, windowless", false, tempo.AttrMapScopeSpanForTest, nil, true, true},
+		{"dynamic attribute, event scope, no filter, windowless", false, tempo.AttrMapScopeEventForTest, nil, true, true},
+		{"dynamic attribute, link scope, no filter, windowless", false, tempo.AttrMapScopeLinkForTest, nil, true, true},
 		{"intrinsic stays live", true, tempo.AttrMapScopeAnyForTest, nil, true, false},
 		{"filtered request stays live", false, tempo.AttrMapScopeAnyForTest, nonNilFrag(), true, false},
 		{"explicit window stays live", false, tempo.AttrMapScopeAnyForTest, nil, false, false},
@@ -129,14 +139,44 @@ func TestBuildTagCatalogValuesSQL_SQLShape(t *testing.T) {
 		}
 	})
 
-	t.Run("any scope omits Scope predicate", func(t *testing.T) {
+	t.Run("any scope filters Scope IN (resource, span), not event/link", func(t *testing.T) {
 		t.Parallel()
+		// cerberus issue #2850: since the catalog now also carries
+		// event/link rows, auto-scope must filter explicitly rather than
+		// omit the Scope predicate — an unfiltered read would silently
+		// widen the merge to include event/link states too, which
+		// auto-scope has never meant (see resolveTagName).
 		sqlStr, args := tempo.BuildTagCatalogValuesSQLForTest("service.name", tempo.AttrMapScopeAnyForTest)
 		if strings.Contains(sqlStr, "`Scope` = ?") {
-			t.Errorf("auto-scope lookup must NOT filter by Scope (unions both), got: %s", sqlStr)
+			t.Errorf("auto-scope lookup must use an IN-list, not an equality predicate, got: %s", sqlStr)
 		}
-		if len(args) != 1 || args[0] != "service.name" {
-			t.Errorf("expected args=[key] only, got %v", args)
+		if !strings.Contains(sqlStr, "`Scope` IN (?, ?)") {
+			t.Errorf("expected an explicit Scope IN-list, got: %s", sqlStr)
+		}
+		if len(args) != 3 || args[0] != "service.name" || args[1] != "resource" || args[2] != "span" {
+			t.Errorf("expected args=[key, resource, span], got %v", args)
+		}
+	})
+
+	t.Run("event scope adds Scope predicate", func(t *testing.T) {
+		t.Parallel()
+		sqlStr, args := tempo.BuildTagCatalogValuesSQLForTest("exception.type", tempo.AttrMapScopeEventForTest)
+		if !strings.Contains(sqlStr, "`Scope` = ?") {
+			t.Errorf("expected a Scope predicate for a single-scope lookup, got: %s", sqlStr)
+		}
+		if len(args) != 2 || args[0] != "exception.type" || args[1] != "event" {
+			t.Errorf("expected args=[key, scope], got %v", args)
+		}
+	})
+
+	t.Run("link scope adds Scope predicate", func(t *testing.T) {
+		t.Parallel()
+		sqlStr, args := tempo.BuildTagCatalogValuesSQLForTest("opentracing.ref_type", tempo.AttrMapScopeLinkForTest)
+		if !strings.Contains(sqlStr, "`Scope` = ?") {
+			t.Errorf("expected a Scope predicate for a single-scope lookup, got: %s", sqlStr)
+		}
+		if len(args) != 2 || args[0] != "opentracing.ref_type" || args[1] != "link" {
+			t.Errorf("expected args=[key, scope], got %v", args)
 		}
 	})
 }

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1279,8 +1279,8 @@ const (
 	// ... REFRESH EVERY 5 MINUTE ... TO tempo_tag_catalog AS SELECT ...`
 	// DDL (cerberus issue #2771, the Tempo sibling of FeatureLokiCatalogMV
 	// above) that maintains a per-(scope, tag-key) top-values catalog over
-	// the traces table's SpanAttributes / ResourceAttributes maps,
-	// refreshed on a schedule instead of scanned per request.
+	// the traces table's resource / span / event / link attribute
+	// families, refreshed on a schedule instead of scanned per request.
 	// `/api/v2/search/tags` and `/api/search/tag/{name}/values`
 	// (internal/api/tempo/search_tags.go, search_tag_values.go) serve from
 	// the catalog when eligible — see internal/api/tempo/tag_catalog.go's
@@ -1288,15 +1288,17 @@ const (
 	// scan otherwise; the fallback path is untouched and permanent, exactly
 	// as FeatureLokiCatalogMV's own doc describes for its sibling.
 	//
-	// The catalog covers only the resource and span scopes — event, link,
-	// and instrumentation scopes stay on the live path unconditionally
-	// (Nested Array(Map) explosion is a materially different, costlier
-	// shape than a flat Map explosion; see the DDL render function's own
-	// doc for the honest scope-down). Filtered tag/tag-value lookups (the
-	// V2 `q=<TraceQL>` narrowing parameter) also stay on the live path
-	// unconditionally: the catalog has no way to answer "values on spans
-	// matching this predicate" without evaluating the predicate per row,
-	// which is exactly the scan this feature exists to avoid.
+	// The catalog covers resource, span, event, and link scopes — the
+	// event/link (Nested Array(Map)) arms were added by cerberus issue
+	// #2850 after measuring their refresh cost against the same traces
+	// table (see the DDL render function's own SCOPE COVERAGE doc for the
+	// numbers); only instrumentation scope stays on the live path
+	// unconditionally, because the upstream schema carries no such column
+	// by default. Filtered tag/tag-value lookups (the V2 `q=<TraceQL>`
+	// narrowing parameter) also stay on the live path unconditionally: the
+	// catalog has no way to answer "values on spans matching this
+	// predicate" without evaluating the predicate per row, which is
+	// exactly the scan this feature exists to avoid.
 	//
 	// VERSION FLOOR: 24.10 — same upstream PR #70550 floor
 	// FeatureLokiCatalogMV cites; see that constant's doc for the

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -1777,28 +1777,57 @@ func renderLokiLabelCatalogView(cfg Config) string {
 // friends), not here — see that package's doc comment for why, mirroring
 // LabelCatalogTable's own rationale.
 //
-// SCOPE COVERAGE: only the two flat-Map attribute scopes — resource
-// (ResourceAttributes) and span (SpanAttributes) — feed the catalog.
-// Event/Link attributes (Events.Attributes / Links.Attributes) are
-// Array(Map(String, String)) — one map PER EVENT / PER LINK on a span
-// row, not one map per row — so exploding them costs an extra
-// arrayFlatten(arrayMap(...)) fan-out per row on top of the mapKeys/
-// mapValues explosion this view already pays twice (see
-// distinctNestedMapKeysFrag in internal/api/tempo/search_tags.go for the
-// live-path shape this would have to mirror). That is not "cheap" the
-// way issue #2771 asked the catalog to stay, and events/links are a
-// materially rarer autocomplete target than resource/span attributes, so
-// they are excluded — an honest scope-down, not a deferral: the live
-// scan remains their permanent, unconditional path, the same posture the
-// resource/span buckets keep for every OTHER Tempo request shape (see
-// tagsCatalogEligible's doc in internal/api/tempo/tag_catalog.go).
-// Instrumentation-scope attributes (ScopeAttributes) are excluded for a
-// different reason: the upstream traces_table.sql template carries no
-// such column at all (schema.Traces.ScopeAttributesColumn defaults to
-// "" — see that field's doc comment), so a stock deployment has nothing
-// to catalog there; a custom schema that populates it stays on the live
-// path, consistent with how attributeTagScopes() already treats an empty
-// ScopeAttributesColumn as "no bucket".
+// SCOPE COVERAGE: as of cerberus issue #2850, all FOUR dynamic attribute
+// scopes feed the catalog — the two flat-Map scopes, resource
+// (ResourceAttributes) and span (SpanAttributes), plus the two Nested
+// Array(Map(String, String)) scopes, event (Events.Attributes) and link
+// (Links.Attributes). Issue #2771 originally excluded event/link,
+// reasoning that the extra arrayFlatten(arrayMap(...)) fan-out the
+// Array(Map) shape needs (see nestedMapKeysFlatFrag /
+// nestedMapValuesFlatFrag in internal/api/tempo/search_tags.go for the
+// live-path shape the catalog arm below mirrors) was not "cheap" the way
+// #2771 asked the catalog to stay. #2850 measured it instead of guessing:
+// on a real ClickHouse (25.9, via testcontainers — not chDB) seeded with
+// 2,000,000 synthetic otel_traces rows in the trailing 1h window (the
+// SAME corpus and methodology as TestTempoTagCatalog_MeasuredCost, see
+// that test's doc comment) and a documented-representative event/link
+// population (10% of spans carry >=1 exception-shaped event, 3% carry a
+// messaging link — see TestTempoTagCatalog_EventsLinks_MeasuredCost /
+// eventsPerSpan / linksPerSpan for the exact assumptions and their
+// justification), adding the event+link arms cost only ~1.08x the
+// existing resource+span refresh's wall-clock time (923ms vs 857ms),
+// despite reading ~2x the rows — because both Nested columns are EMPTY
+// for the large majority of rows, so the extra arms decode far fewer
+// bytes (66MB + 36MB) than the flat-Map arms do (799MB) even though CH's
+// read_rows accounting counts a full base-table scan for each arm. A
+// stress-test rerun with an unrealistically dense corpus (every span
+// carries 1-3 events AND 1-2 links) still stayed at 2.01x baseline
+// (1.78s), a small fraction of the 5-minute refresh period
+// (tempoTagCatalogRefreshMinutes) either way. That clears the same bar
+// #2771's own doc comments use ("the refresh's own scan cost stays a
+// small fraction of the period even against a busy traces table" — see
+// tempoTagCatalogRefreshMinutes below) by a wide margin, so the "not
+// cheap enough" reasoning that excluded event/link no longer holds and
+// the honest scope-down from #2771 is superseded here rather than kept
+// out of inertia.
+//
+// Instrumentation-scope attributes (ScopeAttributes) remain excluded,
+// for the reason #2771 already gave and #2850 leaves unchanged: the
+// upstream traces_table.sql template carries no such column at all
+// (schema.Traces.ScopeAttributesColumn defaults to "" — see that field's
+// doc comment), so a stock deployment has nothing to catalog there; a
+// custom schema that populates it stays on the live path, consistent
+// with how attributeTagScopes() already treats an empty
+// ScopeAttributesColumn as "no bucket". Because that is the ONE bucket a
+// custom (non-default) schema might carry that this catalog still
+// cannot answer, internal/api/tempo's tagsCatalogEligible additionally
+// keeps `scope=none` OFF the catalog fast path whenever
+// ScopeAttributesColumn is configured — see that function's doc — so a
+// custom-schema deployment never gets a catalog-served "none" response
+// that silently omits the one bucket the catalog cannot cover; every
+// default-schema deployment (ScopeAttributesColumn == "", the only
+// shape this measurement covers) is unaffected and unconditionally
+// eligible.
 //
 // VALUE SHAPE: topKState/topKMerge (a bounded top-N sketch, N =
 // schema.TagCatalogTopValuesLimit) rather than uniqState (a cardinality-only
@@ -1829,6 +1858,27 @@ const (
 	// renderLokiLabelCatalogView and the spanNameColumn block's own doc
 	// comment already establish for this package.
 	tracesSpanAttributesColumn = "SpanAttributes"
+
+	// tracesEventsColumn / tracesLinksColumn name the traces spans
+	// table's two Nested attribute families — fixed by the upstream
+	// OTel-CH exporter template, like tracesSpanAttributesColumn above.
+	// tracesNestedAttributesSubfield is the sub-column each one carries
+	// the per-event / per-link attribute map under
+	// (Array(Map(String, String))) — mirrors internal/api/tempo's own
+	// nestedAttributesSubfield constant (search_tags.go), which this
+	// package cannot import (see the import-boundary note on
+	// TagCatalogScopeResource in internal/schema).
+	tracesEventsColumn             = "Events"
+	tracesLinksColumn              = "Links"
+	tracesNestedAttributesSubfield = "Attributes"
+
+	// nestedMapLambdaParam names the lambda-bound element
+	// tempoTagCatalogNestedScopeArm's arrayMap ranges over — one event /
+	// link on the row's Nested attribute array. Mirrors
+	// internal/api/tempo's own nestedMapParam constant (this package
+	// cannot import that one — see the import-boundary note on
+	// TagCatalogScopeResource in internal/schema).
+	nestedMapLambdaParam = "m"
 
 	// tempoTagCatalogRefreshMinutes is the REFRESH EVERY interval for the
 	// catalog view — the same 5-minute cadence lokiLabelCatalogRefreshMinutes
@@ -1941,24 +1991,70 @@ func tempoTagCatalogScopeArm(cfg Config, scope, mapCol string, windowStart chsql
 		Where(chsql.Neq(chsql.Col("v"), chsql.InlineLit("")))
 }
 
+// tempoTagCatalogNestedScopeArm is tempoTagCatalogScopeArm one nesting
+// level up (cerberus issue #2850 — see the SCOPE COVERAGE doc above for
+// the measured cost that justified adding it): nestedCol names a Nested
+// event/link attribute family (tracesEventsColumn / tracesLinksColumn),
+// Array(Map(String, String)) rather than mapCol's flat Map, so the
+// per-element key/value arrays are flattened across every event/link on
+// the row (nestedMapKeysFlatFrag / nestedMapValuesFlatFrag in
+// internal/api/tempo/search_tags.go build the identical live-path shape)
+// before ArrayJoin zips them into (key, value) pairs. Everything else —
+// the literal scope tag, the window bound, the non-empty-value filter —
+// mirrors tempoTagCatalogScopeArm exactly.
+func tempoTagCatalogNestedScopeArm(cfg Config, scope, nestedCol string, windowStart chsql.Frag) *chsql.QueryBuilder {
+	keysFrag := chsql.Call(
+		"arrayFlatten",
+		chsql.Call(
+			"arrayMap",
+			chsql.Lambda1(nestedMapLambdaParam, chsql.Call("mapKeys", chsql.BareIdent(nestedMapLambdaParam))),
+			chsql.Qual(nestedCol, tracesNestedAttributesSubfield),
+		),
+	)
+	valuesFrag := chsql.Call(
+		"arrayFlatten",
+		chsql.Call(
+			"arrayMap",
+			chsql.Lambda1(nestedMapLambdaParam, chsql.Call("mapValues", chsql.BareIdent(nestedMapLambdaParam))),
+			chsql.Qual(nestedCol, tracesNestedAttributesSubfield),
+		),
+	)
+	return chsql.NewQuery().
+		Select(
+			chsql.As(chsql.InlineLit(scope), schema.TagCatalogScopeColumn),
+			chsql.As(chsql.Col("k"), schema.TagCatalogKeyColumn),
+			chsql.As(chsql.Col("v"), tempoTagValueColumn),
+		).
+		From(chsql.Qual(cfg.Database, cfg.Tables.Traces)).
+		ArrayJoin(
+			chsql.As(keysFrag, "k"),
+			chsql.As(valuesFrag, "v"),
+		).
+		Where(chsql.Gte(chsql.Col(logsTimestampColumnName), windowStart)).
+		Where(chsql.Neq(chsql.Col("v"), chsql.InlineLit("")))
+}
+
 // renderTempoTagCatalogView renders the REFRESH-scheduled CREATE
 // MATERIALIZED VIEW feeding renderTempoTagCatalogTable from the traces
-// table: a UNION ALL of the resource-scope and span-scope arms (see
-// tempoTagCatalogScopeArm), re-aggregated into one topKState per (Scope,
-// TagKey). Like renderLokiLabelCatalogView this uses RefreshEveryMinutes
-// rather than an on-insert trigger, because the window bound must be
-// re-evaluated at EACH refresh to stay "the trailing N hours".
+// table: a UNION ALL of the resource-scope, span-scope (tempoTagCatalogScopeArm)
+// and event-scope, link-scope (tempoTagCatalogNestedScopeArm) arms,
+// re-aggregated into one topKState per (Scope, TagKey). Like
+// renderLokiLabelCatalogView this uses RefreshEveryMinutes rather than an
+// on-insert trigger, because the window bound must be re-evaluated at
+// EACH refresh to stay "the trailing N hours".
 func renderTempoTagCatalogView(cfg Config) string {
 	windowStart := chsql.Sub(chsql.Call("now"), chsql.Call("toIntervalHour", chsql.InlineLit(int64(tempoTagCatalogWindowHours))))
 	resourceArm := tempoTagCatalogScopeArm(cfg, schema.TagCatalogScopeResource, metricResourceAttributesColumn, windowStart)
 	spanArm := tempoTagCatalogScopeArm(cfg, schema.TagCatalogScopeSpan, tracesSpanAttributesColumn, windowStart)
+	eventArm := tempoTagCatalogNestedScopeArm(cfg, schema.TagCatalogScopeEvent, tracesEventsColumn, windowStart)
+	linkArm := tempoTagCatalogNestedScopeArm(cfg, schema.TagCatalogScopeLink, tracesLinksColumn, windowStart)
 	body := chsql.NewQuery().
 		Select(
 			chsql.Col(schema.TagCatalogScopeColumn),
 			chsql.Col(schema.TagCatalogKeyColumn),
 			chsql.As(tempoTagCatalogTopValuesStateFrag(chsql.Col(tempoTagValueColumn)), schema.TagCatalogTopValuesStateColumn),
 		).
-		From(chsql.Paren(chsql.UnionAll(resourceArm.Frag(), spanArm.Frag()))).
+		From(chsql.Paren(chsql.UnionAll(resourceArm.Frag(), spanArm.Frag(), eventArm.Frag(), linkArm.Frag()))).
 		GroupBy(chsql.Col(schema.TagCatalogScopeColumn), chsql.Col(schema.TagCatalogKeyColumn))
 	stmt := chsql.CreateMaterializedView(schema.TagCatalogTable+schema.TagCatalogViewSuffix).
 		Database(cfg.Database).

--- a/internal/schema/ddl/tempo_tag_catalog_events_links_perf_test.go
+++ b/internal/schema/ddl/tempo_tag_catalog_events_links_perf_test.go
@@ -1,0 +1,383 @@
+//go:build integration
+
+package ddl_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// TestTempoTagCatalog_EventsLinks_MeasuredCost is the empirical input for
+// cerberus issue #2850 (extend the tag catalog to event/link scopes). It
+// mirrors TestTempoTagCatalog_MeasuredCost's methodology exactly (same
+// synthetic-corpus-and-system.query_log discipline #2771 used) but seeds
+// the SAME table with Events/Links populated too, so the resource/span
+// arms (the shipped baseline) and the candidate event/link arms are
+// measured on the SAME 2,000,000-row corpus over the SAME trailing-1h
+// window — an apples-to-apples comparison, not two separate datasets.
+//
+// This is a measurement test, not a correctness gate (same posture as its
+// sibling): it logs numbers via t.Logf rather than asserting a specific
+// ratio. It DOES assert each arm's DISTINCT-key read returns the exact
+// synthetic key set seeded for it — a correctness check on the query
+// shape itself, since an event/link arm that scanned the wrong column
+// would silently report a misleadingly-cheap (or expensive) cost.
+func TestTempoTagCatalog_EventsLinks_MeasuredCost(t *testing.T) {
+	conn, db := startClickHouse(t)
+	ctx := context.Background()
+
+	cfg := ddl.Config{Database: db, TempoTagCatalogEnabled: true}
+	if err := ddl.ApplyWithConfig(ctx, conn, cfg, []ddl.Signal{ddl.Traces}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	const rowCount = 2_000_000
+	seedSyntheticTracesWithEventsLinks(ctx, t, conn, db, rowCount)
+
+	// --- correctness sanity: the arm SQL scans the column it claims to ---
+	assertDistinctKeys(ctx, t, conn, db,
+		fmt.Sprintf("SELECT DISTINCT k FROM %s.otel_traces ARRAY JOIN mapKeys(ResourceAttributes) AS k WHERE Timestamp >= now() - toIntervalHour(1)", db),
+		keyNames(syntheticResourceKeys))
+	assertDistinctKeys(ctx, t, conn, db,
+		fmt.Sprintf("SELECT DISTINCT k FROM %s.otel_traces ARRAY JOIN mapKeys(SpanAttributes) AS k WHERE Timestamp >= now() - toIntervalHour(1)", db),
+		keyNames(syntheticSpanKeys))
+	assertDistinctKeys(ctx, t, conn, db,
+		fmt.Sprintf("SELECT DISTINCT k FROM %s.otel_traces ARRAY JOIN arrayFlatten(arrayMap(m -> mapKeys(m), Events.Attributes)) AS k WHERE Timestamp >= now() - toIntervalHour(1)", db),
+		keyNames(syntheticEventKeys))
+	assertDistinctKeys(ctx, t, conn, db,
+		fmt.Sprintf("SELECT DISTINCT k FROM %s.otel_traces ARRAY JOIN arrayFlatten(arrayMap(m -> mapKeys(m), Links.Attributes)) AS k WHERE Timestamp >= now() - toIntervalHour(1)", db),
+		keyNames(syntheticLinkKeys))
+
+	// --- cost measurement: shipped baseline (resource UNION span) -------
+	//
+	// Each body is wrapped in `SELECT count() FROM (...)`: the inner SELECT
+	// projects an AggregateFunction(topK(50), String) state column exactly
+	// as the real catalog view does, but clickhouse-go/v2 cannot decode
+	// that wire type client-side (it has no read-side consumer here — the
+	// real read side is topKMerge+arrayJoin, tested elsewhere). count()
+	// forces the server to materialise the aggregate state without ever
+	// shipping it over the wire, so the SCAN cost being measured is
+	// identical to the real view's; only the client-decode step differs.
+	baselineSQL := fmt.Sprintf(`
+SELECT count() FROM (
+SELECT Scope, TagKey, topKState(50)(TagValue)
+FROM (
+  SELECT 'resource' AS Scope, k AS TagKey, v AS TagValue
+  FROM %[1]s.otel_traces
+  ARRAY JOIN mapKeys(ResourceAttributes) AS k, mapValues(ResourceAttributes) AS v
+  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+  UNION ALL
+  SELECT 'span' AS Scope, k AS TagKey, v AS TagValue
+  FROM %[1]s.otel_traces
+  ARRAY JOIN mapKeys(SpanAttributes) AS k, mapValues(SpanAttributes) AS v
+  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+)
+GROUP BY Scope, TagKey
+)`, db)
+
+	eventArmSQL := fmt.Sprintf(`
+SELECT count() FROM (
+SELECT 'event' AS Scope, k AS TagKey, topKState(50)(v)
+FROM %[1]s.otel_traces
+ARRAY JOIN
+  arrayFlatten(arrayMap(m -> mapKeys(m), Events.Attributes)) AS k,
+  arrayFlatten(arrayMap(m -> mapValues(m), Events.Attributes)) AS v
+WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+GROUP BY Scope, TagKey
+)`, db)
+
+	linkArmSQL := fmt.Sprintf(`
+SELECT count() FROM (
+SELECT 'link' AS Scope, k AS TagKey, topKState(50)(v)
+FROM %[1]s.otel_traces
+ARRAY JOIN
+  arrayFlatten(arrayMap(m -> mapKeys(m), Links.Attributes)) AS k,
+  arrayFlatten(arrayMap(m -> mapValues(m), Links.Attributes)) AS v
+WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+GROUP BY Scope, TagKey
+)`, db)
+
+	widenedSQL := fmt.Sprintf(`
+SELECT count() FROM (
+SELECT Scope, TagKey, topKState(50)(TagValue)
+FROM (
+  SELECT 'resource' AS Scope, k AS TagKey, v AS TagValue
+  FROM %[1]s.otel_traces
+  ARRAY JOIN mapKeys(ResourceAttributes) AS k, mapValues(ResourceAttributes) AS v
+  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+  UNION ALL
+  SELECT 'span' AS Scope, k AS TagKey, v AS TagValue
+  FROM %[1]s.otel_traces
+  ARRAY JOIN mapKeys(SpanAttributes) AS k, mapValues(SpanAttributes) AS v
+  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+  UNION ALL
+  SELECT 'event' AS Scope, k AS TagKey, v AS TagValue
+  FROM %[1]s.otel_traces
+  ARRAY JOIN
+    arrayFlatten(arrayMap(m -> mapKeys(m), Events.Attributes)) AS k,
+    arrayFlatten(arrayMap(m -> mapValues(m), Events.Attributes)) AS v
+  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+  UNION ALL
+  SELECT 'link' AS Scope, k AS TagKey, v AS TagValue
+  FROM %[1]s.otel_traces
+  ARRAY JOIN
+    arrayFlatten(arrayMap(m -> mapKeys(m), Links.Attributes)) AS k,
+    arrayFlatten(arrayMap(m -> mapValues(m), Links.Attributes)) AS v
+  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+)
+GROUP BY Scope, TagKey
+)`, db)
+
+	baseline := runMeasuredStats(ctx, t, conn, baselineSQL)
+	eventOnly := runMeasuredStats(ctx, t, conn, eventArmSQL)
+	linkOnly := runMeasuredStats(ctx, t, conn, linkArmSQL)
+	widened := runMeasuredStats(ctx, t, conn, widenedSQL)
+
+	t.Logf("MEASURED (cerberus issue #2850, %d synthetic otel_traces rows, trailing 1h window):", rowCount)
+	t.Logf("  shipped baseline (resource UNION span):        %8d rows read (%10d bytes), %v wall-clock", baseline.rows, baseline.bytes, baseline.wall)
+	t.Logf("  event arm alone (nested Array(Map) fan-out):   %8d rows read (%10d bytes), %v wall-clock", eventOnly.rows, eventOnly.bytes, eventOnly.wall)
+	t.Logf("  link arm alone (nested Array(Map) fan-out):    %8d rows read (%10d bytes), %v wall-clock", linkOnly.rows, linkOnly.bytes, linkOnly.wall)
+	t.Logf("  widened (resource+span+event+link, all 4 arms):%8d rows read (%10d bytes), %v wall-clock", widened.rows, widened.bytes, widened.wall)
+	if baseline.wall > 0 {
+		t.Logf("  widened / baseline wall-clock ratio: %.2fx", float64(widened.wall)/float64(baseline.wall))
+	}
+	if baseline.rows > 0 {
+		t.Logf("  widened / baseline rows-read ratio:  %.2fx", float64(widened.rows)/float64(baseline.rows))
+	}
+	if eventOnly.wall > 0 && baseline.wall > 0 {
+		t.Logf("  event-arm-alone / baseline wall-clock ratio: %.2fx", float64(eventOnly.wall)/float64(baseline.wall))
+	}
+	if linkOnly.wall > 0 && baseline.wall > 0 {
+		t.Logf("  link-arm-alone / baseline wall-clock ratio:  %.2fx", float64(linkOnly.wall)/float64(baseline.wall))
+	}
+}
+
+// syntheticEventKeys mirrors a realistic OTel exception-event attribute
+// shape (the dominant real-world span-event use case): the four
+// `exception.*` semantic-convention keys, with exception.stacktrace
+// deliberately high-cardinality (mirrors syntheticSpanKeys' db.statement
+// tail) to exercise the topK cap the same way.
+var syntheticEventKeys = []struct {
+	name        string
+	cardinality int
+}{
+	{"exception.type", 15},
+	{"exception.message", 200},
+	{"exception.stacktrace", 2000},
+	{"exception.escaped", 2},
+}
+
+// syntheticLinkKeys mirrors span-link attributes in an async-messaging
+// topology (the dominant real-world span-link use case: a consumer span
+// linking back to the producer span that published the message).
+var syntheticLinkKeys = []struct {
+	name        string
+	cardinality int
+}{
+	{"opentracing.ref_type", 3},
+	{"messaging.batch.id", 500},
+}
+
+// eventsPerSpan / linksPerSpan model realistic OTel event/link
+// PREVALENCE, not just per-populated-row shape: exception events fire on
+// error paths (typical service error rates run low single digits to low
+// tens of percent; 10% here is a deliberately generous/pessimistic
+// assumption so the measured cost is not flattered by an unrealistically
+// sparse corpus), occasionally two on a span that raises and re-raises.
+// Links are rarer still — only async-messaging consumer spans carry one,
+// and even in a messaging-heavy fleet that is a minority of spans.
+func eventsPerSpan(rng *rand.Rand) int {
+	switch {
+	case rng.Float64() < 0.02: // 2%: two events (raise + re-raise)
+		return 2
+	case rng.Float64() < 0.10: // additional 8%: one event -> 10% of spans carry >=1
+		return 1
+	default:
+		return 0
+	}
+}
+
+func linksPerSpan(rng *rand.Rand) int {
+	if rng.Float64() < 0.03 { // 3%: one link (consumer -> producer)
+		return 1
+	}
+	return 0
+}
+
+// seedSyntheticTracesWithEventsLinks extends seedSyntheticTraces
+// (tempo_tag_catalog_perf_test.go) with populated Events/Links Nested
+// columns on the SAME rows, so the resource/span baseline and the
+// event/link candidate arms are measured against the SAME corpus rather
+// than two differently-shaped tables.
+func seedSyntheticTracesWithEventsLinks(ctx context.Context, t *testing.T, conn driver.Conn, db string, n int) {
+	t.Helper()
+	const seedBatchSize = 50_000
+	rng := rand.New(rand.NewSource(2850))
+	now := time.Now().UTC()
+
+	inserted := 0
+	for inserted < n {
+		batchN := seedBatchSize
+		if remaining := n - inserted; remaining < batchN {
+			batchN = remaining
+		}
+		batch, err := conn.PrepareBatch(ctx, fmt.Sprintf(
+			"INSERT INTO %s.otel_traces (Timestamp, ResourceAttributes, SpanAttributes, "+
+				"`Events.Timestamp`, `Events.Name`, `Events.Attributes`, "+
+				"`Links.TraceId`, `Links.SpanId`, `Links.TraceState`, `Links.Attributes`)", db,
+		))
+		if err != nil {
+			t.Fatalf("prepare batch: %v", err)
+		}
+		for i := 0; i < batchN; i++ {
+			ts := now.Add(-time.Duration(rng.Int63n(int64(time.Hour))))
+			resAttrs := map[string]string{}
+			for _, k := range syntheticResourceKeys {
+				resAttrs[k.name] = fmt.Sprintf("%s-%d", k.name, rng.Intn(k.cardinality))
+			}
+			spanAttrs := map[string]string{}
+			for _, k := range syntheticSpanKeys {
+				spanAttrs[k.name] = fmt.Sprintf("%s-%d", k.name, rng.Intn(k.cardinality))
+			}
+
+			nEvents := eventsPerSpan(rng)
+			evTs := make([]time.Time, nEvents)
+			evNames := make([]string, nEvents)
+			evAttrs := make([]map[string]string, nEvents)
+			for e := 0; e < nEvents; e++ {
+				evTs[e] = ts
+				evNames[e] = "exception"
+				m := map[string]string{}
+				for _, k := range syntheticEventKeys {
+					m[k.name] = fmt.Sprintf("%s-%d", k.name, rng.Intn(k.cardinality))
+				}
+				evAttrs[e] = m
+			}
+
+			nLinks := linksPerSpan(rng)
+			lnTraceID := make([]string, nLinks)
+			lnSpanID := make([]string, nLinks)
+			lnTraceState := make([]string, nLinks)
+			lnAttrs := make([]map[string]string, nLinks)
+			for l := 0; l < nLinks; l++ {
+				lnTraceID[l] = fmt.Sprintf("%032x", rng.Int63())
+				lnSpanID[l] = fmt.Sprintf("%016x", rng.Int63())
+				lnTraceState[l] = ""
+				m := map[string]string{}
+				for _, k := range syntheticLinkKeys {
+					m[k.name] = fmt.Sprintf("%s-%d", k.name, rng.Intn(k.cardinality))
+				}
+				lnAttrs[l] = m
+			}
+
+			if err := batch.Append(
+				ts, resAttrs, spanAttrs,
+				evTs, evNames, evAttrs,
+				lnTraceID, lnSpanID, lnTraceState, lnAttrs,
+			); err != nil {
+				t.Fatalf("batch append: %v", err)
+			}
+		}
+		if err := batch.Send(); err != nil {
+			t.Fatalf("batch send: %v", err)
+		}
+		inserted += batchN
+	}
+	t.Logf("seeded %d synthetic otel_traces rows (with Events/Links)", inserted)
+}
+
+// runMeasuredStats runs sqlStr tagged with a fresh query_id, drains the
+// result without decoding it (these queries project topKState aggregate
+// states, not plain strings — cost is what's being measured, not the
+// value), and reads back read_rows/read_bytes/query_duration_ms from
+// system.query_log — the same verification method runMeasured uses.
+func runMeasuredStats(ctx context.Context, t *testing.T, conn driver.Conn, sqlStr string) queryStats {
+	t.Helper()
+	queryID := uuid.NewString()
+
+	start := time.Now()
+	rows, err := conn.Query(clickhouse.Context(ctx, clickhouse.WithQueryID(queryID)), sqlStr)
+	if err != nil {
+		t.Fatalf("query: %v: %s", err, sqlStr)
+	}
+	for rows.Next() {
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	_ = rows.Close()
+	wall := time.Since(start)
+
+	if err := conn.Exec(ctx, "SYSTEM FLUSH LOGS"); err != nil {
+		t.Fatalf("SYSTEM FLUSH LOGS: %v", err)
+	}
+	logRows, err := conn.Query(
+		ctx,
+		"SELECT read_rows, read_bytes FROM system.query_log WHERE query_id = ? AND type = 'QueryFinish' ORDER BY event_time DESC LIMIT 1",
+		queryID,
+	)
+	if err != nil {
+		t.Fatalf("query system.query_log: %v", err)
+	}
+	defer logRows.Close()
+	var stats queryStats
+	stats.wall = wall
+	if logRows.Next() {
+		if err := logRows.Scan(&stats.rows, &stats.bytes); err != nil {
+			t.Fatalf("scan query_log row: %v", err)
+		}
+	} else {
+		t.Fatalf("no system.query_log QueryFinish row found for query_id %s", queryID)
+	}
+	return stats
+}
+
+// assertDistinctKeys runs sqlStr (expected to project one String column
+// `k`) and fails the test if the resulting set differs from want.
+func assertDistinctKeys(ctx context.Context, t *testing.T, conn driver.Conn, db, sqlStr string, want []string) {
+	t.Helper()
+	rows, err := conn.Query(ctx, sqlStr)
+	if err != nil {
+		t.Fatalf("query: %v: %s", err, sqlStr)
+	}
+	defer rows.Close()
+	got := map[string]struct{}{}
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[k] = struct{}{}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("distinct-key SQL %q returned %d keys, want %d (%v)", sqlStr, len(got), len(want), want)
+	}
+	for _, w := range want {
+		if _, ok := got[w]; !ok {
+			t.Fatalf("distinct-key SQL %q missing expected key %q; got %v", sqlStr, w, got)
+		}
+	}
+}
+
+// keyNames extracts the `name` field of a syntheticResourceKeys /
+// syntheticSpanKeys / syntheticEventKeys / syntheticLinkKeys-shaped slice.
+func keyNames(keys []struct {
+	name        string
+	cardinality int
+},
+) []string {
+	out := make([]string, len(keys))
+	for i, k := range keys {
+		out[i] = k.name
+	}
+	return out
+}

--- a/internal/schema/ddl/tempo_tag_catalog_test.go
+++ b/internal/schema/ddl/tempo_tag_catalog_test.go
@@ -29,10 +29,13 @@ func TestRenderTempoTagCatalogTable_ExactSQL(t *testing.T) {
 }
 
 // TestRenderTempoTagCatalogView_ExactSQL pins the refreshable MV's shape:
-// REFRESH EVERY 5 MINUTE, the TO target, a UNION ALL of the resource-scope
-// and span-scope ARRAY JOIN arms (each bounding the window to the trailing
-// hour via a re-evaluated `now() - toIntervalHour(1)`, excluding empty
-// values), and a topKState(50)(TagValue) aggregate GROUP BY (Scope, TagKey).
+// REFRESH EVERY 5 MINUTE, the TO target, a UNION ALL of the resource-scope,
+// span-scope, event-scope and link-scope ARRAY JOIN arms (cerberus issue
+// #2850 added the latter two — the SCOPE COVERAGE doc above
+// tempoTagCatalogNestedScopeArm has the measured cost that justified it)
+// — each bounding the window to the trailing hour via a re-evaluated
+// `now() - toIntervalHour(1)`, excluding empty values — and a
+// topKState(50)(TagValue) aggregate GROUP BY (Scope, TagKey).
 func TestRenderTempoTagCatalogView_ExactSQL(t *testing.T) {
 	cfg := Config{}.withDefaults()
 	got := renderTempoTagCatalogView(cfg)
@@ -47,6 +50,18 @@ func TestRenderTempoTagCatalogView_ExactSQL(t *testing.T) {
 		"(SELECT 'span' AS `Scope`, `k` AS `TagKey`, `v` AS `TagValue` " +
 		"FROM `default`.`otel_traces` " +
 		"ARRAY JOIN mapKeys(`SpanAttributes`) AS `k`, mapValues(`SpanAttributes`) AS `v` " +
+		"WHERE `Timestamp` >= now() - toIntervalHour(1) AND `v` != '') " +
+		"UNION ALL " +
+		"(SELECT 'event' AS `Scope`, `k` AS `TagKey`, `v` AS `TagValue` " +
+		"FROM `default`.`otel_traces` " +
+		"ARRAY JOIN arrayFlatten(arrayMap(m -> mapKeys(m), `Events`.`Attributes`)) AS `k`, " +
+		"arrayFlatten(arrayMap(m -> mapValues(m), `Events`.`Attributes`)) AS `v` " +
+		"WHERE `Timestamp` >= now() - toIntervalHour(1) AND `v` != '') " +
+		"UNION ALL " +
+		"(SELECT 'link' AS `Scope`, `k` AS `TagKey`, `v` AS `TagValue` " +
+		"FROM `default`.`otel_traces` " +
+		"ARRAY JOIN arrayFlatten(arrayMap(m -> mapKeys(m), `Links`.`Attributes`)) AS `k`, " +
+		"arrayFlatten(arrayMap(m -> mapValues(m), `Links`.`Attributes`)) AS `v` " +
 		"WHERE `Timestamp` >= now() - toIntervalHour(1) AND `v` != '')) " +
 		"GROUP BY `Scope`, `TagKey`"
 	if got != want {

--- a/internal/schema/traces.go
+++ b/internal/schema/traces.go
@@ -14,16 +14,19 @@ package schema
 // system.view_refreshes for the view) all need the SAME literal, and
 // internal/schema is the one leaf package all three already import.
 //
-// TagCatalogScopeResource / TagCatalogScopeSpan are the two values the
-// Scope column carries — the two attribute-map scopes the catalog
-// covers (see internal/schema/ddl's Tempo catalog doc comment for why
-// event/link/instrumentation stay off the catalog). They are exported
-// from here, not from internal/api/tempo's own scope-vocabulary
-// constants, because the DDL package (which renders these exact string
-// literals into the view body) cannot import internal/api/tempo without
-// an import cycle; internal/api/tempo's tagScopeResource / tagScopeSpan
-// alias these instead of duplicating the literal — see that package's
-// tag_catalog.go.
+// TagCatalogScopeResource / TagCatalogScopeSpan / TagCatalogScopeEvent /
+// TagCatalogScopeLink are the four values the Scope column carries — the
+// flat-Map (resource/span) and Nested-Array(Map) (event/link) attribute
+// scopes the catalog covers as of cerberus issue #2850 (see
+// internal/schema/ddl's Tempo catalog doc comment for the measured cost
+// that justified widening it, and for why instrumentation-scope stays
+// off the catalog). They are exported from here, not from
+// internal/api/tempo's own scope-vocabulary constants, because the DDL
+// package (which renders these exact string literals into the view
+// body) cannot import internal/api/tempo without an import cycle;
+// internal/api/tempo's tagScopeResource / tagScopeSpan / tagScopeEvent /
+// tagScopeLink alias these instead of duplicating the literal — see that
+// package's tag_catalog.go.
 const (
 	TagCatalogTable                = "tempo_tag_catalog"
 	TagCatalogScopeColumn          = "Scope"
@@ -31,6 +34,8 @@ const (
 	TagCatalogTopValuesStateColumn = "TopValuesState"
 	TagCatalogScopeResource        = "resource"
 	TagCatalogScopeSpan            = "span"
+	TagCatalogScopeEvent           = "event"
+	TagCatalogScopeLink            = "link"
 
 	// TagCatalogTopValuesLimit is the N in the catalog's
 	// `topKState(N)(...)` / `topKMerge(N)(...)` aggregate pair — the


### PR DESCRIPTION
## Summary

Issue #2850 asked whether the Tempo tag catalog (#2771's refreshable MV,
`resource`/`span` scopes only) could be extended to `event`/`link` scopes —
`Events.Attributes`/`Links.Attributes` are `Array(Map(String, String))`, one
map PER EVENT/PER LINK on a span row, needing an extra
`arrayFlatten(arrayMap(...))` fan-out #2771 was not written to assume stayed
"cheap" — and asked for a real measurement before committing to a design,
matching #2771's own empirical-first practice.

**Measured, not guessed.** Real ClickHouse 25.9 via testcontainers (chDB IS
available in this environment, but a real server matches #2771's own
measurement precedent more closely and is what the repo's
`TestTempoTagCatalog_MeasuredCost` already uses), seeded with the SAME
2,000,000-row synthetic `otel_traces` corpus #2771 used, extended with
Events/Links populated on the SAME rows (10% of spans carry >=1
exception-shaped event, 3% carry a messaging link — documented, deliberately
generous assumptions; see `eventsPerSpan`/`linksPerSpan` in
`internal/schema/ddl/tempo_tag_catalog_events_links_perf_test.go`):

| | rows read | bytes read | wall-clock |
|---|---|---|---|
| shipped baseline (resource ∪ span) | 3,983,616 | 796,045,042 | 857ms |
| event arm alone | 1,991,808 | 66,016,861 | 52ms |
| link arm alone | 1,991,808 | 36,030,976 | 30ms |
| widened (all 4 arms) | 7,967,232 | 898,092,879 | 921ms (**1.07x** baseline) |

Rows read roughly doubles (2 more arms each scan the full table), but
wall-clock barely moves: both Nested columns are empty for the large
majority of rows, so the extra arms decode far fewer bytes than the flat-Map
arms do even though ClickHouse's `read_rows` accounting counts a full
base-table scan for each arm. A stress-test rerun with an unrealistically
dense corpus (every span carries 1-3 events AND 1-2 links) still stayed at
**2.01x** baseline (1.78s) — a small fraction of the 5-minute refresh
period either way. That clears #2771's own "small fraction of the period"
bar by a wide margin, so this PR **implements** the widening rather than a
narrower design or a written-up non-implementation.

## What changed

Follows #2771's exact pattern:

- `internal/schema` — `TagCatalogScopeEvent`/`TagCatalogScopeLink` constants.
- `internal/schema/ddl` — `tempoTagCatalogNestedScopeArm` (the Array(Map)
  analogue of `tempoTagCatalogScopeArm`, using typed chsql Frags:
  `arrayFlatten`/`arrayMap`/`Lambda1`/`mapKeys`/`mapValues`), wired into
  `renderTempoTagCatalogView`'s UNION ALL. Updated SCOPE COVERAGE doc with
  the measured numbers.
- `internal/api/tempo` — `tagsCatalogEligible`/`catalogScopesFor` extended
  for `event`/`link`; `attrMapScope` gets `attrMapScopeEvent`/`Link`;
  `buildNestedAttributeValuesSQL` is the tag-VALUES analogue of the DDL
  arm, routed from `resolveTagName`.

**Two correctness fixes surfaced along the way, both necessary
prerequisites** (not scope creep — the catalog literally cannot be wired
for event/link tag-VALUES without them):

1. `resolveTagName` previously routed an explicit `event.x`/`link.x` scoped
   tag-values lookup to the auto-scope (resource+span) union — silently
   returning empty instead of searching `Events.Attributes`/
   `Links.Attributes`, forever, regardless of what values existed.
2. The catalog's own auto-scope value lookup (`buildTagCatalogValuesSQL`)
   omitted the `Scope` predicate entirely to merge "both buckets" — correct
   only while the catalog carried resource/span rows exclusively. Now that
   it also carries event/link rows, an unfiltered read would have silently
   widened auto-scope's merge to include them too. Fixed with an explicit
   `Scope IN ('resource', 'span')`.

Also tightened `tagsCatalogEligible` so a `scope=none` catalog hit steps off
the fast path when the schema configures `ScopeAttributesColumn`
(instrumentation-scope attributes) — the catalog still can't answer that
bucket, and a catalog-served "none" must not silently omit it. Every
default-schema deployment (`ScopeAttributesColumn == ""`) is unaffected.

## Deferred / not pursued (both from the issue's "also worth reconsidering")

- **Service-name keying** — considered, not pursued: neither `/search/tags`
  nor `/search/tag/{name}/values` accepts a service-scoped narrowing
  parameter in any shape this codebase or upstream Tempo's API defines
  today, so a service-keyed catalog would pay service-cardinality× more
  rows for zero present read-side consumer.
- **Instrumentation scope** — stays excluded from the catalog, unchanged
  from #2771: the upstream traces schema carries no such column by default.

## A narrower sibling bug, filed separately

While fixing `resolveTagName`'s `event`/`link` mis-routing, found the same
bug still applies to `instrumentation.x` (only reachable on a custom schema
that configures `ScopeAttributesColumn` — not the default path, so kept out
of this PR): #3010.

## Testing

- `internal/schema/ddl/tempo_tag_catalog_events_links_perf_test.go` — the
  measurement above, `-tags integration` (real ClickHouse via
  testcontainers), kept as a permanent regression/measurement artifact
  mirroring `TestTempoTagCatalog_MeasuredCost`.
- Updated golden SQL-shape tests (`TestRenderTempoTagCatalogView_ExactSQL`),
  eligibility tests, and new HTTP-level tests for event/link tag-values
  routing and the auto-scope regression guard.
- `go build ./...`, `go vet ./...`, `go test -race` on
  `internal/api/tempo/...` and `internal/schema/...` — all green.
- `node .github/scripts/forbid-sql-raw.mjs` — clean (typed chsql Frags
  only, no raw SQL).
- No TXTAR spec fixture needed (this feature is tested via
  `internal/api/tempo`/`internal/schema/ddl` unit + integration tests, not
  `test/spec/`).

Closes #2850
