### PR TITLE
fix(logql): make the dynamicLabels gate call its shared predicate, not restate it

### DIFF
--- a/internal/api/loki/limit_pushdown_chdb_test.go
+++ b/internal/api/loki/limit_pushdown_chdb_test.go
@@ -217,7 +217,7 @@ func TestLimitPushdown_SafeShapes_IdenticalToGoOnlyClamp_ChDB(t *testing.T) {
 // would silently return the wrong log lines.
 //
 // `| pattern` never changes labelsExpr in the lowering (it extracts
-// purely in Go — see internal/logql/lower.go's isDynamicLabelStage /
+// purely in Go — see internal/logql/lower.go's IsDynamicLabelStage /
 // lowerStage's OpParserTypePattern case), so for
 // `{app="x"} | pattern "<lvl> <_>" | __error__=""` the SQL Filter this
 // PR would wrap a naive Limit(OrderBy(...)) around carries ONLY

--- a/internal/api/loki/post_process.go
+++ b/internal/api/loki/post_process.go
@@ -55,17 +55,26 @@ func postProcessExtract(expr syntax.Expr) (lineTransform, error) {
 	}
 
 	var steps []lineTransform
-	// dynamicLabels mirrors internal/logql/lower.go's
-	// lowerPipelineWithLabels gate: once a `| pattern` stage runs, the
-	// lowering skips SQL predicate generation for any downstream
-	// LabelFilterExpr that tests the `__error__` / `__error_details__`
-	// family specifically (see that function's doc comment for why — the
-	// structured-metadata SQL fallback used for ordinary label names is
-	// actively wrong for these two magic keys). Such filters have to be
-	// applied here instead, once the dynamic stage's own step has
-	// actually computed them.
+	// dynamicLabels calls internal/logql.IsDynamicLabelStage — the SAME
+	// predicate lowerPipelineWithLabels' own dynamicLabels gate uses —
+	// rather than re-deciding "is this stage dynamic" from this file's own
+	// switch shape. Once a `| pattern` stage runs, the lowering skips SQL
+	// predicate generation for any downstream LabelFilterExpr that tests
+	// the `__error__` / `__error_details__` family specifically (see
+	// IsDynamicLabelStage's doc comment for why — the structured-metadata
+	// SQL fallback used for ordinary label names is actively wrong for
+	// these two magic keys). Such filters have to be applied here
+	// instead, once the dynamic stage's own step has actually computed
+	// them. Calling the shared predicate (rather than setting this flag
+	// inline in the LineParserExpr/OpParserTypePattern arm below, as a
+	// literal `true`) is what keeps this gate from silently diverging
+	// from lowerPipelineWithLabels' if IsDynamicLabelStage's own
+	// definition of "dynamic" ever changes or widens.
 	dynamicLabels := false
 	for _, st := range pipe.MultiStages {
+		if logql.IsDynamicLabelStage(st) {
+			dynamicLabels = true
+		}
 		switch v := st.(type) {
 		case *syntax.LineFmtExpr:
 			step, err := newLineFormatStep(v.Value)
@@ -91,7 +100,6 @@ func postProcessExtract(expr syntax.Expr) (lineTransform, error) {
 					return nil, err
 				}
 				steps = append(steps, step)
-				dynamicLabels = true
 			}
 		case *syntax.DropLabelsExpr, *syntax.KeepLabelsExpr:
 			// In a multi-case type switch v keeps the type-switch

--- a/internal/logql/gremlins_kill_2949_lower_test.go
+++ b/internal/logql/gremlins_kill_2949_lower_test.go
@@ -107,7 +107,7 @@ func TestPipelineLineExprSeedsFirstUnpackWithBodyColumn(t *testing.T) {
 // singles out.
 //
 // An `__error__` filter that follows a dynamic label stage (`| pattern`,
-// per [isDynamicLabelStage]) is deliberately NOT lowered into SQL —
+// per [IsDynamicLabelStage]) is deliberately NOT lowered into SQL —
 // internal/api/loki's newLabelFilterStep re-applies it in Go once the
 // stage's transform has computed the row's real `__error__` label.
 // Skipping it must not abandon the stages BEHIND it, which still lower

--- a/internal/logql/limit_pushdown_test.go
+++ b/internal/logql/limit_pushdown_test.go
@@ -75,7 +75,7 @@ func TestLogLineLimitPushdown_ShapeAndGating(t *testing.T) {
 		},
 
 		// The one unsafe shape: pattern's own extraction runs entirely in Go
-		// (see internal/logql/lower.go's isDynamicLabelStage — only `| pattern`
+		// (see internal/logql/lower.go's IsDynamicLabelStage — only `| pattern`
 		// sets dynamicLabels), so a downstream __error__/__error_details__
 		// filter is evaluated ONLY in Go
 		// (internal/api/loki/post_process.go's newLabelFilterStep) — the SQL

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -278,7 +278,7 @@ func maybePushLogLineLimit(expr syntax.Expr, plan chplan.Node, s schema.Logs, lc
 // This mirrors [lowerPipelineWithLabels]'s own dynamicLabels gate
 // stage-for-stage, built off the SAME two exported primitives both that
 // gate and postProcessExtract's own dynamicLabels gate use —
-// [isDynamicLabelStage] and [FiltersErrorLabel] — so all three call sites
+// [IsDynamicLabelStage] and [FiltersErrorLabel] — so all three call sites
 // derive from one shared answer to "does this pipeline shape need a
 // Go-side re-filter" rather than three that could drift apart. See
 // unpackParseDetailStep's doc comment in post_process.go for why a second
@@ -302,7 +302,7 @@ func pipelineCanDropRowsInGo(stages syntax.MultiStageExpr) bool {
 		if lf, ok := stage.(*syntax.LabelFilterExpr); ok && dynamicLabels && FiltersErrorLabel(lf.LabelFilterer) {
 			return true
 		}
-		if isDynamicLabelStage(stage) {
+		if IsDynamicLabelStage(stage) {
 			dynamicLabels = true
 		}
 	}
@@ -429,7 +429,7 @@ func lowerPipelineWithLabels(e *syntax.PipelineExpr, s schema.Logs, lc lowerCtx)
 		if newLabels != nil {
 			labelsExpr = newLabels
 		}
-		if isDynamicLabelStage(stage) {
+		if IsDynamicLabelStage(stage) {
 			dynamicLabels = true
 		}
 		// Post-fetch stages (`| line_format`, `| decolorize`) return a
@@ -450,12 +450,15 @@ func lowerPipelineWithLabels(e *syntax.PipelineExpr, s schema.Logs, lc lowerCtx)
 	return &chplan.Filter{Input: inner, Predicate: pred}, labelsExpr, nil
 }
 
-// isDynamicLabelStage reports whether stage is a `| pattern` parser
+// IsDynamicLabelStage reports whether stage is a `| pattern` parser
 // stage — see [lowerPipelineWithLabels]'s dynamicLabels gate. `| unpack`
 // is deliberately NOT one: its `__error__` markers come from SQL, so a
 // following `__error__` filter lowers normally and needs no Go-side
-// re-evaluation. internal/api/loki's pipelineSteps draws the same line.
-func isDynamicLabelStage(stage syntax.StageExpr) bool {
+// re-evaluation. Exported so internal/api/loki's postProcessExtract can
+// apply the exact same gate when deciding which stages need a Go-side
+// dynamicLabels re-evaluation (see post_process.go) — mirroring why
+// [FiltersErrorLabel] just below is exported for the same caller.
+func IsDynamicLabelStage(stage syntax.StageExpr) bool {
 	lp, ok := stage.(*syntax.LineParserExpr)
 	if !ok {
 		return false


### PR DESCRIPTION
An [ACPR](https://github.com/tsouza/cerberus/pull/3009#issuecomment) on #3009 (the Loki
LIMIT-pushdown safety classification, `pipelineCanDropRowsInGo`) found that its doc comment claimed
the SQL-side safety gate and `postProcessExtract`'s own `dynamicLabels` gate were "built off the SAME
two exported primitives" — `isDynamicLabelStage` and `FiltersErrorLabel`.

That was true for `FiltersErrorLabel` only. `isDynamicLabelStage` was unexported, so
`internal/api/loki` could not call it and didn't: `postProcessExtract` independently reimplemented
the identical `| pattern`-detection logic inline, setting `dynamicLabels = true` as a side effect of
building the pattern step deep inside a nested switch arm.

## Why this matters beyond the doc comment being wrong

The two copies agreed today — verified independently before this fix, not just trusted from the
ACPR. But nothing forced them to keep agreeing. If `postProcessExtract`'s inline copy were ever
changed (a new stage type, a widened definition of "dynamic") without a matching update to
`isDynamicLabelStage`, the SQL-side gate would keep classifying a now-different pipeline shape as
safe to push a LIMIT into, while the Go side could still drop rows post-decode. That's the exact
silently-wrong-answer class #3009 exists to prevent — an unguarded path back to it, not a hypothetical
one.

## The fix

Export `IsDynamicLabelStage` and call it directly from `postProcessExtract`'s loop, once per stage,
rather than only inside the Pattern arm's side effect. There is now one predicate, not two copies of
it — the divergence is structurally impossible rather than merely absent today.

## Scope

Comment-only + one boolean-source change. No behavior change: `IsDynamicLabelStage(st)` returns `true`
for exactly the same stage the old inline check did (a `*syntax.LineParserExpr` with
`Op == syntax.OpParserTypePattern`), and false for everything the old default-false path covered.
Verified: `go build ./...`, `go test -race ./internal/logql/... ./internal/api/loki/...` (all green),
`verify-code-citations.mjs` and `forbid-contradicted-mutants.mjs` clean.

No `Closes` keyword — this doesn't close a tracked issue, it fixes an ACPR finding on already-merged
work.
