### PR TITLE
fix(tempo): route instrumentation-scope tag-values off auto-scope fallback

### DIFF
--- a/internal/api/tempo/export_test.go
+++ b/internal/api/tempo/export_test.go
@@ -49,16 +49,17 @@ func ResolvedTagNameForTest(isIntrinsic bool, key string, mapScope AttrMapScopeF
 	return resolvedTagName{IsIntrinsic: isIntrinsic, Key: key, MapScope: attrMapScope(mapScope)}
 }
 
-// AttrMapScopeForTest re-exports the attrMapScope type + its three
+// AttrMapScopeForTest re-exports the attrMapScope type + its six
 // values for ResolvedTagNameForTest callers in the external package.
 type AttrMapScopeForTest = attrMapScope
 
 const (
-	AttrMapScopeAnyForTest      = attrMapScopeAny
-	AttrMapScopeResourceForTest = attrMapScopeResource
-	AttrMapScopeSpanForTest     = attrMapScopeSpan
-	AttrMapScopeEventForTest    = attrMapScopeEvent
-	AttrMapScopeLinkForTest     = attrMapScopeLink
+	AttrMapScopeAnyForTest             = attrMapScopeAny
+	AttrMapScopeResourceForTest        = attrMapScopeResource
+	AttrMapScopeSpanForTest            = attrMapScopeSpan
+	AttrMapScopeEventForTest           = attrMapScopeEvent
+	AttrMapScopeLinkForTest            = attrMapScopeLink
+	AttrMapScopeInstrumentationForTest = attrMapScopeInstrumentation
 )
 
 // BuildAttributeValuesSQLForTest re-exports buildAttributeValuesSQL

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -147,17 +147,30 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, route
 
 	resolved, _ := resolveTagName(name, h.Schema)
 
+	// An instrumentation-scope request against a schema that carries no
+	// instrumentation-scope attribute column (schema.Traces.
+	// ScopeAttributesColumn == "", the default) has nothing to search —
+	// mirror attributeTagScopes()'s treatment of the same unconfigured
+	// bucket for /search/tags (the bucket is simply absent, a 200 with
+	// no values) rather than build SQL against an empty column name
+	// (cerberus issue #3010).
+	instrumentationUnconfigured := resolved.MapScope == attrMapScopeInstrumentation && h.Schema.ScopeAttributesColumn == ""
+
 	// Catalog-eligible fast path (cerberus issue #2771): see
 	// tagValuesCatalogEligible's doc comment for the exact rule. A miss
 	// falls straight through to the SAME live per-key lookup every other
-	// request already takes — that path is untouched below.
+	// request already takes — that path is untouched below. (The
+	// catalog never covers instrumentation scope regardless of
+	// configuration — tagValuesCatalogEligible excludes it — so
+	// instrumentationUnconfigured's guard below is what actually skips
+	// the live query for the unconfigured case.)
 	var values []string
 	valueTyp := "string"
 	fromCatalog := false
 	if h.TagCatalogEnabled && tagValuesCatalogEligible(resolved, filter, windowless) {
 		values, fromCatalog = h.tagValuesFromCatalog(ctx, resolved)
 	}
-	if !fromCatalog {
+	if !fromCatalog && !instrumentationUnconfigured {
 		var (
 			sqlStr string
 			args   []any
@@ -281,6 +294,16 @@ func buildIntrinsicValuesSQL(s schema.Traces, col string, filter chsql.Frag, sta
 // column short-circuit (#2776/#2870 only ever provision materialized
 // columns for SpanAttributes/ResourceAttributes keys) nor the scalar
 // mapAtFrag/mapContainsFrag shape below applies to them.
+//
+// attrMapScopeInstrumentation (cerberus issue #3010) is the opposite
+// case: the instrumentation-scope attribute map IS a flat Map(String,
+// String), so it takes the SAME mapAtFrag/mapContainsFrag shape as
+// attrMapScopeResource/Span, just against s.ScopeAttributesColumn. The
+// caller (respondTagValues) never invokes this function for that scope
+// when s.ScopeAttributesColumn == "" (the default, unconfigured case) —
+// it short-circuits to an empty result instead, the same treatment
+// attributeTagScopes() already gives an unconfigured instrumentation
+// bucket for /search/tags.
 func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, filter chsql.Frag, start, end time.Time) (string, []any) {
 	switch scope {
 	case attrMapScopeEvent:
@@ -320,6 +343,13 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 	case attrMapScopeSpan:
 		selFrag = chsql.As(mapAtFrag(s.AttributesColumn, name), "v")
 		whereFrag = mapContainsFrag(s.AttributesColumn, name)
+	case attrMapScopeInstrumentation:
+		// cerberus issue #3010: the flat-Map shape, same as
+		// Resource/Span above — never reached with an empty
+		// s.ScopeAttributesColumn; respondTagValues guards that case
+		// before calling this function at all.
+		selFrag = chsql.As(mapAtFrag(s.ScopeAttributesColumn, name), "v")
+		whereFrag = mapContainsFrag(s.ScopeAttributesColumn, name)
 	default: // attrMapScopeAny
 		selFrag = attrValueArrayJoinFrag(s.AttributesColumn, s.ResourceAttributesColumn, name)
 		whereFrag = mapContainsAnyFrag(s.AttributesColumn, s.ResourceAttributesColumn, name)
@@ -591,6 +621,17 @@ const (
 	// attrMapScopeLink is attrMapScopeEvent's sibling for the Nested
 	// Links.Attributes family (Tempo's `link.x` scoped form).
 	attrMapScopeLink
+	// attrMapScopeInstrumentation consults only the instrumentation-scope
+	// attribute map (Tempo's `instrumentation.x` scoped form) — cerberus
+	// issue #3010, mirroring #2850's event/link fix. Unlike event/link,
+	// the instrumentation-scope column is a flat Map(String, String), not
+	// Nested, so this routes through the SAME mapAtFrag/mapContainsFrag
+	// shape attrMapScopeResource/Span use, not buildNestedAttributeValuesSQL.
+	// The underlying column (schema.Traces.ScopeAttributesColumn) is empty
+	// by default — see resolveTagName and buildAttributeValuesSQL for the
+	// empty-column guard that keeps this scope from ever building SQL
+	// against a nonexistent column.
+	attrMapScopeInstrumentation
 )
 
 func (s attrMapScope) String() string {
@@ -603,6 +644,8 @@ func (s attrMapScope) String() string {
 		return "event"
 	case attrMapScopeLink:
 		return "link"
+	case attrMapScopeInstrumentation:
+		return "instrumentation"
 	default:
 		return "any"
 	}
@@ -682,6 +725,15 @@ func resolveTagName(name string, s schema.Traces) (resolvedTagName, error) {
 		ms = attrMapScopeEvent
 	case traceql.AttributeScopeLink:
 		ms = attrMapScopeLink // same fix, for Links.Attributes.
+	case traceql.AttributeScopeInstrumentation:
+		// cerberus issue #3010: same fix as #2850 above, for an explicit
+		// `instrumentation.x` tag-values request against the
+		// instrumentation-scope attribute map — see
+		// buildAttributeValuesSQL's attrMapScopeInstrumentation case for
+		// the flat-Map SQL shape and respondTagValues for the guard that
+		// keeps an unconfigured schema.Traces.ScopeAttributesColumn from
+		// ever building SQL against a nonexistent column.
+		ms = attrMapScopeInstrumentation
 	default:
 		ms = attrMapScopeAny
 	}

--- a/internal/api/tempo/search_tag_values_instrumentation_chdb_test.go
+++ b/internal/api/tempo/search_tag_values_instrumentation_chdb_test.go
@@ -1,0 +1,108 @@
+//go:build chdb
+
+// chDB-backed correctness roundtrip for cerberus issue #3010's
+// attrMapScopeInstrumentation routing. buildAttributeValuesSQL's flat-Map
+// shape for this scope is asserted at the Frag level by the
+// non-chdb-tagged tests in search_tag_values_test.go; this file proves
+// the query, executed against a real (chDB) ClickHouse engine, both:
+//
+//  1. finds a value that lives ONLY in the instrumentation-scope column
+//     (ScopeAttributes) — the case #2850/#3010 exist to fix, since the
+//     pre-fix attrMapScopeAny routing never reads that column at all;
+//  2. does NOT surface a value planted under the SAME key name in
+//     SpanAttributes/ResourceAttributes but absent from ScopeAttributes
+//     — the discriminating proof that the query is scope-ISOLATED, not
+//     merely scope-labeled: a query that accidentally still unioned all
+//     three maps would pass case 1 but fail this one.
+//
+// Mirrors search_tag_values_autoscope_chdb_test.go's seed/window
+// conventions (a Memory-engine otel_traces projection, one row per
+// second from a fixed UTC base, chclienttest.NewChDB).
+package tempo_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// instrumentationScopeWindowBase anchors every seeded row well away from
+// wall-clock drift, mirroring autoScopeWindowBase.
+var instrumentationScopeWindowBase = time.Date(2026, 6, 3, 0, 0, 0, 0, time.UTC)
+
+// instrumentationScopeSeedTable carries all three dynamic-attribute maps
+// so a routing regression (falling back to attrMapScopeAny, which reads
+// only Span/ResourceAttributes) is distinguishable from correct
+// attrMapScopeInstrumentation routing (which reads only ScopeAttributes)
+// against the SAME rows.
+const instrumentationScopeSeedTable = "CREATE TABLE otel_traces (\n" +
+	"    Timestamp DateTime64(9),\n" +
+	"    ScopeAttributes Map(String, String),\n" +
+	"    SpanAttributes Map(String, String),\n" +
+	"    ResourceAttributes Map(String, String)\n" +
+	") ENGINE = Memory;"
+
+// TestBuildAttributeValuesSQL_ChDB_InstrumentationScope_IsolatedFromSpanResource
+// seeds four rows for the key `otel.scope.name`:
+//   - r0/r1: the value lives in ScopeAttributes ONLY — the values a
+//     correct instrumentation-scope query must return.
+//   - r2: the SAME key name carries a DIFFERENT value in SpanAttributes,
+//     with ScopeAttributes empty on that row — must NOT surface.
+//   - r3: same key name, DIFFERENT value in ResourceAttributes, with
+//     ScopeAttributes empty on that row — must NOT surface either.
+func TestBuildAttributeValuesSQL_ChDB_InstrumentationScope_IsolatedFromSpanResource(t *testing.T) {
+	const tsFmt = "2006-01-02 15:04:05.000"
+	rows := []struct{ scopeMapSQL, spanMapSQL, resourceMapSQL string }{
+		{scopeMapSQL: "map('otel.scope.name','otelcol-contrib')", spanMapSQL: "map()", resourceMapSQL: "map()"},
+		{scopeMapSQL: "map('otel.scope.name','otelcol-collector')", spanMapSQL: "map()", resourceMapSQL: "map()"},
+		{scopeMapSQL: "map()", spanMapSQL: "map('otel.scope.name','span-leaked-value')", resourceMapSQL: "map()"},
+		{scopeMapSQL: "map()", spanMapSQL: "map()", resourceMapSQL: "map('otel.scope.name','resource-leaked-value')"},
+	}
+	seed := instrumentationScopeSeedTable
+	for i, r := range rows {
+		ts := instrumentationScopeWindowBase.Add(time.Duration(i) * time.Second).Format(tsFmt)
+		seed += "\nINSERT INTO otel_traces (Timestamp, ScopeAttributes, SpanAttributes, ResourceAttributes) VALUES" +
+			" (toDateTime64('" + ts + "', 9), " + r.scopeMapSQL + ", " + r.spanMapSQL + ", " + r.resourceMapSQL + ");"
+	}
+
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, seed)
+	start := instrumentationScopeWindowBase.Add(-time.Minute)
+	end := instrumentationScopeWindowBase.Add(time.Duration(len(rows))*time.Second + time.Minute)
+
+	s := schema.DefaultOTelTraces()
+	s.ScopeAttributesColumn = "ScopeAttributes"
+
+	sqlStr, args := tempo.BuildAttributeValuesSQLForTest(
+		s, "otel.scope.name", tempo.AttrMapScopeInstrumentationForTest, nil, start, end,
+	)
+
+	got, err := c.QueryStrings(context.Background(), sqlStr, args...)
+	if err != nil {
+		t.Fatalf("query failed: %v\nSQL: %s", err, sqlStr)
+	}
+	sort.Strings(got)
+
+	want := []string{"otelcol-collector", "otelcol-contrib"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v (SQL: %s)", got, want, sqlStr)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got %v, want %v (SQL: %s)", got, want, sqlStr)
+			break
+		}
+	}
+	for _, leaked := range []string{"span-leaked-value", "resource-leaked-value"} {
+		for _, v := range got {
+			if v == leaked {
+				t.Errorf("instrumentation-scope query must not surface a Span/ResourceAttributes-only value, got %v", got)
+			}
+		}
+	}
+}

--- a/internal/api/tempo/search_tag_values_test.go
+++ b/internal/api/tempo/search_tag_values_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 // TestSearchTagValues_Intrinsic_Name — the path `/api/search/tag/name/values`
@@ -436,6 +437,131 @@ func TestSearchTagValuesV2_LinkScope(t *testing.T) {
 	}
 	if hits < 1 {
 		t.Errorf("expected key %q bound, got args %v", "opentracing.ref_type", q.lastArgs)
+	}
+}
+
+// TestSearchTagValuesV2_InstrumentationScope_Configured — cerberus issue
+// #3010's live-path fix: `instrumentation.x` on a schema that DOES
+// configure ScopeAttributesColumn must route to a flat-Map lookup
+// against that column, the SAME mapAtFrag/mapContainsFrag shape
+// resource./span. use — never the auto-scope arrayJoin union over
+// SpanAttributes/ResourceAttributes that resolveTagName's `default:`
+// arm silently fell to before this fix. Asserting the SQL contains the
+// ScopeAttributes column and omits Span/ResourceAttributes AND arrayJoin
+// is the discriminating proof that routing changed, not just that a new
+// code path exists unreached: before this fix, the SQL for this exact
+// request would contain arrayJoin(...) over the flat maps instead.
+func TestSearchTagValuesV2_InstrumentationScope_Configured(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelTraces()
+	s.ScopeAttributesColumn = "ScopeAttributes"
+	q := &stubQuerier{strings: []string{"otel-collector-contrib"}}
+	srv := newServerWithSchema(q, s, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v2/search/tag/instrumentation.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if !strings.Contains(q.lastSQL, "`ScopeAttributes`[") {
+		t.Errorf("expected a ScopeAttributes lookup, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "`SpanAttributes`[") || strings.Contains(q.lastSQL, "`ResourceAttributes`[") {
+		t.Errorf("instrumentation scope should NOT touch Span/ResourceAttributes, got: %s", q.lastSQL)
+	}
+	if strings.Contains(q.lastSQL, "arrayJoin(") {
+		t.Errorf("single-scope path should NOT emit an arrayJoin union, got: %s", q.lastSQL)
+	}
+	var body tempo.SearchTagValuesResponseV2
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.TagValues) != 1 || body.TagValues[0].Value != "otel-collector-contrib" {
+		t.Errorf("expected the ScopeAttributes-sourced value in response: %+v", body.TagValues)
+	}
+	hits := 0
+	for _, a := range q.lastArgs {
+		if s, ok := a.(string); ok && s == "name" {
+			hits++
+		}
+	}
+	if hits < 2 {
+		t.Errorf("expected key %q bound >=2 times, got %d in %v", "name", hits, q.lastArgs)
+	}
+}
+
+// TestSearchTagValues_InstrumentationScope_DefaultSchema_ReturnsEmpty —
+// cerberus issue #3010's empty-column guard: on the default schema
+// (ScopeAttributesColumn == "", the only shape the upstream OTel-CH
+// traces DDL populates), an `instrumentation.x` values request must
+// return an empty 200 — mirroring attributeTagScopes()'s treatment of
+// the same unconfigured bucket for /search/tags (the bucket is simply
+// absent) — rather than build SQL against an empty column name (a CH
+// error / malformed SQL) or silently answer from the wrong scope. The
+// lastSQL assertion proves NO query was even attempted, not just that
+// the response happened to come back empty.
+func TestSearchTagValues_InstrumentationScope_DefaultSchema_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	q := &stubQuerier{strings: []string{"should-never-surface"}}
+	srv := newServer(q, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tag/instrumentation.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if q.lastSQL != "" {
+		t.Errorf("expected no CH query to run against an unconfigured ScopeAttributesColumn, got SQL: %s", q.lastSQL)
+	}
+	var body tempo.SearchTagValuesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.TagValues) != 0 {
+		t.Errorf("expected an empty result, got: %v", body.TagValues)
+	}
+}
+
+// TestSearchTagValues_InstrumentationScope_NeverUsesCatalog — the tag
+// catalog MV never carries an instrumentation-scope arm (internal/schema
+// /ddl's SCOPE COVERAGE doc), so an instrumentation-scope tag-values
+// request must stay off the catalog fast path even when every other
+// eligibility condition (catalog enabled, no `q=` filter, windowless)
+// holds — cerberus issue #3010's tagValuesCatalogEligible exclusion.
+// Without it, catalogScopeForMapScope's unmatched default arm would
+// silently mis-serve the request as an auto-scope resource+span catalog
+// read instead of falling through to the live per-key scan.
+func TestSearchTagValues_InstrumentationScope_NeverUsesCatalog(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelTraces()
+	s.ScopeAttributesColumn = "ScopeAttributes"
+	q := &stubQuerier{stringsBySQL: map[string][]string{
+		"tempo_tag_catalog": {"should-never-surface"},
+	}, strings: []string{"otel-collector-contrib"}}
+	srv := newCatalogServerWithSchema(q, s, "v1.0.0-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/tag/instrumentation.name/values")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	if strings.Contains(q.lastSQL, "tempo_tag_catalog") {
+		t.Errorf("instrumentation scope must never query the tag catalog, last SQL was: %s", q.lastSQL)
+	}
+	if !strings.Contains(q.lastSQL, "`ScopeAttributes`[") {
+		t.Errorf("expected the live ScopeAttributes lookup, got: %s", q.lastSQL)
 	}
 }
 

--- a/internal/api/tempo/tag_catalog.go
+++ b/internal/api/tempo/tag_catalog.go
@@ -93,8 +93,22 @@ func tagsCatalogEligible(scope string, filter chsql.Frag, windowless, scopeAttrs
 // tagValuesCatalogEligible reports whether a
 // /search/tag/{name}/values (or V2) request may be served from the
 // catalog.
+//
+// attrMapScopeInstrumentation stays off the fast path unconditionally
+// (cerberus issue #3010): the catalog MV never carries an
+// instrumentation-scope arm at all (internal/schema/ddl's SCOPE
+// COVERAGE doc — unlike tagsCatalogEligible's `scope=none`, which is
+// merely narrowed when the schema configures ScopeAttributesColumn, an
+// explicit instrumentation-scope tag-VALUES request has no partial-
+// coverage case to preserve; the catalog has nothing for it whether or
+// not the schema carries a column, so it must always fall through to
+// the live path catalogScopeForMapScope's default arm would otherwise
+// silently mis-serve as auto-scope resource+span).
 func tagValuesCatalogEligible(resolved resolvedTagName, filter chsql.Frag, windowless bool) bool {
 	if filter != nil || !windowless {
+		return false
+	}
+	if resolved.MapScope == attrMapScopeInstrumentation {
 		return false
 	}
 	return !resolved.IsIntrinsic

--- a/internal/api/tempo/tag_catalog_test.go
+++ b/internal/api/tempo/tag_catalog_test.go
@@ -15,7 +15,15 @@ import (
 // newCatalogServer is newServer with TagCatalogEnabled=true — the
 // cerberus issue #2771 fast path this file exercises.
 func newCatalogServer(q tempo.Querier, version string) *testServer {
-	h := tempo.New(q, schema.DefaultOTelTraces(), version, nil)
+	return newCatalogServerWithSchema(q, schema.DefaultOTelTraces(), version)
+}
+
+// newCatalogServerWithSchema is newCatalogServer for the tests that need
+// a traces schema other than the OTel default — e.g. one that points
+// ScopeAttributesColumn at a real column (cerberus issue #3010), mirroring
+// handler_test.go's newServerWithSchema.
+func newCatalogServerWithSchema(q tempo.Querier, s schema.Traces, version string) *testServer {
+	h := tempo.New(q, s, version, nil)
 	h.TagCatalogEnabled = true
 	mux := http.NewServeMux()
 	h.Mount(mux)
@@ -76,7 +84,11 @@ func TestTagsCatalogEligible(t *testing.T) {
 // only for a non-intrinsic resolved name, a nil filter, and a windowless
 // request — MapScope (resource/span/event/link/any) never restricts
 // eligibility, all five are catalog-servable (cerberus issue #2850 added
-// event/link).
+// event/link). attrMapScopeInstrumentation is the one exception (cerberus
+// issue #3010): the catalog MV never carries an instrumentation-scope
+// arm at all, so that scope stays off the fast path regardless of filter
+// or window — the case below pins it alongside a nil-filter/windowless
+// combination that would otherwise be eligible for every other scope.
 func TestTagValuesCatalogEligible(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
@@ -92,6 +104,7 @@ func TestTagValuesCatalogEligible(t *testing.T) {
 		{"dynamic attribute, span scope, no filter, windowless", false, tempo.AttrMapScopeSpanForTest, nil, true, true},
 		{"dynamic attribute, event scope, no filter, windowless", false, tempo.AttrMapScopeEventForTest, nil, true, true},
 		{"dynamic attribute, link scope, no filter, windowless", false, tempo.AttrMapScopeLinkForTest, nil, true, true},
+		{"dynamic attribute, instrumentation scope stays live even when otherwise eligible", false, tempo.AttrMapScopeInstrumentationForTest, nil, true, false},
 		{"intrinsic stays live", true, tempo.AttrMapScopeAnyForTest, nil, true, false},
 		{"filtered request stays live", false, tempo.AttrMapScopeAnyForTest, nonNilFrag(), true, false},
 		{"explicit window stays live", false, tempo.AttrMapScopeAnyForTest, nil, false, false},


### PR DESCRIPTION
## Problem

`resolveTagName` (`internal/api/tempo/search_tag_values.go`) maps a TraceQL-scoped tag-name
identifier onto the internal `attrMapScope` a `/search/tag/{name}/values` (or `/api/v2/...`) lookup
consults. Before cerberus issue #2850, `event.`/`link.` fell through to the `default:` arm and
silently resolved to `attrMapScopeAny` (the auto-scope union of `SpanAttributes` +
`ResourceAttributes` only). The same `default:` arm still existed for `instrumentation.x`
(`traceql.AttributeScopeInstrumentation`), which the TraceQL parser recognises but
`resolveTagName`'s switch did not special-case.

On a schema that configures `schema.Traces.ScopeAttributesColumn` (empty/absent by default), a
`/search/tag/instrumentation.x/values` request silently searched `SpanAttributes`/
`ResourceAttributes` instead of the configured column, and returned an empty result instead of the
real values or a clear error — the same silent-wrong-answer class #2850 fixed for `event.`/`link.`.

## Fix

- Added `attrMapScopeInstrumentation` to the `attrMapScope` enum.
- Routed `traceql.AttributeScopeInstrumentation` to it in `resolveTagName`'s switch.
- Added an `attrMapScopeInstrumentation` case to `buildAttributeValuesSQL` using the same flat-Map
  `mapAtFrag`/`mapContainsFrag` shape `attrMapScopeResource`/`attrMapScopeSpan` already use —
  instrumentation attributes are a flat `Map(String, String)`, not Nested like event/link.
- Guarded the empty-column case in `respondTagValues`: when `s.ScopeAttributesColumn == ""` (the
  default, unconfigured case), the handler returns an empty 200 rather than building SQL against an
  empty column name — mirroring `attributeTagScopes()`'s existing treatment of the same unconfigured
  bucket for `/search/tags` (the bucket is simply absent).
- Excluded the new scope from the tag-catalog fast path (`tagValuesCatalogEligible`): the catalog MV
  never carries an instrumentation-scope arm (`internal/schema/ddl`'s SCOPE COVERAGE doc), so without
  this exclusion a windowless/unfiltered request would fall into `catalogScopeForMapScope`'s unmatched
  default arm and be silently mis-served from the catalog's auto-scope resource+span union — the same
  bug class one layer down. `tagValuesCatalogEligible`'s existing intrinsic/filter/window checks are
  otherwise unchanged, and the tag-catalog SQL builders themselves are untouched.

## Verification

- `attributeTagScopes()`'s existing empty-column treatment (mirrored here): it simply omits the
  `instrumentation` bucket from its returned slice when `s.ScopeAttributesColumn == ""` — the bucket
  is absent, not present-and-empty, and the live loop never queries it. `respondTagValues` mirrors
  this by skipping the query entirely (`instrumentationUnconfigured` guard) and leaving `values` nil,
  rather than building any SQL.
- Three-way correctness proof:
  - `TestSearchTagValuesV2_InstrumentationScope_Configured` — schema WITH `ScopeAttributesColumn`
    configured, a real value present, asserts the SQL reads `ScopeAttributes` and NOT
    `SpanAttributes`/`ResourceAttributes`/`arrayJoin`, and the response carries the correct value.
  - `TestSearchTagValues_InstrumentationScope_DefaultSchema_ReturnsEmpty` — default schema
    (`ScopeAttributesColumn == ""`), asserts an empty 200 AND that no CH query was even attempted
    (`q.lastSQL == ""`), ruling out both an error and a garbage-SQL crash.
  - `TestSearchTagValues_InstrumentationScope_NeverUsesCatalog` — proves the tag-catalog exclusion
    (`tagValuesCatalogEligible`) so a windowless/unfiltered request stays off the catalog fast path.
  - Routing-changed proof: temporarily reverted the `resolveTagName` routing case and the
    `buildAttributeValuesSQL` case independently; both times the new tests failed exactly as expected
    (the configured-schema test read from `Span`/`ResourceAttributes` with an `arrayJoin` union
    instead of `ScopeAttributes`), then restored and confirmed green — the tests exercise the real
    bug, not an unreached code path.
- chDB was available in this worktree. Added
  `TestBuildAttributeValuesSQL_ChDB_InstrumentationScope_IsolatedFromSpanResource`
  (`search_tag_values_instrumentation_chdb_test.go`, `chdb` build tag), mirroring
  `search_tag_values_autoscope_chdb_test.go`'s seed/window conventions: seeds rows where the same key
  name carries different values in `ScopeAttributes` vs. `SpanAttributes`/`ResourceAttributes` and
  proves the routed query returns only the `ScopeAttributes` values — a real ClickHouse (chDB)
  execution roundtrip, not just a Frag-shape assertion. Reverting the fix makes this test fail with
  the leaked cross-scope values, confirming it is load-bearing.
- `tagValuesCatalogEligible` needed a small change beyond the issue's literal proposal ("needs no
  change"): without it, a windowless/unfiltered instrumentation-scope values request would be served
  wrong data from the catalog's auto-scope union instead of an empty/live result. Verified this by
  reading `catalogScopeForMapScope`'s unmatched-default behavior before adding the exclusion, and
  confirmed with `TestSearchTagValues_InstrumentationScope_NeverUsesCatalog`.
- `tagValuesCatalogEligible` and `catalogScopeForMapScope` — the tag-catalog SQL builders themselves —
  are otherwise untouched, per the issue's scope note: the catalog MV genuinely does not cover
  instrumentation scope.

## Checks run locally

- `go build ./...` and `go build -tags chdb ./...`
- `go test -race ./internal/api/tempo/...` and `go test -tags chdb -race ./internal/api/tempo/...`
- `node .github/scripts/verify-code-citations.mjs`
- `node .github/scripts/forbid-sql-raw.mjs`
- `gofumpt -l` (clean)

Closes #3010
