### PR TITLE
test(schema): CI-pin the stress-corpus tag-catalog perf claim

### DIFF
--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -1800,10 +1800,24 @@ func renderLokiLabelCatalogView(cfg Config) string {
 // for the large majority of rows, so the extra arms decode far fewer
 // bytes (66MB + 36MB) than the flat-Map arms do (799MB) even though CH's
 // read_rows accounting counts a full base-table scan for each arm. A
-// stress-test rerun with an unrealistically dense corpus (every span
-// carries 1-3 events AND 1-2 links) still stayed at 2.01x baseline
-// (1.78s), a small fraction of the 5-minute refresh period
-// (tempoTagCatalogRefreshMinutes) either way. That clears the same bar
+// stress-corpus sibling test
+// (TestTempoTagCatalog_EventsLinks_StressCorpusMeasuredCost, added for
+// cerberus issue #3018 so this claim is CI-pinned rather than prose) reruns
+// the SAME comparison against an unrealistically dense corpus (every span
+// carries 1-3 events AND 1-2 links, vs the 10%/3% realistic population
+// above) on the same 2,000,000-row corpus: 7,825,000 rows / 1.5GB / 3.03s
+// widened vs 3,912,500 rows / 782MB / 1.63s baseline (~1.9x). That test
+// deliberately does NOT pin the exact ratio or absolute figure — repeat
+// local runs of the identical query against the identical corpus size
+// measured anywhere from ~1.8s to ~3.3s widened, confirming wall-clock is
+// CI-runner-noisy rather than reproducible (the same reasoning
+// TestTempoTagCatalog_MeasuredCost's doc comment gives for logging instead
+// of asserting a ratio) — it instead asserts a generous absolute ceiling
+// (tempoTagCatalogStressWallClockCeilingFraction of the refresh period,
+// currently 30s), a regression backstop rather than a tight
+// reproducibility claim. Either way it stays a small fraction of the
+// 5-minute refresh period (tempoTagCatalogRefreshMinutes). That clears the
+// same bar
 // #2771's own doc comments use ("the refresh's own scan cost stays a
 // small fraction of the period even against a busy traces table" — see
 // tempoTagCatalogRefreshMinutes below) by a wide margin, so the "not

--- a/internal/schema/ddl/tempo_tag_catalog_events_links_perf_test.go
+++ b/internal/schema/ddl/tempo_tag_catalog_events_links_perf_test.go
@@ -67,22 +67,7 @@ func TestTempoTagCatalog_EventsLinks_MeasuredCost(t *testing.T) {
 	// forces the server to materialise the aggregate state without ever
 	// shipping it over the wire, so the SCAN cost being measured is
 	// identical to the real view's; only the client-decode step differs.
-	baselineSQL := fmt.Sprintf(`
-SELECT count() FROM (
-SELECT Scope, TagKey, topKState(50)(TagValue)
-FROM (
-  SELECT 'resource' AS Scope, k AS TagKey, v AS TagValue
-  FROM %[1]s.otel_traces
-  ARRAY JOIN mapKeys(ResourceAttributes) AS k, mapValues(ResourceAttributes) AS v
-  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
-  UNION ALL
-  SELECT 'span' AS Scope, k AS TagKey, v AS TagValue
-  FROM %[1]s.otel_traces
-  ARRAY JOIN mapKeys(SpanAttributes) AS k, mapValues(SpanAttributes) AS v
-  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
-)
-GROUP BY Scope, TagKey
-)`, db)
+	baselineSQL := tempoTagCatalogBaselineCostSQL(db)
 
 	eventArmSQL := fmt.Sprintf(`
 SELECT count() FROM (
@@ -106,7 +91,62 @@ WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
 GROUP BY Scope, TagKey
 )`, db)
 
-	widenedSQL := fmt.Sprintf(`
+	widenedSQL := tempoTagCatalogWidenedCostSQL(db)
+
+	baseline := runMeasuredStats(ctx, t, conn, baselineSQL)
+	eventOnly := runMeasuredStats(ctx, t, conn, eventArmSQL)
+	linkOnly := runMeasuredStats(ctx, t, conn, linkArmSQL)
+	widened := runMeasuredStats(ctx, t, conn, widenedSQL)
+
+	t.Logf("MEASURED (cerberus issue #2850, %d synthetic otel_traces rows, trailing 1h window):", rowCount)
+	t.Logf("  shipped baseline (resource UNION span):        %8d rows read (%10d bytes), %v wall-clock", baseline.rows, baseline.bytes, baseline.wall)
+	t.Logf("  event arm alone (nested Array(Map) fan-out):   %8d rows read (%10d bytes), %v wall-clock", eventOnly.rows, eventOnly.bytes, eventOnly.wall)
+	t.Logf("  link arm alone (nested Array(Map) fan-out):    %8d rows read (%10d bytes), %v wall-clock", linkOnly.rows, linkOnly.bytes, linkOnly.wall)
+	t.Logf("  widened (resource+span+event+link, all 4 arms):%8d rows read (%10d bytes), %v wall-clock", widened.rows, widened.bytes, widened.wall)
+	if baseline.wall > 0 {
+		t.Logf("  widened / baseline wall-clock ratio: %.2fx", float64(widened.wall)/float64(baseline.wall))
+	}
+	if baseline.rows > 0 {
+		t.Logf("  widened / baseline rows-read ratio:  %.2fx", float64(widened.rows)/float64(baseline.rows))
+	}
+	if eventOnly.wall > 0 && baseline.wall > 0 {
+		t.Logf("  event-arm-alone / baseline wall-clock ratio: %.2fx", float64(eventOnly.wall)/float64(baseline.wall))
+	}
+	if linkOnly.wall > 0 && baseline.wall > 0 {
+		t.Logf("  link-arm-alone / baseline wall-clock ratio:  %.2fx", float64(linkOnly.wall)/float64(baseline.wall))
+	}
+}
+
+// tempoTagCatalogBaselineCostSQL and tempoTagCatalogWidenedCostSQL render the
+// shipped-baseline (resource UNION span) and candidate-widened
+// (resource+span+event+link) cost-measurement queries shared by
+// TestTempoTagCatalog_EventsLinks_MeasuredCost and its stress-corpus sibling
+// TestTempoTagCatalog_EventsLinks_StressCorpusMeasuredCost — the query SHAPE
+// under test does not depend on corpus density, only the seeded data does,
+// so both tests measure the identical SQL against differently-seeded
+// otel_traces tables. See baselineSQL's inline comment (on the first caller)
+// for why each body is wrapped in `SELECT count() FROM (...)`.
+func tempoTagCatalogBaselineCostSQL(db string) string {
+	return fmt.Sprintf(`
+SELECT count() FROM (
+SELECT Scope, TagKey, topKState(50)(TagValue)
+FROM (
+  SELECT 'resource' AS Scope, k AS TagKey, v AS TagValue
+  FROM %[1]s.otel_traces
+  ARRAY JOIN mapKeys(ResourceAttributes) AS k, mapValues(ResourceAttributes) AS v
+  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+  UNION ALL
+  SELECT 'span' AS Scope, k AS TagKey, v AS TagValue
+  FROM %[1]s.otel_traces
+  ARRAY JOIN mapKeys(SpanAttributes) AS k, mapValues(SpanAttributes) AS v
+  WHERE Timestamp >= now() - toIntervalHour(1) AND v != ''
+)
+GROUP BY Scope, TagKey
+)`, db)
+}
+
+func tempoTagCatalogWidenedCostSQL(db string) string {
+	return fmt.Sprintf(`
 SELECT count() FROM (
 SELECT Scope, TagKey, topKState(50)(TagValue)
 FROM (
@@ -136,28 +176,94 @@ FROM (
 )
 GROUP BY Scope, TagKey
 )`, db)
+}
 
-	baseline := runMeasuredStats(ctx, t, conn, baselineSQL)
-	eventOnly := runMeasuredStats(ctx, t, conn, eventArmSQL)
-	linkOnly := runMeasuredStats(ctx, t, conn, linkArmSQL)
-	widened := runMeasuredStats(ctx, t, conn, widenedSQL)
+// tempoTagCatalogRefreshPeriodSeconds mirrors ddl.tempoTagCatalogRefreshMinutes
+// (unexported — this file is package ddl_test, which cannot see it) — the
+// REFRESH EVERY cadence the widened catalog view runs on. Duplicated here,
+// not imported, because the two packages cannot share unexported names; a
+// change to that cadence needs the matching edit here too (both names are
+// distinctive enough to find by search).
+const tempoTagCatalogRefreshPeriodSeconds = 5 * 60
 
-	t.Logf("MEASURED (cerberus issue #2850, %d synthetic otel_traces rows, trailing 1h window):", rowCount)
-	t.Logf("  shipped baseline (resource UNION span):        %8d rows read (%10d bytes), %v wall-clock", baseline.rows, baseline.bytes, baseline.wall)
-	t.Logf("  event arm alone (nested Array(Map) fan-out):   %8d rows read (%10d bytes), %v wall-clock", eventOnly.rows, eventOnly.bytes, eventOnly.wall)
-	t.Logf("  link arm alone (nested Array(Map) fan-out):    %8d rows read (%10d bytes), %v wall-clock", linkOnly.rows, linkOnly.bytes, linkOnly.wall)
-	t.Logf("  widened (resource+span+event+link, all 4 arms):%8d rows read (%10d bytes), %v wall-clock", widened.rows, widened.bytes, widened.wall)
+// tempoTagCatalogStressWallClockCeilingFraction bounds how much of the
+// refresh period (tempoTagCatalogRefreshPeriodSeconds) the widened
+// (resource+span+event+link) arm may spend against the STRESS corpus in
+// TestTempoTagCatalog_EventsLinks_StressCorpusMeasuredCost below — the same
+// "stays a small fraction of the period" bar ddl.go's
+// tempoTagCatalogRefreshMinutes doc comment sets. It is deliberately a
+// GENEROUS backstop rather than a tight reproducibility claim: wall-clock
+// time on shared CI hardware is inherently noisy (this package's sibling
+// TestTempoTagCatalog_MeasuredCost doc comment explains why its own
+// measurement logs rather than asserts a speedup ratio for the same
+// reason), so this bound exists to catch a genuine multi-x cost regression
+// long before it would threaten the refresh cadence itself, not to pin the
+// exact figure.
+const tempoTagCatalogStressWallClockCeilingFraction = 0.10
+
+// eventsPerSpanStress / linksPerSpanStress model the "unrealistically dense
+// corpus" ddl.go's doc comment stress-tests the widened catalog against:
+// EVERY span carries 1-3 events AND 1-2 links, far above any real fleet's
+// event/link prevalence (contrast eventsPerSpan/linksPerSpan's 10%/3% of
+// spans carrying any at all) — deliberately pathological, to bound the
+// widened arms' cost even under a corpus no real deployment would produce.
+func eventsPerSpanStress(rng *rand.Rand) int {
+	const minStressEventsPerSpan = 1
+	const maxStressEventsPerSpan = 3
+	return minStressEventsPerSpan + rng.Intn(maxStressEventsPerSpan-minStressEventsPerSpan+1)
+}
+
+func linksPerSpanStress(rng *rand.Rand) int {
+	const minStressLinksPerSpan = 1
+	const maxStressLinksPerSpan = 2
+	return minStressLinksPerSpan + rng.Intn(maxStressLinksPerSpan-minStressLinksPerSpan+1)
+}
+
+// TestTempoTagCatalog_EventsLinks_StressCorpusMeasuredCost is the
+// reproducible, CI-pinned form of the stress-corpus claim in ddl.go's
+// event/link tag-catalog doc comment (cerberus issue #3018): with EVERY
+// span carrying 1-3 events AND 1-2 links (eventsPerSpanStress /
+// linksPerSpanStress — an unrealistically dense corpus no real fleet would
+// produce), the widened (resource+span+event+link) catalog refresh still
+// stays a small, bounded fraction of the 5-minute refresh period.
+//
+// Like TestTempoTagCatalog_MeasuredCost and
+// TestTempoTagCatalog_EventsLinks_MeasuredCost, this does NOT assert a
+// tight wall-clock ratio against the baseline — that would be exactly the
+// flaky, CI-runner-noise-sensitive assertion this package's established
+// posture avoids (see TestTempoTagCatalog_MeasuredCost's doc comment). It
+// DOES assert a real, generous absolute ceiling
+// (tempoTagCatalogStressWallClockCeilingFraction of the refresh period) —
+// a regression backstop, not a tight reproducibility pin.
+func TestTempoTagCatalog_EventsLinks_StressCorpusMeasuredCost(t *testing.T) {
+	conn, db := startClickHouse(t)
+	ctx := context.Background()
+
+	cfg := ddl.Config{Database: db, TempoTagCatalogEnabled: true}
+	if err := ddl.ApplyWithConfig(ctx, conn, cfg, []ddl.Signal{ddl.Traces}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	const rowCount = 2_000_000
+	seedSyntheticTracesWithEventsLinksDensity(ctx, t, conn, db, rowCount, eventsPerSpanStress, linksPerSpanStress, "stress")
+
+	baseline := runMeasuredStats(ctx, t, conn, tempoTagCatalogBaselineCostSQL(db))
+	widened := runMeasuredStats(ctx, t, conn, tempoTagCatalogWidenedCostSQL(db))
+
+	t.Logf("STRESS MEASURED (cerberus issue #3018, %d synthetic otel_traces rows, EVERY span 1-3 events AND 1-2 links, trailing 1h window):", rowCount)
+	t.Logf("  shipped baseline (resource UNION span):         %8d rows read (%10d bytes), %v wall-clock", baseline.rows, baseline.bytes, baseline.wall)
+	t.Logf("  widened (resource+span+event+link, all 4 arms): %8d rows read (%10d bytes), %v wall-clock", widened.rows, widened.bytes, widened.wall)
 	if baseline.wall > 0 {
 		t.Logf("  widened / baseline wall-clock ratio: %.2fx", float64(widened.wall)/float64(baseline.wall))
 	}
 	if baseline.rows > 0 {
 		t.Logf("  widened / baseline rows-read ratio:  %.2fx", float64(widened.rows)/float64(baseline.rows))
 	}
-	if eventOnly.wall > 0 && baseline.wall > 0 {
-		t.Logf("  event-arm-alone / baseline wall-clock ratio: %.2fx", float64(eventOnly.wall)/float64(baseline.wall))
-	}
-	if linkOnly.wall > 0 && baseline.wall > 0 {
-		t.Logf("  link-arm-alone / baseline wall-clock ratio:  %.2fx", float64(linkOnly.wall)/float64(baseline.wall))
+
+	ceiling := time.Duration(float64(tempoTagCatalogRefreshPeriodSeconds)*tempoTagCatalogStressWallClockCeilingFraction) * time.Second
+	if widened.wall > ceiling {
+		t.Errorf("widened stress-corpus wall-clock %v exceeds the %v ceiling (%.0f%% of the %ds refresh period) — investigate a cost regression in the event/link catalog arms",
+			widened.wall, ceiling, tempoTagCatalogStressWallClockCeilingFraction*100, tempoTagCatalogRefreshPeriodSeconds)
 	}
 }
 
@@ -217,8 +323,24 @@ func linksPerSpan(rng *rand.Rand) int {
 // (tempo_tag_catalog_perf_test.go) with populated Events/Links Nested
 // columns on the SAME rows, so the resource/span baseline and the
 // event/link candidate arms are measured against the SAME corpus rather
-// than two differently-shaped tables.
+// than two differently-shaped tables. Uses the realistic
+// eventsPerSpan/linksPerSpan prevalence (10%/3% of spans) — see
+// seedSyntheticTracesWithEventsLinksDensity for the stress-corpus sibling.
 func seedSyntheticTracesWithEventsLinks(ctx context.Context, t *testing.T, conn driver.Conn, db string, n int) {
+	t.Helper()
+	seedSyntheticTracesWithEventsLinksDensity(ctx, t, conn, db, n, eventsPerSpan, linksPerSpan, "realistic")
+}
+
+// seedSyntheticTracesWithEventsLinksDensity is the shared seeding loop
+// behind seedSyntheticTracesWithEventsLinks and its stress-corpus sibling
+// (TestTempoTagCatalog_EventsLinks_StressCorpusMeasuredCost) — identical in
+// every respect except which eventsPerSpan/linksPerSpan-shaped PREVALENCE
+// function decides how many events/links a given span carries, so the two
+// corpora stay apples-to-apples on everything but density.
+func seedSyntheticTracesWithEventsLinksDensity(
+	ctx context.Context, t *testing.T, conn driver.Conn, db string, n int,
+	eventsPerSpanFn, linksPerSpanFn func(*rand.Rand) int, densityLabel string,
+) {
 	t.Helper()
 	const seedBatchSize = 50_000
 	rng := rand.New(rand.NewSource(2850))
@@ -249,7 +371,7 @@ func seedSyntheticTracesWithEventsLinks(ctx context.Context, t *testing.T, conn 
 				spanAttrs[k.name] = fmt.Sprintf("%s-%d", k.name, rng.Intn(k.cardinality))
 			}
 
-			nEvents := eventsPerSpan(rng)
+			nEvents := eventsPerSpanFn(rng)
 			evTs := make([]time.Time, nEvents)
 			evNames := make([]string, nEvents)
 			evAttrs := make([]map[string]string, nEvents)
@@ -263,7 +385,7 @@ func seedSyntheticTracesWithEventsLinks(ctx context.Context, t *testing.T, conn 
 				evAttrs[e] = m
 			}
 
-			nLinks := linksPerSpan(rng)
+			nLinks := linksPerSpanFn(rng)
 			lnTraceID := make([]string, nLinks)
 			lnSpanID := make([]string, nLinks)
 			lnTraceState := make([]string, nLinks)
@@ -292,7 +414,7 @@ func seedSyntheticTracesWithEventsLinks(ctx context.Context, t *testing.T, conn 
 		}
 		inserted += batchN
 	}
-	t.Logf("seeded %d synthetic otel_traces rows (with Events/Links)", inserted)
+	t.Logf("seeded %d %s-density synthetic otel_traces rows (with Events/Links)", inserted, densityLabel)
 }
 
 // runMeasuredStats runs sqlStr tagged with a fresh query_id, drains the


### PR DESCRIPTION
## What

Issue #3018: `internal/schema/ddl/ddl.go`'s doc comment for the event/link tag-catalog widening
(#2850) permanently asserted a specific, unreproducible stress-test figure ("2.01x baseline
(1.78s)") with no corresponding test anywhere in the repo.

## Fix chosen: Option A — made the claim real

Added `TestTempoTagCatalog_EventsLinks_StressCorpusMeasuredCost` to
`internal/schema/ddl/tempo_tag_catalog_events_links_perf_test.go`, seeding the SAME
"every span carries 1-3 events AND 1-2 links" dense corpus the comment describes, against a real
ClickHouse (testcontainers, matching the file's existing pattern exactly). Refactored the shared
seeding loop and cost-measurement SQL into density-parameterized / reusable helpers so the
realistic-corpus and stress-corpus tests share one source of truth instead of duplicating ~140
lines.

Measured on 2,000,000 synthetic `otel_traces` rows (real ClickHouse 25.9-alpine via
testcontainers), stress corpus (every span carries 1-3 events AND 1-2 links):

- baseline (resource UNION span): 3,912,500 rows read (782 MB), 1.63s wall-clock
- widened (resource+span+event+link): 7,825,000 rows read (1.5 GB), 3.03s wall-clock
- ratio: 1.86-1.96x wall-clock (varied across three separate local runs), 2.00x rows-read (exact
  every run — structural, not density-sensitive, since CH's read_rows accounting counts a full
  base-table scan per arm regardless of how populated the Nested columns are)

This differs from the old unbacked "2.01x baseline (1.78s)" claim — the ratio lands in the same
ballpark but the absolute wall-clock does not (1.63-3.3s measured here across repeated runs vs the
1.78s originally claimed). Three separate local runs of the identical query against the identical
corpus size produced three different absolute wall-clock numbers, which is itself direct evidence
that the absolute figure isn't reproducible run-to-run — exactly the risk the issue flagged.

Rather than assert a tight ratio against the baseline (which this package's own established
posture — see `TestTempoTagCatalog_MeasuredCost`'s doc comment — explicitly avoids as a flaky,
CI-runner-noise-sensitive assertion), the new test asserts a generous **absolute ceiling**:
widened wall-clock must stay under `tempoTagCatalogStressWallClockCeilingFraction` (10%) of the
5-minute refresh period (30s) — a regression backstop with a wide margin over the measured cost,
not a tight reproducibility pin. `ddl.go`'s comment now cites the actual measured figures and
points at the new test by name.

## Why Option A over Option B

Considered softening the comment to a qualitative-only claim instead (Option B). Measured first:
the stress-corpus query itself is cheap (1.6-3.3s against a 5-minute refresh budget) and the added
CI cost is bounded (~2 more minutes on the already-required `schema-ddl` gate, once, forever) —
small enough, and the regression-catching value real enough, to justify a permanent test. The part
that IS genuinely flaky (absolute wall-clock, demonstrated by three different numbers across three
runs) is handled the same way this file's own established posture already handles it elsewhere
(`TestTempoTagCatalog_MeasuredCost`'s doc comment) — log it, don't pin it tightly. What the new
test asserts instead is a generous absolute ceiling, `tempoTagCatalogStressWallClockCeilingFraction`
(10% of the 5-minute refresh period = 30s) — a 9-18x margin over every measured run, so it won't
flake on slower CI hardware, but it still catches a genuine multi-x regression (e.g. an accidental
Cartesian join in a future edit to the catalog arms) long before it threatens the refresh cadence.

Closes #3018
