### PR TITLE
fix(promql): split irate() into a CUMULATIVE-native/DELTA-fan-out union

### DIFF
--- a/internal/promql/gremlins_kill_lower_structural_test.go
+++ b/internal/promql/gremlins_kill_lower_structural_test.go
@@ -23,9 +23,15 @@ import (
 // test — only its Go type is.
 func unionArmWindow() *chplan.RangeWindow { return &chplan.RangeWindow{Func: "rate"} }
 
-// unionArmNative is the CUMULATIVE native-grid arm's stand-in, for the same
-// reason.
-func unionArmNative() *chplan.RangeWindowGridNative { return &chplan.RangeWindowGridNative{} }
+// unionArmNative is the CUMULATIVE native-grid arm's stand-in. Func is
+// pinned to "rate" — one of the two functions
+// [rateIncreaseTemporalityUnionArms] actually recognizes (cerberus issue
+// #2803's Func guard, added once irate() started building a structurally
+// identical union of its own) — rather than left at its zero value; every
+// other field is irrelevant to the structural recogniser under test.
+func unionArmNative() *chplan.RangeWindowGridNative {
+	return &chplan.RangeWindowGridNative{Func: "rate"}
+}
 
 // temporalityUnion wraps arms in the Project-over-UnionAll shape
 // [rateIncreaseTemporalityUnionArms] recognises.
@@ -36,14 +42,19 @@ func temporalityUnion(arms ...chplan.Node) chplan.Node {
 // TestRateIncreaseTemporalityUnionArms_RecognisesOnlyTheExactTwoArmShape pins
 // every structural clause of the recogniser independently.
 //
-// The recogniser's whole contract is that it identifies ONE construction
-// site's output. Its caller folds an outer sum/min/max into the native arm and
-// leaves the delta arm alone, so a false positive rewrites a plan the fold was
-// never proven against: a third arm would be silently dropped, and a
-// mis-typed arm would be folded as if it were the native grid. Both are
-// answered here by the arm count and the two type assertions, and both
-// survived because the corpus only ever hands this function the exact shape
-// [derivedRateArm] builds.
+// The recogniser's whole contract is that it identifies rate()/increase()'s
+// OWN construction site's output, not merely A shape that happens to match
+// positionally. Its caller folds an outer sum/min/max into the native arm
+// and leaves the delta arm alone, so a false positive rewrites a plan the
+// fold was never proven against: a third arm would be silently dropped, a
+// mis-typed arm would be folded as if it were the native grid, and (since
+// cerberus issue #2803) a native arm from a DIFFERENT function that merely
+// builds the same node layout — irate(), via derivedIrateArm — would be
+// folded as if its per-cell values composed the same way rate/increase's
+// do, which was never verified. All three are answered here: the arm count
+// and the two type assertions for the first two, the native arm's own Func
+// field for the third. Every clause survived because the corpus only ever
+// hands this function the exact shape [derivedRateArm] builds.
 func TestRateIncreaseTemporalityUnionArms_RecognisesOnlyTheExactTwoArmShape(t *testing.T) {
 	t.Parallel()
 
@@ -87,6 +98,14 @@ func TestRateIncreaseTemporalityUnionArms_RecognisesOnlyTheExactTwoArmShape(t *t
 			name:  "second arm is not a fan-out window",
 			input: temporalityUnion(unionArmNative(), unionArmNative()),
 			why:   "the delta arm is the raw fan-out; a second native arm is not the shape derivedRateArm builds",
+		},
+		{
+			name:  "native arm Func is irate, not rate/increase",
+			input: temporalityUnion(&chplan.RangeWindowGridNative{Func: "irate"}, unionArmWindow()),
+			why: "derivedIrateArm (cerberus issue #2803) builds a positionally identical " +
+				"Project{UnionAll{RangeWindowGridNative, RangeWindow}} shape for irate(), whose " +
+				"trailing-pair counter-reset correction was never verified to compose the same way " +
+				"under the ts_grid_vector_agg fold — admitting it here would silently widen that fold",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -4549,11 +4549,22 @@ var nativeGridVectorAggUnionFns = map[chplan.Fn]struct{}{
 // [derivedRateArm] builds for a temporality-bearing rate()/increase() range
 // window (cerberus issue #2843's union split: NativeRateLowerer.LowerRate /
 // NativeIncreaseLowerer.LowerIncrease). Returns the native CUMULATIVE arm and
-// the raw DELTA-temporality fan-out arm when input matches that exact shape,
-// or ok=false otherwise — a plain structural check (arm kinds, arm count),
-// since derivedRateArm(UnionAll{...}) is the ONLY construction site pairing a
-// *RangeWindowGridNative with a *RangeWindow inside a UnionAll anywhere in
-// this package.
+// the raw DELTA-temporality fan-out arm when input matches that shape AND
+// the native arm's own Func is "rate" or "increase"; ok=false otherwise.
+//
+// derivedRateArm(UnionAll{...}) is no longer the ONLY construction site
+// pairing a *RangeWindowGridNative with a *RangeWindow inside a UnionAll:
+// irate()'s own temporality union (derivedIrateArm, internal/promql/
+// lower_strategy.go, cerberus issue #2803) builds a POSITIONALLY IDENTICAL
+// shape. The Func check below is what keeps the two apart — deliberately,
+// not by oversight: irate's trailing-pair counter-reset correction makes
+// its per-cell value semantically different from rate/increase's plain
+// division, and nativeGridVectorAggUnionFns' sum/min/max/avg/count
+// composition proofs were verified only against rate/increase's shape (no
+// fixture has ever combined ts_grid_vector_agg with irate, bare or
+// unioned). Widening this match to admit "irate" too is a real, separate
+// engineering decision for a future issue to make and verify, not a side
+// effect of the two arms happening to share a node layout.
 //
 // delta() is deliberately never recognized here: it never threads
 // TemporalityColumn (counterTemporalityRangeFn excludes it — delta() applies
@@ -4573,6 +4584,9 @@ func rateIncreaseTemporalityUnionArms(input chplan.Node) (native *chplan.RangeWi
 	native, isNative := union.Inputs[0].(*chplan.RangeWindowGridNative)
 	delta, isDelta := union.Inputs[1].(*chplan.RangeWindow)
 	if !isNative || !isDelta {
+		return nil, nil, false
+	}
+	if native.Func != "rate" && native.Func != "increase" {
 		return nil, nil, false
 	}
 	return native, delta, true

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -1425,19 +1425,86 @@ type NativeIrateLowerer struct {
 // LowerIrate returns a RangeWindowGridNative for an eligible range-mode
 // irate shape, or delegates to the embedded Fallback otherwise. Same
 // intrinsic SHAPE check as delta (irate func, materialised grid, plain
-// Scan/Filter input). irate needs no dedicated DELTA/CUMULATIVE union split
-// of its own — nativeTSGridMatrixNode's existing TemporalityColumn guard
-// already sends any DELTA-temporality counter to the Fallback
-// unconditionally, exactly like every other native ts_grid member, so the
-// counter-reset correction the trailing-pair aggregate applies is only ever
-// reached for a CUMULATIVE (or temporality-less) counter. irate takes no
-// scalar and carries no -State/-Merge combinator pair, so
-// nativeTSGridMatrixNode is always called with noRecollapse.
+// Scan/Filter input). irate takes no scalar and carries no -State/-Merge
+// combinator pair, so nativeTSGridMatrixNode is always called with
+// noRecollapse.
+//
+// A temporality-bearing window splits into complementary CUMULATIVE-native
+// and DELTA-fan-out arms (cerberus issue #2803) — mirrors
+// [NativeRateLowerer.LowerRate] exactly, because the native aggregate's
+// counter-reset correction (the trailing-pair repair a differential sweep
+// against a real server proved, see this file's own irate/idelta section
+// doc above) has no DELTA semantics, while the fan-out emitter's
+// CounterOrDeltaPairDelta already threads the DELTA branch correctly. This
+// closes the gap #2746 deliberately left open: rangeVectorCounterTemporalityColumn
+// sets TemporalityColumn whenever a selector routes to exactly one Sum-typed
+// table — precisely the shape of any `_total`-suffixed counter, the
+// realistic case almost every production irate() query targets — so before
+// this split, nativeTSGridMatrixNode's unconditional TemporalityColumn guard
+// sent that realistic shape to the Fallback unconditionally and the native
+// tier stayed dormant for it.
+//
+// UNLIKE NativeRateLowerer's temporality union, the resulting
+// Project{UnionAll{RangeWindowGridNative, RangeWindow}} is wrapped by
+// [derivedIrateArm], a function DISTINCT from [derivedRateArm]: see its own
+// doc for why irate's union deliberately does NOT fold into ts_grid_vector_agg
+// the way rate()/increase()'s does (rateIncreaseTemporalityUnionArms,
+// internal/promql/lower.go, guards on the native arm's own Func specifically
+// to keep the two apart).
 func (n NativeIrateLowerer) LowerIrate(rw *chplan.RangeWindow, s schema.Metrics) chplan.Node {
+	if rw.TemporalityColumn != "" {
+		cumulative := *rw
+		cumulative.Input = nativeTemporalityFilter(rw.Input, rw.TemporalityColumn)
+		// The native aggregate is safe only after DELTA rows are excluded.
+		cumulative.TemporalityColumn = ""
+		if native := nativeTSGridMatrixNode(&cumulative, "irate", s, noRecollapse); native != nil {
+			delta := *rw
+			delta.Input = temporalityFilter(rw.Input, rw.TemporalityColumn, chplan.OpEq)
+			return derivedIrateArm(&chplan.UnionAll{Inputs: []chplan.Node{
+				native,
+				&delta,
+			}}, s)
+		}
+	}
 	if native := nativeTSGridMatrixNode(rw, "irate", s, noRecollapse); native != nil {
 		return native
 	}
 	return n.Fallback.LowerIrate(rw, s)
+}
+
+// derivedIrateArm restores the derived metric name the complementary
+// CUMULATIVE-native/DELTA-fan-out irate arms expose to downstream PromQL
+// nodes — the irate()-specific twin of [derivedRateArm], built as a
+// DISTINCT function rather than shared with it (cerberus issue #2803's own
+// scope note). The two build POSITIONALLY IDENTICAL
+// Project{UnionAll{RangeWindowGridNative, RangeWindow}} shapes, but
+// rateIncreaseTemporalityUnionArms (internal/promql/lower.go) tells them
+// apart by the native arm's own Func field ("rate"/"increase" vs "irate")
+// and folds ONLY the former into ts_grid_vector_agg
+// (RangeWindowGridNativeVectorAgg, cerberus issue #2852): irate's
+// counter-reset correction on the trailing pair makes its per-cell value
+// semantically different from rate/increase's plain division, and no
+// existing fixture had ever combined ts_grid_vector_agg with irate — bare
+// or unioned — to verify sum/min/max/avg/count still compose correctly over
+// it. Keeping a second, distinctly named construction site is what lets
+// that structural guard hold without inspecting Func at every call site.
+//
+// irate drops the source __name__ exactly like rate/increase — dropName is
+// true for every range function except last_over_time/first_over_time (see
+// promql/engine.go's own dropName rule, mirrored at this package's
+// dropNameGuardAnchor) — so the restored value is likewise the empty
+// literal.
+func derivedIrateArm(input chplan.Node, s schema.Metrics) *chplan.Project {
+	return &chplan.Project{
+		Input: input,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: chplan.RangeWindowAnchorColumn}, Alias: chplan.RangeWindowAnchorColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+		},
+	}
 }
 
 // NativeIdeltaLowerer mirrors [NativeIrateLowerer] for idelta, emitting

--- a/internal/promql/native_irate_temporality_test.go
+++ b/internal/promql/native_irate_temporality_test.go
@@ -1,0 +1,235 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestNativeIrateLowererSplitsTemporality pins cerberus issue #2803's fix:
+// irate() over a `_total`-suffixed counter (routes to exactly one Sum table,
+// so rangeVectorCounterTemporalityColumn sets TemporalityColumn) now splits
+// into complementary CUMULATIVE-native / DELTA-fan-out arms instead of
+// falling back to the fan-out unconditionally — mirrors
+// TestNativeRateLowererSplitsTemporality exactly, modulo the derivedIrateArm
+// wrapper and the native arm's own Func="irate".
+func TestNativeIrateLowererSplitsTemporality(t *testing.T) {
+	t.Parallel()
+
+	plan := lowerNativeTemporalityIrate(t, "irate(cerberus_queries_total[5m])")
+	derived, union := temporalityIrateUnion(t, plan)
+	if len(union.Inputs) != 2 {
+		t.Fatalf("temporality-bearing native irate has %d arms, want 2", len(union.Inputs))
+	}
+
+	native, ok := union.Inputs[0].(*chplan.RangeWindowGridNative)
+	if !ok {
+		t.Fatalf("cumulative union arm = %T, want *chplan.RangeWindowGridNative", union.Inputs[0])
+	}
+	if native.Func != "irate" {
+		t.Errorf("cumulative union arm Func = %q, want %q", native.Func, "irate")
+	}
+	fanout, ok := union.Inputs[1].(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("delta union arm = %T, want *chplan.RangeWindow", union.Inputs[1])
+	}
+	if fanout.TemporalityColumn != schema.DefaultOTelMetrics().AggregationTemporalityColumn {
+		t.Errorf("fan-out TemporalityColumn = %q, want schema temporality column", fanout.TemporalityColumn)
+	}
+	assertIrateTemporalityFilter(t, native.Input, chplan.OpNe)
+	assertIrateTemporalityFilter(t, fanout.Input, chplan.OpEq)
+	assertDerivedIrateProjection(t, derived)
+}
+
+// TestNativeIrateLowererTemporalitySplitPreservesOffsetGrid mirrors
+// TestNativeRateLowererTemporalitySplitPreservesOffsetGrid for irate: an
+// `offset` modifier must thread identically onto both split arms.
+func TestNativeIrateLowererTemporalitySplitPreservesOffsetGrid(t *testing.T) {
+	t.Parallel()
+
+	const queryOffset = time.Minute
+	plan := lowerNativeTemporalityIrate(t, "irate(cerberus_queries_total[5m] offset 1m)")
+	derived, union := temporalityIrateUnion(t, plan)
+	if len(union.Inputs) != 2 {
+		t.Fatalf("offset temporality split has %d arms, want 2", len(union.Inputs))
+	}
+	native := union.Inputs[0].(*chplan.RangeWindowGridNative)
+	fanout := union.Inputs[1].(*chplan.RangeWindow)
+
+	if native.Offset != queryOffset || fanout.Offset != queryOffset {
+		t.Errorf("arm offsets = native %s, fan-out %s, want %s", native.Offset, fanout.Offset, queryOffset)
+	}
+	if !native.Start.Equal(fanout.Start) || !native.End.Equal(fanout.End) || native.Step != fanout.Step {
+		t.Errorf("arm grids diverge: native [%v,%v]/%s, fan-out [%v,%v]/%s",
+			native.Start, native.End, native.Step, fanout.Start, fanout.End, fanout.Step)
+	}
+	assertDerivedIrateProjection(t, derived)
+	// UNSPECIFIED is deliberately admitted by the native arm: only a positive
+	// DELTA reading takes the fan-out branch.
+	if schema.AggregationTemporalityUnspecified == schema.AggregationTemporalityDelta {
+		t.Fatal("UNSPECIFIED must remain distinct from DELTA for the native predicate")
+	}
+	assertIrateTemporalityFilter(t, native.Input, chplan.OpNe)
+}
+
+// TestNativeIrateLowererUnsupportedShapeFallsBack mirrors
+// TestNativeRateLowererUnsupportedShapeFallsBack: an INSTANT (Step == 0)
+// irate() shape is outside nativeTSGridMatrixNode's eligibility and must
+// still fall back to the plain fan-out RangeWindow, temporality split or
+// not — irate's instant arm carries no union split (unlike its matrix arm),
+// matching NativeRateLowerer's own Instant-arm scope note.
+func TestNativeIrateLowererUnsupportedShapeFallsBack(t *testing.T) {
+	t.Parallel()
+
+	plan := lowerNativeTemporalityIrateAt(t, "irate(cerberus_queries_total[5m])")
+	if _, ok := plan.(*chplan.RangeWindow); !ok {
+		t.Errorf("instant native irate shape = %T, want unchanged fan-out RangeWindow", plan)
+	}
+}
+
+// TestNativeIrateTemporalityUnionDeclinesVectorAggFold is the CRITICAL SCOPE
+// regression guard cerberus issue #2803 exists to pin: irate's own
+// temporality union (derivedIrateArm) is POSITIONALLY IDENTICAL to rate/
+// increase's (derivedRateArm) — Project{UnionAll{RangeWindowGridNative,
+// RangeWindow}} — so `sum by(...) (irate(...))` over that union must NOT
+// silently fold into ts_grid_vector_agg's RangeWindowGridNativeVectorAgg the
+// way the rate/increase union does (rateIncreaseTemporalityUnionArms,
+// internal/promql/lower.go, guards on the native arm's own Func). That fold
+// was never validated for irate — this test fails loudly if a future change
+// widens the Func guard (or otherwise re-couples the two shapes) without
+// updating this pin.
+func TestNativeIrateTemporalityUnionDeclinesVectorAggFold(t *testing.T) {
+	t.Parallel()
+
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr("sum by(host) (irate(cerberus_queries_total[5m]))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(), start, start.Add(5*time.Minute),
+		time.Minute, promql.LowerOpts{Lowerers: promql.RangeLowerers{
+			Irate:     promql.NativeIrateLowerer{Fallback: promql.FanoutIrateLowerer{}},
+			VectorAgg: true,
+		}})
+	if err != nil {
+		t.Fatalf("lower sum(irate(...)): %v", err)
+	}
+
+	outer, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("sum(irate(...)) plan = %T, want the wrapping Project [wrapAggregateForSample] builds", plan)
+	}
+	agg, ok := outer.Input.(*chplan.Aggregate)
+	if !ok {
+		t.Fatalf("sum(irate(...)) aggregate input = %T, want the ORDINARY *chplan.Aggregate — "+
+			"a RangeWindowGridNativeVectorAgg or a combining Aggregate here would mean irate's "+
+			"temporality union started matching rateIncreaseTemporalityUnionArms", outer.Input)
+	}
+	derived, ok := agg.Input.(*chplan.Project)
+	if !ok {
+		t.Fatalf("aggregate input = %T, want irate's own derivedIrateArm Project unchanged", agg.Input)
+	}
+	union, ok := derived.Input.(*chplan.UnionAll)
+	if !ok {
+		t.Fatalf("derivedIrateArm input = %T, want the two-arm UnionAll", derived.Input)
+	}
+	native, ok := union.Inputs[0].(*chplan.RangeWindowGridNative)
+	if !ok || native.Func != "irate" {
+		t.Fatalf("union native arm = %#v, want a RangeWindowGridNative with Func=irate", union.Inputs[0])
+	}
+}
+
+func temporalityIrateUnion(t *testing.T, plan chplan.Node) (*chplan.Project, *chplan.UnionAll) {
+	t.Helper()
+	derived, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("temporality-bearing irate = %T, want derived Project", plan)
+	}
+	union, ok := derived.Input.(*chplan.UnionAll)
+	if !ok {
+		t.Fatalf("derived irate input = %T, want two-arm UnionAll", derived.Input)
+	}
+	return derived, union
+}
+
+func assertDerivedIrateProjection(t *testing.T, project *chplan.Project) {
+	t.Helper()
+	if !project.Projections[2].Expr.Equal(&chplan.ColumnRef{Name: chplan.RangeWindowAnchorColumn}) ||
+		project.Projections[2].Alias != chplan.RangeWindowAnchorColumn ||
+		project.Projections[3].Alias != schema.DefaultOTelMetrics().TimestampColumn {
+		t.Errorf("derived irate projection does not preserve the anchor and output timestamp contract: %#v", project.Projections)
+	}
+}
+
+func lowerNativeTemporalityIrate(t *testing.T, query string) chplan.Node {
+	t.Helper()
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(), start, start.Add(5*time.Minute),
+		time.Minute, promql.LowerOpts{Lowerers: promql.RangeLowerers{Irate: promql.NativeIrateLowerer{
+			Fallback: promql.FanoutIrateLowerer{},
+		}}})
+	if err != nil {
+		t.Fatalf("lower %q: %v", query, err)
+	}
+	return plan
+}
+
+func lowerNativeTemporalityIrateAt(t *testing.T, query string) chplan.Node {
+	t.Helper()
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr(query)
+	if err != nil {
+		t.Fatalf("parse %q: %v", query, err)
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, schema.DefaultOTelMetrics(), time.Time{}, time.Time{},
+		time.Duration(0), promql.LowerOpts{Lowerers: promql.RangeLowerers{Irate: promql.NativeIrateLowerer{
+			Fallback: promql.FanoutIrateLowerer{},
+		}}})
+	if err != nil {
+		t.Fatalf("lower %q: %v", query, err)
+	}
+	return plan
+}
+
+func assertIrateTemporalityFilter(t *testing.T, input chplan.Node, want chplan.BinaryOp) {
+	t.Helper()
+	filter, ok := input.(*chplan.Filter)
+	if !ok {
+		project, projectOK := input.(*chplan.Project)
+		if !projectOK {
+			t.Fatalf("arm input = %T, want a Filter or selector Project", input)
+		}
+		filter, ok = project.Input.(*chplan.Filter)
+		if !ok {
+			t.Fatalf("selector Project input = %T, want *chplan.Filter", project.Input)
+		}
+	}
+	predicate, ok := filter.Predicate.(*chplan.Binary)
+	if !ok {
+		t.Fatalf("filter predicate = %T, want *chplan.Binary", filter.Predicate)
+	}
+	if predicate.Op == chplan.OpAnd {
+		combined := predicate
+		predicate, ok = combined.Right.(*chplan.Binary)
+		if !ok {
+			t.Fatalf("combined filter right predicate = %T, want *chplan.Binary", combined.Right)
+		}
+	}
+	if predicate.Op != want ||
+		!predicate.Left.Equal(&chplan.ColumnRef{Name: schema.DefaultOTelMetrics().AggregationTemporalityColumn}) ||
+		!predicate.Right.Equal(&chplan.LitInt{V: schema.AggregationTemporalityDelta}) {
+		t.Errorf("filter predicate is not the aggregation-temporality DELTA partition")
+	}
+	if _, nested := filter.Input.(*chplan.Filter); nested {
+		t.Error("temporality partition remained a nested Filter instead of fusing with the selector predicate")
+	}
+}

--- a/test/perf/cardinality-baseline/promql/native_irate_temporality_union.json
+++ b/test/perf/cardinality-baseline/promql/native_irate_temporality_union.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/native_irate_temporality_union",
+  "fan_factor": 4.0625,
+  "scan_rows": 16,
+  "peak_intermediate": 65,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/irate_delta_temporality/native.json
+++ b/test/perf/solver-decision-baseline/irate_delta_temporality/native.json
@@ -6,6 +6,6 @@
   "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
-  "cumulative_d": "1m0s",
+  "cumulative_d": "2m0s",
   "outer_range": "1h0m0s"
 }

--- a/test/perf/solver-decision-baseline/irate_delta_temporality_cumulative_control/native.json
+++ b/test/perf/solver-decision-baseline/irate_delta_temporality_cumulative_control/native.json
@@ -6,6 +6,6 @@
   "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
-  "cumulative_d": "1m0s",
+  "cumulative_d": "2m0s",
   "outer_range": "1h0m0s"
 }

--- a/test/perf/solver-decision-baseline/irate_delta_temporality_range/native.json
+++ b/test/perf/solver-decision-baseline/irate_delta_temporality_range/native.json
@@ -6,6 +6,6 @@
   "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
-  "cumulative_d": "1m0s",
+  "cumulative_d": "2m0s",
   "outer_range": "1h0m0s"
 }

--- a/test/perf/solver-decision-baseline/lag_adjacency_irate_delta_temporality_range/native.json
+++ b/test/perf/solver-decision-baseline/lag_adjacency_irate_delta_temporality_range/native.json
@@ -6,6 +6,6 @@
   "reason": "below-threshold",
   "n_anchors": 241,
   "fanout": 4,
-  "cumulative_d": "1m0s",
+  "cumulative_d": "2m0s",
   "outer_range": "1h0m0s"
 }

--- a/test/perf/solver-decision-baseline/native_irate_temporality_union/fanout.json
+++ b/test/perf/solver-decision-baseline/native_irate_temporality_union/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "native_irate_temporality_union/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/native_irate_temporality_union/native.json
+++ b/test/perf/solver-decision-baseline/native_irate_temporality_union/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "native_irate_temporality_union/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 6,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "10m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -463,6 +463,7 @@ native_idelta_range_step.txtar
 native_increase_range_step.txtar
 native_increase_vector_agg_temporality_union.txtar
 native_irate_range_step.txtar
+native_irate_temporality_union.txtar
 native_last_over_time_range_step.txtar
 native_predict_linear_negative_horizon_fanout.txtar
 native_predict_linear_range_step.txtar

--- a/test/spec/promql/native_irate_range_step.txtar
+++ b/test/spec/promql/native_irate_range_step.txtar
@@ -14,16 +14,19 @@
 # its selector as a COUNTER, and rangeVectorCounterTemporalityColumn sets
 # RangeWindow.TemporalityColumn whenever the selector routes to EXACTLY ONE
 # table (Sum or Histogram) — the case for any unambiguous `_total`-suffixed
-# name. nativeTSGridMatrixNode's TemporalityColumn guard then sends the whole
-# window to the fan-out/lagInFrame fallback unconditionally (no union split —
-# see NativeIrateLowerer's own doc). An UNSUFFIXED name routes ambiguously to
-# (Gauge, Sum) instead, so TemporalityColumn stays empty and the native path
-# fires. That means this fixture — like every realistic `_total` counter
-# query under the default schema — currently stays on the fan-out; tracked as
-# cerberus issue #2803 (add the CUMULATIVE-native/DELTA-fan-out union split
-# NativeRateLowerer already has for rate()/increase()). This fixture uses an
-# unsuffixed name SPECIFICALLY to reach and pin the native SQL shape ahead of
-# that follow-up landing.
+# name. An UNSUFFIXED name routes ambiguously to (Gauge, Sum) instead, so
+# TemporalityColumn stays empty and nativeTSGridMatrixNode's TemporalityColumn
+# guard never fires at all — this fixture pins that BARE (no union split)
+# native SQL shape deliberately, still the simplest and most direct coverage
+# of the plain timeSeriesInstantRateToGrid emit. cerberus issue #2803 closed
+# the companion gap this note used to track: a `_total`-suffixed counter (the
+# realistic case almost every production irate() query targets) now ALSO
+# reaches the native tier, via a CUMULATIVE-native/DELTA-fan-out union split —
+# see NativeIrateLowerer.LowerIrate's own doc — pinned separately by
+# native_irate_temporality_union.txtar, whose UnionAll{RangeWindowGridNative,
+# RangeWindow} shape (wrapped by derivedIrateArm) differs from this fixture's
+# bare RangeWindowGridNative, so the two fixtures deliberately stay distinct
+# rather than merged into one.
 #
 # COUNTER-RESET EVIDENCE. The seed's 300 -> 150 dip at 00:01:00 -> 00:01:30 is
 # deliberate: irate's trailing pair at anchor 00:01:30 is exactly that

--- a/test/spec/promql/native_irate_temporality_union.txtar
+++ b/test/spec/promql/native_irate_temporality_union.txtar
@@ -70,4 +70,70 @@ INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value, Aggregati
   ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:04:30', 9), 27.0, 1),
   ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:05:00', 9), 30.0, 1);
 -- expected_rows --
-[]
+[
+  ["", {"host": "a"}, "2026-01-01T00:00:30Z", "2026-01-01T00:00:30Z", 3.3333333333333335],
+  ["", {"host": "a"}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 3.3333333333333335],
+  ["", {"host": "a"}, "2026-01-01T00:01:30Z", "2026-01-01T00:01:30Z", 5],
+  ["", {"host": "a"}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 8.333333333333334],
+  ["", {"host": "a"}, "2026-01-01T00:02:30Z", "2026-01-01T00:02:30Z", 8.333333333333334],
+  ["", {"host": "a"}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 8.333333333333334],
+  ["", {"host": "a"}, "2026-01-01T00:03:30Z", "2026-01-01T00:03:30Z", 8.333333333333334],
+  ["", {"host": "a"}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 8.333333333333334],
+  ["", {"host": "a"}, "2026-01-01T00:04:30Z", "2026-01-01T00:04:30Z", 8.333333333333334],
+  ["", {"host": "a"}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 8.333333333333334],
+  ["", {"host": "b"}, "2026-01-01T00:00:30Z", "2026-01-01T00:00:30Z", 0.1],
+  ["", {"host": "b"}, "2026-01-01T00:01:00Z", "2026-01-01T00:01:00Z", 0.2],
+  ["", {"host": "b"}, "2026-01-01T00:01:30Z", "2026-01-01T00:01:30Z", 0.3],
+  ["", {"host": "b"}, "2026-01-01T00:02:00Z", "2026-01-01T00:02:00Z", 0.4],
+  ["", {"host": "b"}, "2026-01-01T00:02:30Z", "2026-01-01T00:02:30Z", 0.5],
+  ["", {"host": "b"}, "2026-01-01T00:03:00Z", "2026-01-01T00:03:00Z", 0.6],
+  ["", {"host": "b"}, "2026-01-01T00:03:30Z", "2026-01-01T00:03:30Z", 0.7],
+  ["", {"host": "b"}, "2026-01-01T00:04:00Z", "2026-01-01T00:04:00Z", 0.8],
+  ["", {"host": "b"}, "2026-01-01T00:04:30Z", "2026-01-01T00:04:30Z", 0.9],
+  ["", {"host": "b"}, "2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z", 1]
+]
+-- args --
+[0] string = ""
+[1] string = "service_name"
+[2] string = "service.name"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = ""
+[7] string = "service_name"
+[8] string = "http_requests_total"
+[9] string = "http.requests.total"
+[10] string = "http.requests/total"
+[11] string = "http.requests_total"
+[12] string = "http/requests/total"
+[13] string = "http/requests_total"
+[14] string = "http_requests.total"
+[15] int64 = 1
+[16] string = "service_name"
+[17] string = "service.name"
+[18] string = "service_name"
+[19] string = "service.name"
+[20] string = "service_name"
+[21] string = ""
+[22] string = "service_name"
+[23] string = "http_requests_total"
+[24] string = "http.requests.total"
+[25] string = "http.requests/total"
+[26] string = "http.requests_total"
+[27] string = "http/requests/total"
+[28] string = "http/requests_total"
+[29] string = "http_requests.total"
+[30] int64 = 1
+-- chplan --
+Project ["" AS MetricName, Attributes AS Attributes, anchor_ts AS anchor_ts, TimeUnix AS TimeUnix, Value AS Value]
+  UnionAll arms=2
+    RangeWindowGridNative func=irate range=5m0s step=30s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=((MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total")) AND (AggregationTemporality != 1))
+          Scan(otel_metrics_sum)
+    RangeWindow func=irate range=5m0s step=30s outerRange=5m0s ts=TimeUnix value=Value temporality=AggregationTemporality groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value, AggregationTemporality AS AggregationTemporality]
+        Filter predicate=((MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total")) AND (AggregationTemporality = 1))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `anchor_ts`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM ((SELECT `Attributes`, toDateTime64(`anchor_ts`, 9) AS `anchor_ts`, toDateTime64(`anchor_ts`, 9) AS `TimeUnix`, toFloat64(assumeNotNull(`grid_val`)) AS `Value` FROM (SELECT `Attributes`, timeSeriesInstantRateToGrid(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30, 300)(`TimeUnix`, `Value`) AS `grid`, timeSeriesRange(toDateTime(1767225600, 'UTC'), toDateTime(1767225900, 'UTC'), 30) AS `grid_ts` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) AND (`AggregationTemporality` != ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`) ARRAY JOIN `grid` AS `grid_val`, `grid_ts` AS `anchor_ts` WHERE `grid_val` IS NOT NULL) UNION ALL (SELECT `Attributes`, `anchor_ts`, anchor_ts AS `TimeUnix`, if(length(window_pairs) > 1 AND dateDiff('nanosecond', tupleElement(window_pairs[length(window_pairs) - 1], 1), tupleElement(window_pairs[length(window_pairs)], 1)) > 0, (if(temporality = 1, tupleElement(window_pairs[length(window_pairs)], 2), if(tupleElement(window_pairs[length(window_pairs)], 2) < tupleElement(window_pairs[length(window_pairs) - 1], 2), tupleElement(window_pairs[length(window_pairs)], 2), tupleElement(window_pairs[length(window_pairs)], 2) - tupleElement(window_pairs[length(window_pairs) - 1], 2)))) / ((dateDiff('nanosecond', tupleElement(window_pairs[length(window_pairs) - 1], 1), tupleElement(window_pairs[length(window_pairs)], 1))) / 1e9), nan) AS Value FROM (SELECT `Attributes`, `anchor_ts`, any(`AggregationTemporality`) AS `temporality`, arrayCompact(arraySort(groupArray((`TimeUnix`, `Value`)))) AS window_pairs FROM (SELECT `Attributes`, `TimeUnix`, `Value`, `AggregationTemporality`, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value`, `AggregationTemporality` AS `AggregationTemporality` FROM (SELECT * FROM `otel_metrics_sum` PREWHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)) AND (`AggregationTemporality` = ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) GROUP BY `Attributes`, `anchor_ts`) WHERE length(`window_pairs`) >= 2))

--- a/test/spec/promql/native_irate_temporality_union.txtar
+++ b/test/spec/promql/native_irate_temporality_union.txtar
@@ -1,0 +1,73 @@
+# Experimental: ClickHouse-native timeSeriesInstantRateToGrid lowering for
+# irate() over a `_total`-suffixed counter (cerberus issue #2803). Unlike
+# native_irate_range_step.txtar (which uses an UNSUFFIXED name specifically
+# to reach the BARE native shape ahead of this fix), this fixture uses the
+# realistic `_total` name every production irate() query targets: the
+# selector routes to exactly one Sum table, so
+# rangeVectorCounterTemporalityColumn sets RangeWindow.TemporalityColumn, and
+# NativeIrateLowerer.LowerIrate now splits into a CUMULATIVE-native arm (fed
+# through timeSeriesInstantRateToGrid) UnionAll'd with a DELTA-fan-out arm
+# (the unchanged trailing-pair fan-out, CounterOrDeltaPairDelta's DELTA
+# branch) — derivedIrateArm restores the derived MetricName/Attributes
+# contract over the union, mirroring derivedRateArm's shape for rate()/
+# increase() (cerberus issue #2843) exactly, as a DISTINCT function (see its
+# own doc for why).
+#
+# TWO DISJOINT SERIES prove the union neither duplicates nor drops a series:
+# host=a is CUMULATIVE-temporality (feeds the native arm), host=b is
+# DELTA-temporality (feeds the raw fan-out arm).
+#
+# COUNTER-RESET EVIDENCE, reused verbatim from native_irate_range_step.txtar.
+# host=a's 300 -> 150 dip at 00:01:00 -> 00:01:30 is the SAME seed shape that
+# fixture's own header proves timeSeriesInstantRateToGrid counter-reset-
+# corrects (the repaired 150/30 = 5 at anchor 00:01:30, never the raw
+# (150-300)/30 = -5) — re-verifying it holds identically once the window is
+# additionally split into this union confirms the split does not disturb the
+# native arm's own correction.
+#
+# host=b's DELTA readings need NO counter-reset rule at all (irate_delta_
+# temporality.txtar's own doc: a DELTA sample already covers `(t_p, t_c]`, so
+# the per-second rate is `c / (t_c - t_p)` with nothing subtracted) — its
+# monotonically-growing values (0, 3, 6, ..., 30) exist only to make each
+# anchor's trailing-pair answer distinct, so a dropped or duplicated point
+# would visibly shift the wrong anchor's answer.
+-- query.promql --
+irate(http_requests_total[5m])
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
+-- range_step --
+30s
+-- experimental_ts_grid_irate --
+-- seed --
+CREATE TABLE otel_metrics_sum (
+  MetricName String,
+  Attributes Map(String, String),
+  ResourceAttributes Map(String, String) DEFAULT map(),
+  TimeUnix DateTime64(9),
+  Value Float64,
+  AggregationTemporality Int32
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- host=a: CUMULATIVE, dip 100 -> 200 -> 300 -> 150 (counter-reset-shaped
+-- dip) -> 400 — identical to native_irate_range_step.txtar's own seed.
+-- host=b: DELTA, monotonically growing per-interval readings.
+INSERT INTO otel_metrics_sum (MetricName, Attributes, TimeUnix, Value, AggregationTemporality) VALUES
+  ('http_requests_total', map('host', 'a'), toDateTime64('2026-01-01 00:00:00', 9), 100.0, 2),
+  ('http_requests_total', map('host', 'a'), toDateTime64('2026-01-01 00:00:30', 9), 200.0, 2),
+  ('http_requests_total', map('host', 'a'), toDateTime64('2026-01-01 00:01:00', 9), 300.0, 2),
+  ('http_requests_total', map('host', 'a'), toDateTime64('2026-01-01 00:01:30', 9), 150.0, 2),
+  ('http_requests_total', map('host', 'a'), toDateTime64('2026-01-01 00:02:00', 9), 400.0, 2),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:00:00', 9), 0.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:00:30', 9), 3.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:01:00', 9), 6.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:01:30', 9), 9.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:02:00', 9), 12.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:02:30', 9), 15.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:03:00', 9), 18.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:03:30', 9), 21.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:04:00', 9), 24.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:04:30', 9), 27.0, 1),
+  ('http_requests_total', map('host', 'b'), toDateTime64('2026-01-01 00:05:00', 9), 30.0, 1);
+-- expected_rows --
+[]


### PR DESCRIPTION
## Summary

`ts_grid_irate` (native `timeSeriesInstantRateToGrid`) never activated for
`_total`-suffixed counters: `NativeIrateLowerer.LowerIrate` had no
CUMULATIVE/DELTA temporality union split, so `nativeTSGridMatrixNode`'s
unconditional `TemporalityColumn` guard sent every such window (the
realistic shape almost every production `irate()` query targets) to the
fan-out fallback unconditionally.

This ports the same split `NativeRateLowerer.LowerRate` already has for
`rate()`/`increase()`: a temporality-bearing window splits into a
CUMULATIVE arm (fed to `timeSeriesInstantRateToGrid` with DELTA rows
filtered out) `UnionAll`'d with a DELTA arm (the unchanged trailing-pair
fan-out, which already threads `CounterOrDeltaPairDelta`'s DELTA branch
correctly).

## Scope decision: distinct wrapper, not a shared vector-agg fold

The union is wrapped by a new `derivedIrateArm` — deliberately a **separate**
function from `derivedRateArm`, not a reuse of it. Both build the exact same
`Project{UnionAll{RangeWindowGridNative, RangeWindow}}` node shape, and
`rateIncreaseTemporalityUnionArms` (`internal/promql/lower.go`) recognizes
that shape purely structurally to fold an outer `sum`/`min`/`max`/`avg`/
`count` into `ts_grid_vector_agg`. Reusing `derivedRateArm` verbatim for
irate would have silently widened that fold to cover irate too, even though:

- No fixture anywhere combines `ts_grid_vector_agg` with irate, bare or
  unioned — that composition has never been verified.
- irate's trailing-pair counter-reset correction makes its per-cell value
  semantically different from rate/increase's plain division, so the
  existing composition proofs (`nativeGridVectorAggUnionFns`'s doc) don't
  automatically transfer.

`rateIncreaseTemporalityUnionArms` now additionally checks the native arm's
own `Func` (`"rate"`/`"increase"` only), so irate's structurally-identical
union is recognized-but-declined rather than silently admitted. Widening
that fold to irate is a real, separate engineering decision left to a future
issue, with its own verification.

## Other changes

- `NativeIrateLowerer.LowerIrate`'s doc comment ("irate needs no dedicated
  DELTA/CUMULATIVE union split of its own") was rewritten — it's now false.
- `test/spec/promql/native_irate_range_step.txtar`'s "NAMING NOTE" (why it
  uses an unsuffixed counter name) is rewritten from a tracked-gap
  disclaimer into a cross-reference to the new fixture.
- New fixture `test/spec/promql/native_irate_temporality_union.txtar` pins
  `irate(http_requests_total[5m])` reaching the native tier via the union,
  with two disjoint series (one CUMULATIVE, one DELTA) proving neither arm
  duplicates nor drops rows, and re-verifying the counter-reset correction
  (the same 300→150 dip `native_irate_range_step.txtar` already pins) still
  holds on the native arm inside the union.
- New unit tests in `internal/promql/native_irate_temporality_test.go`,
  mirroring `native_rate_temporality_test.go`'s structure for irate,
  including a regression guard
  (`TestNativeIrateTemporalityUnionDeclinesVectorAggFold`) that fails loudly
  if a future change re-widens `rateIncreaseTemporalityUnionArms` to admit
  irate without a deliberate decision.

## Deliberately NOT touched

- `idelta()` — `counterTemporalityRangeFn` never sets `wantsTemporalityColumn`
  for it, so its `TemporalityColumn` is always empty already.
- `test/perf/nightly/realch_ts_grid_instant_memory_integration_test.go` — its
  `AggregationTemporalityColumn` clearing (lines ~132-143) is for `rate()`'s
  **instant** arm (`nativeTSGridInstantNode`), which the file's own comment
  and `NativeRateLowerer.LowerRate`'s doc both explicitly attribute to
  cerberus issue #2843 (the strictly-serialized follow-up to this one, not
  in scope here). Fixing it would mean pre-building #2843's own instant-arm
  union split.
- `native_rate_recollapse_*.txtar` — already fixed by #2888; confirmed
  unaffected by this change (full suite run below).

## Test plan

- [x] `go test -race -run 'TestNativeIrate'` — new unit tests pass.
- [x] `go test -race -run '^TestLower$' ./internal/promql/...` — green after
      golden regeneration via `update-golden.yml` (commit `8200bd6ba`).
- [x] `just test-unit` — full tree, green.
- [x] All 92 CI checks on this PR green, including all 12
      `gremlins phase4-promql-*` legs.

Note: an earlier local pass caught a real regression before push — the
`rateIncreaseTemporalityUnionArms` Func guard (see above) rejected the
existing `gremlins_kill_lower_structural_test.go` test's own baseline
rate/increase fixture, because its `unionArmNative()` helper built a
`RangeWindowGridNative` stand-in with a zero-value `Func`. Fixed by pinning
`Func: "rate"` on the stand-in and adding a dedicated rejection case for
`Func: "irate"` (commit `42e89daeb`), verified green locally before pushing.

Closes #2803

