### PR TITLE
fix(chplan): detect the instant rate()/increase() delta-prefix JOIN in HasJoin

### DIFF
--- a/internal/chplan/join.go
+++ b/internal/chplan/join.go
@@ -61,11 +61,21 @@ package chplan
 //   - RangeWindow with a non-nil DeltaPrefixAggregateInput — the
 //     delta-prefix LEFT JOIN (internal/chsql/range_window.go's
 //     deltaPrefixAggregateSource) that side-feeds the day-bucket aggregate
-//     input into the raw window. cerberus issue #3014 tracks a SEPARATE,
-//     narrower join this predicate does not yet cover: the instant-shape
-//     (OuterRange == 0) default fallback (instantDeltaPrefixSource) also
-//     emits a JOIN, on temporality-aware counters, with no
-//     DeltaPrefixAggregateInput involved at all.
+//     input into the raw window.
+//   - RangeWindow with OuterRange == 0 (instant shape), a populated
+//     TemporalityColumn, and a counter Func (rate / increase, per
+//     IsCounterRangeWindowFunc — not delta, which is a gauge delta) — the
+//     SEPARATE, narrower join cerberus issue #3014 found the predicate
+//     above did not cover: instant emitWindowedArrayExtrapolated's default
+//     fallback (instantDeltaPrefixSource, used whenever the
+//     DeltaPrefixAggregateInput-backed mechanism above is not ALSO opted
+//     into) LEFT/CROSS JOINs a per-series prefix-sum subquery back onto the
+//     window unconditionally on every such query — no DeltaPrefixAggregateInput
+//     needed to trigger it. Any RangeWindow already caught by the arm above
+//     (a non-nil DeltaPrefixAggregateInput) is also caught by this one when
+//     it is instant-shaped, but is reported redundantly-true either way, so
+//     the two arms are combined with OR rather than requiring
+//     DeltaPrefixAggregateInput == nil here.
 //
 // ClickHouse's ARRAY JOIN (RangeWindowStaleResample, RangeBucketGridNative,
 // RangeWindowGridNative, RangeWindowGridNativeVectorAgg, …) is deliberately
@@ -97,7 +107,8 @@ func HasJoin(node Node) bool {
 				found = true
 			}
 		case *RangeWindow:
-			if v.DeltaPrefixAggregateInput != nil {
+			if v.DeltaPrefixAggregateInput != nil ||
+				(v.OuterRange == 0 && v.TemporalityColumn != "" && IsCounterRangeWindowFunc(v.Func)) {
 				found = true
 			}
 		}

--- a/internal/chplan/join_test.go
+++ b/internal/chplan/join_test.go
@@ -5,6 +5,7 @@ import (
 	"go/parser"
 	"go/token"
 	"testing"
+	"time"
 )
 
 // synthetic fixtures. Every value here is invented for the test — no
@@ -44,6 +45,21 @@ func joinCarrierCases() []struct {
 				DeltaPrefixAggregateInput: &Scan{Table: "fixture_metrics_delta_prefix"},
 			},
 		},
+		{
+			// cerberus issue #3014: instant rate()/increase() over a
+			// temporality-projected counter, with NO DeltaPrefixAggregateInput
+			// at all — the default, no-backfill shape. Reaches
+			// instantDeltaPrefixSource's unconditional LEFT/CROSS JOIN
+			// (internal/chsql/range_window.go's emitWindowedArrayExtrapolated),
+			// which the row above's condition alone never sees.
+			"RangeWindow instant rate() over temporality-projected counter (instant delta-prefix JOIN, #3014)",
+			&RangeWindow{
+				Input:             joinScanFixture(),
+				Func:              "rate",
+				OuterRange:        0,
+				TemporalityColumn: "AggregationTemporality",
+			},
+		},
 	}
 }
 
@@ -52,7 +68,7 @@ func joinCarrierCases() []struct {
 // TestHasJoin_CoversEveryJoinEmittingNode catches independently by deriving
 // straight from join.go's source) still fails loudly rather than the table
 // quietly shrinking to whatever HasJoin currently does.
-const wantJoinCarrierCount = 10
+const wantJoinCarrierCount = 11
 
 // TestHasJoin_DetectsEveryJoinCarrier covers every join-bearing chplan node
 // HasJoin claims to find: each one alone is enough to trip the detector.
@@ -87,6 +103,40 @@ func TestHasJoin_NonJoinPlansUnaffected(t *testing.T) {
 		{"RangeWindow with no delta-prefix side feed", &RangeWindow{Input: joinScanFixture()}},
 		{"MetricsCompare with no RootLookup", &MetricsCompare{Inner: joinScanFixture()}},
 		{"VectorSetOp (semi/anti-join lowers to WHERE IN, never a SQL JOIN)", &VectorSetOp{Left: joinScanFixture(), Right: joinScanFixture()}},
+		{
+			// delta() is a gauge delta, not a counter — extrapolationKind's
+			// isCounter() (and IsCounterRangeWindowFunc) is false for it, so
+			// needsDeltaFirstLevel never goes true and instantDeltaPrefixSource
+			// never runs, regardless of TemporalityColumn.
+			"RangeWindow instant delta() over temporality-projected column (not a counter func)",
+			&RangeWindow{
+				Input:             joinScanFixture(),
+				Func:              "delta",
+				OuterRange:        0,
+				TemporalityColumn: "AggregationTemporality",
+			},
+		},
+		{
+			// No TemporalityColumn: windowTemporalityProjected(r) is false, so
+			// needsDeltaFirstLevel is false and instantDeltaPrefixSource never
+			// runs even for a counter Func.
+			"RangeWindow instant rate() with no TemporalityColumn",
+			&RangeWindow{Input: joinScanFixture(), Func: "rate", OuterRange: 0},
+		},
+		{
+			// Matrix shape (OuterRange > 0) with no DeltaPrefixAggregateInput:
+			// the matrix emitter's default fallback is deltaMatrixLevelSource, a
+			// window function over the fanned-out rows — genuinely join-free,
+			// unlike the instant shape's default fallback.
+			"RangeWindow matrix rate() over temporality-projected counter, no DeltaPrefixAggregateInput",
+			&RangeWindow{
+				Input:             joinScanFixture(),
+				Func:              "rate",
+				OuterRange:        10 * time.Minute,
+				Step:              time.Minute,
+				TemporalityColumn: "AggregationTemporality",
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/chplan/range_window_funcs.go
+++ b/internal/chplan/range_window_funcs.go
@@ -111,6 +111,36 @@ func IsPromQLRangeWindowFunc(name string) bool {
 	return rangeWindowFuncs[name].promQL
 }
 
+// counterRangeWindowFuncs is the vocabulary of [RangeWindow].Func values
+// that run through Prom's counter-reset-aware delta + clamp-to-zero
+// shortcut (`extrapolatedRate`'s `isCounter` branch) rather than a plain
+// gauge delta. This is the ONE definition of that classification.
+//
+// internal/chsql's emitter re-derives the identical fact per emit-time
+// call as `extrapolationKind.isCounter()`, keyed off the SAME three
+// names (rate → extrapolationKindRate, increase → extrapolationKindIncrease,
+// delta → extrapolationKindDelta) via extrapolatingKindForFunc — but that
+// type is unexported chsql machinery bound to per-call emitter state, not a
+// value chplan can read (and chsql already imports chplan, so the
+// dependency cannot run the other way). Rather than hand-duplicate the
+// classification as a second switch on these same three strings,
+// [IsCounterRangeWindowFunc] is the canonical, chsql-independent answer;
+// TestInstantCounterJoinAgreesWithHasJoin (internal/chsql) pins agreement
+// with the emitter's actual behaviour by asserting the SQL it renders for
+// each classification, rather than by comparing two switches in the
+// abstract.
+var counterRangeWindowFuncs = map[string]bool{
+	"rate":     true,
+	"increase": true,
+}
+
+// IsCounterRangeWindowFunc reports whether name is a [RangeWindow].Func
+// whose raw window value is Prom's counter-reset-aware delta (rate /
+// increase) rather than a plain gauge delta (delta and everything else).
+func IsCounterRangeWindowFunc(name string) bool {
+	return counterRangeWindowFuncs[name]
+}
+
 // RangeWindowFuncNames returns every [RangeWindow].Func in the
 // vocabulary, sorted. The SQL emitter's dispatch ratchet diffs its own
 // table against this, so a reducer added to one side and not the other

--- a/internal/chsql/range_window_instant_counter_join_test.go
+++ b/internal/chsql/range_window_instant_counter_join_test.go
@@ -1,0 +1,136 @@
+package chsql
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestInstantCounterJoinAgreesWithHasJoin pins cerberus issue #3014 at the
+// emission level: chplan.HasJoin's *RangeWindow arm must agree with
+// emitWindowedArrayExtrapolated's OWN needsDeltaFirstLevel branch — not
+// merely a plausible-looking proxy for it — for the instant shape
+// (OuterRange == 0) default fallback (instantDeltaPrefixSource, taken
+// whenever DeltaPrefixAggregateInput is nil or the operator has not opted
+// into WithDeltaPrefixReadEnabled).
+//
+// Each case asserts BOTH sides of the agreement against the SAME plan:
+// the SQL chsql.Emit actually renders (LEFT JOIN when the plan carries a
+// GroupBy key, CROSS JOIN when it does not — instantDeltaPrefixSource's own
+// branch), and chplan.HasJoin's verdict. A predicate that merely LOOKED
+// right (e.g. checked TemporalityColumn alone, without the counter-Func
+// gate, or fired for the matrix shape too) would diverge from one of these
+// rows exactly the way #3014 itself describes three OTHER things
+// diverging.
+func TestInstantCounterJoinAgreesWithHasJoin(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(10 * time.Minute)
+
+	newInstantRangeWindow := func(fn string, temporality, groupBy bool, outerRange time.Duration) *chplan.RangeWindow {
+		r := &chplan.RangeWindow{
+			Input:           &chplan.Scan{Table: "otel_metrics_sum"},
+			Func:            fn,
+			Range:           5 * time.Minute,
+			End:             end,
+			TimestampColumn: "TimeUnix",
+			ValueColumn:     "Value",
+		}
+		if temporality {
+			r.TemporalityColumn = "AggregationTemporality"
+		}
+		if groupBy {
+			r.GroupBy = []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}}
+		}
+		if outerRange > 0 {
+			r.OuterRange = outerRange
+			r.Step = time.Minute
+			r.Start = start
+		}
+		return r
+	}
+
+	cases := []struct {
+		name string
+		r    *chplan.RangeWindow
+		// wantJoinToken is "" when the emitted SQL must contain NO join at
+		// all; otherwise the exact SQL keyword instantDeltaPrefixSource's
+		// GroupBy-vs-no-GroupBy branch must render.
+		wantJoinToken string
+		wantHasJoin   bool
+	}{
+		{
+			name:          "instant rate() over temporality-projected counter, grouped: LEFT JOIN",
+			r:             newInstantRangeWindow("rate", true, true, 0),
+			wantJoinToken: "LEFT JOIN",
+			wantHasJoin:   true,
+		},
+		{
+			name:          "instant rate() over temporality-projected counter, ungrouped: CROSS JOIN",
+			r:             newInstantRangeWindow("rate", true, false, 0),
+			wantJoinToken: "CROSS JOIN",
+			wantHasJoin:   true,
+		},
+		{
+			name:          "instant increase() over temporality-projected counter, grouped: LEFT JOIN",
+			r:             newInstantRangeWindow("increase", true, true, 0),
+			wantJoinToken: "LEFT JOIN",
+			wantHasJoin:   true,
+		},
+		{
+			name:          "instant delta() over temporality-projected column: delta is not a counter, no JOIN",
+			r:             newInstantRangeWindow("delta", true, true, 0),
+			wantJoinToken: "",
+			wantHasJoin:   false,
+		},
+		{
+			name:          "instant rate() with no TemporalityColumn: no JOIN",
+			r:             newInstantRangeWindow("rate", false, true, 0),
+			wantJoinToken: "",
+			wantHasJoin:   false,
+		},
+		{
+			name: "matrix rate() (OuterRange > 0) over temporality-projected counter, no DeltaPrefixAggregateInput: " +
+				"deltaMatrixLevelSource is a window function, not a JOIN",
+			r:             newInstantRangeWindow("rate", true, true, 10*time.Minute),
+			wantJoinToken: "",
+			wantHasJoin:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, _, err := Emit(context.Background(), tc.r)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+
+			gotJoin := strings.Contains(sql, "LEFT JOIN") || strings.Contains(sql, "CROSS JOIN")
+			wantJoin := tc.wantJoinToken != ""
+			if gotJoin != wantJoin {
+				t.Errorf("emitted SQL join-presence = %v, want %v\nSQL: %s", gotJoin, wantJoin, sql)
+			}
+			if tc.wantJoinToken != "" && !strings.Contains(sql, tc.wantJoinToken) {
+				t.Errorf("emitted SQL missing %q\nSQL: %s", tc.wantJoinToken, sql)
+			}
+
+			if got := chplan.HasJoin(tc.r); got != tc.wantHasJoin {
+				t.Errorf("chplan.HasJoin = %v, want %v (disagrees with the emitted SQL's actual join-presence "+
+					"of %v — this IS the #3014 gap if it reopens)", got, tc.wantHasJoin, gotJoin)
+			}
+
+			// The two assertions above must never disagree with EACH OTHER
+			// either: HasJoin's whole job is predicting gotJoin.
+			if tc.wantHasJoin != wantJoin {
+				t.Fatalf("test bug: wantHasJoin (%v) and wantJoinToken-implied wantJoin (%v) disagree in the "+
+					"table itself", tc.wantHasJoin, wantJoin)
+			}
+		})
+	}
+}

--- a/internal/routememo/key_test.go
+++ b/internal/routememo/key_test.go
@@ -191,7 +191,7 @@ func TestKeyForWalksEveryRangeAndCombinatorNodeKind(t *testing.T) {
 // This test's job is narrower and KeyFor-specific: prove Key.HasJoin
 // actually forwards chplan.HasJoin's verdict, for the full known set,
 // including a join chplan.HasJoin can only see via WalkDeep.
-const wantRouteMemoJoinCarrierCount = 10
+const wantRouteMemoJoinCarrierCount = 11
 
 // TestKeyForHasJoin_CoversEveryJoinCarrier asserts Key.HasJoin against the
 // CANONICAL join-carrier set (internal/chplan/join.go's HasJoin), not
@@ -225,6 +225,14 @@ func TestKeyForHasJoin_CoversEveryJoinCarrier(t *testing.T) {
 		{
 			"RangeWindow with DeltaPrefixAggregateInput",
 			&chplan.RangeWindow{Input: scan, DeltaPrefixAggregateInput: scan, Func: "rate"},
+		},
+		{
+			// cerberus issue #3014: instant rate() over a temporality-projected
+			// counter with no DeltaPrefixAggregateInput — see
+			// internal/chplan/join_test.go's identical row for the emission
+			// evidence.
+			"RangeWindow instant rate() over temporality-projected counter (#3014)",
+			&chplan.RangeWindow{Input: scan, Func: "rate", TemporalityColumn: "AggregationTemporality"},
 		},
 	}
 	if len(cases) != wantRouteMemoJoinCarrierCount {


### PR DESCRIPTION
## Problem

`chplan.HasJoin`'s `*RangeWindow` arm (post-#3016 consolidation) only fired when
`DeltaPrefixAggregateInput != nil` — the condition for the MATRIX shape
(`OuterRange > 0`) delta-prefix JOIN. The INSTANT shape (`OuterRange == 0`) has a
second, unconditional JOIN the predicate never saw: `internal/chsql/range_window.go`'s
`emitWindowedArrayExtrapolated` (the instant emitter for `rate()`/`increase()`)
computes `needsDeltaFirstLevel := hasTemporality && kind.isCounter()` and, whenever
that's true and the operator has not separately backfilled/opted into the
`DeltaPrefixAggregateInput` mechanism (the default for every deployment), calls
`instantDeltaPrefixSource`, which LEFT/CROSS JOINs a per-series prefix-sum subquery
back onto the window — unconditionally, on every instant `rate()`/`increase()` query
over an OTel counter that reports `AggregationTemporality`.

This meant `applyJoinSpillSettings` never stamped `max_bytes_before_external_join`
for this shape (no memory-spill backstop on a real hash-table build),
`plan_shape_id.go`'s `join` log_comment modifier under-reported, and
`routememo/key.go`'s `HasJoin` field under-reported.

## Verification of the emission mechanism

Read `emitWindowedArrayExtrapolated`, `emitRangeWindowRate`/`emitRangeWindowIncrease`/
`emitRangeWindowDelta`, `windowTemporalityProjected`, `instantDeltaPrefixSource`, and
`extrapolationKind.isCounter()` directly, and traced `FixedAccumulatorExtrapolated`'s
gating (`fixedAccumulatorEligible` requires `OuterRange > 0`) to confirm it can never
divert an instant plan away from `emitWindowedArrayExtrapolated`. Confirmed
independently:

- `rate`/`increase` map to `extrapolationKindRate`/`extrapolationKindIncrease`
  (`isCounter() == true`); `delta` maps to `extrapolationKindDelta`
  (`isCounter() == false`).
- `irate`/`idelta` never reach `emitWindowedArrayExtrapolated` at all (their own
  emit functions), so they are correctly excluded from this predicate.
- The instant default fallback (`DeltaPrefixAggregateInput == nil`, or non-nil but
  `deltaPrefixReadEnabled == false`) always JOINs; the matrix default fallback
  (`deltaMatrixLevelSource`) is genuinely join-free (a window function), matching
  the issue's claim precisely.

## Fix

`chplan.HasJoin`'s `*RangeWindow` arm now also fires when
`OuterRange == 0 && TemporalityColumn != "" && IsCounterRangeWindowFunc(Func)`.

`IsCounterRangeWindowFunc` is a new exported function in
`internal/chplan/range_window_funcs.go` — the canonical, chsql-independent
classification (`rate`/`increase` → true, everything else → false), following the
existing `rangeWindowFuncs` vocabulary-table pattern in that same file. chsql already
imports chplan (not the other way around), so chsql's own
`extrapolationKind.isCounter()` could not be called from `chplan` without an import
cycle; rather than hand-duplicate the two-name classification as a second switch,
`chplan` now owns it as the single source of truth.

## Regression test

`internal/chsql/range_window_instant_counter_join_test.go` is the "prove it isn't
vacuous" test: for each of 6 cases it emits real SQL via `chsql.Emit` AND calls
`chplan.HasJoin` on the SAME plan, asserting both agree with the emitter's actual
branch — not a proxy for it:

- instant `rate()`/`increase()` over a temporality-projected counter, grouped →
  `LEFT JOIN` present, `HasJoin` true
- instant `rate()` over a temporality-projected counter, ungrouped → `CROSS JOIN`
  present, `HasJoin` true
- instant `delta()` over a temporality-projected column → no JOIN, `HasJoin` false
  (delta is not a counter)
- instant `rate()` with no `TemporalityColumn` → no JOIN, `HasJoin` false
- matrix `rate()` (`OuterRange > 0`) over a temporality-projected counter, no
  `DeltaPrefixAggregateInput` → no JOIN (`deltaMatrixLevelSource`'s window function),
  `HasJoin` false

`internal/chplan/join_test.go`'s `TestHasJoin_DetectsEveryJoinCarrier` also gained
the #3014 shape as an 11th carrier row (`wantJoinCarrierCount` bumped 10 → 11), plus
three new negative rows in `TestHasJoin_NonJoinPlansUnaffected` (delta, no
TemporalityColumn, matrix shape). Reverted the new `HasJoin` condition locally and
confirmed `TestHasJoin_DetectsEveryJoinCarrier` fails naming exactly the new row
(`HasJoin(...) = false; want true`), then restored the fix and confirmed green —
the mutation-style red/green proof.

## Downstream consumers

Confirmed by direct grep that all three named consumers call `chplan.HasJoin`
directly with no separate/stale narrower copy:

- `internal/engine/spill.go`'s `applyJoinSpillSettings` — `!chplan.HasJoin(plan)`
- `internal/engine/plan_shape_id.go` — `hasJoin := chplan.HasJoin(plan)`
- `internal/routememo/key.go` — `w.hasJoin = chplan.HasJoin(n)`

All three get the fix automatically. Also added the #3014 shape as an 11th row to
`internal/routememo/key_test.go`'s `TestKeyForHasJoin_CoversEveryJoinCarrier` (its
own canonical-carrier proof table, kept in step with `join_test.go`'s), proving
`KeyFor(...).HasJoin` forwards the corrected verdict end-to-end.

`applyJoinSpillSettings` itself was deliberately NOT given a new instant-rate-shaped
test case: its own test file's header comment states join-carrier detection is
`chplan.HasJoin`'s contract, pinned by `internal/chplan/join_test.go`, and
`applyJoinSpillSettings`'s test only needs to prove it GATES on that verdict
correctly (already covered generically with a synthetic `VectorJoin` fixture) — a
redundant instant-rate-specific case there would duplicate exactly what the chplan-
and chsql-level tests above already prove, against the repo's own stated test-layer
boundary. chDB is present in this environment, but a chDB-backed integration test
for this specific shape would re-derive the same "does HasJoin fire" fact the
chplan+chsql tests already pin at the emission-SQL-text level — the floor here is
also the strongest available proof.

## Scope

Touches only `internal/chplan/{join.go,join_test.go,range_window_funcs.go}`,
`internal/chsql/range_window_instant_counter_join_test.go` (new), and
`internal/routememo/key_test.go`. No other M2 issue's files touched.

Closes #3014
