### PR TITLE
refactor(tempo): add a canonical tag-scope enumeration and completeness ratchets

### DIFF
--- a/internal/api/tempo/scope_completeness_test.go
+++ b/internal/api/tempo/scope_completeness_test.go
@@ -1,0 +1,245 @@
+package tempo
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// This file is cerberus issue #3019's completeness ratchet for the
+// Tempo tag-scope enumeration: internal package tests (package tempo, not
+// tempo_test) because they reference allAttrMapScopes,
+// allCatalogCoveredTagScopes, and catalogScopeMode directly rather than
+// through the *ForTest re-exports in export_test.go. Each test below
+// checks one of the ~7 switches the issue found independently re-encoding
+// the same scope vocabulary against the canonical list it should have been
+// deriving from all along — see allAttrMapScopes' and
+// allCatalogCoveredTagScopes' own doc comments for the full picture, and
+// each function's doc for why it either got restructured (an explicit
+// case per scope, panicking on anything else) or was already
+// correct-by-construction and only needed a pinning test here.
+
+// TestAttrMapScope_StringCoversEveryScope pins attrMapScope.String() over
+// every canonical scope, plus the fallback shape for a value none of them
+// name — proving the fallback no longer silently answers "any" (a real,
+// meaningful value) for an unrecognised scope.
+func TestAttrMapScope_StringCoversEveryScope(t *testing.T) {
+	t.Parallel()
+	if len(allAttrMapScopes) != wantAttrMapScopeCount {
+		t.Fatalf("allAttrMapScopes has %d entries, want %d — update wantAttrMapScopeCount alongside "+
+			"any deliberate change to the scope set", len(allAttrMapScopes), wantAttrMapScopeCount)
+	}
+	want := map[attrMapScope]string{
+		attrMapScopeAny:             "any",
+		attrMapScopeResource:        "resource",
+		attrMapScopeSpan:            "span",
+		attrMapScopeEvent:           "event",
+		attrMapScopeLink:            "link",
+		attrMapScopeInstrumentation: "instrumentation",
+	}
+	for _, s := range allAttrMapScopes {
+		if got, want := s.String(), want[s]; got != want {
+			t.Errorf("attrMapScope(%d).String() = %q, want %q", int(s), got, want)
+		}
+	}
+
+	const unknownScope = attrMapScope(99)
+	if got := unknownScope.String(); got == "any" || !strings.Contains(got, "99") {
+		t.Errorf(`attrMapScope(99).String() = %q, want it to name the unhandled value (contain `+
+			`"99"), not silently answer "any" the way an unlabelled default used to`, got)
+	}
+}
+
+// TestResolveTagName_CoversEveryAttributeScope pins resolveTagName's
+// traceql.AttributeScope -> attrMapScope mapping over one URL form per
+// canonical attrMapScope, then cross-checks that the union of MapScope
+// values it exercises is exactly allAttrMapScopes — so a scope silently
+// left off both this table AND resolveTagName's switch (the "two
+// independently-incomplete things agree by omission" trap) still fails
+// here by name.
+func TestResolveTagName_CoversEveryAttributeScope(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelTraces()
+	s.ScopeAttributesColumn = "ScopeAttributes"
+
+	cases := []struct {
+		name    string
+		urlName string
+		want    attrMapScope
+	}{
+		{"resource-scoped", "resource.service.name", attrMapScopeResource},
+		{"span-scoped", "span.http.method", attrMapScopeSpan},
+		{"event-scoped", "event.exception.message", attrMapScopeEvent},
+		{"link-scoped", "link.opentracing.ref_type", attrMapScopeLink},
+		{"instrumentation-scoped", "instrumentation.name", attrMapScopeInstrumentation},
+		{"auto-scope leading-dot", ".service.name", attrMapScopeAny},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resolved, err := resolveTagName(tc.urlName, s)
+			if err != nil {
+				t.Fatalf("resolveTagName(%q): %v", tc.urlName, err)
+			}
+			if resolved.MapScope != tc.want {
+				t.Errorf("resolveTagName(%q).MapScope = %v, want %v", tc.urlName, resolved.MapScope, tc.want)
+			}
+		})
+	}
+
+	exercised := make(map[attrMapScope]bool, len(cases))
+	for _, tc := range cases {
+		exercised[tc.want] = true
+	}
+	for _, want := range allAttrMapScopes {
+		if !exercised[want] {
+			t.Errorf("allAttrMapScopes contains %v with no resolveTagName case above producing it — add a row", want)
+		}
+	}
+}
+
+// TestBuildAttributeValuesSQL_HandlesEveryScope pins that the final,
+// SQL-shape-deciding switch in buildAttributeValuesSQL (cerberus issue
+// #3019) explicitly handles every canonical attrMapScope — none of them
+// panics — and that a scope none of the six name panics loudly instead of
+// silently rendering the attrMapScopeAny SQL shape (what an unlabelled
+// `default:` used to do).
+func TestBuildAttributeValuesSQL_HandlesEveryScope(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelTraces()
+	s.ScopeAttributesColumn = "ScopeAttributes"
+
+	for _, scope := range allAttrMapScopes {
+		t.Run(scope.String(), func(t *testing.T) {
+			t.Parallel()
+			sqlStr, _ := buildAttributeValuesSQL(s, "some.key", scope, nil, time.Time{}, time.Time{})
+			if sqlStr == "" {
+				t.Errorf("buildAttributeValuesSQL(%v) produced empty SQL", scope)
+			}
+		})
+	}
+
+	t.Run("unrecognised scope panics rather than silently building attrMapScopeAny SQL", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected buildAttributeValuesSQL to panic for an unrecognised attrMapScope")
+			}
+		}()
+		buildAttributeValuesSQL(s, "some.key", attrMapScope(99), nil, time.Time{}, time.Time{})
+	})
+}
+
+// TestCatalogScopeForMapScope_CoversEveryScope is the completeness test for
+// the site cerberus issue #3019 proved non-exhaustive: it pins the exact
+// (scope, mode) catalogScopeForMapScope returns for every canonical
+// attrMapScope, and that an unrecognised one panics instead of falling
+// through the old unlabelled default (which used to silently mean
+// "treat as attrMapScopeAny").
+func TestCatalogScopeForMapScope_CoversEveryScope(t *testing.T) {
+	t.Parallel()
+	want := map[attrMapScope]struct {
+		scope string
+		mode  catalogScopeMode
+	}{
+		attrMapScopeResource:        {schema.TagCatalogScopeResource, catalogScopeSingle},
+		attrMapScopeSpan:            {schema.TagCatalogScopeSpan, catalogScopeSingle},
+		attrMapScopeEvent:           {schema.TagCatalogScopeEvent, catalogScopeSingle},
+		attrMapScopeLink:            {schema.TagCatalogScopeLink, catalogScopeSingle},
+		attrMapScopeAny:             {"", catalogScopeUnion},
+		attrMapScopeInstrumentation: {"", catalogScopeUncovered},
+	}
+	if len(want) != wantAttrMapScopeCount {
+		t.Fatalf("want table has %d entries, expected one per allAttrMapScopes entry (%d)",
+			len(want), wantAttrMapScopeCount)
+	}
+	for _, s := range allAttrMapScopes {
+		gotScope, gotMode := catalogScopeForMapScope(s)
+		wantEntry := want[s]
+		if gotScope != wantEntry.scope || gotMode != wantEntry.mode {
+			t.Errorf("catalogScopeForMapScope(%v) = (%q, %v), want (%q, %v)",
+				s, gotScope, gotMode, wantEntry.scope, wantEntry.mode)
+		}
+	}
+
+	t.Run("unrecognised scope panics", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected catalogScopeForMapScope to panic for an unrecognised attrMapScope")
+			}
+		}()
+		catalogScopeForMapScope(attrMapScope(99))
+	})
+}
+
+// TestCatalogScopesFor_CoversEveryCatalogScope pins catalogScopesFor over
+// every scope allCatalogCoveredTagScopes lists, plus "none" (the umbrella
+// that expands to all of them), and that a scope tagsCatalogEligible would
+// already have rejected panics here too, rather than this function's own
+// (now removed) unlabelled default silently treating it as "none".
+func TestCatalogScopesFor_CoversEveryCatalogScope(t *testing.T) {
+	t.Parallel()
+	want := map[string]string{
+		tagScopeResource: schema.TagCatalogScopeResource,
+		tagScopeSpan:     schema.TagCatalogScopeSpan,
+		tagScopeEvent:    schema.TagCatalogScopeEvent,
+		tagScopeLink:     schema.TagCatalogScopeLink,
+	}
+	if len(want) != len(allCatalogCoveredTagScopes) {
+		t.Fatalf("want table has %d entries, allCatalogCoveredTagScopes has %d",
+			len(want), len(allCatalogCoveredTagScopes))
+	}
+	for _, scope := range allCatalogCoveredTagScopes {
+		got := catalogScopesFor(scope)
+		if len(got) != 1 || got[0] != want[scope] {
+			t.Errorf("catalogScopesFor(%q) = %v, want [%q]", scope, got, want[scope])
+		}
+	}
+
+	gotNone := catalogScopesFor(tagScopeNone)
+	wantNone := []string{
+		schema.TagCatalogScopeResource, schema.TagCatalogScopeSpan,
+		schema.TagCatalogScopeEvent, schema.TagCatalogScopeLink,
+	}
+	if !slices.Equal(gotNone, wantNone) {
+		t.Errorf("catalogScopesFor(tagScopeNone) = %v, want %v", gotNone, wantNone)
+	}
+
+	t.Run("unrecognised scope panics", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected catalogScopesFor to panic for a scope tagsCatalogEligible would have rejected")
+			}
+		}()
+		catalogScopesFor("bogus")
+	})
+}
+
+// TestTagsCatalogEligible_CoversEveryCatalogScope pins tagsCatalogEligible
+// against the SAME canonical allCatalogCoveredTagScopes list
+// catalogScopesFor is checked against, so the two functions cannot drift
+// apart on which scopes the catalog covers without one of these tests
+// noticing. tagsCatalogEligible itself needed no restructuring — its
+// `default: return false` is unambiguous (false has exactly one meaning,
+// unlike a default that returns a real scope value) — this test only pins
+// the contract.
+func TestTagsCatalogEligible_CoversEveryCatalogScope(t *testing.T) {
+	t.Parallel()
+	for _, scope := range allCatalogCoveredTagScopes {
+		if !tagsCatalogEligible(scope, nil, true, false) {
+			t.Errorf("tagsCatalogEligible(%q, nil, windowless=true, scopeAttrsConfigured=false) = false, "+
+				"want true — every catalog-covered scope must be eligible under the base conditions", scope)
+		}
+	}
+	for _, scope := range []string{tagScopeInstrumentation, tagScopeIntrinsic, tagScopeTrace, "bogus"} {
+		if tagsCatalogEligible(scope, nil, true, false) {
+			t.Errorf("tagsCatalogEligible(%q, nil, windowless=true, scopeAttrsConfigured=false) = true, "+
+				"want false — this scope carries no catalog arm", scope)
+		}
+	}
+}

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -2,6 +2,7 @@ package tempo
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -336,6 +337,12 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 		selFrag   chsql.Frag
 		whereFrag chsql.Frag
 	)
+	// Exhaustive over every attrMapScope value by construction (cerberus
+	// issue #3019) — TestBuildAttributeValuesSQL_HandlesEveryScope pins
+	// this switch's case set against allAttrMapScopes, so a future
+	// attrMapScope value that reaches here without a decision fails loudly
+	// via the panic default below rather than silently rendering the
+	// attrMapScopeAny SQL shape (what an unlabelled `default:` used to do).
 	switch scope {
 	case attrMapScopeResource:
 		selFrag = chsql.As(mapAtFrag(s.ResourceAttributesColumn, name), "v")
@@ -350,9 +357,24 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 		// before calling this function at all.
 		selFrag = chsql.As(mapAtFrag(s.ScopeAttributesColumn, name), "v")
 		whereFrag = mapContainsFrag(s.ScopeAttributesColumn, name)
-	default: // attrMapScopeAny
+	case attrMapScopeAny:
 		selFrag = attrValueArrayJoinFrag(s.AttributesColumn, s.ResourceAttributesColumn, name)
 		whereFrag = mapContainsAnyFrag(s.AttributesColumn, s.ResourceAttributesColumn, name)
+	case attrMapScopeEvent, attrMapScopeLink:
+		// Unreachable in practice: the switch at the top of this function
+		// returns before falling through to here for both scopes. Named
+		// explicitly (rather than left to the panic default below) so a
+		// regression that removes or bypasses that early return fails
+		// loudly, naming the scope, instead of silently building this
+		// scope's SQL as attrMapScopeAny's — the exact "two switches
+		// compose correctly only by call-order coincidence" shape cerberus
+		// issue #3019 found in catalogScopeForMapScope, guarded against
+		// here too.
+		panic(fmt.Sprintf("cerberus: buildAttributeValuesSQL: attrMapScope %v reached the "+
+			"flat-Map switch — the Event/Link early return above should have intercepted it", scope))
+	default:
+		panic(fmt.Sprintf("cerberus: buildAttributeValuesSQL: unhandled attrMapScope %d — extend "+
+			"this switch in search_tag_values.go", int(scope)))
 	}
 	inner := chsql.NewQuery().
 		Select(selFrag).
@@ -634,8 +656,35 @@ const (
 	attrMapScopeInstrumentation
 )
 
+// allAttrMapScopes is the canonical enumeration of every attrMapScope value
+// that exists today — cerberus issue #3019's single source of truth. Every
+// switch in this package that dispatches on attrMapScope is checked against
+// it: TestAttrMapScope_StringCoversEveryScope,
+// TestResolveTagName_CoversEveryAttributeScope,
+// TestBuildAttributeValuesSQL_HandlesEveryScope (search_tag_values_test.go)
+// and TestCatalogScopeForMapScope_CoversEveryScope (tag_catalog_test.go).
+// wantAttrMapScopeCount pins its length the same way join_test.go's
+// wantJoinCarrierCount pins joinCarrierCases: a row silently dropped from
+// this slice would make every completeness test above vacuously pass over a
+// smaller set, so a deliberate edit to both is required to add or remove a
+// scope.
+var allAttrMapScopes = []attrMapScope{
+	attrMapScopeAny,
+	attrMapScopeResource,
+	attrMapScopeSpan,
+	attrMapScopeEvent,
+	attrMapScopeLink,
+	attrMapScopeInstrumentation,
+}
+
+// wantAttrMapScopeCount is allAttrMapScopes' expected length — see that
+// var's doc.
+const wantAttrMapScopeCount = 6
+
 func (s attrMapScope) String() string {
 	switch s {
+	case attrMapScopeAny:
+		return "any"
 	case attrMapScopeResource:
 		return "resource"
 	case attrMapScopeSpan:
@@ -647,7 +696,14 @@ func (s attrMapScope) String() string {
 	case attrMapScopeInstrumentation:
 		return "instrumentation"
 	default:
-		return "any"
+		// Unreachable for any of the six values allAttrMapScopes lists —
+		// TestAttrMapScope_StringCoversEveryScope pins that every one of
+		// them hits an explicit case above. A future attrMapScope value
+		// added without a case here must not silently borrow "any"'s
+		// string (itself a real, meaningful answer, not a safe filler);
+		// naming the numeric value instead makes the gap visible instead
+		// of plausible (cerberus issue #3019).
+		return fmt.Sprintf("attrMapScope(%d)", int(s))
 	}
 }
 

--- a/internal/api/tempo/search_tag_values_test.go
+++ b/internal/api/tempo/search_tag_values_test.go
@@ -536,9 +536,11 @@ func TestSearchTagValues_InstrumentationScope_DefaultSchema_ReturnsEmpty(t *test
 // request must stay off the catalog fast path even when every other
 // eligibility condition (catalog enabled, no `q=` filter, windowless)
 // holds — cerberus issue #3010's tagValuesCatalogEligible exclusion.
-// Without it, catalogScopeForMapScope's unmatched default arm would
-// silently mis-serve the request as an auto-scope resource+span catalog
-// read instead of falling through to the live per-key scan.
+// Belt AND suspenders since cerberus issue #3019: even without that
+// upstream exclusion, catalogScopeForMapScope now independently refuses
+// (catalogScopeUncovered) to let buildTagCatalogValuesSQL build SQL for
+// this scope at all, rather than the two of them composing correctly only
+// because of THIS test's caller order — see catalogScopeForMapScope's doc.
 func TestSearchTagValues_InstrumentationScope_NeverUsesCatalog(t *testing.T) {
 	t.Parallel()
 	s := schema.DefaultOTelTraces()

--- a/internal/api/tempo/tag_catalog.go
+++ b/internal/api/tempo/tag_catalog.go
@@ -2,6 +2,7 @@ package tempo
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -101,9 +102,14 @@ func tagsCatalogEligible(scope string, filter chsql.Frag, windowless, scopeAttrs
 // merely narrowed when the schema configures ScopeAttributesColumn, an
 // explicit instrumentation-scope tag-VALUES request has no partial-
 // coverage case to preserve; the catalog has nothing for it whether or
-// not the schema carries a column, so it must always fall through to
-// the live path catalogScopeForMapScope's default arm would otherwise
-// silently mis-serve as auto-scope resource+span).
+// not the schema carries a column). This exclusion is a cheap fast-fail
+// that skips the catalog attempt (and its SQL round trip) entirely; it is
+// no longer the SOLE guard against a wrong catalog read for this scope —
+// catalogScopeForMapScope (cerberus issue #3019) independently refuses to
+// build SQL for attrMapScopeInstrumentation too, so removing this
+// exclusion would cost a wasted round trip, not a wrong answer. Belt AND
+// suspenders, not a mask over a gap: see catalogScopeForMapScope's doc for
+// the full history.
 func tagValuesCatalogEligible(resolved resolvedTagName, filter chsql.Frag, windowless bool) bool {
 	if filter != nil || !windowless {
 		return false
@@ -114,11 +120,33 @@ func tagValuesCatalogEligible(resolved resolvedTagName, filter chsql.Frag, windo
 	return !resolved.IsIntrinsic
 }
 
+// allCatalogCoveredTagScopes is the canonical enumeration of every `?scope=`
+// query-param value (see the tagScope* constants in search_tags.go) the tag
+// catalog actually carries an arm for — cerberus issue #3019's counterpart
+// to allAttrMapScopes for this package's OTHER scope vocabulary (the
+// request-facing scope string, not the internal attrMapScope enum
+// buildAttributeValuesSQL dispatches on). "none" is deliberately not a
+// member: it is the umbrella that catalogScopesFor expands to every entry
+// here, not a catalog arm of its own. tagsCatalogEligible and
+// catalogScopesFor are both checked against it —
+// TestCatalogScopesFor_CoversEveryCatalogScope and
+// TestTagsCatalogEligible_CoversEveryCatalogScope in tag_catalog_test.go.
+var allCatalogCoveredTagScopes = []string{
+	tagScopeResource,
+	tagScopeSpan,
+	tagScopeEvent,
+	tagScopeLink,
+}
+
 // catalogScopesFor maps the `?scope=` query parameter to the catalog
 // Scope value(s) a /search/tags catalog read should fetch: every covered
 // bucket for "none" (the default / unscoped request), one bucket for an
 // explicit "resource", "span", "event", or "link". Only called after
-// tagsCatalogEligible has already rejected every other scope value.
+// tagsCatalogEligible has already rejected every other scope value, so the
+// panic default below is a real invariant, not a defensive nicety: it fires
+// only if that upstream guarantee is ever broken, naming the unexpected
+// scope instead of this function silently guessing "none" the way an
+// unlabelled `default:` used to (cerberus issue #3019).
 func catalogScopesFor(scope string) []string {
 	switch scope {
 	case tagScopeResource:
@@ -129,33 +157,80 @@ func catalogScopesFor(scope string) []string {
 		return []string{schema.TagCatalogScopeEvent}
 	case tagScopeLink:
 		return []string{schema.TagCatalogScopeLink}
-	default: // tagScopeNone
+	case tagScopeNone:
 		return []string{
 			schema.TagCatalogScopeResource, schema.TagCatalogScopeSpan,
 			schema.TagCatalogScopeEvent, schema.TagCatalogScopeLink,
 		}
+	default:
+		panic(fmt.Sprintf("cerberus: catalogScopesFor: unhandled scope %q — tagsCatalogEligible "+
+			"should have rejected it before this function was ever called; extend this switch in "+
+			"tag_catalog.go if a new catalog-covered scope was added", scope))
 	}
 }
 
+// catalogScopeMode is catalogScopeForMapScope's classification of how (or
+// whether) buildTagCatalogValuesSQL should filter the catalog's Scope
+// column for one attrMapScope value.
+type catalogScopeMode int
+
+const (
+	// catalogScopeSingle: filter to exactly the Scope value
+	// catalogScopeForMapScope also returns.
+	catalogScopeSingle catalogScopeMode = iota
+	// catalogScopeUnion: attrMapScopeAny — filter to
+	// `Scope IN ('resource', 'span')`. Auto-scope has only ever meant
+	// "resource or span" (see resolveTagName: event./link. require an
+	// explicit prefix), so an explicit IN-list is required rather than
+	// omitting the Scope filter — cerberus issue #2850 widened the catalog
+	// to also carry event/link rows, which an unfiltered read would then
+	// wrongly merge in.
+	catalogScopeUnion
+	// catalogScopeUncovered: the catalog carries NO arm for this
+	// attrMapScope at all (attrMapScopeInstrumentation —
+	// internal/schema/ddl's SCOPE COVERAGE doc). buildTagCatalogValuesSQL
+	// refuses to build SQL at all for this mode.
+	catalogScopeUncovered
+)
+
 // catalogScopeForMapScope maps a resolved tag-VALUES lookup's attrMapScope
-// to the single catalog Scope value to filter by, or ok=false for
-// attrMapScopeAny — the auto-scope form, which unions the resource AND
-// span buckets ONLY (never event/link — those require an explicit
-// event./link. prefix, see resolveTagName) via the explicit
-// TagCatalogScopeResource/Span IN-list buildTagCatalogValuesSQL applies
-// when ok is false.
-func catalogScopeForMapScope(ms attrMapScope) (string, bool) {
+// to how buildTagCatalogValuesSQL should filter the catalog's Scope column.
+// Exhaustive over allAttrMapScopes by construction (cerberus issue #3019;
+// TestCatalogScopeForMapScope_CoversEveryScope pins the case set against
+// that canonical list) — the panic default fires for an attrMapScope this
+// function does not recognise, rather than an unlabelled `default:` that
+// used to mean "treat as attrMapScopeAny" for BOTH the real Any case and
+// any value nobody had made a decision for yet.
+//
+// attrMapScopeInstrumentation reports catalogScopeUncovered: this function
+// is now the SOLE authority for that decision. buildTagCatalogValuesSQL
+// asks it and refuses the catalog read itself on catalogScopeUncovered,
+// rather than depending on tagValuesCatalogEligible having already excluded
+// the scope upstream. Before this change, two independently-incomplete
+// switches (this one's unlabelled default, and tagValuesCatalogEligible's
+// instrumentation check) composed correctly only because of THAT call
+// order — nothing enforced it, and catalogScopeForMapScope on its own would
+// have silently mis-served an instrumentation-scope request as
+// attrMapScopeAny's resource+span union had the caller ever changed. See
+// tagValuesCatalogEligible's own doc: it keeps its exclusion too, now as a
+// cheap fast-fail that skips the round trip, not as the only safeguard.
+func catalogScopeForMapScope(ms attrMapScope) (scope string, mode catalogScopeMode) {
 	switch ms {
 	case attrMapScopeResource:
-		return schema.TagCatalogScopeResource, true
+		return schema.TagCatalogScopeResource, catalogScopeSingle
 	case attrMapScopeSpan:
-		return schema.TagCatalogScopeSpan, true
+		return schema.TagCatalogScopeSpan, catalogScopeSingle
 	case attrMapScopeEvent:
-		return schema.TagCatalogScopeEvent, true
+		return schema.TagCatalogScopeEvent, catalogScopeSingle
 	case attrMapScopeLink:
-		return schema.TagCatalogScopeLink, true
+		return schema.TagCatalogScopeLink, catalogScopeSingle
+	case attrMapScopeAny:
+		return "", catalogScopeUnion
+	case attrMapScopeInstrumentation:
+		return "", catalogScopeUncovered
 	default:
-		return "", false
+		panic(fmt.Sprintf("cerberus: catalogScopeForMapScope: unhandled attrMapScope %d — extend "+
+			"the switch in tag_catalog.go", int(ms)))
 	}
 }
 
@@ -189,9 +264,14 @@ func (h *Handler) tagsFromCatalog(ctx context.Context, scope string) ([]TagScope
 // tagValuesFromCatalog attempts the catalog read for a resolved dynamic
 // attribute tag name (never called for an intrinsic — see
 // tagValuesCatalogEligible). ok=true only on a genuine hit — at least one
-// value came back.
+// value came back. Also false, before any query even runs, when
+// buildTagCatalogValuesSQL itself refuses the scope (catalogScopeUncovered
+// — see catalogScopeForMapScope's doc).
 func (h *Handler) tagValuesFromCatalog(ctx context.Context, resolved resolvedTagName) ([]string, bool) {
-	sqlStr, args := buildTagCatalogValuesSQL(resolved.Key, resolved.MapScope)
+	sqlStr, args, ok := buildTagCatalogValuesSQL(resolved.Key, resolved.MapScope)
+	if !ok {
+		return nil, false
+	}
 	values, err := h.Client.QueryStrings(ctx, sqlStr, args...)
 	if err != nil {
 		h.Logger.Debug("cerberus tempo tag-value catalog lookup failed; falling back to live scan",
@@ -233,31 +313,43 @@ func buildTagCatalogKeysSQL(scope string) (string, []any) {
 // the shape chclient.QueryStrings (a single-string-column scan) expects.
 //
 // A single-scope mapScope (resource./span./event./link. forms) adds an
-// exact Scope predicate; the auto-scope "any" form (catalogScopeForMapScope's
-// ok=false) adds an explicit `Scope IN ('resource', 'span')` predicate
-// instead of omitting the Scope filter — auto-scope has only ever meant
-// "resource or span" (see resolveTagName: event./link. require an
-// explicit prefix, so attr.Scope only resolves to attrMapScopeAny for a
+// exact Scope predicate (catalogScopeSingle); the auto-scope "any" form
+// (catalogScopeUnion) adds an explicit `Scope IN ('resource', 'span')`
+// predicate instead of omitting the Scope filter — auto-scope has only
+// ever meant "resource or span" (see resolveTagName: event./link. require
+// an explicit prefix, so attr.Scope only resolves to attrMapScopeAny for a
 // bare or dotted identifier), and since cerberus issue #2850 the catalog
 // ALSO carries event/link rows, so an unfiltered read here would widen
-// auto-scope's merge to include them too — a genuine behaviour change
-// the explicit IN prevents. The result is the catalog's analogue of
+// auto-scope's merge to include them too — a genuine behaviour change the
+// explicit IN prevents. The result is the catalog's analogue of
 // attrValueArrayJoinFrag's live-path union of SpanAttributes and
 // ResourceAttributes ONLY, pre-aggregated instead of per-row.
-func buildTagCatalogValuesSQL(key string, mapScope attrMapScope) (string, []any) {
+//
+// ok is false only for catalogScopeUncovered (attrMapScopeInstrumentation,
+// cerberus issue #3019) — the catalog has no arm to filter by, so no SQL
+// this function could build would be meaningful. The returned string/args
+// are the zero value in that case; the caller (tagValuesFromCatalog) must
+// not run them, and doesn't.
+func buildTagCatalogValuesSQL(key string, mapScope attrMapScope) (string, []any, bool) {
+	catScope, mode := catalogScopeForMapScope(mapScope)
+	if mode == catalogScopeUncovered {
+		return "", nil, false
+	}
 	sb := chsql.NewQuery().
 		Select(chsql.As(chsql.Call("arrayJoin", tagCatalogTopValuesMergeFrag(chsql.Col(schema.TagCatalogTopValuesStateColumn))), "value")).
 		From(chsql.Col(schema.TagCatalogTable)).
 		Where(chsql.Eq(chsql.Col(schema.TagCatalogKeyColumn), chsql.Lit(key)))
-	if catScope, ok := catalogScopeForMapScope(mapScope); ok {
+	switch mode {
+	case catalogScopeSingle:
 		sb.Where(chsql.Eq(chsql.Col(schema.TagCatalogScopeColumn), chsql.Lit(catScope)))
-	} else {
+	case catalogScopeUnion:
 		sb.Where(chsql.In(
 			chsql.Col(schema.TagCatalogScopeColumn),
 			chsql.Lit(schema.TagCatalogScopeResource), chsql.Lit(schema.TagCatalogScopeSpan),
 		))
 	}
-	return sb.Build()
+	sqlStr, args := sb.Build()
+	return sqlStr, args, true
 }
 
 // tagCatalogTopValuesMergeFrag renders `topKMerge(N)(<col>)` — CH's

--- a/internal/api/tempo/tag_catalog_test.go
+++ b/internal/api/tempo/tag_catalog_test.go
@@ -142,7 +142,10 @@ func TestBuildTagCatalogValuesSQL_SQLShape(t *testing.T) {
 
 	t.Run("single scope adds Scope predicate", func(t *testing.T) {
 		t.Parallel()
-		sqlStr, args := tempo.BuildTagCatalogValuesSQLForTest("http.method", tempo.AttrMapScopeSpanForTest)
+		sqlStr, args, ok := tempo.BuildTagCatalogValuesSQLForTest("http.method", tempo.AttrMapScopeSpanForTest)
+		if !ok {
+			t.Fatalf("expected ok=true for attrMapScopeSpan")
+		}
 		if !strings.Contains(sqlStr, "topKMerge(50)(`TopValuesState`)") {
 			t.Errorf("expected topKMerge(50)(...), got: %s", sqlStr)
 		}
@@ -161,7 +164,10 @@ func TestBuildTagCatalogValuesSQL_SQLShape(t *testing.T) {
 		// omit the Scope predicate — an unfiltered read would silently
 		// widen the merge to include event/link states too, which
 		// auto-scope has never meant (see resolveTagName).
-		sqlStr, args := tempo.BuildTagCatalogValuesSQLForTest("service.name", tempo.AttrMapScopeAnyForTest)
+		sqlStr, args, ok := tempo.BuildTagCatalogValuesSQLForTest("service.name", tempo.AttrMapScopeAnyForTest)
+		if !ok {
+			t.Fatalf("expected ok=true for attrMapScopeAny")
+		}
 		if strings.Contains(sqlStr, "`Scope` = ?") {
 			t.Errorf("auto-scope lookup must use an IN-list, not an equality predicate, got: %s", sqlStr)
 		}
@@ -175,7 +181,10 @@ func TestBuildTagCatalogValuesSQL_SQLShape(t *testing.T) {
 
 	t.Run("event scope adds Scope predicate", func(t *testing.T) {
 		t.Parallel()
-		sqlStr, args := tempo.BuildTagCatalogValuesSQLForTest("exception.type", tempo.AttrMapScopeEventForTest)
+		sqlStr, args, ok := tempo.BuildTagCatalogValuesSQLForTest("exception.type", tempo.AttrMapScopeEventForTest)
+		if !ok {
+			t.Fatalf("expected ok=true for attrMapScopeEvent")
+		}
 		if !strings.Contains(sqlStr, "`Scope` = ?") {
 			t.Errorf("expected a Scope predicate for a single-scope lookup, got: %s", sqlStr)
 		}
@@ -186,12 +195,28 @@ func TestBuildTagCatalogValuesSQL_SQLShape(t *testing.T) {
 
 	t.Run("link scope adds Scope predicate", func(t *testing.T) {
 		t.Parallel()
-		sqlStr, args := tempo.BuildTagCatalogValuesSQLForTest("opentracing.ref_type", tempo.AttrMapScopeLinkForTest)
+		sqlStr, args, ok := tempo.BuildTagCatalogValuesSQLForTest("opentracing.ref_type", tempo.AttrMapScopeLinkForTest)
+		if !ok {
+			t.Fatalf("expected ok=true for attrMapScopeLink")
+		}
 		if !strings.Contains(sqlStr, "`Scope` = ?") {
 			t.Errorf("expected a Scope predicate for a single-scope lookup, got: %s", sqlStr)
 		}
 		if len(args) != 2 || args[0] != "opentracing.ref_type" || args[1] != "link" {
 			t.Errorf("expected args=[key, scope], got %v", args)
+		}
+	})
+
+	t.Run("instrumentation scope refuses to build SQL at all", func(t *testing.T) {
+		t.Parallel()
+		// cerberus issue #3019: the catalog carries no instrumentation-scope
+		// arm, so buildTagCatalogValuesSQL now refuses this scope itself
+		// (catalogScopeForMapScope's catalogScopeUncovered) instead of
+		// depending on tagValuesCatalogEligible having already excluded it
+		// upstream — see catalogScopeForMapScope's doc for the full history.
+		sqlStr, args, ok := tempo.BuildTagCatalogValuesSQLForTest("service.name", tempo.AttrMapScopeInstrumentationForTest)
+		if ok {
+			t.Fatalf("expected ok=false for attrMapScopeInstrumentation, got sql=%q args=%v", sqlStr, args)
 		}
 	})
 }


### PR DESCRIPTION
## What

The Tempo tag-scope enumeration (resource/span/event/link/instrumentation) was independently
re-encoded across every switch in `internal/api/tempo` that dispatches on it, with no shared source
of truth and no completeness check tying them together — issue #3019.

## Canonical enumeration

`attrMapScope` (`internal/api/tempo/search_tag_values.go`) is a `const`-block `int` enum. Its
canonical list, `allAttrMapScopes` (6 values), lives right beside the type definition, pinned with a
`wantAttrMapScopeCount` row-count const (the same shape `join_test.go`'s `wantJoinCarrierCount` uses,
so a value silently dropped from the list can't make the completeness tests below vacuously pass over
a smaller set).

A second, related but distinct vocabulary — the `?scope=` request-facing string the tag catalog
covers (`resource`/`span`/`event`/`link`, `none` as the umbrella) — got its own canonical list,
`allCatalogCoveredTagScopes`, in `tag_catalog.go`.

## The ~7 sites, re-enumerated

| Site | Outcome |
|---|---|
| `resolveTagName`'s switch | Already correct-by-construction — pinned with a behavioural completeness test (one URL form per canonical scope, plus a check that the union of scopes it produces equals `allAttrMapScopes`). |
| `attrMapScope.String()` | **Fixed.** `default: return "any"` conflated "the real Any case" with "an unrecognised future value" — now `attrMapScopeAny` is an explicit case, and the default names the unhandled value instead of guessing. |
| `buildAttributeValuesSQL`'s 3 switches | The first two (event/link nested-routing guard, materialized-column fast path) are correct-by-construction — partial coverage by design, safe to fall through. The **third** (the actual SQL-shape decision) is now exhaustive over all 6 scopes explicitly, including a defensive panic arm for Event/Link (unreachable in practice, guards the same "two switches compose correctly only by call order" shape found in `catalogScopeForMapScope`) and a true panic default. |
| `catalogScopeForMapScope` | **The proven non-exhaustive site (#3010's root cause).** Fixed the coupling, not just documented it: it now returns a 3-way `catalogScopeMode` (`catalogScopeSingle` / `catalogScopeUnion` / `catalogScopeUncovered`), and `buildTagCatalogValuesSQL` refuses to build SQL at all on `catalogScopeUncovered` — so `attrMapScopeInstrumentation` is rejected by the function that owns the catalog-coverage decision, independent of `tagValuesCatalogEligible` having already excluded it upstream. |
| `catalogScopesFor` | Same shape as `catalogScopeForMapScope` — an unlabelled default silently meant "none". Fixed: explicit `tagScopeNone` case, panicking default. |
| `tagsCatalogEligible` | Already correct-by-construction — `default: return false` is unambiguous (false has exactly one meaning). No restructuring, only a pinning test against `allCatalogCoveredTagScopes`. |
| DDL's UNION-ALL scope-arm construction (`internal/schema/ddl`) | **Out of scope for this PR** — outside `internal/api/tempo`, and another agent had a concurrent worktree touching `internal/schema/ddl` tonight. Filed as #3021 (sub-issue of #3019), milestone M2. |

## Non-vacuity

Every completeness test was proven non-vacuous by temporarily removing the corresponding arm and
confirming the test goes red (then restoring):
- `String()`: dropping the Link case → `TestAttrMapScope_StringCoversEveryScope` fails, reporting `"attrMapScope(4)"` instead of `"link"`.
- `buildAttributeValuesSQL`'s final switch: dropping the Instrumentation case → `TestBuildAttributeValuesSQL_HandlesEveryScope` panics instead of silently building the Any-shaped SQL.
- `catalogScopeForMapScope`: dropping the Instrumentation case → `TestCatalogScopeForMapScope_CoversEveryScope` panics.
- `catalogScopesFor`: dropping the `tagScopeLink` case → `TestCatalogScopesFor_CoversEveryCatalogScope` panics.
- `resolveTagName`: breaking the Link arm to map to `attrMapScopeAny` → `TestResolveTagName_CoversEveryAttributeScope` fails, reporting `any` instead of `link`.
- `tagsCatalogEligible`: dropping `tagScopeLink` from the true-case list → `TestTagsCatalogEligible_CoversEveryCatalogScope` fails.

## Testing

- `go build ./...`
- `go test -race ./internal/api/tempo/...` — full existing suite, unchanged, passes.
- `go test -tags chdb -count=1 ./internal/api/tempo/...` — chDB-backed round-trip tests (including the instrumentation-scope and auto-scope tag-values fixtures) pass.
- `node .github/scripts/verify-code-citations.mjs`
- `node .github/scripts/forbid-sql-raw.mjs`
- `gofmt` / `gofumpt` / `goimports` clean.

Behavior is byte-identical for every currently-correct request shape: every panic arm added is
reachable only by an `attrMapScope`/scope-string value that cannot occur today (proven by the
non-vacuity tests above, which is how each gap was exercised at all).

## Filed

#3021 — schema/ddl: tie the tag-catalog UNION-ALL scope arms to the canonical catalog-scope
enumeration (sub-issue of #3019, milestone M2).

Closes #3019
