### PR TITLE
test(loki): pin the sample-budget 400-to-rows repro for M2's exit criterion

### DIFF
--- a/internal/api/loki/limit_pushdown_sample_budget_chdb_test.go
+++ b/internal/api/loki/limit_pushdown_sample_budget_chdb_test.go
@@ -1,0 +1,282 @@
+//go:build chdb
+
+// Symptom-first regression test for cerberus issue #2829's M2 milestone
+// exit criterion ("M2: No knowingly-wrong answers on the default path").
+// #2829 itself is closed — internal/logql/lower.go's maybePushLogLineLimit
+// pushes Loki's `limit` into a real SQL `ORDER BY ... LIMIT N`, and
+// limit_pushdown_test.go / limit_pushdown_chdb_test.go already characterize
+// the plan-shape and correctness side of that change. What none of those
+// tests cover is the PRODUCTION SYMPTOM the issue names: a wide-window Loki
+// range query tripping the per-query sample budget
+// (CERBERUS_QUERY_MAX_SAMPLES / chclient.TooManySamplesError) and
+// surfacing as HTTP 400, because without a SQL-side LIMIT the query
+// decodes the entire matching window before anything in cerberus ever
+// gets to clamp it.
+//
+// This file starts from that symptom (Phase 1 proves the pre-#2829 plan
+// shape really does trip the budget against a genuine chDB-decoded row
+// count, not an injected error), then proves the shipped, unmodified
+// production handler resolves it for the IDENTICAL query and window
+// (Phase 2), and finally confirms the emitted plan carries the
+// ORDER BY + LIMIT shape and is eligible for lazy materialization
+// (Phase 3).
+package loki
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/logql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// sampleBudgetedQuerier wraps chclienttest.Client and reproduces the
+// row-count-over-budget rejection the REAL production *chclient.Client's
+// cursor enforces (Config.MaxQuerySamples, checked in
+// internal/chclient/client.go's drainBudgetExceeded / cursor.go's
+// rowsCursor.maxSamples abort). chclienttest.Client — the chDB test double
+// every other chdb-tagged test in this package uses — never consults a
+// budget at all: it is a thin decode-everything double, not a
+// budget-aware cursor. Without this wrapper a chDB-backed test could never
+// observe a genuine *chclient.TooManySamplesError produced from a REAL
+// decoded row count; it could only inject one synthetically (as
+// handler_sample_budget_test.go's stubQuerier does for the generic
+// error-mapping proof).
+//
+// The boundary matches production exactly: a positive maxSamples aborts
+// once the decoded count exceeds it (">", not ">="), and maxSamples<=0
+// disables the check.
+type sampleBudgetedQuerier struct {
+	*chclienttest.Client
+	maxSamples int64
+}
+
+func (q *sampleBudgetedQuerier) Query(ctx context.Context, sql string, args ...any) ([]chclient.Sample, error) {
+	samples, err := q.Client.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	if q.maxSamples > 0 && int64(len(samples)) > q.maxSamples {
+		return nil, &chclient.TooManySamplesError{Limit: q.maxSamples}
+	}
+	return samples, nil
+}
+
+// streamsRangeResponse decodes a /loki/api/v1/query_range "streams" body
+// with Result typed directly as []Stream, sidestepping the any-typed
+// QueryData.Result field so the test can read entry counts without a
+// re-marshal round trip.
+type streamsRangeResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string   `json:"resultType"`
+		Result     []Stream `json:"result"`
+	} `json:"data"`
+}
+
+// TestLimitPushdown_SampleBudget400ThenRows_ChDB is the M2 exit-criterion
+// proof: it starts from the symptom (a wide-window query tripping the
+// sample budget), proves that symptom is real, and then proves the
+// shipped fix resolves it for the identical query.
+//
+// Arithmetic this test pins: seedRows (2000) > maxSamples (300) — decoding
+// the full matching window WOULD exceed the budget — while reqLimit (50)
+// stays under maxSamples (300), so SQL-side truncation to reqLimit keeps
+// the decoded count comfortably under budget. A real deployment's window
+// and CERBERUS_QUERY_MAX_SAMPLES=5,000,000 budget have the identical
+// shape at production scale; the magnitudes here are only shrunk to keep
+// chDB seeding fast.
+func TestLimitPushdown_SampleBudget400ThenRows_ChDB(t *testing.T) {
+	const (
+		seedRows   = 2000
+		rowSpacing = 5 * time.Second
+		maxSamples = 300
+		reqLimit   = 50
+	)
+	if seedRows <= maxSamples {
+		t.Fatalf("test misconfigured: seedRows (%d) must exceed maxSamples (%d), or the pre-pushdown decode would not actually trip the budget", seedRows, maxSamples)
+	}
+	if reqLimit >= maxSamples {
+		t.Fatalf("test misconfigured: reqLimit (%d) must stay under maxSamples (%d), or SQL-side truncation would not actually land under budget", reqLimit, maxSamples)
+	}
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(seedRows * rowSpacing)
+	s := schema.DefaultOTelLogs()
+
+	ddl := insertRows(
+		seedRows,
+		start,
+		func(i int) map[string]string { return map[string]string{"app": "x"} },
+		func(i int) string { return fmt.Sprintf("line %d", i) },
+	)
+
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, ddl)
+	q := &sampleBudgetedQuerier{Client: c, maxSamples: maxSamples}
+	h := New(q, s, nil)
+
+	const query = `{app="x"}`
+	expr, err := logql.ParseExprPermissive(query)
+	if err != nil {
+		t.Fatalf("ParseExprPermissive(%q): %v", query, err)
+	}
+
+	// --- Phase 1: the pre-#2829 plan genuinely trips the sample budget. ---
+	//
+	// logql.LowerAt (no LowerOpts) is the exact plan shape every log-line
+	// query got before #2829 — no Limit(OrderBy(...)) wrap, full-window
+	// decode. It is not a hypothetical or a deleted code path:
+	// TestLogLineLimitPushdown_ShapeAndGating (internal/logql) pins it as
+	// the base plan maybePushLogLineLimit wraps additively, and it is
+	// exercised here exactly as that test builds it.
+	basePlan, err := logql.LowerAt(context.Background(), expr, s, start, end)
+	if err != nil {
+		t.Fatalf("LowerAt (pre-pushdown plan): %v", err)
+	}
+	langOld := &logql.Lang{Schema: s, Start: start, End: end, LogLineLimit: int64(reqLimit), LogLineBackward: true}
+	meta := engine.Meta{IsMetric: false, ResponseShape: "loki-streams", Extra: map[string]any{"expr": expr}}
+
+	_, errOld := h.Engine.QueryPlan(context.Background(), langOld, basePlan, meta)
+	if errOld == nil {
+		t.Fatalf("pre-pushdown plan against %d seeded rows (budget %d) succeeded; want a genuine sample-budget rejection — the repro did not reproduce the bug", seedRows, maxSamples)
+	}
+	var tooMany *chclient.TooManySamplesError
+	if !errors.As(errOld, &tooMany) {
+		t.Fatalf("pre-pushdown plan error = %v (%T), want errors.As(_, *chclient.TooManySamplesError) — the repro must fail the SAME way the issue claims, not some other error", errOld, errOld)
+	}
+	if tooMany.Limit != maxSamples {
+		t.Errorf("TooManySamplesError.Limit = %d, want %d", tooMany.Limit, maxSamples)
+	}
+
+	// classifyEngineErr is the SAME function handleQueryRange calls on
+	// every h.Engine.Query/QueryPlan error (see classifyEngineErr's
+	// sample-budget branch) — TestQueryRange_SampleBudget400
+	// (handler_sample_budget_test.go) pins its wire-level output against
+	// an INJECTED error; this call feeds it the REAL error Phase 1 just
+	// produced from a genuine over-budget chDB decode.
+	mapped := classifyEngineErr(errOld)
+	apiErr, ok := mapped.(*apiError)
+	if !ok {
+		t.Fatalf("classifyEngineErr(%v) = %T, want *apiError", errOld, mapped)
+	}
+	if apiErr.Status != http.StatusBadRequest {
+		t.Errorf("mapped Status = %d, want %d", apiErr.Status, http.StatusBadRequest)
+	}
+	if apiErr.Kind != ErrBadData {
+		t.Errorf("mapped Kind = %q, want %q", apiErr.Kind, ErrBadData)
+	}
+	wantMsg := fmt.Sprintf(
+		"maximum number of samples (%d) reached for a single query; consider reducing the query range or resolution",
+		maxSamples,
+	)
+	if apiErr.Err.Error() != wantMsg {
+		t.Errorf("mapped message = %q, want %q", apiErr.Err.Error(), wantMsg)
+	}
+
+	// --- Phase 2: the SAME query, through the CURRENT, unmodified,
+	// real HTTP handler, returns 200 with rows. ---
+	//
+	// handleQueryRange threads the request's own `limit` unconditionally
+	// (langForRangeRequest) and internal/logql/lower.go's
+	// maybePushLogLineLimit pushes it into SQL for this safe bare-selector
+	// shape — this is not a bypass or a reconstruction, it is the exact
+	// code path a real /query_range request runs today.
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	var inspected int64
+	h.SetOnQueryRangeDrain(func(n int64) { inspected = n })
+
+	reqURL := fmt.Sprintf(
+		"%s/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=%d&direction=backward",
+		srv.URL,
+		url.QueryEscape(query),
+		start.UnixNano(),
+		end.UnixNano(),
+		reqLimit,
+	)
+	resp, err := http.Get(reqURL) //nolint:noctx // test-local httptest.Server, no context to thread
+	if err != nil {
+		t.Fatalf("GET %s: %v", reqURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (the SAME query that tripped the sample budget in Phase 1 must now succeed) — body: %s", resp.StatusCode, rawBody)
+	}
+
+	var body streamsRangeResponse
+	if err := json.Unmarshal(rawBody, &body); err != nil {
+		t.Fatalf("decode body: %v (body: %s)", err, rawBody)
+	}
+	if body.Status != "success" {
+		t.Fatalf("status field: got %q, want \"success\"", body.Status)
+	}
+	entries := 0
+	for _, stream := range body.Data.Result {
+		entries += len(stream.Values)
+	}
+	if entries == 0 {
+		t.Fatal("response carries zero log entries; want rows")
+	}
+
+	// Anti-vacuous: the drain genuinely happened under budget, and
+	// truncated to the request's own limit rather than the full
+	// seedRows-row window — proving SQL-side LIMIT, not luck, kept
+	// decode under budget.
+	if inspected == 0 {
+		t.Fatal("Inspected drain count never fired (onQueryRangeDrain hook not observed)")
+	}
+	if inspected > maxSamples {
+		t.Errorf("Inspected = %d, exceeds maxSamples %d — the same query that 400ed in Phase 1 would 400 again", inspected, maxSamples)
+	}
+	if inspected != reqLimit {
+		t.Errorf("Inspected = %d, want exactly %d (SQL must have truncated to the request limit; %d seeded rows were available to decode without it)", inspected, reqLimit, seedRows)
+	}
+
+	// --- Phase 3: the emitted plan carries ORDER BY + LIMIT, and
+	// qualifies for lazy materialization. ---
+	pushedPlan, err := logql.LowerAtRangeOpts(context.Background(), expr, s, start, end, 0, logql.LowerOpts{
+		LogLineLimit:    int64(reqLimit),
+		LogLineBackward: true,
+	})
+	if err != nil {
+		t.Fatalf("LowerAtRangeOpts (pushed plan): %v", err)
+	}
+	lim, ok := pushedPlan.(*chplan.Limit)
+	if !ok {
+		t.Fatalf("pushed plan top node = %T, want *chplan.Limit", pushedPlan)
+	}
+	if lim.Count != int64(reqLimit) {
+		t.Errorf("Limit.Count = %d, want %d", lim.Count, reqLimit)
+	}
+	if _, ok := lim.Input.(*chplan.OrderBy); !ok {
+		t.Fatalf("Limit.Input = %T, want *chplan.OrderBy — the ORDER BY + LIMIT shape the milestone's exit criterion requires", lim.Input)
+	}
+
+	elLimit, elOK := engine.EligibleForLazyMaterialization(pushedPlan)
+	if !elOK {
+		t.Fatal("EligibleForLazyMaterialization(pushedPlan) ok = false, want true — the pushed Loki plan must qualify for query_plan_optimize_lazy_materialization")
+	}
+	if elLimit != int64(reqLimit) {
+		t.Errorf("EligibleForLazyMaterialization limit = %d, want %d", elLimit, reqLimit)
+	}
+}

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1570,7 +1570,7 @@ const (
 	// FeatureLazyMaterialization stamps query_plan_optimize_lazy_materialization=1
 	// + query_plan_max_limit_for_lazy_materialization=<the query's own LIMIT> on
 	// any plan carrying an `ORDER BY Timestamp DESC LIMIT N` (or ASC) shape — see
-	// internal/engine.eligibleForLazyMaterialization, which is head-agnostic (it
+	// internal/engine.EligibleForLazyMaterialization, which is head-agnostic (it
 	// matches the chplan shape, not the query language). Tempo's handler.go
 	// builds it directly for /search/recent, boundNewestTraces, and
 	// structural_two_phase.go's phase-A ranking; since cerberus issue #2829,

--- a/internal/engine/lazy_materialization_test.go
+++ b/internal/engine/lazy_materialization_test.go
@@ -9,7 +9,7 @@ import (
 
 // tempoSearchRecentPlan builds the exact shape internal/api/tempo
 // handler.go's /search/recent constructs: Limit(OrderBy(Filter(Scan))) —
-// see eligibleForLazyMaterialization's doc for why the bare Limit(OrderBy(...))
+// see EligibleForLazyMaterialization's doc for why the bare Limit(OrderBy(...))
 // shape, not the full Project wrap, is what the eligibility check matches.
 func tempoSearchRecentPlan(limit int64) chplan.Node {
 	return &chplan.Limit{
@@ -138,7 +138,7 @@ func TestEligibleForLazyMaterialization(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			limit, ok := eligibleForLazyMaterialization(tc.plan)
+			limit, ok := EligibleForLazyMaterialization(tc.plan)
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v; want %v", ok, tc.wantOK)
 			}

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -70,7 +70,7 @@ const settingQueryPlanOptimizeLazyMaterialization = "query_plan_optimize_lazy_ma
 // carry for settingQueryPlanOptimizeLazyMaterialization to still engage —
 // verified on a live chDB 26.5 probe (EXPLAIN PLAN) that a query whose LIMIT
 // exceeds this knob silently falls back to eager reads, so
-// eligibleForLazyMaterialization sizes it to the query's OWN LIMIT rather
+// EligibleForLazyMaterialization sizes it to the query's OWN LIMIT rather
 // than a fixed ceiling, guaranteeing it never under-shoots.
 //
 // perf-sentinel: neutral — an eligibility threshold for the lazy-materialisation
@@ -223,7 +223,7 @@ type SettingsRules struct {
 	// query_plan_optimize_lazy_materialization=1 +
 	// query_plan_max_limit_for_lazy_materialization=<the query's own LIMIT>
 	// on a plan carrying exactly one Limit(OrderBy(...)) shape (see
-	// eligibleForLazyMaterialization) — the head-agnostic check applies to
+	// EligibleForLazyMaterialization) — the head-agnostic check applies to
 	// whichever head's plan happens to carry the shape: the Tempo
 	// `ORDER BY Timestamp DESC LIMIT N` search shapes (/search/recent,
 	// boundNewestTraces, structural two-phase's phase-A ranking), and,
@@ -318,7 +318,7 @@ func (r SettingsRules) apply(ctx context.Context, plan chplan.Node) context.Cont
 		ctx = chclient.WithResultCacheSetting(ctx, int64(r.ResultCacheTTL.Seconds()))
 	}
 	if r.LazyMaterialization {
-		if limit, ok := eligibleForLazyMaterialization(plan); ok {
+		if limit, ok := EligibleForLazyMaterialization(plan); ok {
 			ctx = chclient.WithQuerySetting(ctx, settingQueryPlanOptimizeLazyMaterialization, 1)
 			ctx = chclient.WithQuerySetting(ctx, settingQueryPlanMaxLimitForLazyMaterialization, limit)
 			// Gated behind the analyzer, exactly like the condition cache above
@@ -509,7 +509,7 @@ func planHasNativeHistogramMerge(plan chplan.Node) bool {
 	return found
 }
 
-// eligibleForLazyMaterialization reports whether plan carries exactly one
+// EligibleForLazyMaterialization reports whether plan carries exactly one
 // Limit node whose Input is a bare *chplan.OrderBy — the top-N-by-sort shape
 // ClickHouse's lazy-materialization optimizer targets — with a positive
 // Count, returning that Count so the caller can size
@@ -532,7 +532,15 @@ func planHasNativeHistogramMerge(plan chplan.Node) bool {
 // knob to (a plan this rule does not attempt to reason about) — the setting
 // is result-equivalent regardless, so under-matching only costs a missed
 // win, never correctness.
-func eligibleForLazyMaterialization(plan chplan.Node) (limit int64, ok bool) {
+//
+// Exported (rather than the package-local rest of this file's unexported
+// eligibleFor* predicates) so a language head's own regression test can
+// confirm ITS lowering's plan shape actually qualifies, not merely a
+// synthetic analog: internal/engine cannot import internal/logql or
+// internal/api/tempo to build that plan itself (both import internal/engine,
+// so the reverse edge would cycle), so the check has to run from the
+// consuming package's test instead.
+func EligibleForLazyMaterialization(plan chplan.Node) (limit int64, ok bool) {
 	count := 0
 	var found int64
 	chplan.WalkDeep(plan, func(n chplan.Node) bool {

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -226,7 +226,7 @@ func lowerWithCtx(ctx context.Context, expr syntax.Expr, s schema.Logs, lc lower
 // result set instead of cerberus decoding and discarding every row in the
 // window. This is what makes the shape eligible for
 // query_plan_optimize_lazy_materialization (internal/engine's
-// eligibleForLazyMaterialization walks for exactly this Limit(OrderBy(...))
+// EligibleForLazyMaterialization walks for exactly this Limit(OrderBy(...))
 // shape) — cerberus issue #2829.
 //
 // It is called exactly once per top-level [lowerWithCtx] call — never from

--- a/test/perf/solver_decision_ratchet_test.go
+++ b/test/perf/solver_decision_ratchet_test.go
@@ -266,7 +266,7 @@ func nativeLowerers(t *testing.T) promql.RangeLowerers {
 			// internal/engine/query_settings_rules.go's apply stamps
 			// query_plan_optimize_lazy_materialization=1 +
 			// query_plan_max_limit_for_lazy_materialization=<limit> based on
-			// eligibleForLazyMaterialization (a Limit(OrderBy(...)) plan shape
+			// EligibleForLazyMaterialization (a Limit(OrderBy(...)) plan shape
 			// that only Tempo's search paths ever build — no PromQL
 			// query_range lowering constructs it), so it has zero effect on
 			// RangeLowerers. FeatureTraceIDBitmapFilter (cerberus issue #2767)


### PR DESCRIPTION
## Why

Issue #2829 pushed Loki's `limit` into SQL as `ORDER BY ... LIMIT`, but the PR that closed it
never added the specific regression test the M2 milestone's exit criterion demands:

> A wide-window Loki range query that previously returned 400 returns rows; the emitted SQL
> carries ORDER BY + LIMIT; the shape becomes eligible for eligibleForLazyMaterialization
> (which requires exactly one Limit over an OrderBy); clampLogRows survives only as a
> post-decode safety net; and the work STARTS with a repro pinning the 400, not with a
> benchmark.

The mechanism criteria (`eligibleForLazyMaterialization` gating, `clampLogRows` surviving as
the post-decode net, and the plan/direction shape tests) were already satisfied by #2829's own
PR. What was missing was a test starting from the production SYMPTOM — a wide-window query
tripping `CERBERUS_QUERY_MAX_SAMPLES` and surfacing as HTTP 400 — rather than only asserting
the pushdown mechanism exists.

## What this PR adds

`internal/api/loki/limit_pushdown_sample_budget_chdb_test.go`
(`TestLimitPushdown_SampleBudget400ThenRows_ChDB`, chDB-tagged):

1. **Phase 1 — proves the pre-#2829 plan genuinely 400s.** `logql.LowerAt` (no `LowerOpts`) is
   the exact plan shape every Loki log-line query got before #2829 — it is not a hypothetical or
   a deleted code path, it is the same base plan `maybePushLogLineLimit` wraps additively today.
   Run through `Engine.QueryPlan` against a chDB table seeded with 2000 matching rows and a
   sample budget of 300 (`seedRows > maxSamples`), it returns a genuine
   `*chclient.TooManySamplesError{Limit: 300}` — a real error from a real over-budget decoded
   row count, not an injected one. That error is fed through the same `classifyEngineErr`
   function `handleQueryRange` calls on every request, confirming it maps to HTTP 400 /
   `bad_data` with the exact upstream-Loki-style message.
2. **Phase 2 — proves the SAME query, through the CURRENT, unmodified, real HTTP handler,
   returns 200 with rows.** A real `httptest.Server` request against `/loki/api/v1/query_range`
   for the identical query/window/`limit=50` returns 200, decodes non-empty streams, and (via
   the existing `SetOnQueryRangeDrain` test hook) shows the engine decoded exactly 50 rows —
   the request's own limit, not the full 2000-row window — proving SQL-side `LIMIT`, not luck,
   kept decode under budget.
3. **Phase 3 — plan-shape and eligibility confirmation.** The pushed plan
   (`logql.LowerAtRangeOpts`) is asserted to be `*chplan.Limit{Count: 50, Input:
   *chplan.OrderBy{...}}`, and `engine.EligibleForLazyMaterialization` — called directly, not
   assumed — confirms `ok=true, limit=50` for that exact plan.

`chclienttest.Client` (the chDB test double every other chdb-tagged handler test in this package
uses) never enforces a sample budget at all, so a small `sampleBudgetedQuerier` wrapper in the
new test reproduces the same "`> maxSamples` aborts" arithmetic the real
`*chclient.Client`'s cursor enforces (`drainBudgetExceeded` / `rowsCursor.maxSamples`), so the
budget trip in Phase 1 comes from a genuine chDB-decoded row count.

### `internal/engine.eligibleForLazyMaterialization` → exported

To let a language head's own test confirm its ACTUAL lowered plan qualifies (not merely a
synthetic analog resembling the shape), `eligibleForLazyMaterialization` is exported as
`EligibleForLazyMaterialization`. `internal/engine` cannot import `internal/logql` itself to
build that plan (`internal/logql/lang.go` already imports `internal/engine`, so the reverse edge
would cycle), so the check has to run from the consuming package's test — hence the export.
Purely a visibility change; the one production call site and the existing
`TestEligibleForLazyMaterialization` were updated to the new name, along with three
comment-only references in `internal/logql/lower.go`, `internal/chopt/registry.go`, and
`test/perf/solver_decision_ratchet_test.go`.

## Direction correction

The milestone's own text flags that the original issue #2829 apparently claimed
`buildTailSQL`'s existing `LIMIT`-shaped query used `DESC`. Verified against the current
`internal/api/loki/tail.go`: it emits `ORDER BY Timestamp ASC`, not `DESC` — confirming the
milestone's correction. This PR's own comments don't cite `tail.go` for direction semantics, so
nothing needed changing there.

## Verification

- `go build ./...`
- `go test -race ./internal/api/loki/... ./internal/logql/...`
- `go test -race -tags chdb ./internal/api/loki/...` (includes the new test)
- `go test -race ./internal/engine/... ./internal/chopt/...` and `go vet ./test/perf/...`
  (covers every file the rename touched)
- `node .github/scripts/verify-code-citations.mjs`

References #2829 — satisfies the M2 milestone exit criterion the merged PR did not cover.
