### PR TITLE
refactor(chplan): consolidate join-carrier detection into chplan.HasJoin

### DIFF
--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -534,11 +534,14 @@ Notes:
   guards (`VectorJoin`'s own `ManyToManyMatchMessage`) and structural shape
   restrictions, neither of which bounds memory, so a big hash build could hit
   a destructive `MEMORY_LIMIT_EXCEEDED` (code 241) abort. The plan-shape gate
-  (`internal/engine.planHasJoin`) covers every join `chplan.WalkDeep` can
-  observe pre-emission — `VectorJoin`, `HistogramVectorJoin`,
-  `HistogramFloatVectorJoin`, `MixedVectorJoin`, `InfoJoin`, `StructuralJoin`,
-  `CrossJoin`, and a `RangeWindow` with a non-nil `DeltaPrefixAggregateInput`
-  (the delta-prefix LEFT JOIN). **Version floor is 26.4**: `max_bytes_before_external_join` carries an EXPERIMENTAL marker at
+  (`chplan.HasJoin`, the one join-carrier registry `internal/engine.spill.go`,
+  `internal/engine.plan_shape_id.go` and `internal/routememo.key.go` all
+  consume) covers every join `chplan.WalkDeep` can observe pre-emission —
+  `VectorJoin`, `HistogramVectorJoin`, `HistogramFloatVectorJoin`,
+  `MixedVectorJoin`, `InfoJoin`, `StructuralJoin`, `CrossJoin`,
+  `NestedSetAnnotate`, a `MetricsCompare` with a non-nil `RootLookup`, and a
+  `RangeWindow` with a non-nil `DeltaPrefixAggregateInput` (the delta-prefix
+  LEFT JOIN). **Version floor is 26.4**: `max_bytes_before_external_join` carries an EXPERIMENTAL marker at
   introduction and is treated as production-grade from 26.5, where its ratio-
   default sibling (`max_bytes_ratio_before_external_join=0.5`) ships — this
   registry entry pins the floor to 26.4, where the setting first exists to

--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -534,8 +534,8 @@ Notes:
   guards (`VectorJoin`'s own `ManyToManyMatchMessage`) and structural shape
   restrictions, neither of which bounds memory, so a big hash build could hit
   a destructive `MEMORY_LIMIT_EXCEEDED` (code 241) abort. The plan-shape gate
-  (`chplan.HasJoin`, the one join-carrier registry `internal/engine.spill.go`,
-  `internal/engine.plan_shape_id.go` and `internal/routememo.key.go` all
+  (`chplan.HasJoin`, the one join-carrier registry `internal/engine/spill.go`,
+  `internal/engine/plan_shape_id.go` and `internal/routememo/key.go` all
   consume) covers every join `chplan.WalkDeep` can observe pre-emission —
   `VectorJoin`, `HistogramVectorJoin`, `HistogramFloatVectorJoin`,
   `MixedVectorJoin`, `InfoJoin`, `StructuralJoin`, `CrossJoin`,

--- a/internal/chplan/join.go
+++ b/internal/chplan/join.go
@@ -1,0 +1,107 @@
+package chplan
+
+// HasJoin reports whether node contains any join-bearing chplan.Node
+// anywhere in its plan tree — a node whose ClickHouse emission renders a
+// real SQL JOIN with a hash-table build side, as opposed to a plan-IR node
+// whose NAME merely contains "Join" or whose doc talks about a
+// relational-algebra join informally. chplan.LabelJoin lowers PromQL's
+// label_join() string function and never emits a SQL JOIN — it is an Expr,
+// not a Node, and can never reach the switch below at all.
+// chplan.VectorSetOp's own doc calls PromQL `and`/`unless` a "semi-join" /
+// "anti-join" over label signatures, but its chsql emitter
+// (internal/chsql/vector_set_op.go) renders that as a `WHERE ... IN
+// (subquery)` / `NOT IN (subquery)` predicate, never a JOIN clause — so it
+// is excluded too. Both are exactly the EMISSION-BEHAVIOUR-vs-name-heuristic
+// traps TestHasJoin_CoversEveryJoinEmittingNode exists to keep this
+// enumeration honest against.
+//
+// This is the SOLE enumeration of join-carrier node kinds in the codebase.
+// internal/engine/spill.go's applyJoinSpillSettings (the memory-spill
+// guard for a join's hash-table build side), internal/engine/plan_shape_id.go's
+// planShapeID (the `join` log_comment modifier), and
+// internal/routememo/key.go's KeyFor (the routing-memo fingerprint) all
+// call this rather than keeping their own switch, so the set cannot drift
+// between callers again the way it did before cerberus issue #2886/#3008.
+//
+// The sweep is WalkDeep, not Walk: a join nested inside a ScalarSubquery's
+// or InSubquery's Expr slot still emits a real ClickHouse JOIN when the
+// query runs, and Walk's Children()-only traversal cannot see it. When the
+// answer gates a resource bound — the join-spill memory setting — that
+// blind spot is a production OOM exposure, not a missed optimisation; see
+// WalkDeep's own doc for the general case.
+//
+// Covers every join chplan.WalkDeep can observe on the plan pre-emission —
+// derived not from the three sites' old, individually-incomplete switches,
+// but from a full sweep of internal/chsql for every call to QueryBuilder's
+// own Join method, matched back to the Node type whose emitter issues it.
+// That sweep is what found two carriers NONE of the three pre-existing
+// enumerations (including spill.go's) knew about:
+//
+//   - VectorJoin / HistogramVectorJoin / HistogramFloatVectorJoin /
+//     MixedVectorJoin — PromQL vector matching: one-to-one, the
+//     group_left()/group_right() many-to-one shape, and the mixed-family
+//     join. VectorJoin's own ManyToManyMatchMessage throwIf guard exists
+//     precisely because a many-to-many match here can build an unbounded
+//     hash table.
+//   - InfoJoin — PromQL's info() label-enrichment join.
+//   - StructuralJoin — TraceQL's structural (descendant/child/sibling) joins.
+//   - CrossJoin — the unconditional Cartesian product.
+//   - NestedSetAnnotate — TraceQL's structure-tab left/right/parent
+//     numbering. internal/chsql/nested_set_annotate.go's emitNestedSetAnnotate
+//     unconditionally LEFT JOINs its input against the recursive-CTE
+//     numbering subquery (and buildNestedSetNumbering's own recursive step
+//     INNER JOINs the CTE to itself) — every NestedSetAnnotate node is a
+//     join, with no gating field to check.
+//   - MetricsCompare with a non-nil RootLookup — TraceQL compare()'s root-span
+//     lookup. chplan.MetricsCompare's own doc names TraceIDColumn "join key
+//     for RootLookup"; internal/chsql/metrics_compare.go's compareBaseQuery
+//     (the single funnel every MetricsCompare emission path renders through)
+//     LEFT JOINs RootLookup exactly when it is set, mirroring RangeWindow's
+//     DeltaPrefixAggregateInput shape on the same IR struct.
+//   - RangeWindow with a non-nil DeltaPrefixAggregateInput — the
+//     delta-prefix LEFT JOIN (internal/chsql/range_window.go's
+//     deltaPrefixAggregateSource) that side-feeds the day-bucket aggregate
+//     input into the raw window. cerberus issue #3014 tracks a SEPARATE,
+//     narrower join this predicate does not yet cover: the instant-shape
+//     (OuterRange == 0) default fallback (instantDeltaPrefixSource) also
+//     emits a JOIN, on temporality-aware counters, with no
+//     DeltaPrefixAggregateInput involved at all.
+//
+// ClickHouse's ARRAY JOIN (RangeWindowStaleResample, RangeBucketGridNative,
+// RangeWindowGridNative, RangeWindowGridNativeVectorAgg, …) is deliberately
+// excluded: it is a row-multiplying unnest with no second relation and no
+// hash-table build side, not the JOIN operator max_bytes_before_external_join
+// bounds.
+func HasJoin(node Node) bool {
+	found := false
+	WalkDeep(node, func(n Node) bool {
+		switch v := n.(type) {
+		case *VectorJoin:
+			found = true
+		case *HistogramVectorJoin:
+			found = true
+		case *HistogramFloatVectorJoin:
+			found = true
+		case *MixedVectorJoin:
+			found = true
+		case *InfoJoin:
+			found = true
+		case *StructuralJoin:
+			found = true
+		case *CrossJoin:
+			found = true
+		case *NestedSetAnnotate:
+			found = true
+		case *MetricsCompare:
+			if v.RootLookup != nil {
+				found = true
+			}
+		case *RangeWindow:
+			if v.DeltaPrefixAggregateInput != nil {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}

--- a/internal/chplan/join_test.go
+++ b/internal/chplan/join_test.go
@@ -1,0 +1,283 @@
+package chplan
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// synthetic fixtures. Every value here is invented for the test — no
+// production table/column names.
+
+func joinScanFixture() Node {
+	return &Scan{Table: "fixture_metrics"}
+}
+
+// joinCarrierCases returns one minimal fixture per join-bearing Node kind
+// HasJoin claims to find — see HasJoin's own doc for the chsql evidence
+// (which QueryBuilder.Join call each one traces back to) behind every row.
+func joinCarrierCases() []struct {
+	name string
+	node Node
+} {
+	return []struct {
+		name string
+		node Node
+	}{
+		{"VectorJoin (PromQL vector matching)", &VectorJoin{}},
+		{"HistogramVectorJoin (group_left/group_right)", &HistogramVectorJoin{}},
+		{"HistogramFloatVectorJoin", &HistogramFloatVectorJoin{}},
+		{"MixedVectorJoin", &MixedVectorJoin{}},
+		{"InfoJoin (info())", &InfoJoin{}},
+		{"StructuralJoin (TraceQL)", &StructuralJoin{}},
+		{"CrossJoin", &CrossJoin{}},
+		{"NestedSetAnnotate (TraceQL structure-tab numbering)", &NestedSetAnnotate{}},
+		{
+			"MetricsCompare with RootLookup (TraceQL compare() root-span lookup)",
+			&MetricsCompare{Inner: joinScanFixture(), RootLookup: joinScanFixture()},
+		},
+		{
+			"RangeWindow with DeltaPrefixAggregateInput (delta-prefix LEFT JOIN)",
+			&RangeWindow{
+				Input:                     joinScanFixture(),
+				DeltaPrefixAggregateInput: &Scan{Table: "fixture_metrics_delta_prefix"},
+			},
+		},
+	}
+}
+
+// wantJoinCarrierCount pins the row count of joinCarrierCases so a table row
+// silently dropped (as opposed to a switch arm dropped, which
+// TestHasJoin_CoversEveryJoinEmittingNode catches independently by deriving
+// straight from join.go's source) still fails loudly rather than the table
+// quietly shrinking to whatever HasJoin currently does.
+const wantJoinCarrierCount = 10
+
+// TestHasJoin_DetectsEveryJoinCarrier covers every join-bearing chplan node
+// HasJoin claims to find: each one alone is enough to trip the detector.
+func TestHasJoin_DetectsEveryJoinCarrier(t *testing.T) {
+	t.Parallel()
+	cases := joinCarrierCases()
+	if len(cases) != wantJoinCarrierCount {
+		t.Fatalf("joinCarrierCases has %d rows, want %d — update wantJoinCarrierCount alongside "+
+			"any deliberate change to the carrier set", len(cases), wantJoinCarrierCount)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if !HasJoin(tc.node) {
+				t.Errorf("HasJoin(%s) = false; want true", tc.name)
+			}
+		})
+	}
+}
+
+// TestHasJoin_NonJoinPlansUnaffected pins the negative side: a bare scan, an
+// aggregation, a RangeWindow with no delta-prefix side feed, and a
+// MetricsCompare with no RootLookup all report no join.
+func TestHasJoin_NonJoinPlansUnaffected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		node Node
+	}{
+		{"bare Scan", &Scan{Table: "fixture_metrics"}},
+		{"Aggregate over Scan", &Aggregate{Input: joinScanFixture()}},
+		{"RangeWindow with no delta-prefix side feed", &RangeWindow{Input: joinScanFixture()}},
+		{"MetricsCompare with no RootLookup", &MetricsCompare{Inner: joinScanFixture()}},
+		{"VectorSetOp (semi/anti-join lowers to WHERE IN, never a SQL JOIN)", &VectorSetOp{Left: joinScanFixture(), Right: joinScanFixture()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if HasJoin(tc.node) {
+				t.Errorf("HasJoin(%s) = true; want false", tc.name)
+			}
+		})
+	}
+}
+
+// TestHasJoin_ReachesJoinNestedInScalarSubquery is the WalkDeep-matters
+// proof: a join buried inside a Filter predicate's ScalarSubquery is
+// invisible to Walk (Children()-only) and must still be found by HasJoin.
+// This is the exact shape a shallow-Walk join detector misses — see
+// routememo/key.go's own history (cerberus issue #3008 added case arms to a
+// Walk-based switch that still could not see a join here).
+func TestHasJoin_ReachesJoinNestedInScalarSubquery(t *testing.T) {
+	t.Parallel()
+
+	buried := &VectorJoin{}
+	plan := &Filter{
+		Input:     joinScanFixture(),
+		Predicate: &ScalarSubquery{Input: buried},
+	}
+
+	// Prove the shallow traversal really cannot see it — otherwise this
+	// test would not distinguish WalkDeep from Walk at all.
+	shallowFound := false
+	Walk(plan, func(n Node) bool {
+		if _, ok := n.(*VectorJoin); ok {
+			shallowFound = true
+		}
+		return true
+	})
+	if shallowFound {
+		t.Fatal("Walk reached the VectorJoin inside the ScalarSubquery; this fixture no longer " +
+			"distinguishes Walk from WalkDeep")
+	}
+
+	if !HasJoin(plan) {
+		t.Error("HasJoin: join nested inside a ScalarSubquery predicate not found; want true")
+	}
+}
+
+// joinHandledTypes returns the Node type names HasJoin's switch (join.go)
+// dispatches on, read out of the source by parsing it — never by re-typing
+// the case list, which would just be a second hand-maintained copy of the
+// first.
+func joinHandledTypes(t *testing.T) map[string]bool {
+	t.Helper()
+
+	const scannedFile = "join.go"
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, scannedFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", scannedFile, err)
+	}
+
+	handled := map[string]bool{}
+	var arms int
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "HasJoin" {
+			return true
+		}
+		ast.Inspect(fn, func(inner ast.Node) bool {
+			cc, ok := inner.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			arms++
+			for _, expr := range cc.List {
+				if name := joinCaseTypeName(expr); name != "" {
+					handled[name] = true
+				}
+			}
+			return true
+		})
+		return false
+	})
+	if arms == 0 {
+		t.Fatalf("scanned %s and found no case arms in HasJoin — the scan lost its grip on the "+
+			"source shape, so this ratchet is vacuous", scannedFile)
+	}
+	return handled
+}
+
+// joinCaseTypeName returns the bare type name of one `case *T:` entry, or ""
+// for a shape the scan does not recognise.
+func joinCaseTypeName(e ast.Expr) string {
+	if star, ok := e.(*ast.StarExpr); ok {
+		e = star.X
+	}
+	if ident, ok := e.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
+}
+
+// nonJoinKinds is the explicit, hand-maintained roster of every OTHER
+// chplan.Node concrete type — one that HasJoin's switch does NOT treat as
+// join-bearing — paired with the reason its chsql emitter never renders a
+// SQL JOIN. It is never trusted on its own:
+// TestHasJoin_CoversEveryJoinEmittingNode asserts its keys, UNIONED with
+// joinHandledTypes' derived set, are exactly the sealed chplan.Node set, so
+// a new Node type added to the package without a decision in ONE of the two
+// lists fails here by name — the same derive-and-diff shape every other
+// exhaustiveness ratchet in this package uses (see sealed_kinds_test.go).
+//
+// The classification is BY EMISSION, verified against internal/chsql at
+// authoring time (every QueryBuilder.Join call site in the package was
+// swept and matched back to its Node — see join.go's own doc), not by
+// whether the type's name or doc mentions "join":
+//   - VectorSetOp's own doc calls `and`/`unless` a "semi-join"/"anti-join",
+//     but internal/chsql/vector_set_op.go lowers both to a
+//     `WHERE ... IN (subquery)` / `NOT IN (subquery)` predicate, never a
+//     JOIN clause.
+//   - SetOperation, UnionAll and NaryVectorSetOp all combine two relations,
+//     but via SQL UNION [ALL], not JOIN.
+var nonJoinKinds = map[string]string{
+	// --- leaf nodes: no second relation to combine at all ---
+	"Scan":     "a single table scan",
+	"OneRow":   "a synthetic single-row source",
+	"StepGrid": "a synthetic anchor-timestamp series",
+
+	// --- single-input reshaping nodes: read one relation, never combine two ---
+	"Filter":                         "row-level predicate over its one Input",
+	"Project":                        "column reshaping over its one Input",
+	"Aggregate":                      "GROUP BY over its one Input",
+	"Limit":                          "row-count cap over its one Input",
+	"OrderBy":                        "sort over its one Input",
+	"TopK":                           "sort + cap over its one Input",
+	"SearchTraceLimit":               "trace-count cap over its one Input",
+	"AbsentOverTime":                 "presence check over its one Input",
+	"HistogramQuantile":              "quantile arithmetic over its one Input",
+	"HistogramQuantileNative":        "quantile arithmetic over its one Input",
+	"HistogramProjection":            "column reshaping over its one Input",
+	"MetricsAggregate":               "GROUP BY over its one Inner",
+	"MetricsHistogramOverTime":       "histogram fold over its one Inner",
+	"MetricsSecondStage":             "post-aggregation reshaping over its one Input",
+	"RangeWindowGridNative":          "windowed-array fold over its one Input",
+	"RangeBucketFanout":              "per-bucket fan-out over its one Input, via array functions",
+	"RangeBucketGridNative":          "windowed-array fold over its one Input, ARRAY JOIN only",
+	"RangeLWR":                       "last-value-lookback fold over its one Input",
+	"RangeWindowGridNativeInstant":   "windowed-array fold over its one Input",
+	"RangeWindowGridNativeVectorAgg": "windowed-array fold over its one Input, ARRAY JOIN only",
+	"RangeWindowStaleResample":       "resample fold over its one Input, ARRAY JOIN only",
+
+	// --- multi-arm combinators that emit SQL UNION, never JOIN ---
+	"UnionAll":        "combines its Inputs via UNION ALL",
+	"SetOperation":    "combines Left/Right via UNION/INTERSECT/EXCEPT DISTINCT",
+	"NaryVectorSetOp": "combines its Arms via UNION ALL + dedup, not a JOIN",
+	"VectorSetOp":     "PromQL and/unless: semi/anti-join by NAME, WHERE IN/NOT IN subquery by emission",
+}
+
+// TestHasJoin_CoversEveryJoinEmittingNode is the completeness ratchet the M2
+// milestone's join-carrier-registry criterion asks for: it keys on EMISSION
+// BEHAVIOUR, not on a type name ending in "Join" (that heuristic both
+// misses RangeWindow's delta-prefix carrier and false-positives on
+// chplan.LabelJoin, an Expr that can never reach a Node switch at all — see
+// TestHasJoin_NonJoinPlansUnaffected's VectorSetOp row for the mirror-image
+// trap: a NAME that says "join" but an emission that never renders one).
+//
+// It partitions every concrete chplan.Node type — derived from the
+// planNode() marker declarations in this package's source, via the same
+// sealedscan machinery every other exhaustiveness ratchet here uses, never
+// hand-counted — into joinHandledTypes (derived from HasJoin's own switch
+// arms in join.go) and nonJoinKinds (hand-classified, with a reason per
+// entry). A Node type landing in NEITHER when a new one is added fails
+// here by name: the author must add it to join.go's switch (if its chsql
+// emitter renders a JOIN) or to nonJoinKinds (with a reason, if it does
+// not) — there is no default that lets it pass silently either way.
+func TestHasJoin_CoversEveryJoinEmittingNode(t *testing.T) {
+	t.Parallel()
+
+	joinKinds := joinHandledTypes(t)
+	for name := range joinKinds {
+		if _, dup := nonJoinKinds[name]; dup {
+			t.Errorf("%s is in BOTH HasJoin's switch and nonJoinKinds — pick one", name)
+		}
+	}
+
+	covered := make(map[string]bool, len(joinKinds)+len(nonJoinKinds))
+	for name := range joinKinds {
+		covered[name] = true
+	}
+	for name := range nonJoinKinds {
+		covered[name] = true
+	}
+	assertCoversEverySealedKind(t, nodeMarkerMethod, covered, "join.go's HasJoin switch + join_test.go's nonJoinKinds",
+		"add the new Node type to HasJoin's switch in join.go if its chsql emitter renders a SQL "+
+			"JOIN, else to nonJoinKinds in join_test.go with the reason it does not")
+}

--- a/internal/engine/join_spill_test.go
+++ b/internal/engine/join_spill_test.go
@@ -7,76 +7,10 @@ import (
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
-// TestPlanHasJoin_DetectsEveryJoinNode covers every join-bearing chplan node
-// planHasJoin claims to find (see its own doc for the list and the tracked
-// late-materialisation gap, #2816): each one alone is enough to trip the
-// detector, and a plain non-join plan does not.
-func TestPlanHasJoin_DetectsEveryJoinNode(t *testing.T) {
-	cases := []struct {
-		name string
-		plan chplan.Node
-	}{
-		{"VectorJoin (PromQL vector matching)", &chplan.VectorJoin{}},
-		{"HistogramVectorJoin (group_left/group_right)", &chplan.HistogramVectorJoin{}},
-		{"HistogramFloatVectorJoin", &chplan.HistogramFloatVectorJoin{}},
-		{"MixedVectorJoin", &chplan.MixedVectorJoin{}},
-		{"InfoJoin (info())", &chplan.InfoJoin{}},
-		{"StructuralJoin (TraceQL)", &chplan.StructuralJoin{}},
-		{"CrossJoin", &chplan.CrossJoin{}},
-		{
-			"RangeWindow with DeltaPrefixAggregateInput (delta-prefix LEFT JOIN)",
-			&chplan.RangeWindow{
-				Input:                     &chplan.Scan{Table: "otel_metrics_sum"},
-				DeltaPrefixAggregateInput: &chplan.Scan{Table: "otel_metrics_sum_delta_prefix"},
-			},
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if !planHasJoin(tc.plan) {
-				t.Errorf("planHasJoin(%s) = false; want true", tc.name)
-			}
-		})
-	}
-}
-
-// TestPlanHasJoin_NonJoinPlansUnaffected pins the negative side: a bare scan,
-// an aggregation, and a RangeWindow with NO delta-prefix side feed all report
-// no join, so join_spill never fires on an ordinary query.
-func TestPlanHasJoin_NonJoinPlansUnaffected(t *testing.T) {
-	cases := []struct {
-		name string
-		plan chplan.Node
-	}{
-		{"bare Scan", &chplan.Scan{Table: "otel_metrics_sum"}},
-		{"Aggregate over Scan", aggOverScan("otel_metrics_sum", "MetricName")},
-		{
-			"RangeWindow with no delta-prefix side feed",
-			&chplan.RangeWindow{Input: &chplan.Scan{Table: "otel_metrics_sum"}},
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if planHasJoin(tc.plan) {
-				t.Errorf("planHasJoin(%s) = true; want false", tc.name)
-			}
-		})
-	}
-}
-
-// TestPlanHasJoin_ReachesJoinNestedInScalarSubquery pins the WalkDeep (not
-// Walk) choice: a join buried inside a Filter predicate's ScalarSubquery is
-// still found, the same total-traversal reasoning planHasMetricsCompare
-// already relies on.
-func TestPlanHasJoin_ReachesJoinNestedInScalarSubquery(t *testing.T) {
-	plan := &chplan.Filter{
-		Input:     &chplan.Scan{Table: "otel_metrics_sum"},
-		Predicate: &chplan.ScalarSubquery{Input: &chplan.VectorJoin{}},
-	}
-	if !planHasJoin(plan) {
-		t.Error("planHasJoin: join nested inside a ScalarSubquery predicate not found; want true")
-	}
-}
+// Join-carrier detection itself (which chplan.Node kinds count, and the
+// WalkDeep-reaches-a-ScalarSubquery proof) is chplan.HasJoin's own contract,
+// pinned by internal/chplan/join_test.go — applyJoinSpillSettings only needs
+// to prove it GATES on that verdict correctly, not re-prove the verdict.
 
 // TestApplyJoinSpillSettings_StampsOnlyWhenEnabledAndJoinBearing exercises the
 // full gate: BOTH the resolved join_spill verdict AND a join-bearing plan are

--- a/internal/engine/plan_shape_id.go
+++ b/internal/engine/plan_shape_id.go
@@ -50,7 +50,6 @@ func shapeModifiers(plan chplan.Node) []string {
 		hasRange    bool
 		hasLWR      bool
 		hasLimit    bool
-		hasJoin     bool
 		hasUnion    bool
 		hasNative   bool
 		hasResample bool
@@ -88,11 +87,17 @@ func shapeModifiers(plan chplan.Node) []string {
 			if len(v.UnionTables) > 0 {
 				hasUnion = true
 			}
-		case *chplan.CrossJoin, *chplan.StructuralJoin, *chplan.VectorJoin, *chplan.InfoJoin:
-			hasJoin = true
 		}
 		return true
 	})
+	// hasJoin is a SEPARATE chplan.HasJoin sweep, not another arm of the Walk
+	// switch above: HasJoin's own contract is WalkDeep (it must see a join
+	// nested inside a ScalarSubquery/InSubquery Expr slot — see its doc), and
+	// widening THIS function's other modifiers (rw/rwn/union/limit/...) to
+	// WalkDeep too would change what every one of them clusters on, which is
+	// its own decision this modifier list doesn't need to make just to fix
+	// join visibility.
+	hasJoin := chplan.HasJoin(plan)
 	if aggKeys >= 0 {
 		mods = append(mods, "agg="+strconv.Itoa(aggKeys))
 	}

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -132,12 +132,12 @@ type SettingsRules struct {
 	ConditionCache bool
 
 	// JoinSpill, when true, stamps max_bytes_before_external_join=cap/2 on a
-	// join-bearing plan (see planHasJoin in spill.go) so a large hash build
-	// spills to disk instead of aborting with MEMORY_LIMIT_EXCEEDED (code
-	// 241). Driven by the join_spill registry feature, which only resolves
-	// in on server >= 26.4; below that the feature is absent from the
-	// resolved set, so this flag is false and nothing is stamped (a no-op on
-	// every server too old to carry the setting). Applied via
+	// join-bearing plan (see chplan.HasJoin) so a large hash build spills to
+	// disk instead of aborting with MEMORY_LIMIT_EXCEEDED (code 241). Driven
+	// by the join_spill registry feature, which only resolves in on server
+	// >= 26.4; below that the feature is absent from the resolved set, so
+	// this flag is false and nothing is stamped (a no-op on every server too
+	// old to carry the setting). Applied via spill.go's
 	// applyJoinSpillSettings rather than inside apply below, because unlike
 	// OptimizeAggregationInOrder/ConditionCache it also needs the live
 	// per-query memory cap — see engine.go's execContext.

--- a/internal/engine/spill.go
+++ b/internal/engine/spill.go
@@ -125,7 +125,7 @@ func applySpillSettings(ctx context.Context, maxMemory int64) context.Context {
 //     to stamp unconditionally: the setting itself does not exist before
 //     26.4, and an unknown setting name errors the whole query rather than
 //     no-op'ing.
-//   - plan contains a join-bearing node (planHasJoin) — join memory is
+//   - plan contains a join-bearing node (chplan.HasJoin) — join memory is
 //     otherwise protected only by throwIf cardinality guards and structural
 //     shape restrictions, never a memory backstop, so any plan that lowers
 //     to a real ClickHouse JOIN can build an unbounded hash table.
@@ -136,60 +136,8 @@ func applySpillSettings(ctx context.Context, maxMemory int64) context.Context {
 // a join approaching the cap spills-and-completes instead of aborting with
 // MEMORY_LIMIT_EXCEEDED (code 241).
 func applyJoinSpillSettings(ctx context.Context, plan chplan.Node, maxMemory int64, joinSpillEnabled bool) context.Context {
-	if !joinSpillEnabled || !planHasJoin(plan) {
+	if !joinSpillEnabled || !chplan.HasJoin(plan) {
 		return ctx
 	}
 	return chclient.WithQuerySetting(ctx, settingMaxBytesBeforeExternalJoin, spillThreshold(maxMemory))
-}
-
-// planHasJoin reports whether plan contains any join-bearing chplan node —
-// a node whose ClickHouse emission renders a real SQL JOIN with a hash-table
-// build side, as opposed to a plan-IR node whose NAME merely contains "Join"
-// (chplan.LabelJoin lowers PromQL's label_join() string function and never
-// emits a SQL JOIN; it is deliberately excluded).
-//
-// The sweep is chplan.WalkDeep, not chplan.Walk, so a join nested inside a
-// scalar subquery's Expr slot is still found — the same total-traversal
-// reasoning applyCompareMemoryBound's planHasMetricsCompare relies on.
-//
-// Covers every join chplan.WalkDeep can observe on the plan pre-emission:
-//
-//   - VectorJoin / HistogramVectorJoin / HistogramFloatVectorJoin /
-//     MixedVectorJoin — PromQL vector matching: one-to-one, the
-//     group_left()/group_right() many-to-one shape, and the mixed-family
-//     join. VectorJoin's own ManyToManyMatchMessage throwIf guard exists
-//     precisely because a many-to-many match here can build an unbounded
-//     hash table.
-//   - InfoJoin — PromQL's info() label-enrichment join.
-//   - StructuralJoin — TraceQL's structural (descendant/child/sibling) joins.
-//   - CrossJoin — the unconditional Cartesian product.
-//   - RangeWindow with a non-nil DeltaPrefixAggregateInput — the
-//     delta-prefix LEFT JOIN (internal/chsql/range_window.go) that
-//     side-feeds the day-bucket aggregate input into the raw window.
-func planHasJoin(plan chplan.Node) bool {
-	found := false
-	chplan.WalkDeep(plan, func(n chplan.Node) bool {
-		switch v := n.(type) {
-		case *chplan.VectorJoin:
-			found = true
-		case *chplan.HistogramVectorJoin:
-			found = true
-		case *chplan.HistogramFloatVectorJoin:
-			found = true
-		case *chplan.MixedVectorJoin:
-			found = true
-		case *chplan.InfoJoin:
-			found = true
-		case *chplan.StructuralJoin:
-			found = true
-		case *chplan.CrossJoin:
-			found = true
-		case *chplan.RangeWindow:
-			if v.DeltaPrefixAggregateInput != nil {
-				found = true
-			}
-		}
-		return !found
-	})
-	return found
 }

--- a/internal/routememo/key.go
+++ b/internal/routememo/key.go
@@ -243,41 +243,6 @@ func (w *keyWalker) walk(n chplan.Node) {
 			// cannot route a plan the solver rejects or slip a query past the
 			// bound. The blast radius of a wrong hit is a wasted route-B attempt
 			// that falls back to route A, never a wrong answer.
-		// VectorJoin, HistogramVectorJoin, HistogramFloatVectorJoin,
-		// MixedVectorJoin and CrossJoin are the step-aligned combinators
-		// PromQL lowers binary vector expressions and absent() into
-		// (internal/promql). Only VectorJoin is registered slice-invariant
-		// (internal/chplan/sliceinvariant.go), so only it can itself route
-		// B; the other four are permanently ineligible under
-		// Planner.classify's "(1) Slice-invariance: any unmarked node
-		// anywhere -> route A" gate and so are never memo-hit-routed. Their
-		// Key is still computed and Observed on every route-A resource
-		// failure regardless (deriveRouteMemoDispatch computes Key before
-		// checking Eligible, and retryOnRouteAResourceFailure's
-		// !d.eligible branch still Observes under it) — an unmarked
-		// HasJoin here would let a failure on one of these plans collide
-		// into, and pollute, an unrelated joinless plan's memo entry that
-		// happens to share every other Key field. StructuralJoin is
-		// TraceQL-only (internal/traceql/lower.go) and cannot reach this
-		// walker at all today: solver.Classify/Eligible gate on
-		// RequestMeta.Lang == LangPromQL (internal/solver/solver.go), so a
-		// TraceQL plan never produces the non-nil seedDecision every
-		// routememo.KeyFor call site in internal/engine requires. Marked
-		// here anyway — it costs nothing, and solver.go's own doc frames
-		// the PromQL-only gate as a foundation choice the other two heads
-		// deferred, not a permanent one.
-		case *chplan.VectorJoin:
-			w.hasJoin = true
-		case *chplan.HistogramVectorJoin:
-			w.hasJoin = true
-		case *chplan.HistogramFloatVectorJoin:
-			w.hasJoin = true
-		case *chplan.MixedVectorJoin:
-			w.hasJoin = true
-		case *chplan.CrossJoin:
-			w.hasJoin = true
-		case *chplan.StructuralJoin:
-			w.hasJoin = true
 		case *chplan.UnionAll:
 			w.hasUnion = true
 		case *chplan.SetOperation:
@@ -291,6 +256,36 @@ func (w *keyWalker) walk(n chplan.Node) {
 		}
 		return true
 	})
+	// HasJoin is a SEPARATE chplan.HasJoin(n) sweep (WalkDeep), not another
+	// arm of the shallow Walk switch above: a join can sit inside a
+	// ScalarSubquery's Expr slot (chplan.RangeWindow's DeltaPrefixAggregateInput
+	// is exactly this shape), which Walk's Children()-only traversal cannot
+	// see — see chplan.HasJoin's own doc. Widening the REST of this walker
+	// (rangeFuncs, aggFuncs, hasUnion, hasLimit, ...) to WalkDeep too would be
+	// a separate, wider behaviour change to the routing memo's fingerprint on
+	// every one of those axes, which this fix does not need to make.
+	//
+	// HasJoin is computed and folded into every Key regardless of whether the
+	// plan's own join kind is currently route-B-eligible. Only chplan.VectorJoin
+	// is registered slice-invariant (internal/chplan/sliceinvariant.go), so a
+	// HistogramVectorJoin/MixedVectorJoin/CrossJoin/InfoJoin plan — all PromQL,
+	// all reachable here — is permanently route-A-only under Planner.classify's
+	// slice-invariance gate; StructuralJoin/NestedSetAnnotate/MetricsCompare-
+	// with-RootLookup are TraceQL-only (internal/traceql/lower.go) and cannot
+	// reach this walker at all today, since solver.Classify/Eligible gates on
+	// RequestMeta.Lang == LangPromQL (internal/solver/solver.go) — a TraceQL
+	// plan never produces the non-nil seedDecision every routememo.KeyFor call
+	// site in internal/engine requires. Both groups still get an honest
+	// HasJoin: Key is computed and Observed on every route-A resource failure
+	// regardless of eligibility (deriveRouteMemoDispatch computes Key before
+	// checking Eligible, and retryOnRouteAResourceFailure's !d.eligible branch
+	// still Observes under it), so an unmarked HasJoin would let a failure on
+	// one of these plans collide into, and pollute, an unrelated joinless
+	// plan's memo entry that happens to share every other Key field. The
+	// TraceQL-only group costs nothing to include even while genuinely
+	// unreachable — solver.go's own doc frames the PromQL-only gate as a
+	// foundation choice the other two heads deferred, not a permanent one.
+	w.hasJoin = chplan.HasJoin(n)
 }
 
 // walkPredicate sweeps a Filter predicate expr tree for matcher-style

--- a/internal/routememo/key_test.go
+++ b/internal/routememo/key_test.go
@@ -102,10 +102,12 @@ func TestKeyForGridGeometryBucketsDiffer(t *testing.T) {
 // kind keyWalker.walk switches on beyond the RangeWindow-based fixtures
 // above — one per range-window sibling (RangeBucketFanout,
 // RangeBucketGridNative, RangeLWR, RangeWindowGridNative,
-// RangeWindowStaleResample) and one per combinator (VectorJoin,
-// HistogramVectorJoin, HistogramFloatVectorJoin, MixedVectorJoin, CrossJoin,
-// StructuralJoin, UnionAll, SetOperation, NaryVectorSetOp, Limit) — so a new
-// case arm added to walk is never silently unexercised again.
+// RangeWindowStaleResample) and one per non-join combinator (UnionAll,
+// SetOperation, NaryVectorSetOp, Limit) — so a new case arm added to walk is
+// never silently unexercised again. HasJoin is NOT covered here: it is a
+// separate chplan.HasJoin sweep, not a walk case arm (see keyWalker.walk's
+// own doc), and TestKeyForHasJoin below asserts it against the CANONICAL
+// join-carrier set rather than whatever this walker happens to switch on.
 func TestKeyForWalksEveryRangeAndCombinatorNodeKind(t *testing.T) {
 	const (
 		nAnchors = 241
@@ -155,30 +157,6 @@ func TestKeyForWalksEveryRangeAndCombinatorNodeKind(t *testing.T) {
 	})
 
 	t.Run("combinator node kinds set their own presence bit", func(t *testing.T) {
-		kJoin := KeyFor(&chplan.VectorJoin{Left: scan, Right: scan, Op: chplan.OpAdd}, nAnchors, fanout, step)
-		if !kJoin.HasJoin {
-			t.Fatalf("VectorJoin must set HasJoin")
-		}
-		kHistogramJoin := KeyFor(&chplan.HistogramVectorJoin{Left: scan, Right: scan}, nAnchors, fanout, step)
-		if !kHistogramJoin.HasJoin {
-			t.Fatalf("HistogramVectorJoin must set HasJoin")
-		}
-		kHistogramFloatJoin := KeyFor(&chplan.HistogramFloatVectorJoin{Left: scan, Right: scan}, nAnchors, fanout, step)
-		if !kHistogramFloatJoin.HasJoin {
-			t.Fatalf("HistogramFloatVectorJoin must set HasJoin")
-		}
-		kMixedJoin := KeyFor(&chplan.MixedVectorJoin{Left: scan, Right: scan}, nAnchors, fanout, step)
-		if !kMixedJoin.HasJoin {
-			t.Fatalf("MixedVectorJoin must set HasJoin")
-		}
-		kCrossJoin := KeyFor(&chplan.CrossJoin{Left: scan, Right: scan}, nAnchors, fanout, step)
-		if !kCrossJoin.HasJoin {
-			t.Fatalf("CrossJoin must set HasJoin")
-		}
-		kStructuralJoin := KeyFor(&chplan.StructuralJoin{Left: scan, Right: scan, Op: chplan.StructuralChild}, nAnchors, fanout, step)
-		if !kStructuralJoin.HasJoin {
-			t.Fatalf("StructuralJoin must set HasJoin")
-		}
 		kUnion := KeyFor(&chplan.UnionAll{Inputs: []chplan.Node{scan, scan}}, nAnchors, fanout, step)
 		if !kUnion.HasUnion {
 			t.Fatalf("UnionAll must set HasUnion")
@@ -194,6 +172,94 @@ func TestKeyForWalksEveryRangeAndCombinatorNodeKind(t *testing.T) {
 		kLimit := KeyFor(&chplan.Limit{Input: scan, Count: 10}, nAnchors, fanout, step)
 		if !kLimit.HasLimit {
 			t.Fatalf("Limit must set HasLimit")
+		}
+	})
+}
+
+// wantRouteMemoJoinCarrierCount pins the row count of
+// TestKeyForHasJoin_CoversEveryJoinCarrier's table. It exists so a table row
+// silently dropped fails loudly here rather than the test quietly shrinking
+// back to "whichever arms keyWalker.walk happens to have" — the exact defect
+// this test replaces (cerberus issue #2886/#3008: the walker's switch grew
+// case arms, but the test that was supposed to guard it only ever checked
+// the arms already present, so it could not have caught InfoJoin or the
+// delta-prefix RangeWindow carrier being missing either).
+//
+// chplan.HasJoin's OWN completeness — that this table names every
+// join-emitting Node kind and no more — is chplan's own job, pinned by
+// TestHasJoin_CoversEveryJoinEmittingNode in internal/chplan/join_test.go.
+// This test's job is narrower and KeyFor-specific: prove Key.HasJoin
+// actually forwards chplan.HasJoin's verdict, for the full known set,
+// including a join chplan.HasJoin can only see via WalkDeep.
+const wantRouteMemoJoinCarrierCount = 10
+
+// TestKeyForHasJoin_CoversEveryJoinCarrier asserts Key.HasJoin against the
+// CANONICAL join-carrier set (internal/chplan/join.go's HasJoin), not
+// against whatever case arms keyWalker.walk's OWN switch happens to have —
+// keyWalker.walk has no join arms at all any more; HasJoin is a dedicated
+// chplan.HasJoin(n) sweep (see its doc). A carrier this table does not name
+// is a gap this test cannot catch, but chplan's own
+// TestHasJoin_CoversEveryJoinEmittingNode is what keeps THAT table from
+// falling behind the IR — the two tests are deliberately not the same test.
+func TestKeyForHasJoin_CoversEveryJoinCarrier(t *testing.T) {
+	const (
+		nAnchors = 241
+		fanout   = int64(20)
+		step     = 15 * time.Second
+	)
+	scan := scanFixture()
+
+	cases := []struct {
+		name string
+		plan chplan.Node
+	}{
+		{"VectorJoin", &chplan.VectorJoin{Left: scan, Right: scan, Op: chplan.OpAdd}},
+		{"HistogramVectorJoin", &chplan.HistogramVectorJoin{Left: scan, Right: scan}},
+		{"HistogramFloatVectorJoin", &chplan.HistogramFloatVectorJoin{Left: scan, Right: scan}},
+		{"MixedVectorJoin", &chplan.MixedVectorJoin{Left: scan, Right: scan}},
+		{"InfoJoin", &chplan.InfoJoin{Input: scan, Info: scan}},
+		{"StructuralJoin", &chplan.StructuralJoin{Left: scan, Right: scan, Op: chplan.StructuralChild}},
+		{"CrossJoin", &chplan.CrossJoin{Left: scan, Right: scan}},
+		{"NestedSetAnnotate", &chplan.NestedSetAnnotate{Input: scan}},
+		{"MetricsCompare with RootLookup", &chplan.MetricsCompare{Inner: scan, RootLookup: scan}},
+		{
+			"RangeWindow with DeltaPrefixAggregateInput",
+			&chplan.RangeWindow{Input: scan, DeltaPrefixAggregateInput: scan, Func: "rate"},
+		},
+	}
+	if len(cases) != wantRouteMemoJoinCarrierCount {
+		t.Fatalf("join carrier table has %d rows, want %d", len(cases), wantRouteMemoJoinCarrierCount)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			k := KeyFor(tc.plan, nAnchors, fanout, step)
+			if !k.HasJoin {
+				t.Errorf("KeyFor(%s).HasJoin = false; want true", tc.name)
+			}
+		})
+	}
+
+	t.Run("non-join plan", func(t *testing.T) {
+		k := KeyFor(scan, nAnchors, fanout, step)
+		if k.HasJoin {
+			t.Errorf("KeyFor(bare Scan).HasJoin = true; want false")
+		}
+	})
+
+	// The WalkDeep-matters case: a join buried inside a Filter predicate's
+	// ScalarSubquery is invisible to keyWalker's own shallow chplan.Walk
+	// pass and must still be found. This is #2886/#3008's actual shipped
+	// gap — before this consolidation, keyWalker.walk's join arms lived
+	// INSIDE the chplan.Walk switch, so no number of added case arms could
+	// ever have found a join here.
+	t.Run("join nested inside a ScalarSubquery", func(t *testing.T) {
+		plan := &chplan.Filter{
+			Input:     scan,
+			Predicate: &chplan.ScalarSubquery{Input: &chplan.VectorJoin{Left: scan, Right: scan, Op: chplan.OpAdd}},
+		}
+		k := KeyFor(plan, nAnchors, fanout, step)
+		if !k.HasJoin {
+			t.Error("KeyFor: join nested inside a ScalarSubquery predicate not found; want HasJoin true")
 		}
 	})
 }

--- a/test/perf/smoke/sentinels.go
+++ b/test/perf/smoke/sentinels.go
@@ -179,13 +179,13 @@ var Sentinels = []Sentinel{
 	{
 		// Join spill, chopt-gated: applyJoinSpillSettings (spill.go) stamps
 		// max_bytes_before_external_join = cap/joinSpillCapDenominator on a
-		// plan planHasJoin matches, but ONLY once SettingsRules.JoinSpill is
+		// plan chplan.HasJoin matches, but ONLY once SettingsRules.JoinSpill is
 		// true — the boot-resolved chopt.FeatureJoinSpill verdict, false on
 		// every server below 26.4. Hence Floor: FloorJoinSpill.
 		//
 		// The query is a vector-vector binary op, which lowers to
 		// chplan.VectorJoin (test/spec/promql/binop_rate_div_rate_on.txtar
-		// pins that shape) — the first arm of planHasJoin's switch, and the
+		// pins that shape) — the first arm of chplan.HasJoin's switch, and the
 		// one carrying VectorJoin's own ManyToManyMatchMessage throwIf guard,
 		// which exists precisely because this shape can build an unbounded
 		// hash table. The two sides use DIFFERENT aggregation operators over

--- a/test/perf/smoke/sentinels_test.go
+++ b/test/perf/smoke/sentinels_test.go
@@ -80,7 +80,7 @@ func TestSentinels_JoinSpillStampIsAsserted(t *testing.T) {
 	query := s.Params(time.Unix(0, 0), time.Unix(0, 0).Add(sentinelWindow)).Get("query")
 	if !strings.Contains(query, " / on (session_id) ") {
 		t.Errorf("join_spill sentinel query %q is not a vector-vector match — it would not lower to "+
-			"chplan.VectorJoin, so planHasJoin would never match it and the stamp could not fire", query)
+			"chplan.VectorJoin, so chplan.HasJoin would never match it and the stamp could not fire", query)
 	}
 
 	const cap1GiB int64 = 1 << 30

--- a/test/perf/solver_decision_ratchet_test.go
+++ b/test/perf/solver_decision_ratchet_test.go
@@ -254,8 +254,9 @@ func nativeLowerers(t *testing.T) promql.RangeLowerers {
 			// strategy — no effect on which lowering table a query takes.
 			// FeatureJoinSpill mirrors the other two exactly: it stamps
 			// max_bytes_before_external_join via internal/engine/spill.go's
-			// applyJoinSpillSettings, gated on plan shape (planHasJoin), not on
-			// which RangeLowerers strategy a query_range matrix lowering picks.
+			// applyJoinSpillSettings, gated on plan shape (chplan.HasJoin), not
+			// on which RangeLowerers strategy a query_range matrix lowering
+			// picks.
 			// FeatureResultCache (cerberus issue #2781) is the same shape again:
 			// internal/engine/query_settings_rules.go's apply stamps
 			// use_query_cache=1 + query_cache_ttl based on


### PR DESCRIPTION
## Why

References #2886, milestone "M2: No knowingly-wrong answers on the default path". #2886 itself is
closed (a PR tonight added case arms to `routememo/key.go`'s join switch), but that PR did not
satisfy the milestone's actual exit criterion for the join-carrier item — quoted verbatim from the
milestone description:

> Exactly ONE audited join-carrier registry exists, seeded from internal/engine/spill.go's
> eight-carrier list — the only complete one, and the only one that knows about *chplan.RangeWindow
> with a non-nil DeltaPrefixAggregateInput — and is the sole enumeration consumed by
> routememo/key.go, engine/plan_shape_id.go and spill.go, ALL traversing with chplan.WalkDeep... The
> completeness ratchet keys on EMISSION BEHAVIOUR, not on a type name ending in 'Join'... routememo/
> key_test.go stops scoping itself to the arms the walker already has.

Before this change three independent, currently-divergent join enumerations existed: spill.go's
`planHasJoin` (8 carriers, `chplan.WalkDeep`), routememo's `keyWalker.walk` (6 carriers after
tonight's PR, shallow `chplan.Walk`), and `plan_shape_id.go`'s `shapeModifiers` (4 carriers, shallow
`chplan.Walk`). The shallow-`Walk` sites could never see a join nested inside a `ScalarSubquery`'s
Expr slot, no matter how many case arms were added.

## What changed

**`internal/chplan/join.go`** — new exported `chplan.HasJoin(node)`, the sole join-carrier
enumeration, swept with `chplan.WalkDeep`. Lives in `chplan` (not `engine` or `routememo`): both of
those already import `chplan`, `chplan` imports neither, and `.go-arch-lint.yml` already declares
that boundary — no cycle risk, verified with `go build ./...`.

**A full sweep of `internal/chsql` for every `QueryBuilder.Join` call site**, matched back to the
Node type whose emitter issues it, found two carriers **none of the three prior enumerations
(including spill.go's) knew about**, added here:

- `*chplan.NestedSetAnnotate` — TraceQL's structure-tab left/right/parent numbering.
  `internal/chsql/nested_set_annotate.go`'s `emitNestedSetAnnotate` unconditionally `LEFT JOIN`s its
  input against the recursive-CTE numbering subquery (and the numbering's own recursive step
  `INNER JOIN`s the CTE to itself) — every `NestedSetAnnotate` node is a join, no gating field to
  check.
- `*chplan.MetricsCompare` with a non-nil `RootLookup` — TraceQL `compare()`'s root-span lookup.
  `chplan.MetricsCompare`'s own doc names `TraceIDColumn` "join key for RootLookup";
  `internal/chsql/metrics_compare.go`'s `compareBaseQuery` (the single funnel every `MetricsCompare`
  emission path renders through) `LEFT JOIN`s `RootLookup` exactly when it is set — the same shape as
  `RangeWindow.DeltaPrefixAggregateInput` on a sibling IR struct.

The completeness ratchet (`TestHasJoin_CoversEveryJoinEmittingNode`,
`internal/chplan/join_test.go`) partitions **every** concrete `chplan.Node` type — derived by
scanning for the `planNode()` marker method via the same `sealedscan` machinery this package's other
exhaustiveness ratchets already use, never hand-counted — into `HasJoin`'s own switch arms (read out
of `join.go`'s source by `go/parser`, not retyped) and an explicit, per-entry-reasoned `nonJoinKinds`
roster. A Node type landing in neither list when a new one is added fails by name. The roster is
built BY EMISSION, not by name: it documents that `chplan.VectorSetOp`'s own doc calls PromQL
`and`/`unless` a "semi-join"/"anti-join", but its emitter lowers both to a `WHERE ... IN (subquery)`
predicate, never a JOIN clause — the exact name-vs-emission trap the milestone criterion calls out,
demonstrated on a real type rather than asserted in the abstract.

**Three call sites now delegate to `chplan.HasJoin`, no independent enumeration left:**

- `internal/engine/spill.go` — `applyJoinSpillSettings` calls `chplan.HasJoin` directly;
  `planHasJoin` is deleted (this file was the extraction source).
- `internal/engine/plan_shape_id.go` — `shapeModifiers`'s `join` log_comment modifier is now a
  **separate** `chplan.HasJoin(plan)` call, not folded into the function's existing shallow-`Walk`
  sweep. Widening the *rest* of that sweep (`rw`/`rwn`/`union`/`limit`/...) to `WalkDeep` too would
  change what every one of those other log_comment dimensions clusters on — a wider behaviour change
  the milestone criterion doesn't ask for.
- `internal/routememo/key.go` — `keyWalker.walk`'s six join case arms are removed; `HasJoin` is set
  by a second, separate `chplan.HasJoin(n)` sweep after the walker's own shallow `chplan.Walk` pass,
  for the identical scoping reason: the criterion only mandates `WalkDeep` for join detection, and
  widening the walker's other fields (`rangeFuncs`, `aggFuncs`, `hasUnion`, ...) to `WalkDeep` is a
  separate behaviour change to the routing memo's fingerprint on those axes, with its own blast
  radius this change doesn't take on.
- `internal/routememo/key_test.go` — the join assertions are pulled out of
  `TestKeyForWalksEveryRangeAndCombinatorNodeKind` (which was scoped to "the arms the walker already
  has" — self-referential, so it could never have caught `InfoJoin` or the delta-prefix `RangeWindow`
  carrier being missing) into a new `TestKeyForHasJoin_CoversEveryJoinCarrier`, asserting `Key.HasJoin`
  against the full canonical 10-carrier set (pinned by `wantRouteMemoJoinCarrierCount`), plus the
  `ScalarSubquery`-nested WalkDeep-matters proof.

## Non-vacuity proof

`TestHasJoin_ReachesJoinNestedInScalarSubquery` (`internal/chplan/join_test.go`) and
`TestKeyForHasJoin_CoversEveryJoinCarrier/join_nested_inside_a_ScalarSubquery`
(`internal/routememo/key_test.go`) both construct a `Filter` whose `Predicate` is a `ScalarSubquery`
wrapping a `VectorJoin`, assert the shallow `chplan.Walk` genuinely cannot see it (so the fixture
isn't accidentally trivial), and assert `chplan.HasJoin` / `KeyFor(...).HasJoin` do. This is the
concrete shape a shallow-`Walk` join detector — including the one `key.go` shipped tonight before
this PR — cannot fix no matter how many case arms it grows.

## Filed separately, verified but out of this PR's scope

Building the completeness ratchet surfaced that `*chplan.RangeWindow`'s join condition is itself
incomplete beyond what this PR extracts (`DeltaPrefixAggregateInput != nil`, verbatim from
spill.go): the **instant**-shape (`OuterRange == 0`) default fallback
(`internal/chsql/range_window.go`'s `instantDeltaPrefixSource`, gated only on
`hasTemporality && kind.isCounter()`, with **no** `DeltaPrefixAggregateInput` involved) also emits a
`CrossJoin`/`LeftJoin`, on every instant `rate()`/`increase()` query over an OTel counter that
reports `AggregationTemporality`. Filed as
[#3014](https://github.com/tsouza/cerberus/issues/3014) (milestone M2) rather than fixed here: it
needs a new IR-level signal mirroring chsql's own `needsDeltaFirstLevel` condition and its own
emission-level regression test — a different, larger unit of review than "delegate three sites to
one existing predicate."

## Testing

- `go build ./...`
- `go test -race ./internal/routememo/... ./internal/engine/... ./internal/chplan/... ./test/perf/...`
- `go vet -tags=agpl_oracle ./internal/...`
- `node .github/scripts/verify-code-citations.mjs`
- `markdownlint-cli2 docs/clickhouse-optimizations.md`
