### PR TITLE
refactor(schema): unify the tag-catalog scope enumeration DDL and tempo share

### DIFF
--- a/internal/api/tempo/tag_catalog.go
+++ b/internal/api/tempo/tag_catalog.go
@@ -131,12 +131,17 @@ func tagValuesCatalogEligible(resolved resolvedTagName, filter chsql.Frag, windo
 // catalogScopesFor are both checked against it —
 // TestCatalogScopesFor_CoversEveryCatalogScope and
 // TestTagsCatalogEligible_CoversEveryCatalogScope in tag_catalog_test.go.
-var allCatalogCoveredTagScopes = []string{
-	tagScopeResource,
-	tagScopeSpan,
-	tagScopeEvent,
-	tagScopeLink,
-}
+//
+// Aliases schema.TagCatalogCoveredScopes rather than re-listing
+// tagScopeResource/Span/Event/Link locally (cerberus issue #3021): before
+// this change, the same "resource/span/event/link, not instrumentation"
+// fact was independently re-encoded here AND as the fixed four-call
+// sequence internal/schema/ddl's renderTempoTagCatalogView used to build
+// its UNION ALL arms, with nothing tying an update to one back to the
+// other. tagScopeResource etc. already alias the underlying
+// schema.TagCatalogScope* constants (see search_tags.go), so this is the
+// same values, one fewer independent list.
+var allCatalogCoveredTagScopes = schema.TagCatalogCoveredScopes
 
 // catalogScopesFor maps the `?scope=` query parameter to the catalog
 // Scope value(s) a /search/tags catalog read should fetch: every covered

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -2048,27 +2048,55 @@ func tempoTagCatalogNestedScopeArm(cfg Config, scope, nestedCol string, windowSt
 		Where(chsql.Neq(chsql.Col("v"), chsql.InlineLit("")))
 }
 
+// tempoTagCatalogScopeArmFor dispatches one schema.TagCatalogCoveredScopes
+// entry to the arm-builder and source column renderTempoTagCatalogView's
+// UNION ALL uses for it: tempoTagCatalogScopeArm against the flat-Map
+// resource/span attribute columns, tempoTagCatalogNestedScopeArm against
+// the Nested event/link attribute families. Exhaustive over
+// schema.TagCatalogCoveredScopes by construction —
+// TestTempoTagCatalogScopeArmFor_CoversEveryCatalogScope pins it — so a
+// scope added there without a case here panics naming the value instead of
+// silently missing an arm from the rendered view (cerberus issue #3021,
+// following the panic-default pattern internal/api/tempo's own
+// catalogScopesFor established for cerberus issue #3019).
+func tempoTagCatalogScopeArmFor(cfg Config, scope string, windowStart chsql.Frag) *chsql.QueryBuilder {
+	switch scope {
+	case schema.TagCatalogScopeResource:
+		return tempoTagCatalogScopeArm(cfg, scope, metricResourceAttributesColumn, windowStart)
+	case schema.TagCatalogScopeSpan:
+		return tempoTagCatalogScopeArm(cfg, scope, tracesSpanAttributesColumn, windowStart)
+	case schema.TagCatalogScopeEvent:
+		return tempoTagCatalogNestedScopeArm(cfg, scope, tracesEventsColumn, windowStart)
+	case schema.TagCatalogScopeLink:
+		return tempoTagCatalogNestedScopeArm(cfg, scope, tracesLinksColumn, windowStart)
+	default:
+		panic(fmt.Sprintf("ddl: tempoTagCatalogScopeArmFor: unhandled tag-catalog scope %q", scope))
+	}
+}
+
 // renderTempoTagCatalogView renders the REFRESH-scheduled CREATE
 // MATERIALIZED VIEW feeding renderTempoTagCatalogTable from the traces
-// table: a UNION ALL of the resource-scope, span-scope (tempoTagCatalogScopeArm)
-// and event-scope, link-scope (tempoTagCatalogNestedScopeArm) arms,
-// re-aggregated into one topKState per (Scope, TagKey). Like
-// renderLokiLabelCatalogView this uses RefreshEveryMinutes rather than an
-// on-insert trigger, because the window bound must be re-evaluated at
-// EACH refresh to stay "the trailing N hours".
+// table: a UNION ALL of one arm per schema.TagCatalogCoveredScopes entry
+// (tempoTagCatalogScopeArmFor dispatches each to the resource-scope,
+// span-scope (tempoTagCatalogScopeArm) or event-scope, link-scope
+// (tempoTagCatalogNestedScopeArm) shape), re-aggregated into one
+// topKState per (Scope, TagKey). Like renderLokiLabelCatalogView this uses
+// RefreshEveryMinutes rather than an on-insert trigger, because the window
+// bound must be re-evaluated at EACH refresh to stay "the trailing N
+// hours".
 func renderTempoTagCatalogView(cfg Config) string {
 	windowStart := chsql.Sub(chsql.Call("now"), chsql.Call("toIntervalHour", chsql.InlineLit(int64(tempoTagCatalogWindowHours))))
-	resourceArm := tempoTagCatalogScopeArm(cfg, schema.TagCatalogScopeResource, metricResourceAttributesColumn, windowStart)
-	spanArm := tempoTagCatalogScopeArm(cfg, schema.TagCatalogScopeSpan, tracesSpanAttributesColumn, windowStart)
-	eventArm := tempoTagCatalogNestedScopeArm(cfg, schema.TagCatalogScopeEvent, tracesEventsColumn, windowStart)
-	linkArm := tempoTagCatalogNestedScopeArm(cfg, schema.TagCatalogScopeLink, tracesLinksColumn, windowStart)
+	arms := make([]chsql.Frag, len(schema.TagCatalogCoveredScopes))
+	for i, scope := range schema.TagCatalogCoveredScopes {
+		arms[i] = tempoTagCatalogScopeArmFor(cfg, scope, windowStart).Frag()
+	}
 	body := chsql.NewQuery().
 		Select(
 			chsql.Col(schema.TagCatalogScopeColumn),
 			chsql.Col(schema.TagCatalogKeyColumn),
 			chsql.As(tempoTagCatalogTopValuesStateFrag(chsql.Col(tempoTagValueColumn)), schema.TagCatalogTopValuesStateColumn),
 		).
-		From(chsql.Paren(chsql.UnionAll(resourceArm.Frag(), spanArm.Frag(), eventArm.Frag(), linkArm.Frag()))).
+		From(chsql.Paren(chsql.UnionAll(arms...))).
 		GroupBy(chsql.Col(schema.TagCatalogScopeColumn), chsql.Col(schema.TagCatalogKeyColumn))
 	stmt := chsql.CreateMaterializedView(schema.TagCatalogTable+schema.TagCatalogViewSuffix).
 		Database(cfg.Database).

--- a/internal/schema/ddl/tempo_tag_catalog_test.go
+++ b/internal/schema/ddl/tempo_tag_catalog_test.go
@@ -3,7 +3,61 @@ package ddl
 import (
 	"strings"
 	"testing"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
 )
+
+// TestTempoTagCatalogScopeArmFor_CoversEveryCatalogScope proves
+// tempoTagCatalogScopeArmFor's switch is exhaustive over
+// schema.TagCatalogCoveredScopes — the canonical list
+// renderTempoTagCatalogView now ranges over to build its UNION ALL arms
+// (cerberus issue #3021, closing the DRY gap #3019 left open on the write
+// side). A scope reaching the switch without a case panics (see that
+// function's doc); this test converts that panic into a named test
+// failure for every entry the canonical list carries today, so removing a
+// case here without also removing the scope from
+// schema.TagCatalogCoveredScopes fails loudly in CI instead of only
+// panicking against a live cluster.
+func TestTempoTagCatalogScopeArmFor_CoversEveryCatalogScope(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	windowStart := chsql.InlineLit(int64(0))
+	for _, scope := range schema.TagCatalogCoveredScopes {
+		t.Run(scope, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("tempoTagCatalogScopeArmFor(%q) panicked: %v", scope, r)
+				}
+			}()
+			if arm := tempoTagCatalogScopeArmFor(cfg, scope, windowStart); arm == nil {
+				t.Fatalf("tempoTagCatalogScopeArmFor(%q) returned a nil arm", scope)
+			}
+		})
+	}
+}
+
+// TestTempoTagCatalogScopeArmFor_UnhandledScopePanics is this file's
+// non-vacuity proof for the completeness test above: an unhandled scope
+// value (one schema.TagCatalogCoveredScopes does not carry) panics naming
+// that value. That panic is exactly the mechanism that would turn a
+// future scope added to schema.TagCatalogCoveredScopes without a matching
+// case in tempoTagCatalogScopeArmFor into a loud CoversEveryCatalogScope
+// failure instead of a silently missing UNION ALL arm.
+func TestTempoTagCatalogScopeArmFor_UnhandledScopePanics(t *testing.T) {
+	cfg := Config{}.withDefaults()
+	windowStart := chsql.InlineLit(int64(0))
+	const unhandledScope = "instrumentation"
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("tempoTagCatalogScopeArmFor(%q) did not panic", unhandledScope)
+		}
+		if msg, ok := r.(string); !ok || !strings.Contains(msg, unhandledScope) {
+			t.Fatalf("panic = %v; want it to name the unhandled scope %q", r, unhandledScope)
+		}
+	}()
+	tempoTagCatalogScopeArmFor(cfg, unhandledScope, windowStart)
+}
 
 // TestRenderTempoTagCatalogTable_ExactSQL pins the catalog table's shape
 // (cerberus issue #2771): String Scope + TagKey ORDER BY (Scope, TagKey)

--- a/internal/schema/traces.go
+++ b/internal/schema/traces.go
@@ -54,6 +54,32 @@ const (
 	TagCatalogViewSuffix = "_mv"
 )
 
+// TagCatalogCoveredScopes is the canonical enumeration of every scope the
+// tag catalog carries an arm for, in the order internal/schema/ddl's
+// renderTempoTagCatalogView UNIONs them — resource and span first (the
+// flat-Map scopes), then event and link (the Nested scopes). It is the
+// single source both internal/api/tempo (allCatalogCoveredTagScopes, the
+// `?scope=` vocabulary the catalog fast path accepts) and
+// internal/schema/ddl (renderTempoTagCatalogView, the write side that
+// builds the UNION ALL arms) derive from — cerberus issue #3021 closing
+// the DRY gap #3019 left open on the write side: before this, the fact
+// "the catalog covers resource/span/event/link, not instrumentation" was
+// independently re-encoded in both packages, with no test tying an update
+// to one back to the other. schema is the natural home because both
+// packages already import it and both already reference the individual
+// TagCatalogScope* constants this slices together — see those constants'
+// doc comment for why they live here rather than in internal/api/tempo.
+// A var, not a const, because Go has no const slice — like
+// internal/api/tempo's own allAttrMapScopes / allCatalogCoveredTagScopes
+// before this change, package-level mutation is a self-inflicted footgun
+// no code here indulges in.
+var TagCatalogCoveredScopes = []string{
+	TagCatalogScopeResource,
+	TagCatalogScopeSpan,
+	TagCatalogScopeEvent,
+	TagCatalogScopeLink,
+}
+
 // Traces describes how cerberus reads spans from ClickHouse. The default
 // (returned by DefaultOTelTraces) matches the OpenTelemetry ClickHouse
 // Exporter v0.x traces schema; users with custom layouts override


### PR DESCRIPTION
## What

cerberus issue #3021 is the one site #3019 explicitly left untouched: `internal/schema/ddl.go`'s
`renderTempoTagCatalogView`, which hand-built the tag-catalog's four UNION ALL scope arms
(resource/span/event/link) as a fixed sequence of calls — an independent re-encoding of the same
"the catalog covers resource/span/event/link, not instrumentation" fact `internal/api/tempo`'s
`allCatalogCoveredTagScopes` (from #3022, now on `main`) already names as one canonical list.

## Investigation

`internal/schema/ddl` cannot import `internal/api/tempo`: `.go-arch-lint.yml`'s `schema-ddl` layer
`mayDependOn` lists only `chsql`, and `internal/schema.TagCatalogScopeResource`'s own doc comment
already states the reason explicitly — the DDL package renders these literals into the view body and
cannot import `internal/api/tempo` without an import cycle (`internal/api/tempo` imports
`internal/schema/ddl` indirectly via the engine wiring, not the reverse). `internal/api/tempo`'s
`allCatalogCoveredTagScopes` from #3022 was already `[]string{tagScopeResource, tagScopeSpan,
tagScopeEvent, tagScopeLink}`, and those `tagScope*` constants already alias
`schema.TagCatalogScope*` (see `search_tags.go`). So the canonical list belonged in `internal/schema`
from the start — both packages already import it and already reference the individual
`TagCatalogScope*` constants it slices together.

## Chosen: Option A (single canonical list, both sides derive from it)

Option A turned out to require no import-direction fight and no new independent enumeration:

- `schema.TagCatalogCoveredScopes` (`internal/schema/traces.go`) is the new canonical
  `[]string{TagCatalogScopeResource, TagCatalogScopeSpan, TagCatalogScopeEvent, TagCatalogScopeLink}`,
  in the same order `renderTempoTagCatalogView` UNIONs them.
- `internal/api/tempo`'s `allCatalogCoveredTagScopes` is now `= schema.TagCatalogCoveredScopes`
  instead of re-listing the same four values.
- `internal/schema/ddl`'s `renderTempoTagCatalogView` now ranges over
  `schema.TagCatalogCoveredScopes`, dispatching each scope to the right arm-builder + source column
  via a new `tempoTagCatalogScopeArmFor` switch (`tempoTagCatalogScopeArm` for the flat-Map
  resource/span scopes, `tempoTagCatalogNestedScopeArm` for the Nested event/link scopes) instead of
  four separate local variables. An unhandled scope panics naming the value — the same panic-default
  discipline #3019 established on the read side — so this is real structural coupling, not just a
  drift *detector*: a scope removed from the switch without being removed from
  `schema.TagCatalogCoveredScopes` fails immediately (see non-vacuity below), and a scope added to
  the canonical list without a matching case fails the same way instead of silently rendering a view
  missing that arm.

This collapses three independent re-encodings of "resource/span/event/link" (tempo's list, ddl's
four-call sequence, and the implicit membership of `schema.TagCatalogScope*`) into one: the single
`schema.TagCatalogCoveredScopes` list, referenced by name everywhere else.

Per-scope arm metadata (which column, flat-Map vs Nested) is NOT a second scope enumeration — it's
DDL-specific rendering detail (`metricResourceAttributesColumn`, `tracesSpanAttributesColumn`, …)
that only `internal/schema/ddl` has any business knowing, so it stays local to the dispatch switch
rather than being hoisted into `schema` alongside the scope list itself.

## Non-vacuity

Temporarily removed the `schema.TagCatalogScopeLink` case from `tempoTagCatalogScopeArmFor`'s
switch and reran the tests: `TestTempoTagCatalogScopeArmFor_CoversEveryCatalogScope/link` failed
naming the missing scope, and the pre-existing `TestRenderTempoTagCatalogView_ExactSQL` panicked for
the same reason — both catch a missing case immediately. Restored the case, confirmed both tests pass
again. `TestTempoTagCatalogScopeArmFor_UnhandledScopePanics` pins the panic mechanism itself so it
can't silently stop firing.

## Byte-identical output confirmed

The pre-existing `TestRenderTempoTagCatalogView_ExactSQL` in `internal/schema/ddl/tempo_tag_catalog_test.go`
pins the full rendered `CREATE MATERIALIZED VIEW` SQL byte-for-byte and passed unchanged before and
after this refactor — all four scopes' arms render identically, same order. No TXTAR golden fixture
exists for this DDL output (checked `test/spec/`), so no `just update-golden` run was needed.

## Verification

- `go build ./...` and `go build -tags chdb ./internal/schema/... ./internal/api/tempo/...`
- `go test -race -count=1 ./internal/schema/... ./internal/api/tempo/...`
- `node .github/scripts/forbid-sql-raw.mjs`
- `node .github/scripts/verify-code-citations.mjs`
- `gofumpt -l` / `goimports -l -local` on every touched file: clean

Closes #3021
