### PR TITLE
feat(promql): widen exp-histogram sumMap merge to range/query_range mode

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1347,15 +1347,14 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 		l.ClassicBucketMerge = promql.FanoutClassicBucketMergeLowerer{}
 	}
 	// exp_histogram_merge_summap (issue #2757) has no version floor to
-	// probe, but ships AutoSelect: false: it is eligible only for the
-	// instant, single-group, SUM-fold shape (never avg, any by/without
-	// grouping, or range mode) and reuses the existing, rows-dominated
-	// budget guard unchanged rather than a newly-calibrated one — see
+	// probe, but ships AutoSelect: false: it now covers every shape —
+	// instant AND range mode (cerberus issue #3027), any by()/without()
+	// grouping (#2865), SUM or AVG fold (#2866) — each with its own
+	// real-ClickHouse-calibrated budget guard rather than a reuse of the
+	// classic fold's rows-dominated one — see
 	// promql.NativeExpHistogramMergeLowerer's own doc.
 	if optSet.Has(chopt.FeatureExpHistogramMergeSumMap) {
-		l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{
-			Fallback: promql.FanoutExpHistogramMergeLowerer{},
-		}
+		l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{}
 	} else {
 		l.ExpHistogramMerge = promql.FanoutExpHistogramMergeLowerer{}
 	}

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1313,18 +1313,14 @@ const (
 	FeatureTempoTagCatalogMV = "tempo_tag_catalog_mv"
 
 	// FeatureExpHistogramMergeSumMap opts the across-series exponential
-	// (native) histogram merge stage (histogram_native_sum.go's
-	// expHistogramGroupMergedInstant, the ONLY eligible call site) onto a
-	// two-pass sumMap-keyed reshape — see
-	// internal/promql/exp_histogram_merge_summap.go — for the INSTANT,
-	// SINGLE-GROUP (no by()/without()), SUM-fold shape only. avg(), any
-	// grouped shape, and range/query_range mode are NOT eligible and
-	// always keep the existing groupArray + arrayReduce/arraySlice picker
-	// fold (histogram_merge_bound.go's own audited `rows x width^2`
-	// finding) regardless of this feature's state — see
-	// promql.NativeExpHistogramMergeLowerer's own doc for exactly why
-	// those shapes need a per-group JOIN this change does not build
-	// (tracked by cerberus issue #2834).
+	// (native) histogram merge stage — both of its call sites,
+	// histogram_native_sum.go's expHistogramGroupMergedInstant (instant
+	// mode) and lowerExpHistogramSumOrAvgRange (range/query_range mode,
+	// cerberus issue #3027) — onto a two-pass sumMap-keyed reshape, see
+	// internal/promql/exp_histogram_merge_summap.go. Every shape is
+	// eligible: instant or range mode, any by()/without() grouping
+	// (cerberus issue #2865), SUM or AVG fold (cerberus issue #2866) —
+	// see promql.NativeExpHistogramMergeLowerer's own doc.
 	//
 	// sumMap is old, always-available ClickHouse functionality — no
 	// version floor to probe, matching FeatureClassicBucketMergeSumMap's
@@ -1339,13 +1335,13 @@ const (
 	// individual bucket layout (width 1,280 and up), because the new
 	// design's own reconstruction step is width^2 in the worst case,
 	// independent of row count (see exp_histogram_merge_summap.go's
-	// header for the full measured table). The
-	// existing histogram-merge budget guard is reused UNCHANGED (proven
-	// safe under the new cost model too, just conservative — see that
-	// same header) rather than newly calibrated, so this feature does not
-	// yet unlock the guard's full potential upside; recalibrating it is
-	// tracked by cerberus issue #2834. Until both land, this feature is reachable
-	// only by explicit CERBERUS_CH_OPTIMIZATIONS=exp_histogram_merge_summap
+	// header for the full measured table). Its own budget guard is now
+	// real-ClickHouse-calibrated per shape — single-group, multi-group
+	// instant, and multi-group range mode each have their OWN ceiling
+	// (exp_histogram_merge_summap_bound.go) — but the proven single-series-
+	// wide-layout regression above is a real, permanent property of this
+	// design, not a calibration gap, so this feature stays reachable only
+	// by explicit CERBERUS_CH_OPTIMIZATIONS=exp_histogram_merge_summap
 	// listing, mirroring FeatureClassicBucketMergeSumMap's own posture for
 	// a feature with a proven, real regression on a specific input shape.
 	FeatureExpHistogramMergeSumMap = "exp_histogram_merge_summap"

--- a/internal/promql/exp_histogram_merge_summap.go
+++ b/internal/promql/exp_histogram_merge_summap.go
@@ -17,16 +17,17 @@ import (
 //
 // # Scope
 //
-// Every INSTANT shape is eligible: `sum(<native-histogram selector>)` or
-// its `avg()` twin (cerberus issue #2866 widened the original SUM-only v1,
+// Every shape is eligible: `sum(<native-histogram selector>)` or its
+// `avg()` twin (cerberus issue #2866 widened the original SUM-only v1,
 // #2757, to include AVG), with or without a `by(...)`/`without(...)`
 // clause (cerberus issue #2865 widened v1's original single-group-only
-// restriction — see "Multi-group mergedScale" below). Range/query_range
-// mode still stays on the existing fold unconditionally; see
-// NativeExpHistogramMergeLowerer for why — the identical per-anchor
-// mergedScale problem multi-group solves for by()/without() applies to
-// range mode too, and cerberus issue #3027 tracks wiring it onto this
-// SAME mechanism.
+// restriction — see "Multi-group mergedScale" below), in both instant and
+// range/query_range mode (cerberus issue #3027 widened #2865's multi-group
+// mechanism to admit a non-nil step anchor — see "Range mode" below). The
+// anchor and a by()/without() grouping key solve the IDENTICAL problem —
+// mergedScale needs one value per OUTPUT GROUP, not one value for the
+// whole query — which is why #3027 needed no new mechanism, only a wider
+// PARTITION BY key.
 //
 // # The two-pass restructure (issue #2757's own "known hard part",
 // # verified here)
@@ -90,6 +91,44 @@ import (
 // single-group path onto it (see above): the two mechanisms already agree
 // on that shape, so there is nothing to gain from unifying them beyond
 // unnecessary golden churn.
+//
+// # Range mode (cerberus issue #3027)
+//
+// Range/query_range mode adds a THIRD partition axis on top of the two
+// above: [chplan.RangeBucketFanout] (histogram_quantile_range.go's
+// buildHistogramBucketFanout, called from lowerExpHistogramSumOrAvgRange)
+// already resolves one newest-in-window sample per series PER STEP
+// ANCHOR before this file's merge ever runs, and each step anchor's rows
+// must merge INDEPENDENTLY of every other step's — exactly the same
+// "mergedScale needs to differ per OUTPUT GROUP" problem multi-group
+// mode solves for by()/without(), just keyed by anchor_ts instead of (or
+// in addition to) the user's grouping labels.
+// [expHistogramMergeScaleWindowPartitionBy] already generalizes to this:
+// it was written accepting an anchor parameter from the day #2865 shipped
+// (this file's own comment on that function explains why), so range mode
+// needs no new mergedScale mechanism — only prepending anchor_ts to the
+// SAME PARTITION BY list multi-group mode builds, and threading anchor
+// through to the merge Aggregate's own GroupBy exactly the way the OLD
+// fold ([expHistogramGroupMergeFanout], histogram_native_sum.go) already
+// does.
+//
+// Because every anchor is its own output group, range mode ALWAYS uses
+// the WindowExpr multi-group mechanism, even with no by()/without()
+// clause: a bare `sum(<selector>)` in range mode still produces one row
+// per step, so mergedScale still needs the per-group (per-anchor)
+// answer, never the single global scalar
+// [expHistogramMergeScaleScalarSubquery] resolves for the truly
+// single-row instant case. See [expHistogramGroupMergeSumMap]'s own doc
+// for exactly which condition selects the WindowExpr path.
+//
+// Range mode's own budget guard is calibrated SEPARATELY from instant
+// mode's multi-group guard above (exp_histogram_merge_summap_bound.go's
+// "Range-mode calibration" section) precisely because its group count is
+// `(step count) x (distinct label groups)`: a wide time range with a
+// small step multiplies group count independently of anything the query
+// text itself suggests, so instant mode's own real-ClickHouse-calibrated
+// ceiling — tuned for one-group-per-label-set — is not safe to reuse
+// here without its own measurement.
 //
 // # Cost model, and the rows-independent budget guard (cerberus issue #2834)
 //
@@ -228,11 +267,9 @@ func expHistogramMergeScaleScalarSubquery(perSeries chplan.Node, s schema.Metric
 // expression list a [chplan.WindowExpr] mergedScale pre-pass needs for a
 // given grouping: the group-key expressions [histogramAggGroupBy] resolves
 // for by()/without(), optionally prefixed by a range-mode step anchor.
-// anchor is nil at every call site wired today (instant mode only — see
-// this file's header); range mode (cerberus issue #3027) reuses this SAME
-// function with its own anchor column, so the partition-key shape is
-// derived exactly once regardless of how many call sites eventually need
-// it.
+// anchor is nil in instant mode and the fan-out's anchor column in range
+// mode (cerberus issue #3027) — both callers share this ONE function so
+// the partition-key shape is derived exactly once regardless of mode.
 func expHistogramMergeScaleWindowPartitionBy(anchor *chplan.ColumnRef, groupBy []chplan.Expr) []chplan.Expr {
 	if anchor == nil {
 		return groupBy
@@ -276,7 +313,14 @@ type expHistogramMergeScaleWindowCols struct {
 // [expHistogramGroupMergeAggsSumMap]'s pass-2 aggregates read — so a
 // column added there without being added here would silently vanish
 // before pass 2 ever sees it.
-func expHistogramMergeScaleWindowProject(perSeries chplan.Node, partitionBy []chplan.Expr, s schema.Metrics) (chplan.Node, expHistogramMergeScaleWindowCols) {
+//
+// anchor is nil in instant mode and the range fan-out's step-anchor column
+// in range mode (cerberus issue #3027): when non-nil it is ALSO passed
+// through explicitly, for the identical reason every other column is —
+// pass 2's merge Aggregate groups by it (mirroring
+// [expHistogramGroupMergeFanout]'s own anchor-prepended GroupBy), so it
+// must survive this reshape too.
+func expHistogramMergeScaleWindowProject(perSeries chplan.Node, anchor *chplan.ColumnRef, partitionBy []chplan.Expr, s schema.Metrics) (chplan.Node, expHistogramMergeScaleWindowCols) {
 	passthrough := func(col string) chplan.Projection {
 		return chplan.Projection{Expr: &chplan.ColumnRef{Name: col}, Alias: col}
 	}
@@ -293,6 +337,9 @@ func expHistogramMergeScaleWindowProject(perSeries chplan.Node, partitionBy []ch
 	}
 	if s.ZeroThresholdColumn != "" {
 		projs = append(projs, passthrough(s.ZeroThresholdColumn))
+	}
+	if anchor != nil {
+		projs = append(projs, passthrough(stepGridAnchorColumn))
 	}
 	projs = append(
 		projs,
@@ -462,12 +509,13 @@ func expHistogramGroupMergeProjectionsSumMap(s schema.Metrics) []chplan.Projecti
 }
 
 // expHistogramGroupMergeSumMap builds the full two-pass merge node for
-// every eligible instant shape — SUM or AVG fold, with or without a
-// by()/without() clause (cerberus issue #2865 widened the original
-// single-group-only v1; see this file's header for both mergedScale
-// mechanisms): pass 1 resolves mergedScale (ScalarSubquery for the
-// single-group shape, the WindowExpr pre-pass for multi-group), pass 2 is
-// the Aggregate (wrapped in this design's OWN budget guard,
+// every eligible shape — instant or range mode (cerberus issue #3027),
+// SUM or AVG fold, with or without a by()/without() clause (cerberus
+// issue #2865 widened the original single-group-only v1; see this file's
+// header for all three mergedScale mechanisms): pass 1 resolves
+// mergedScale (ScalarSubquery for the single-group INSTANT shape, the
+// WindowExpr pre-pass for every other shape), pass 2 is the Aggregate
+// (wrapped in this design's OWN budget guard,
 // [wrapExpHistogramMergeSumMapBudgetGuard] — see this file's header and
 // exp_histogram_merge_summap_bound.go for the calibration behind it), and
 // the reshape Project. No [expHistogramMergeSortStage] call: that stage
@@ -475,6 +523,19 @@ func expHistogramGroupMergeProjectionsSumMap(s schema.Metrics) []chplan.Projecti
 // deterministic per-series summation order (cerberus issue #2254);
 // sumMap's own per-key grouping is order-invariant, so this path has
 // nothing to resort.
+//
+// anchor is nil in instant mode and the range fan-out's step-anchor
+// column in range mode — mirroring [expHistogramGroupMergeFanout]'s own
+// parameter exactly. rangeMode (anchor != nil) forces the WindowExpr
+// path even with an empty groupBy: every step anchor is its own output
+// group, so a bare `sum(<selector>)` in range mode still needs a
+// PER-GROUP mergedScale, never [expHistogramMergeScaleScalarSubquery]'s
+// single global scalar (which assumes the WHOLE input collapses to one
+// row — true only for the truly single-row instant shape). anchor is
+// also prepended to the merge Aggregate's own GroupBy/GroupByAliases and
+// to the output projection, exactly the way the OLD fold's anchor
+// handling works, so the two merge strategies agree on the range-mode
+// row shape byte-for-byte.
 //
 // Count / Sum stay on the existing groupArray + Kahan fold, byte-for-byte
 // — this file touches only the bucket-ladder scale/offset/counts fields,
@@ -496,21 +557,31 @@ func expHistogramGroupMergeProjectionsSumMap(s schema.Metrics) []chplan.Projecti
 // divides the five count-bearing fields of projs by it before capping the
 // Project. Both steps are conditional on expHistogramGroupIsAvg(agg)
 // exactly like the fold path's own, so sum() emits byte-identical SQL to
-// before this file learned about avg.
-func expHistogramGroupMergeSumMap(perSeries chplan.Node, agg *parser.AggregateExpr, s schema.Metrics, maxCostUnits int64) chplan.Node {
+// before this file learned about avg — and this holds identically in
+// range mode, verified by an explicit differential test (cerberus issue
+// #3027's own "confirm avg() generalizes for free" item) rather than
+// assumed from the instant-mode result.
+func expHistogramGroupMergeSumMap(perSeries chplan.Node, anchor *chplan.ColumnRef, agg *parser.AggregateExpr, s schema.Metrics, maxCostUnits int64) chplan.Node {
 	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(agg, &chplan.ColumnRef{Name: s.AttributesColumn}, s)
-	multiGroup := len(groupBy) > 0
+	rangeMode := anchor != nil
+	multiGroup := rangeMode || len(groupBy) > 0
 
 	mergeInput := perSeries
 	var mergedScale chplan.Expr
 	var totalRowCount, totalGroupCount chplan.Expr
 	if multiGroup {
-		partitionBy := expHistogramMergeScaleWindowPartitionBy(nil, groupBy)
+		partitionBy := expHistogramMergeScaleWindowPartitionBy(anchor, groupBy)
 		var winCols expHistogramMergeScaleWindowCols
-		mergeInput, winCols = expHistogramMergeScaleWindowProject(perSeries, partitionBy, s)
+		mergeInput, winCols = expHistogramMergeScaleWindowProject(perSeries, anchor, partitionBy, s)
 		mergedScale, totalRowCount, totalGroupCount = winCols.MergedScale, winCols.TotalRowCount, winCols.TotalGroupCount
 	} else {
 		mergedScale = expHistogramMergeScaleScalarSubquery(perSeries, s)
+	}
+
+	mergeGroupBy, mergeGroupByAliases := groupBy, groupByAliases
+	if rangeMode {
+		mergeGroupBy = append([]chplan.Expr{anchor}, groupBy...)
+		mergeGroupByAliases = append([]string{stepGridAnchorColumn}, groupByAliases...)
 	}
 
 	aggFuncs := append(
@@ -533,20 +604,23 @@ func expHistogramGroupMergeSumMap(perSeries chplan.Node, agg *parser.AggregateEx
 	}
 	merged := &chplan.Aggregate{
 		Input:              mergeInput,
-		GroupBy:            groupBy,
-		GroupByAliases:     groupByAliases,
+		GroupBy:            mergeGroupBy,
+		GroupByAliases:     mergeGroupByAliases,
 		AggFuncs:           aggFuncs,
 		DropEmptyOnNoGroup: true,
 	}
-	guarded := wrapExpHistogramMergeSumMapBudgetGuard(merged, maxCostUnits, multiGroup)
-	projs := append(
-		[]chplan.Projection{
-			{Expr: attrsRebuild, Alias: s.AttributesColumn},
-			{Expr: promHistogramKahanSum(&chplan.ColumnRef{Name: hqMergeCountsArrayAlias}), Alias: s.CountColumn},
-			{Expr: promHistogramKahanSum(&chplan.ColumnRef{Name: hqMergeSumsArrayAlias}), Alias: s.SumColumn},
-		},
-		expHistogramGroupMergeProjectionsSumMap(s)...,
+	guarded := wrapExpHistogramMergeSumMapBudgetGuard(merged, maxCostUnits, multiGroup, rangeMode)
+	var projs []chplan.Projection
+	if rangeMode {
+		projs = append(projs, chplan.Projection{Expr: anchor, Alias: stepGridAnchorColumn})
+	}
+	projs = append(
+		projs,
+		chplan.Projection{Expr: attrsRebuild, Alias: s.AttributesColumn},
+		chplan.Projection{Expr: promHistogramKahanSum(&chplan.ColumnRef{Name: hqMergeCountsArrayAlias}), Alias: s.CountColumn},
+		chplan.Projection{Expr: promHistogramKahanSum(&chplan.ColumnRef{Name: hqMergeSumsArrayAlias}), Alias: s.SumColumn},
 	)
+	projs = append(projs, expHistogramGroupMergeProjectionsSumMap(s)...)
 	if isAvg {
 		projs = expHistogramAvgScaleProjections(projs, s)
 	}
@@ -559,13 +633,12 @@ func expHistogramGroupMergeSumMap(perSeries chplan.Node, agg *parser.AggregateEx
 // lowerExpHistogramSumOrAvgRange) collects and merges every contributing
 // row's distribution: the existing groupArray + arrayReduce/arraySlice
 // picker fold (every shape), or this file's two-pass sumMap reshape
-// (instant mode, with or without by()/without(), SUM or AVG fold —
-// chopt.FeatureExpHistogramMergeSumMap). It never returns nil.
+// (instant AND range mode, with or without by()/without(), SUM or AVG
+// fold — chopt.FeatureExpHistogramMergeSumMap). It never returns nil.
 type ExpHistogramMergeLowerer interface {
 	// LowerExpHistogramMerge returns the merged chplan.Node. anchor is nil
-	// in instant mode (eligible for the sumMap path) and non-nil in range
-	// mode (never eligible yet — see this file's header, cerberus issue
-	// #3027).
+	// in instant mode and the step-anchor column in range mode (cerberus
+	// issue #3027) — both are eligible for the sumMap path.
 	LowerExpHistogramMerge(perSeries chplan.Node, anchor *chplan.ColumnRef, agg *parser.AggregateExpr, s schema.Metrics, maxCostUnits int64) chplan.Node
 }
 
@@ -582,27 +655,28 @@ func (FanoutExpHistogramMergeLowerer) LowerExpHistogramMerge(
 }
 
 // NativeExpHistogramMergeLowerer is the boot-wired ExpHistogramMergeLowerer
-// that routes every eligible INSTANT shape (anchor == nil — any grouping,
-// including by()/without(), cerberus issue #2865; SUM or AVG fold,
-// cerberus issue #2866) onto expHistogramGroupMergeSumMap. cmd/cerberus
-// wires it ONLY when chopt resolved exp_histogram_merge_summap at boot.
-// Range mode (anchor != nil) delegates to the embedded Fallback
-// unconditionally — see this file's header for why, and issue #3027 for
-// wiring it onto the same mechanism.
-type NativeExpHistogramMergeLowerer struct {
-	// Fallback is the concrete lowerer for every ineligible shape. Boot
-	// wires it to FanoutExpHistogramMergeLowerer{}.
-	Fallback ExpHistogramMergeLowerer
-}
+// that routes EVERY shape reaching this interface — instant or range mode
+// (anchor nil or not, cerberus issue #3027), any grouping including
+// by()/without() (cerberus issue #2865), SUM or AVG fold (cerberus issue
+// #2866) — onto expHistogramGroupMergeSumMap. cmd/cerberus wires it ONLY
+// when chopt resolved exp_histogram_merge_summap at boot.
+//
+// Unlike most other Native*Lowerer types in this package (e.g.
+// NativeRateLowerer), this one embeds no Fallback: every shape the two
+// call sites above can produce is a real by()/without()/anchor
+// combination [histogramAggGroupBy] and [expHistogramMergeScaleWindowPartitionBy]
+// already handle uniformly (see this file's header, "Range mode"), so
+// there is no remaining ineligible shape for a fallback to catch — the
+// same posture [NativeQuantileRankWalkLowerer] takes for the identical
+// reason. A budget-guard rejection is a RUNTIME throw against the row/
+// width shape, not a lowering-time ineligibility, so it does not need one
+// either.
+type NativeExpHistogramMergeLowerer struct{}
 
 // LowerExpHistogramMerge returns expHistogramGroupMergeSumMap(...) for
-// every instant shape (anchor == nil), or delegates to n.Fallback for
-// range mode.
-func (n NativeExpHistogramMergeLowerer) LowerExpHistogramMerge(
+// every shape (instant or range mode).
+func (NativeExpHistogramMergeLowerer) LowerExpHistogramMerge(
 	perSeries chplan.Node, anchor *chplan.ColumnRef, agg *parser.AggregateExpr, s schema.Metrics, maxCostUnits int64,
 ) chplan.Node {
-	if anchor == nil {
-		return expHistogramGroupMergeSumMap(perSeries, agg, s, maxCostUnits)
-	}
-	return n.Fallback.LowerExpHistogramMerge(perSeries, anchor, agg, s, maxCostUnits)
+	return expHistogramGroupMergeSumMap(perSeries, anchor, agg, s, maxCostUnits)
 }

--- a/internal/promql/exp_histogram_merge_summap_bound.go
+++ b/internal/promql/exp_histogram_merge_summap_bound.go
@@ -231,13 +231,21 @@ func expHistogramMergeSumMapBudgetGuardExpr(maxCostUnits int64) chplan.Expr {
 // this file's own budget guard, the sumMap-path counterpart of
 // [wrapExpHistogramMergeBudgetGuard]. multiGroup selects between the
 // single-group guard above (byte-identical to before cerberus issue #2865,
-// no golden churn) and [expHistogramMergeSumMapMultiGroupBudgetGuardExpr]
-// below — see this file's "Multi-group calibration" section for why
-// multi-group needs a genuinely different guard, not just a wider single-
-// group one.
-func wrapExpHistogramMergeSumMapBudgetGuard(merged chplan.Node, maxCostUnits int64, multiGroup bool) chplan.Node {
+// no golden churn) and one of the two multi-group guards below;
+// rangeMode (only meaningful when multiGroup is true — range mode is
+// ALWAYS multi-group, see [expHistogramGroupMergeSumMap]'s own doc)
+// further selects between [expHistogramMergeSumMapMultiGroupBudgetGuardExpr]
+// (instant, cerberus issue #2865) and
+// [expHistogramMergeSumMapRangeBudgetGuardExpr] (range mode, cerberus
+// issue #3027) — see this file's "Multi-group calibration" and
+// "Range-mode calibration" sections for why each shape needs its OWN
+// real-measured ceiling rather than sharing one.
+func wrapExpHistogramMergeSumMapBudgetGuard(merged chplan.Node, maxCostUnits int64, multiGroup, rangeMode bool) chplan.Node {
 	predicate := expHistogramMergeSumMapBudgetGuardExpr(maxCostUnits)
-	if multiGroup {
+	switch {
+	case multiGroup && rangeMode:
+		predicate = expHistogramMergeSumMapRangeBudgetGuardExpr(maxCostUnits)
+	case multiGroup:
 		predicate = expHistogramMergeSumMapMultiGroupBudgetGuardExpr(maxCostUnits)
 	}
 	return &chplan.Filter{Input: merged, Predicate: predicate}
@@ -379,6 +387,167 @@ func expHistogramMergeSumMapMultiGroupBudgetGuardExpr(maxCostUnits int64) chplan
 			Fn: chplan.FnThrowIf,
 			Args: []chplan.Expr{
 				expHistogramMergeSumMapMultiGroupCostOverBudgetExpr(seriesCount, maxCostUnits),
+				&chplan.InlineString{V: chplan.HistogramMergeBudgetMessage},
+			},
+		},
+		Right: &chplan.LitInt{V: 0},
+	}
+}
+
+// # Range-mode calibration (cerberus issue #3027, real ClickHouse 26.6.4, a
+// # standalone `docker run clickhouse/clickhouse-server:26.6-alpine`
+// # container — not chDB — seeded with otel_metrics_exponential_histogram-
+// # shaped rows and measured via the ACTUAL emitted SQL for a query_range
+// # `sum(<selector>)` / `sum by(instance)(<selector>)` (chsql.Emit over
+// # promql.LowerAtRangeOpts's own output through
+// # [NativeExpHistogramMergeLowerer], run through `SYSTEM FLUSH LOGS` +
+// # system.query_log.memory_usage — the SAME discipline the single-group
+// # and instant multi-group tables above use, via a throwaway harness
+// # deleted before this fix merged, same precedent as those tables)
+//
+// Range mode is ALWAYS multi-group (every step anchor is its own output
+// group — see [expHistogramGroupMergeSumMap]'s own doc), so it always
+// goes through the SAME WindowExpr pre-pass the instant multi-group guard
+// above bounds. But range mode ALSO pays a cost the instant path never
+// does: [chplan.RangeBucketFanout] (histogram_quantile_range.go's
+// buildHistogramBucketFanout) resolves one row per series PER STEP
+// BEFORE this merge ever runs, via a per-row arrayJoin fan-out over every
+// candidate anchor in that row's own staleness lookback window. That
+// stage's cost is real and is NOT bounded by anything this file adds (it
+// has its own, pre-existing "series-times-anchors resource bound" —
+// histogram_quantile_range.go / internal/chsql/lwr_fanout_bound.go); this
+// guard only has to be honest that its own two ceilings sit on top of
+// that other, already-real cost, not that it can ignore it.
+//
+// A real measurement isolating the GROUP-COUNT axis (fixed width 160, no
+// by()/without() clause — one output group per step anchor, exactly one
+// series contributing to each — the range-mode counterpart of the
+// instant multi-group table's own "1,000 groups of 1 row each" sweep):
+//
+//	steps   total rows   peak memory
+//	   100         100      67.1 MiB
+//	   500         500     303.9 MiB
+//	   600         600     364.0 MiB
+//	   700         700     424.1 MiB
+//	  1000       1,000     604.4 MiB
+//
+// This axis is cleanly linear (~0.6 MiB/step + a small fixed overhead)
+// across every checkpoint above — MUCH steeper than the instant multi-
+// group guard's own ~0.0095-0.0138 MiB/group, confirming the issue's own
+// prediction that range mode's per-group cost is materially higher (the
+// extra RangeBucketFanout pass every group pays before this merge even
+// starts). The sweep was NOT extended past ~1,400 steps at this shape:
+// somewhere in that neighborhood the measurement stopped being
+// deterministic — repeated runs at an IDENTICAL step count (1,406 to
+// 1,409 tested) returned either the same ~0.6 MiB/step trend (~850 MiB)
+// or a markedly cheaper ~100 MiB reading, nondeterministically, and
+// settled back to a fully deterministic (repeat-tested), much cheaper
+// ~0.043 MiB/step trend for every larger step count tried (2,000 through
+// 40,000). That instability sits well outside the ceiling this file
+// picks below and does not change its safety — [maxHistogramMergeCostUnits]'s
+// own margin discipline already assumes worst-case, not best-case,
+// execution — but it is flagged here, not silently smoothed over, as a
+// real ClickHouse behavior (plausibly a plan-selection threshold — e.g.
+// aggregation-in-order eligibility — flipping near that row count) a
+// future session should understand before raising this ceiling.
+//
+// A second sweep isolates the ROWS-PER-GROUP axis: a fixed, low step
+// count (100, far inside the ceiling below) while the series contributing
+// to EACH step grows (the range-mode counterpart of the instant multi-
+// group guard's own rows-per-group sweep):
+//
+//	steps   rows/step   total rows   peak memory
+//	   100          10        1,000      68.8 MiB
+//	   100          50        5,000     325.9 MiB
+//	   100          60        6,000     389.6 MiB
+//	   100          80        8,000     521.4 MiB
+//	   100         100       10,000     534.2 MiB
+//
+// Both sweeps land at a REAL cost per unit far above the instant multi-
+// group guard's own two sweeps (0.6 MiB/step here versus ~0.01 MiB/group
+// there; ~0.065 MiB/row here versus well under 0.001 MiB/row there at
+// comparable total row counts) — this is the RangeBucketFanout overhead
+// above, not a WindowExpr/sumMap regression: the identical shape run
+// through [FanoutExpHistogramMergeLowerer] (the OLD fold) at a few
+// checkpoints in this same range was COSTLIER still (e.g. 940.5 MiB at
+// 2,000 steps / 1 row-per-step, where the sumMap path measured only
+// 137.9 MiB — sumMap keeps its OWN cost advantage over the fold in range
+// mode too, it just does not erase RangeBucketFanout's shared cost). This
+// is why range mode needs its OWN, separately-pinned ceilings rather than
+// reusing the instant multi-group guard's 40,000 / 200,000 — at THOSE
+// values this shape's real memory would be roughly 40,000 x 0.6 MiB
+// (tens of gigabytes) before even accounting for RangeBucketFanout's own
+// resource bound, wildly unsafe.
+//
+// [maxHistogramMergeSumMapRangeGroupCountGuard] is pinned at the exact,
+// measured 600-step checkpoint (364.0 MiB, ~35.5% of the 1024 MiB
+// CERBERUS_CH_QUERY_MAX_MEMORY default target — the same margin
+// discipline [maxHistogramMergeSumMapGroupCountGuard]'s own doc uses),
+// comfortably below the ~1,400-step instability neighborhood identified
+// above. [maxHistogramMergeSumMapRangeTotalRowCountGuard] is pinned at
+// the measured 6,000-row checkpoint (389.6 MiB, ~38.0% of the same
+// target) — both far tighter than the instant multi-group guard's own
+// ceilings, reflecting range mode's genuinely higher real per-unit cost
+// rather than an arbitrary choice.
+//
+// avg()'s own cost is not independently re-measured on this axis: this
+// guard's cost formula reads the SAME groupArray/window columns
+// regardless of whether the caller is sum() or avg() (identical to the
+// reasoning [maxHistogramMergeSumMapGroupCountGuard]'s own doc gives,
+// which cerberus issue #2866 confirmed empirically for the instant
+// shape) — avg()'s extra division happens entirely in the OUTPUT
+// projection, after this guard's Filter has already run.
+//
+// A future session with a wider real-ClickHouse budget should still
+// investigate the ~1,400-step nondeterminism directly (it is currently
+// only characterized, not root-caused) before considering either ceiling
+// for an increase.
+const (
+	// maxHistogramMergeSumMapRangeTotalRowCountGuard bounds the TOTAL row
+	// count entering the WindowExpr pre-pass across every (step, group)
+	// pair in a range-mode merge — see this file's "Range-mode
+	// calibration" section above for the measured 6,000-row / 389.6 MiB
+	// checkpoint this is pinned at.
+	maxHistogramMergeSumMapRangeTotalRowCountGuard = 6_000
+
+	// maxHistogramMergeSumMapRangeGroupCountGuard bounds the TOTAL number
+	// of DISTINCT (step anchor, label group) pairs a range-mode merge may
+	// produce — see this file's "Range-mode calibration" section above
+	// for the measured 600-step / 364.0 MiB checkpoint this is pinned at.
+	maxHistogramMergeSumMapRangeGroupCountGuard = 600
+)
+
+// expHistogramMergeSumMapRangeCostOverBudgetExpr is
+// [expHistogramMergeSumMapMultiGroupCostOverBudgetExpr]'s range-mode
+// counterpart: the SAME per-group cost term and the SAME max()-collected
+// whole-query totals, checked against range mode's OWN, separately
+// calibrated ceilings.
+func expHistogramMergeSumMapRangeCostOverBudgetExpr(rowCount chplan.Expr, maxCostUnits int64) chplan.Expr {
+	totalRowCount := &chplan.ColumnRef{Name: hqAggMultiGroupTotalRowCountAlias}
+	totalGroupCount := &chplan.ColumnRef{Name: hqAggMultiGroupTotalGroupCountAlias}
+	return orExpr(
+		expHistogramMergeSumMapCostOverBudgetExpr(rowCount, maxCostUnits),
+		orExpr(
+			gtLit(totalRowCount, maxHistogramMergeSumMapRangeTotalRowCountGuard),
+			gtLit(totalGroupCount, maxHistogramMergeSumMapRangeGroupCountGuard),
+		),
+	)
+}
+
+// expHistogramMergeSumMapRangeBudgetGuardExpr is
+// [expHistogramMergeSumMapMultiGroupBudgetGuardExpr]'s range-mode
+// counterpart: identical throwIf(...) = 0 shape, reading the SAME columns
+// through [expHistogramMergeSumMapRangeCostOverBudgetExpr] instead.
+func expHistogramMergeSumMapRangeBudgetGuardExpr(maxCostUnits int64) chplan.Expr {
+	scalesArr := &chplan.ColumnRef{Name: hqAggScalesArrayAlias}
+	seriesCount := &chplan.FuncCall{Fn: chplan.FnLength, Args: []chplan.Expr{scalesArr}}
+
+	return &chplan.Binary{
+		Op: chplan.OpEq,
+		Left: &chplan.FuncCall{
+			Fn: chplan.FnThrowIf,
+			Args: []chplan.Expr{
+				expHistogramMergeSumMapRangeCostOverBudgetExpr(seriesCount, maxCostUnits),
 				&chplan.InlineString{V: chplan.HistogramMergeBudgetMessage},
 			},
 		},

--- a/internal/promql/exp_histogram_merge_summap_bound_chdb_test.go
+++ b/internal/promql/exp_histogram_merge_summap_bound_chdb_test.go
@@ -38,7 +38,7 @@ import (
 // for every ineligible shape — the same table
 // exp_histogram_merge_summap_chdb_test.go's differential proof uses.
 var expHistSumMapBoundNativeLowerers = promql.RangeLowerers{
-	ExpHistogramMerge: promql.NativeExpHistogramMergeLowerer{Fallback: promql.FanoutExpHistogramMergeLowerer{}},
+	ExpHistogramMerge: promql.NativeExpHistogramMergeLowerer{},
 }
 
 // runExpHistSumMapBoundQuery lowers + emits `sum(<metric>)` through the

--- a/internal/promql/exp_histogram_merge_summap_bound_range_chdb_test.go
+++ b/internal/promql/exp_histogram_merge_summap_bound_range_chdb_test.go
@@ -1,0 +1,217 @@
+//go:build chdb
+
+// chDB-backed proof that cerberus issue #3027's range-mode budget guard
+// (exp_histogram_merge_summap_bound.go's expHistogramMergeSumMapRangeBudgetGuardExpr)
+// actually FIRES — and stays silent on a legitimate range-mode merge — at
+// real ClickHouse execution, mirroring
+// exp_histogram_merge_summap_bound_multigroup_chdb_test.go's own structure
+// for the instant multi-group guard. chDB is fine here: these tests pin
+// the throwIf's deterministic ARITHMETIC (step/group count and row count,
+// known from the seed), not real peak memory — real-memory calibration is
+// exp_histogram_merge_summap_bound.go's own header doc, against a real
+// standalone server, never chDB (see that file's "Range-mode calibration"
+// section).
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// expHistSumMapRangeBoundStep is the query_range step every case below
+// uses to build its anchor grid.
+const expHistSumMapRangeBoundStep = 60 * time.Second
+
+// runExpHistSumMapRangeBoundQuery lowers + emits query as a query_range
+// request ([start,end] at expHistSumMapRangeBoundStep, `steps` anchors)
+// through [expHistSumMapBoundNativeLowerers] and runs it against fixture,
+// mirroring runExpHistSumMapMultiGroupBoundQuery's own count()-wrapping
+// rationale.
+func runExpHistSumMapRangeBoundQuery(t *testing.T, fixture *chdbFixture, query string, steps int) error {
+	t.Helper()
+	s := schema.DefaultOTelMetrics()
+	p := promparser.NewParser(promparser.Options{})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	end := expHistSumMapRangeBoundBaseline.Add(time.Duration(steps) * expHistSumMapRangeBoundStep)
+	start := end.Add(-time.Duration(steps-1) * expHistSumMapRangeBoundStep)
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, s, start, end, expHistSumMapRangeBoundStep,
+		promql.LowerOpts{Lowerers: expHistSumMapBoundNativeLowerers})
+	if err != nil {
+		t.Fatalf("LowerAtRangeOpts(%q): %v", query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(%q): %v", query, err)
+	}
+	wrapped := "SELECT count() FROM (" + sqlStr + ")"
+	rows, qerr := fixture.db.Query(wrapped, args...)
+	if qerr != nil {
+		return qerr
+	}
+	defer func() { _ = rows.Close() }()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		t.Fatal("count() query returned no rows")
+	}
+	return rows.Err()
+}
+
+// expHistSumMapRangeBoundBaseline anchors every seed below at a fixed
+// instant so [runExpHistSumMapRangeBoundQuery]'s own start/end derivation
+// (from `steps` alone) lines up with whatever [seedExpHistSumMapRangeBoundRows]
+// wrote for the SAME `steps`.
+var expHistSumMapRangeBoundBaseline = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// seedExpHistSumMapRangeBoundRows seeds `steps` step anchors, each with
+// `rowsPerStep` distinct single-bucket-wide series (Scale 0,
+// PositiveOffset 0, one bucket) contributing to it — trivial per-group
+// cost (width 1), so a test using this seed isolates the range-mode
+// multi-group axes (total row count / total group count) from the
+// existing per-group width^2 term entirely, mirroring
+// seedExpHistSumMapMultiGroupBoundRows's identical isolation for instant
+// mode. Every row is timestamped one second before its own anchor, well
+// inside the default 5m staleness lookback and closer to that anchor than
+// to any neighbor (expHistSumMapRangeBoundStep is 60s).
+func seedExpHistSumMapRangeBoundRows(t *testing.T, steps, rowsPerStep int) *chdbFixture {
+	t.Helper()
+	end := expHistSumMapRangeBoundBaseline.Add(time.Duration(steps) * expHistSumMapRangeBoundStep)
+	start := end.Add(-time.Duration(steps-1) * expHistSumMapRangeBoundStep)
+
+	var b strings.Builder
+	b.WriteString(histogramMergeBoundSeedDDL)
+	b.WriteString("INSERT INTO otel_metrics_exponential_histogram (MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n")
+	tuples := make([]string, 0, steps*rowsPerStep)
+	for step := 0; step < steps; step++ {
+		anchor := start.Add(time.Duration(step) * expHistSumMapRangeBoundStep)
+		ts := anchor.Add(-time.Second)
+		for i := 0; i < rowsPerStep; i++ {
+			tuples = append(tuples, fmt.Sprintf(
+				"('%s', map('series', 's%d_%d'), toDateTime64('%s', 9), 1, 1.0, 0, 0, 0, [1], 0, [])",
+				histogramMergeBoundMetric, step, i, ts.Format("2006-01-02 15:04:05"),
+			))
+		}
+	}
+	b.WriteString("    " + strings.Join(tuples, ",\n    ") + ";\n")
+	return newChDBFixture(t, b.String())
+}
+
+// TestExpHistogramMergeSumMapBudget_ChDB_RangeGroupCountOverflowGuard
+// seeds one past [maxHistogramMergeSumMapRangeGroupCountGuard] (600) —
+// one row per step, no by()/without(), trivial per-group cost — isolating
+// the STEP/group-count axis no per-group check can see
+// (exp_histogram_merge_summap_bound.go's own "Range-mode calibration"
+// section: the real 600-step checkpoint this ceiling is pinned at).
+func TestExpHistogramMergeSumMapBudget_ChDB_RangeGroupCountOverflowGuard(t *testing.T) {
+	const steps, rowsPerStep = 601, 1
+	fixture := seedExpHistSumMapRangeBoundRows(t, steps, rowsPerStep)
+
+	query := fmt.Sprintf("sum(%s)", histogramMergeBoundMetric)
+	err := runExpHistSumMapRangeBoundQuery(t, fixture, query, steps)
+	if err == nil {
+		t.Fatal("expected the range-mode budget guard to abort the query (601 step anchors exceeds " +
+			"maxHistogramMergeSumMapRangeGroupCountGuard=600, even though every individual anchor's own " +
+			"cost is trivial), got no error")
+	}
+	if !strings.Contains(err.Error(), chplan.HistogramMergeBudgetMessage) {
+		t.Fatalf("query failed, but not with the merge budget guard's throwIf: %v", err)
+	}
+}
+
+// TestExpHistogramMergeSumMapBudget_ChDB_RangeTotalRowCountOverflowGuard
+// seeds 2 step anchors of 3,001 rows each (6,002 total, one past
+// [maxHistogramMergeSumMapRangeTotalRowCountGuard]=6,000) — each anchor's
+// OWN row count (3,001) stays under the EXISTING, unchanged per-group
+// [maxHistogramMergeRowCountOverflowGuard] backstop (4,096) and the
+// step/group count (2) stays far under
+// [maxHistogramMergeSumMapRangeGroupCountGuard] (600), so this isolates
+// the TOTAL-row-count axis exactly like
+// TestExpHistogramMergeSumMapBudget_ChDB_MultiGroupTotalRowCountOverflowGuard
+// does for instant mode.
+func TestExpHistogramMergeSumMapBudget_ChDB_RangeTotalRowCountOverflowGuard(t *testing.T) {
+	const steps, rowsPerStep = 2, 3_001
+	fixture := seedExpHistSumMapRangeBoundRows(t, steps, rowsPerStep)
+
+	query := fmt.Sprintf("sum(%s)", histogramMergeBoundMetric)
+	err := runExpHistSumMapRangeBoundQuery(t, fixture, query, steps)
+	if err == nil {
+		t.Fatal("expected the range-mode budget guard to abort the query (2 anchors x 3,001 rows = " +
+			"6,002 total rows exceeds maxHistogramMergeSumMapRangeTotalRowCountGuard=6,000, even though " +
+			"each individual anchor's own row count stays under the existing per-group backstop and the " +
+			"anchor count stays under the range group-count ceiling), got no error")
+	}
+	if !strings.Contains(err.Error(), chplan.HistogramMergeBudgetMessage) {
+		t.Fatalf("query failed, but not with the merge budget guard's throwIf: %v", err)
+	}
+}
+
+// TestExpHistogramMergeSumMapBudget_ChDB_RangePerGroupCostStillEnforced
+// seeds TWO step anchors — one legitimate, one with an unusually wide
+// single series (width 4,000, cost 4x4000^2=64,000,000, over the
+// 60,000,000 default) — proving the range-mode guard still ORs in
+// [expHistogramMergeSumMapCostOverBudgetExpr]'s existing per-group check
+// rather than replacing it, exactly like
+// TestExpHistogramMergeSumMapBudget_ChDB_MultiGroupPerGroupCostStillEnforced
+// does for instant mode.
+func TestExpHistogramMergeSumMapBudget_ChDB_RangePerGroupCostStillEnforced(t *testing.T) {
+	const steps = 2
+	end := expHistSumMapRangeBoundBaseline.Add(time.Duration(steps) * expHistSumMapRangeBoundStep)
+	start := end.Add(-time.Duration(steps-1) * expHistSumMapRangeBoundStep)
+	ts0 := start.Add(-time.Second).Format("2006-01-02 15:04:05")
+	ts1 := start.Add(expHistSumMapRangeBoundStep).Add(-time.Second).Format("2006-01-02 15:04:05")
+
+	var b strings.Builder
+	b.WriteString(histogramMergeBoundSeedDDL)
+	b.WriteString("INSERT INTO otel_metrics_exponential_histogram " + histogramMergeBoundInsertColumns + " VALUES\n")
+	wideBuckets := make([]string, 4000)
+	for i := range wideBuckets {
+		wideBuckets[i] = "1"
+	}
+	tuples := []string{
+		fmt.Sprintf("('%s', map('series', 's0'), toDateTime64('%s', 9), 1, 1.0, 0, 0, 0, [%s], 0, [])",
+			histogramMergeBoundMetric, ts0, strings.Join(wideBuckets, ",")),
+		fmt.Sprintf("('%s', map('series', 's1'), toDateTime64('%s', 9), 1, 1.0, 0, 0, 0, [1], 0, [])",
+			histogramMergeBoundMetric, ts1),
+	}
+	b.WriteString("    " + strings.Join(tuples, ",\n    ") + ";\n")
+	fixture := newChDBFixture(t, b.String())
+
+	query := fmt.Sprintf("sum(%s)", histogramMergeBoundMetric)
+	err := runExpHistSumMapRangeBoundQuery(t, fixture, query, steps)
+	if err == nil {
+		t.Fatal("expected the range-mode guard to still reject the first anchor's own width-4000 series " +
+			"(cost 4x4000^2=64,000,000 exceeds the 60,000,000 default) via the existing per-group check, got no error")
+	}
+	if !strings.Contains(err.Error(), chplan.HistogramMergeBudgetMessage) {
+		t.Fatalf("query failed, but not with the merge budget guard's throwIf: %v", err)
+	}
+}
+
+// TestExpHistogramMergeSumMapBudget_ChDB_RangeWithinBudget seeds a small,
+// legitimate range-mode merge (3 step anchors, 2 series each) and asserts
+// the range-mode guard does not fire on ordinary data, mirroring
+// TestExpHistogramMergeSumMapBudget_ChDB_MultiGroupWithinBudget for
+// instant mode.
+func TestExpHistogramMergeSumMapBudget_ChDB_RangeWithinBudget(t *testing.T) {
+	const steps, rowsPerStep = 3, 2
+	fixture := seedExpHistSumMapRangeBoundRows(t, steps, rowsPerStep)
+
+	query := fmt.Sprintf("sum(%s)", histogramMergeBoundMetric)
+	if err := runExpHistSumMapRangeBoundQuery(t, fixture, query, steps); err != nil {
+		t.Fatalf("a legitimate 3-anchor, 2-series-per-anchor range merge must not trip the range-mode budget guard: %v", err)
+	}
+}

--- a/internal/promql/exp_histogram_merge_summap_chdb_test.go
+++ b/internal/promql/exp_histogram_merge_summap_chdb_test.go
@@ -73,9 +73,7 @@ func expHistSumMapDiffLowerers(native bool) promql.RangeLowerers {
 		return promql.RangeLowerers{}
 	}
 	return promql.RangeLowerers{
-		ExpHistogramMerge: promql.NativeExpHistogramMergeLowerer{
-			Fallback: promql.FanoutExpHistogramMergeLowerer{},
-		},
+		ExpHistogramMerge: promql.NativeExpHistogramMergeLowerer{},
 	}
 }
 

--- a/internal/promql/exp_histogram_merge_summap_range_chdb_test.go
+++ b/internal/promql/exp_histogram_merge_summap_range_chdb_test.go
@@ -1,0 +1,238 @@
+//go:build chdb
+
+// chDB-backed differential proof for cerberus issue #3027's range/
+// query_range extension of [expHistogramGroupMergeSumMap]
+// (exp_histogram_merge_summap.go): the SAME range query and seed, lowered
+// once through the default groupArray + picker fold
+// (expHistogramGroupMergeFanout, via lowerExpHistogramSumOrAvgRange) and
+// once through [promql.NativeExpHistogramMergeLowerer] (chopt
+// exp_histogram_merge_summap), executed against real ClickHouse (chDB) and
+// compared row set for row set. Mirrors
+// exp_histogram_merge_summap_multigroup_chdb_test.go's structure, widened
+// with a non-nil anchor: every fixture here produces MORE THAN ONE step
+// anchor in the SAME query_range request, exercising the anchor-prefixed
+// WindowExpr PARTITION BY [expHistogramMergeScaleWindowPartitionBy] builds
+// when anchor != nil.
+//
+//   - TestExpHistogramMergeSumMapRangeDifferential_NoGrouping is `sum(...)`
+//     with no by()/without() clause over TWO steps — every anchor is its
+//     own output group (cerberus issue #3027's core claim: range mode is
+//     ALWAYS multi-group, see [expHistogramGroupMergeSumMap]'s own doc),
+//     each with its OWN cross-series scale negotiation via a series
+//     update that lands strictly between the two anchors.
+//   - TestExpHistogramMergeSumMapRangeDifferential_By is `sum by(route)`
+//     over the SAME two-anchor seed — TWO groups PER anchor, proving the
+//     anchor-prefixed partition key does not leak across either axis.
+//   - TestExpHistogramMergeSumMapRangeDifferential_Without is the
+//     `without(route)` twin (histogramAggGroupBy's OTHER branch).
+//   - TestExpHistogramMergeSumMapRangeDifferential_Avg is the `by()`
+//     case's avg() twin — cerberus issue #3027's own "confirm avg()
+//     generalizes for free" item, verified explicitly rather than
+//     assumed from the instant-mode result (cerberus issue #2866 did the
+//     identical verification for instant mode).
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	promparser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// expHistSumMapRangeMetric is the metric name every case below queries —
+// distinct from every other fixture sharing this package's chDB session
+// (fixture_chdb_test.go).
+const expHistSumMapRangeMetric = "exp_histogram_merge_summap_range_diff_exp_hist"
+
+// expHistSumMapRangeStep is the query_range step every case below uses.
+const expHistSumMapRangeStep = 60 * time.Second
+
+// expHistSumMapRangeStart / expHistSumMapRangeEnd are the two step
+// anchors every case below evaluates.
+var (
+	expHistSumMapRangeStart = time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)
+	expHistSumMapRangeEnd   = expHistSumMapRangeStart.Add(expHistSumMapRangeStep)
+)
+
+// expHistSumMapRangeDiffRow is one merged-histogram output row, keyed by
+// its own (timestamp, Attributes) pair — the differential comparison
+// sorts rows by that key so the two strategies' potentially differently
+// -ordered output still compares equal.
+type expHistSumMapRangeDiffRow struct {
+	ts                     string
+	attrs                  string
+	scale                  int64
+	zeroCount              float64
+	posOffset, negOffset   int64
+	posBuckets, negBuckets string
+	count, sum             float64
+}
+
+// runExpHistSumMapRangeDiffQuery lowers query as a query_range request
+// (expHistSumMapRangeStart to expHistSumMapRangeEnd, step
+// expHistSumMapRangeStep — two anchors) under the given strategy and
+// returns every resulting merged-histogram row, sorted by (timestamp,
+// Attributes) so the two strategies' potentially differently-ordered
+// output still compares equal.
+func runExpHistSumMapRangeDiffQuery(t *testing.T, fixture *chdbFixture, native bool, query string) []expHistSumMapRangeDiffRow {
+	t.Helper()
+	s := schema.DefaultOTelMetrics()
+	p := promparser.NewParser(promparser.Options{})
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, s,
+		expHistSumMapRangeStart, expHistSumMapRangeEnd, expHistSumMapRangeStep,
+		promql.LowerOpts{Lowerers: expHistSumMapDiffLowerers(native)})
+	if err != nil {
+		t.Fatalf("LowerAtRangeOpts(native=%v, %q): %v", native, query, err)
+	}
+	sqlStr, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit(native=%v, %q): %v", native, query, err)
+	}
+	rows := fixture.queryOverEmitted(t,
+		"toString(TimeUnix), toString(Attributes), HistogramScale, toString(HistogramZeroCount), HistogramPositiveOffset, toString(HistogramPositiveBucketCounts), "+
+			"HistogramNegativeOffset, toString(HistogramNegativeBucketCounts), toString(HistogramCount), toString(HistogramSum)",
+		sqlStr, args)
+	defer func() { _ = rows.Close() }()
+
+	var out []expHistSumMapRangeDiffRow
+	for rows.Next() {
+		var row expHistSumMapRangeDiffRow
+		var zeroCountStr, countStr, sumStr string
+		if err := rows.Scan(&row.ts, &row.attrs, &row.scale, &zeroCountStr, &row.posOffset, &row.posBuckets,
+			&row.negOffset, &row.negBuckets, &countStr, &sumStr); err != nil {
+			t.Fatalf("scan (native=%v): %v", native, err)
+		}
+		row.zeroCount = mustParseFloat(t, zeroCountStr)
+		row.count = mustParseFloat(t, countStr)
+		row.sum = mustParseFloat(t, sumStr)
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("query error (native=%v): %v", native, err)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ts != out[j].ts {
+			return out[i].ts < out[j].ts
+		}
+		return out[i].attrs < out[j].attrs
+	})
+	return out
+}
+
+func assertExpHistSumMapRangeDiffEqual(t *testing.T, fanout, native []expHistSumMapRangeDiffRow) {
+	t.Helper()
+	if len(fanout) != len(native) {
+		t.Fatalf("fanout and native (sumMap) range merges disagree on ROW COUNT: fanout=%d native=%d\n  fanout = %+v\n  native = %+v",
+			len(fanout), len(native), fanout, native)
+	}
+	for i := range fanout {
+		if fanout[i] != native[i] {
+			t.Fatalf("fanout and native (sumMap) range merges disagree at row %d:\n  fanout = %+v\n  native = %+v", i, fanout[i], native[i])
+		}
+	}
+}
+
+// newExpHistSumMapRangeDiffFixture seeds route `a` with two series: `s1`
+// holds ONE sample (scale 0) valid at BOTH anchors, and `s2` holds TWO
+// samples — an OLDER one (scale 2) valid only at the FIRST anchor and a
+// NEWER one (scale 1) landing strictly between the two anchors, so it
+// becomes the newest-in-window sample for the SECOND anchor only. Route
+// `a`'s own cross-series scale negotiation therefore differs across the
+// two anchors even though its mergedScale happens to coincide
+// (min(0,2)=0, then min(0,1)=0) — the RECONSTRUCTED bucket ladder still
+// differs, since s2's own contribution changes between the two anchors.
+// Route `b` holds a single, stable series (`s3`, unchanged across both
+// anchors) as a control: if the anchor-prefixed WindowExpr partition
+// leaked across anchors OR across groups, route `b`'s output would drift
+// even though nothing about it changes between the two anchors — and any
+// such leak would show up as a divergence from the fold's own,
+// independently-correct per-(anchor, group) computation.
+func newExpHistSumMapRangeDiffFixture(t *testing.T) *chdbFixture {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(expHistSumMapDiffSeedDDL)
+	b.WriteString("INSERT INTO otel_metrics_exponential_histogram (MetricName, Attributes, TimeUnix, Count, Sum, Scale, ZeroCount, PositiveOffset, PositiveBucketCounts, NegativeOffset, NegativeBucketCounts) VALUES\n")
+	rows := []string{
+		fmt.Sprintf("('%s', map('route', 'a', 'series', 's1'), toDateTime64('2026-01-01 00:00:30', 9), 10, 1.0, 0, 0, 5, [1,2,3,4], 0, [])", expHistSumMapRangeMetric),
+		fmt.Sprintf("('%s', map('route', 'a', 'series', 's2'), toDateTime64('2026-01-01 00:00:30', 9), 283, 1.0, 2, 0, 17, [10,20,30,40,50,60,70], 0, [])", expHistSumMapRangeMetric),
+		fmt.Sprintf("('%s', map('route', 'a', 'series', 's2'), toDateTime64('2026-01-01 00:01:30', 9), 6, 4.0, 1, 0, -2, [1,2,3], 0, [])", expHistSumMapRangeMetric),
+		fmt.Sprintf("('%s', map('route', 'b', 'series', 's3'), toDateTime64('2026-01-01 00:00:30', 9), 6, 3.0, 1, 0, -2, [1,2,3], 0, [])", expHistSumMapRangeMetric),
+	}
+	b.WriteString("    " + strings.Join(rows, ",\n    ") + ";\n")
+	return newChDBFixture(t, b.String())
+}
+
+// TestExpHistogramMergeSumMapRangeDifferential_NoGrouping is `sum(...)`
+// (no by()/without()) over [newExpHistSumMapRangeDiffFixture] — every
+// step anchor is its own output group, cerberus issue #3027's core claim
+// that range mode is ALWAYS multi-group.
+func TestExpHistogramMergeSumMapRangeDifferential_NoGrouping(t *testing.T) {
+	fixture := newExpHistSumMapRangeDiffFixture(t)
+	query := fmt.Sprintf("sum(%s)", expHistSumMapRangeMetric)
+	fanout := runExpHistSumMapRangeDiffQuery(t, fixture, false, query)
+	native := runExpHistSumMapRangeDiffQuery(t, fixture, true, query)
+	if len(native) != 2 {
+		t.Fatalf("expected 2 rows (one per step anchor), got %d: %+v", len(native), native)
+	}
+	assertExpHistSumMapRangeDiffEqual(t, fanout, native)
+}
+
+// TestExpHistogramMergeSumMapRangeDifferential_By is `sum by(route)` over
+// the SAME two-anchor seed — TWO groups PER anchor (route a, route b),
+// four rows total, proving the anchor-prefixed partition key does not
+// leak across either axis.
+func TestExpHistogramMergeSumMapRangeDifferential_By(t *testing.T) {
+	fixture := newExpHistSumMapRangeDiffFixture(t)
+	query := fmt.Sprintf("sum by(route) (%s)", expHistSumMapRangeMetric)
+	fanout := runExpHistSumMapRangeDiffQuery(t, fixture, false, query)
+	native := runExpHistSumMapRangeDiffQuery(t, fixture, true, query)
+	if len(native) != 4 {
+		t.Fatalf("expected 4 rows (2 anchors x 2 routes), got %d: %+v", len(native), native)
+	}
+	assertExpHistSumMapRangeDiffEqual(t, fanout, native)
+}
+
+// TestExpHistogramMergeSumMapRangeDifferential_Without is the SAME seed
+// and shape under `sum without(route)` — histogramAggGroupBy's OTHER
+// branch. `without(route)` groups by every OTHER label, which here is
+// just `series` — three distinct values (s1, s2, s3), all present at
+// both anchors — so this produces SIX rows (2 anchors x 3 series),
+// unlike the `by(route)` case's four.
+func TestExpHistogramMergeSumMapRangeDifferential_Without(t *testing.T) {
+	fixture := newExpHistSumMapRangeDiffFixture(t)
+	query := fmt.Sprintf("sum without(route) (%s)", expHistSumMapRangeMetric)
+	fanout := runExpHistSumMapRangeDiffQuery(t, fixture, false, query)
+	native := runExpHistSumMapRangeDiffQuery(t, fixture, true, query)
+	if len(native) != 6 {
+		t.Fatalf("expected 6 rows (2 anchors x 3 series), got %d: %+v", len(native), native)
+	}
+	assertExpHistSumMapRangeDiffEqual(t, fanout, native)
+}
+
+// TestExpHistogramMergeSumMapRangeDifferential_Avg is
+// [TestExpHistogramMergeSumMapRangeDifferential_By]'s `avg()` twin —
+// cerberus issue #3027's own "confirm avg() generalizes for free" item:
+// route `a`'s two-series group divides by 2, route `b`'s one-series group
+// divides by 1, independently at EACH anchor.
+func TestExpHistogramMergeSumMapRangeDifferential_Avg(t *testing.T) {
+	fixture := newExpHistSumMapRangeDiffFixture(t)
+	query := fmt.Sprintf("avg by(route) (%s)", expHistSumMapRangeMetric)
+	fanout := runExpHistSumMapRangeDiffQuery(t, fixture, false, query)
+	native := runExpHistSumMapRangeDiffQuery(t, fixture, true, query)
+	if len(native) != 4 {
+		t.Fatalf("expected 4 rows (2 anchors x 2 routes), got %d: %+v", len(native), native)
+	}
+	assertExpHistSumMapRangeDiffEqual(t, fanout, native)
+}

--- a/internal/promql/native_strategy_coverage_test.go
+++ b/internal/promql/native_strategy_coverage_test.go
@@ -205,9 +205,7 @@ var nativeStrategies = []nativeStrategy{
 		field:   "ExpHistogramMerge",
 		section: "experimental_exp_histogram_merge_summap",
 		wire: func(l *promql.RangeLowerers, _ func(string) bool) {
-			l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{
-				Fallback: promql.FanoutExpHistogramMergeLowerer{},
-			}
+			l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{}
 		},
 	},
 	{

--- a/test/perf/cardinality-baseline/promql/exp_histogram_merge_summap_range_multigroup.json
+++ b/test/perf/cardinality-baseline/promql/exp_histogram_merge_summap_range_multigroup.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/exp_histogram_merge_summap_range_multigroup",
+  "fan_factor": 9.25,
+  "scan_rows": 4,
+  "peak_intermediate": 37,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_merge_summap_range_multigroup/fanout.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_merge_summap_range_multigroup/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_merge_summap_range_multigroup/fanout",
+  "lowering": "fanout",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/exp_histogram_merge_summap_range_multigroup/native.json
+++ b/test/perf/solver-decision-baseline/exp_histogram_merge_summap_range_multigroup/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "exp_histogram_merge_summap_range_multigroup/native",
+  "lowering": "native",
+  "routed": false,
+  "k": 0,
+  "reason": "not-sliceable",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/regression/parity-enrolment-baselines/promql/baseline.txt
+++ b/test/regression/parity-enrolment-baselines/promql/baseline.txt
@@ -184,6 +184,7 @@ exp_histogram_increase_scale_coarsening_hides_reset.txtar
 exp_histogram_irate.txtar
 exp_histogram_merge_summap.txtar
 exp_histogram_merge_summap_multigroup.txtar
+exp_histogram_merge_summap_range_multigroup.txtar
 exp_histogram_rate.txtar
 exp_histogram_rate_range.txtar
 exp_histogram_resets.txtar

--- a/test/spec/promql/exp_histogram_merge_summap_range_multigroup.txtar
+++ b/test/spec/promql/exp_histogram_merge_summap_range_multigroup.txtar
@@ -49,4 +49,195 @@ INSERT INTO otel_metrics_exponential_histogram VALUES
     ('http_server_duration_exp_hist', map('route', 'api', 'series', 'coarse'), toDateTime64('2026-01-01 00:02:00', 9), 20, 3.0, 2, 0, 0, [7, 11, 13],  0, []),
     ('http_server_duration_exp_hist', map('route', 'web', 'series', 'solo'),   toDateTime64('2026-01-01 00:00:00', 9), 6,  3.0, 2, 0, -1, [1, 2, 3],   0, []);
 -- expected_rows --
-[]
+[
+  ["", {"route": "api"}, "2026-01-01T00:00:00Z", 0, 25, 3, 0, 0, 0, 0, [8,17], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:00:30Z", 0, 25, 3, 0, 0, 0, 0, [8,17], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:01:00Z", 0, 25, 3, 0, 0, 0, 0, [8,17], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:01:30Z", 0, 25, 3, 0, 0, 0, 0, [8,17], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:02:00Z", 0, 30, 4, 1, 0, 0, 0, [19,15,3,4], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:02:30Z", 0, 30, 4, 1, 0, 0, 0, [19,15,3,4], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:03:00Z", 0, 30, 4, 1, 0, 0, 0, [19,15,3,4], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:03:30Z", 0, 30, 4, 1, 0, 0, 0, [19,15,3,4], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:04:00Z", 0, 30, 4, 1, 0, 0, 0, [19,15,3,4], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:04:30Z", 0, 30, 4, 1, 0, 0, 0, [19,15,3,4], 0, []],
+  ["", {"route": "api"}, "2026-01-01T00:05:00Z", 0, 20, 3, 2, 0, 0, 0, [7,11,13], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:00:00Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:00:30Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:01:00Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:01:30Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:02:00Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:02:30Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:03:00Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:03:30Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:04:00Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []],
+  ["", {"route": "web"}, "2026-01-01T00:04:30Z", 0, 6, 3, 2, 0, 0, -1, [1,2,3], 0, []]
+]
+-- args --
+[0] string = ""
+[1] float64 = 0
+[2] string = "route"
+[3] int64 = 1
+[4] int64 = 2
+[5] float64 = 0
+[6] int64 = 2
+[7] int64 = 1
+[8] int64 = 1
+[9] int64 = 1
+[10] int64 = 1
+[11] int64 = 1
+[12] float64 = 0
+[13] float64 = 0
+[14] int64 = 1
+[15] int64 = 1
+[16] int64 = 2
+[17] float64 = 0
+[18] int64 = 2
+[19] int64 = 1
+[20] int64 = 1
+[21] int64 = 1
+[22] int64 = 1
+[23] int64 = 1
+[24] float64 = 0
+[25] float64 = 0
+[26] int64 = 1
+[27] int64 = 1
+[28] int64 = 2
+[29] float64 = 0
+[30] int64 = 2
+[31] int64 = 1
+[32] int64 = 1
+[33] int64 = 1
+[34] int64 = 1
+[35] int64 = 1
+[36] float64 = 0
+[37] float64 = 0
+[38] int64 = 1
+[39] int64 = 1
+[40] int64 = 0
+[41] int64 = 0
+[42] int64 = 1
+[43] int64 = 1
+[44] int64 = 0
+[45] float64 = 0
+[46] int64 = 2
+[47] int64 = 1
+[48] int64 = 1
+[49] int64 = 1
+[50] int64 = 1
+[51] int64 = 1
+[52] int64 = 1
+[53] int64 = 1
+[54] int64 = 0
+[55] int64 = 0
+[56] int64 = 1
+[57] int64 = 1
+[58] int64 = 0
+[59] float64 = 0
+[60] int64 = 2
+[61] int64 = 1
+[62] int64 = 1
+[63] int64 = 1
+[64] int64 = 1
+[65] int64 = 1
+[66] int64 = 1
+[67] string = "route"
+[68] int64 = 1
+[69] int64 = 1
+[70] string = "route"
+[71] string = "route"
+[72] string = "service_name"
+[73] string = "service.name"
+[74] string = "service_name"
+[75] string = "service.name"
+[76] string = "service_name"
+[77] string = ""
+[78] string = "service_name"
+[79] string = "http_server_duration_exp_hist"
+[80] string = "http.server.duration.exp.hist"
+[81] string = "http.server.duration.exp/hist"
+[82] string = "http.server.duration.exp_hist"
+[83] string = "http.server.duration/exp/hist"
+[84] string = "http.server.duration/exp_hist"
+[85] string = "http.server.duration_exp.hist"
+[86] string = "http.server.duration_exp_hist"
+[87] string = "http.server/duration/exp/hist"
+[88] string = "http.server/duration/exp_hist"
+[89] string = "http.server/duration_exp_hist"
+[90] string = "http.server_duration.exp.hist"
+[91] string = "http.server_duration.exp_hist"
+[92] string = "http.server_duration_exp.hist"
+[93] string = "http.server_duration_exp_hist"
+[94] string = "http/server/duration/exp/hist"
+[95] string = "http/server/duration/exp_hist"
+[96] string = "http/server/duration_exp_hist"
+[97] string = "http/server_duration_exp_hist"
+[98] string = "http_server.duration.exp.hist"
+[99] string = "http_server.duration.exp_hist"
+[100] string = "http_server.duration_exp.hist"
+[101] string = "http_server.duration_exp_hist"
+[102] string = "http_server_duration.exp.hist"
+[103] string = "http_server_duration.exp_hist"
+[104] string = "http_server_duration_exp.hist"
+[105] string = "http_server_duration_exp_hist"
+[106] string = "http.server.duration.exp.hist"
+[107] string = "http.server.duration.exp/hist"
+[108] string = "http.server.duration.exp_hist"
+[109] string = "http.server.duration/exp/hist"
+[110] string = "http.server.duration/exp_hist"
+[111] string = "http.server.duration_exp.hist"
+[112] string = "http.server.duration_exp_hist"
+[113] string = "http.server/duration/exp/hist"
+[114] string = "http.server/duration/exp_hist"
+[115] string = "http.server/duration_exp_hist"
+[116] string = "http.server_duration.exp.hist"
+[117] string = "http.server_duration.exp_hist"
+[118] string = "http.server_duration_exp.hist"
+[119] string = "http.server_duration_exp_hist"
+[120] string = "http/server/duration/exp/hist"
+[121] string = "http/server/duration/exp_hist"
+[122] string = "http/server/duration_exp_hist"
+[123] string = "http/server_duration_exp_hist"
+[124] string = "http_server.duration.exp.hist"
+[125] string = "http_server.duration.exp_hist"
+[126] string = "http_server.duration_exp.hist"
+[127] string = "http_server.duration_exp_hist"
+[128] string = "http_server_duration.exp.hist"
+[129] string = "http_server_duration.exp_hist"
+[130] string = "http_server_duration_exp.hist"
+[131] int64 = 4096
+[132] int64 = 4
+[133] int64 = 0
+[134] int64 = 1
+[135] int64 = 1
+[136] int64 = 1
+[137] int64 = 100000
+[138] int64 = 0
+[139] int64 = 1
+[140] int64 = 1
+[141] int64 = 1
+[142] int64 = 100000
+[143] int64 = 0
+[144] int64 = 1
+[145] int64 = 1
+[146] int64 = 1
+[147] int64 = 100000
+[148] int64 = 0
+[149] int64 = 1
+[150] int64 = 1
+[151] int64 = 1
+[152] int64 = 100000
+[153] int64 = 60000000
+[154] int64 = 6000
+[155] int64 = 600
+[156] int64 = 0
+-- chplan --
+HistogramProjection project=["" AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, 0 AS Value]
+  Project [anchor_ts AS anchor_ts, mapWithoutEmpty(FnMap("route", gkey_0)) AS Attributes, FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_counts, FnTuple(0, 0))))[1] AS Count, FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_sums, FnTuple(0, 0))))[1] AS Sum, _hq_merged_scale AS Scale, FnArrayMap(kh_final -> (FnTupleElement(kh_final, 1) + FnTupleElement(kh_final, 2)), FnArray(FnArrayFold((kh_acc, kh_x) -> FnArrayMap(kh_total -> FnTuple(kh_total, FnIf(FnIsInfinite(kh_total), 0, (FnTupleElement(kh_acc, 2) + FnIf((FnAbs(FnTupleElement(kh_acc, 1)) >= FnAbs(kh_x)), ((FnTupleElement(kh_acc, 1) - kh_total) + kh_x), ((kh_x - kh_total) + FnTupleElement(kh_acc, 1)))))), FnArray((FnTupleElement(kh_acc, 1) + kh_x)))[1], _hq_merge_zero_counts, FnTuple(0, 0))))[1] AS ZeroCount, FnIf((FnLength(FnTupleElement(_hq_pos_summap, 1)) = 0), 0, FnArrayMin(FnTupleElement(_hq_pos_summap, 1))) AS PositiveOffset, FnIf((FnLength(FnTupleElement(_hq_pos_summap, 1)) = 0), FnEmptyArrayFloat64(), FnArrayMap(t -> FnArrayConcat(FnArray(0), FnTupleElement(_hq_pos_summap, 2))[(FnIndexOf(FnTupleElement(_hq_pos_summap, 1), (FnArrayMin(FnTupleElement(_hq_pos_summap, 1)) + t)) + 1)], FnRange(FnToUInt64(((FnArrayMax(FnTupleElement(_hq_pos_summap, 1)) - FnArrayMin(FnTupleElement(_hq_pos_summap, 1))) + 1))))) AS PositiveBucketCounts, FnIf((FnLength(FnTupleElement(_hq_neg_summap, 1)) = 0), 0, FnArrayMin(FnTupleElement(_hq_neg_summap, 1))) AS NegativeOffset, FnIf((FnLength(FnTupleElement(_hq_neg_summap, 1)) = 0), FnEmptyArrayFloat64(), FnArrayMap(t -> FnArrayConcat(FnArray(0), FnTupleElement(_hq_neg_summap, 2))[(FnIndexOf(FnTupleElement(_hq_neg_summap, 1), (FnArrayMin(FnTupleElement(_hq_neg_summap, 1)) + t)) + 1)], FnRange(FnToUInt64(((FnArrayMax(FnTupleElement(_hq_neg_summap, 1)) - FnArrayMin(FnTupleElement(_hq_neg_summap, 1))) + 1))))) AS NegativeBucketCounts]
+    Filter predicate=(FnThrowIf((((FnLength(_hq_scales) > 4096) OR ((4 * ((FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1], 100000) * FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets, _hq_pos_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_pos_offsets))))[1], 100000)) + (FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1], 100000) * FnLeast(FnArrayMap(mst -> FnGreatest(0, ((FnArrayMax(FnArrayMap((sm, om, am) -> FnBitShiftRight((om + (FnLength(am) - 1)), (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets, _hq_neg_buckets)) - mst) + 1)), FnArray(FnArrayMin(FnArrayMap((sm, om) -> FnBitShiftRight(om, (sm - _hq_merged_scale)), _hq_scales, _hq_neg_offsets))))[1], 100000)))) > 60000000)) OR ((_hq_agg_total_row_count > 6000) OR (_hq_agg_total_group_count > 600))), "native histogram merge exceeds the series-per-group or merged-bucket-width resource bound") = 0)
+      Aggregate groupBy=[anchor_ts AS anchor_ts, Attributes["route"] AS gkey_0] funcs=[FnGroupArray(Count) AS _hq_merge_counts, FnGroupArray(Sum) AS _hq_merge_sums, FnMin(Scale) AS _hq_merged_scale, FnGroupArray(ZeroCount) AS _hq_merge_zero_counts, FnGroupArray(Scale) AS _hq_scales, FnGroupArray(PositiveOffset) AS _hq_pos_offsets, FnGroupArray(PositiveBucketCounts) AS _hq_pos_buckets, FnGroupArray(NegativeOffset) AS _hq_neg_offsets, FnGroupArray(NegativeBucketCounts) AS _hq_neg_buckets, FnSumMap(FnArrayMap(j -> FnBitShiftRight(((PositiveOffset + j) - 1), (Scale - _hq_win_merged_scale)), FnArrayEnumerate(PositiveBucketCounts)), FnArrayMap(x -> FnToFloat64(x), PositiveBucketCounts)) AS _hq_pos_summap, FnSumMap(FnArrayMap(j -> FnBitShiftRight(((NegativeOffset + j) - 1), (Scale - _hq_win_merged_scale)), FnArrayEnumerate(NegativeBucketCounts)), FnArrayMap(x -> FnToFloat64(x), NegativeBucketCounts)) AS _hq_neg_summap, FnMax(_hq_win_total_row_count) AS _hq_agg_total_row_count, FnMax(_hq_win_total_group_count) AS _hq_agg_total_group_count]
+        Project [Attributes AS Attributes, Count AS Count, Sum AS Sum, Scale AS Scale, ZeroCount AS ZeroCount, PositiveOffset AS PositiveOffset, PositiveBucketCounts AS PositiveBucketCounts, NegativeOffset AS NegativeOffset, NegativeBucketCounts AS NegativeBucketCounts, anchor_ts AS anchor_ts, FnMin(Scale) OVER (PARTITION BY [anchor_ts, Attributes["route"]]) AS _hq_win_merged_scale, FnCount() OVER (PARTITION BY []) AS _hq_win_total_row_count, FnUniqExact(anchor_ts, Attributes["route"]) OVER (PARTITION BY []) AS _hq_win_total_group_count]
+          RangeBucketFanout step=30s lookback=5m0s groupBy=[FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes] funcs=[FnArgMax(Count, TimeUnix) AS Count, FnArgMax(Sum, TimeUnix) AS Sum, FnArgMax(Scale, TimeUnix) AS Scale, FnArgMax(ZeroCount, TimeUnix) AS ZeroCount, FnArgMax(PositiveOffset, TimeUnix) AS PositiveOffset, FnArgMax(PositiveBucketCounts, TimeUnix) AS PositiveBucketCounts, FnArgMax(NegativeOffset, TimeUnix) AS NegativeOffset, FnArgMax(NegativeBucketCounts, TimeUnix) AS NegativeBucketCounts] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+            Filter predicate=(MetricName IN ("http_server_duration_exp_hist", "http.server.duration.exp.hist", "http.server.duration.exp/hist", "http.server.duration.exp_hist", "http.server.duration/exp/hist", "http.server.duration/exp_hist", "http.server.duration_exp.hist", "http.server.duration_exp_hist", "http.server/duration/exp/hist", "http.server/duration/exp_hist", "http.server/duration_exp_hist", "http.server_duration.exp.hist", "http.server_duration.exp_hist", "http.server_duration_exp.hist", "http.server_duration_exp_hist", "http/server/duration/exp/hist", "http/server/duration/exp_hist", "http/server/duration_exp_hist", "http/server_duration_exp_hist", "http_server.duration.exp.hist", "http_server.duration.exp_hist", "http_server.duration_exp.hist", "http_server.duration_exp_hist", "http_server_duration.exp.hist", "http_server_duration.exp_hist", "http_server_duration_exp.hist"))
+              Scan(otel_metrics_exponential_histogram)
+-- sql --
+SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, toFloat64(?) AS `Value`, toFloat64(`Count`) AS `HistogramCount`, toFloat64(`Sum`) AS `HistogramSum`, toInt32(`Scale`) AS `HistogramScale`, toFloat64(0.) AS `HistogramZeroThreshold`, toFloat64(`ZeroCount`) AS `HistogramZeroCount`, toInt32(`PositiveOffset`) AS `HistogramPositiveOffset`, arrayMap(x -> toFloat64(x), `PositiveBucketCounts`) AS `HistogramPositiveBucketCounts`, toInt32(`NegativeOffset`) AS `HistogramNegativeOffset`, arrayMap(x -> toFloat64(x), `NegativeBucketCounts`) AS `HistogramNegativeBucketCounts` FROM (SELECT `anchor_ts` AS `anchor_ts`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_counts`, tuple(toFloat64(?), toFloat64(?)))))[?] AS `Count`, arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_sums`, tuple(toFloat64(?), toFloat64(?)))))[?] AS `Sum`, `_hq_merged_scale` AS `Scale`, arrayMap(kh_final -> (tupleElement(kh_final, ?) + tupleElement(kh_final, ?)), array(arrayFold((kh_acc, kh_x) -> arrayMap(kh_total -> tuple(kh_total, if(isInfinite(kh_total), toFloat64(?), (tupleElement(kh_acc, ?) + if((abs(tupleElement(kh_acc, ?)) >= abs(kh_x)), ((tupleElement(kh_acc, ?) - kh_total) + kh_x), ((kh_x - kh_total) + tupleElement(kh_acc, ?)))))), array((tupleElement(kh_acc, ?) + kh_x)))[?], `_hq_merge_zero_counts`, tuple(toFloat64(?), toFloat64(?)))))[?] AS `ZeroCount`, if((length(tupleElement(`_hq_pos_summap`, ?)) = ?), ?, arrayMin(tupleElement(`_hq_pos_summap`, ?))) AS `PositiveOffset`, if((length(tupleElement(`_hq_pos_summap`, ?)) = ?), emptyArrayFloat64(), arrayMap(t -> arrayConcat(array(toFloat64(?)), tupleElement(`_hq_pos_summap`, ?))[(indexOf(tupleElement(`_hq_pos_summap`, ?), (arrayMin(tupleElement(`_hq_pos_summap`, ?)) + t)) + ?)], range(toUInt64(((arrayMax(tupleElement(`_hq_pos_summap`, ?)) - arrayMin(tupleElement(`_hq_pos_summap`, ?))) + ?))))) AS `PositiveBucketCounts`, if((length(tupleElement(`_hq_neg_summap`, ?)) = ?), ?, arrayMin(tupleElement(`_hq_neg_summap`, ?))) AS `NegativeOffset`, if((length(tupleElement(`_hq_neg_summap`, ?)) = ?), emptyArrayFloat64(), arrayMap(t -> arrayConcat(array(toFloat64(?)), tupleElement(`_hq_neg_summap`, ?))[(indexOf(tupleElement(`_hq_neg_summap`, ?), (arrayMin(tupleElement(`_hq_neg_summap`, ?)) + t)) + ?)], range(toUInt64(((arrayMax(tupleElement(`_hq_neg_summap`, ?)) - arrayMin(tupleElement(`_hq_neg_summap`, ?))) + ?))))) AS `NegativeBucketCounts` FROM (SELECT * FROM (SELECT `anchor_ts` AS `anchor_ts`, `Attributes`[?] AS `gkey_0`, groupArray(`Count`) AS `_hq_merge_counts`, groupArray(`Sum`) AS `_hq_merge_sums`, min(`Scale`) AS `_hq_merged_scale`, groupArray(`ZeroCount`) AS `_hq_merge_zero_counts`, groupArray(`Scale`) AS `_hq_scales`, groupArray(`PositiveOffset`) AS `_hq_pos_offsets`, groupArray(`PositiveBucketCounts`) AS `_hq_pos_buckets`, groupArray(`NegativeOffset`) AS `_hq_neg_offsets`, groupArray(`NegativeBucketCounts`) AS `_hq_neg_buckets`, sumMap(arrayMap(j -> bitShiftRight(((`PositiveOffset` + j) - ?), (`Scale` - `_hq_win_merged_scale`)), arrayEnumerate(`PositiveBucketCounts`)), arrayMap(x -> toFloat64(x), `PositiveBucketCounts`)) AS `_hq_pos_summap`, sumMap(arrayMap(j -> bitShiftRight(((`NegativeOffset` + j) - ?), (`Scale` - `_hq_win_merged_scale`)), arrayEnumerate(`NegativeBucketCounts`)), arrayMap(x -> toFloat64(x), `NegativeBucketCounts`)) AS `_hq_neg_summap`, max(`_hq_win_total_row_count`) AS `_hq_agg_total_row_count`, max(`_hq_win_total_group_count`) AS `_hq_agg_total_group_count` FROM (SELECT `Attributes` AS `Attributes`, `Count` AS `Count`, `Sum` AS `Sum`, `Scale` AS `Scale`, `ZeroCount` AS `ZeroCount`, `PositiveOffset` AS `PositiveOffset`, `PositiveBucketCounts` AS `PositiveBucketCounts`, `NegativeOffset` AS `NegativeOffset`, `NegativeBucketCounts` AS `NegativeBucketCounts`, `anchor_ts` AS `anchor_ts`, min(`Scale`) OVER (PARTITION BY `anchor_ts`, `Attributes`[?]) AS `_hq_win_merged_scale`, count() OVER () AS `_hq_win_total_row_count`, uniqExact(`anchor_ts`, `Attributes`[?]) OVER () AS `_hq_win_total_group_count` FROM (SELECT anchor_ts AS `anchor_ts`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, argMax(`Count`, `TimeUnix`) AS `Count`, argMax(`Sum`, `TimeUnix`) AS `Sum`, argMax(`Scale`, `TimeUnix`) AS `Scale`, argMax(`ZeroCount`, `TimeUnix`) AS `ZeroCount`, argMax(`PositiveOffset`, `TimeUnix`) AS `PositiveOffset`, argMax(`PositiveBucketCounts`, `TimeUnix`) AS `PositiveBucketCounts`, argMax(`NegativeOffset`, `TimeUnix`) AS `NegativeOffset`, argMax(`NegativeBucketCounts`, `TimeUnix`) AS `NegativeBucketCounts` FROM (SELECT * FROM (SELECT * FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) LIMIT 4000001) WHERE throwIf((SELECT count() AS `n` FROM (SELECT `TimeUnix` FROM (SELECT *, arrayJoin(arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)) - 300000000000, toInt64(30000000000)) < 0) + 1), least(11, intDiv(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) - (modulo(dateDiff('nanosecond', `TimeUnix`, toDateTime64('2026-01-01 00:05:00.000000000', 9)), toInt64(30000000000)) < 0) + 1)))) AS anchor_ts FROM (SELECT * FROM `otel_metrics_exponential_histogram` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9)) LIMIT 4000001)) > 4000000, 'histogram/LWR sample fanout exceeds the series-times-anchors resource bound') = 0) GROUP BY anchor_ts, `Attributes`)) GROUP BY `anchor_ts`, `gkey_0`) WHERE (throwIf((((length(`_hq_scales`) > ?) OR ((? * ((least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?], ?) * least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`, `_hq_pos_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_pos_offsets`))))[?], ?)) + (least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?], ?) * least(arrayMap(mst -> greatest(?, ((arrayMax(arrayMap((sm, om, am) -> bitShiftRight((om + (length(am) - ?)), (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`, `_hq_neg_buckets`)) - mst) + ?)), array(arrayMin(arrayMap((sm, om) -> bitShiftRight(om, (sm - `_hq_merged_scale`)), `_hq_scales`, `_hq_neg_offsets`))))[?], ?)))) > ?)) OR ((`_hq_agg_total_row_count` > ?) OR (`_hq_agg_total_group_count` > ?))), 'native histogram merge exceeds the series-per-group or merged-bucket-width resource bound') = ?)))

--- a/test/spec/promql/exp_histogram_merge_summap_range_multigroup.txtar
+++ b/test/spec/promql/exp_histogram_merge_summap_range_multigroup.txtar
@@ -1,0 +1,52 @@
+-- query.promql --
+sum by(route) (http_server_duration_exp_hist)
+-- parity --
+oracle: prometheus
+endpoint: /api/v1/query_range
+scope: full
+-- range_step --
+30s
+-- experimental_exp_histogram_merge_summap --
+-- seed --
+CREATE TABLE otel_metrics_exponential_histogram (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Count UInt64,
+    Sum Float64,
+    Scale Int32,
+    ZeroCount UInt64,
+    PositiveOffset Int32,
+    PositiveBucketCounts Array(UInt64),
+    NegativeOffset Int32,
+    NegativeBucketCounts Array(UInt64)
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+-- cerberus issue #3027's range-mode counterpart of
+-- exp_histogram_merge_summap_multigroup.txtar's INSTANT sibling: the SAME
+-- `sum by(route)` shape (chopt exp_histogram_merge_summap opted in via the
+-- `experimental_exp_histogram_merge_summap` marker section) but evaluated
+-- as a query_range request — the shape [NativeExpHistogramMergeLowerer]
+-- fell back to the classic groupArray + picker fold for, regardless of
+-- the marker, before this issue widened its gate to admit a non-nil step
+-- anchor.
+--
+-- route=api carries two series at DIFFERENT Scales (0 and 1), the SAME
+-- downscale-collapse merge the instant sibling pins, now resolved
+-- independently at EVERY step anchor by the anchor-prefixed WindowExpr
+-- `min(Scale) OVER (PARTITION BY <anchor>, <group-key>)` pre-pass. Series
+-- `coarse` gets a SECOND, later sample at 00:02:00 with a DIFFERENT
+-- layout (Scale 2) — so the early anchors (00:00:00 through 00:01:30)
+-- merge route api's ORIGINAL pair, while the later anchors (00:02:00
+-- onward) merge the UPDATED pair, proving each anchor resolves its own
+-- mergedScale independently rather than reusing one value across the
+-- whole grid. route=web carries exactly ONE series across the whole
+-- window — the singleton-partition control: its output must stay
+-- IDENTICAL at every anchor, proving route=api's per-anchor changes
+-- don't leak across groups.
+INSERT INTO otel_metrics_exponential_histogram VALUES
+    ('http_server_duration_exp_hist', map('route', 'api', 'series', 'fine'),   toDateTime64('2026-01-01 00:00:00', 9), 10, 1.0, 1, 0, 0, [1, 2, 3, 4], 0, []),
+    ('http_server_duration_exp_hist', map('route', 'api', 'series', 'coarse'), toDateTime64('2026-01-01 00:00:00', 9), 15, 2.0, 0, 0, 0, [5, 10],      0, []),
+    ('http_server_duration_exp_hist', map('route', 'api', 'series', 'coarse'), toDateTime64('2026-01-01 00:02:00', 9), 20, 3.0, 2, 0, 0, [7, 11, 13],  0, []),
+    ('http_server_duration_exp_hist', map('route', 'web', 'series', 'solo'),   toDateTime64('2026-01-01 00:00:00', 9), 6,  3.0, 2, 0, -1, [1, 2, 3],   0, []);
+-- expected_rows --
+[]


### PR DESCRIPTION
## Summary

Widens the exp-histogram sumMap cross-series merge (`internal/promql/exp_histogram_merge_summap.go`, #2757/#2834/#2865) to cover range/`query_range` mode, completing the `chplan.WindowExpr` mechanism #2865 shipped for instant multi-group `by()`/`without()` queries.

- `expHistogramGroupMergeSumMap` now takes the same `anchor *chplan.ColumnRef` parameter `expHistogramGroupMergeFanout` already threads. Range mode is *always* multi-group (every step anchor is its own output group), so it forces the `WindowExpr` `min(Scale) OVER (PARTITION BY anchor_ts[, group-key])` pre-pass even with no `by()`/`without()` clause.
- `expHistogramMergeScaleWindowPartitionBy` and `expHistogramMergeScaleWindowProject` — already generalized in #2865 to accept a non-nil anchor — are now actually exercised by a non-instant caller.
- `NativeExpHistogramMergeLowerer`'s `anchor == nil` gate is gone: every shape reaching the interface (instant/range, any grouping, sum/avg) now routes onto the sumMap mechanism unconditionally. Since there is no longer any shape this lowerer falls back on, its `Fallback` field is removed (mirroring `NativeQuantileRankWalkLowerer`, the other Native lowerer in this package with no residual fallback case) rather than left dead.
- **A brand-new, separately-calibrated range-mode budget guard** (`maxHistogramMergeSumMapRangeGroupCountGuard` / `maxHistogramMergeSumMapRangeTotalRowCountGuard`), because range mode's real group count is `(step count) x (distinct label groups)` and its cost profile is materially different from instant mode's — see "Calibration" below.

## Calibration methodology

Real ClickHouse 26.6.4 (`docker run clickhouse/clickhouse-server:26.6-alpine`), never chDB, matching #2865's own methodology exactly: a throwaway Go harness (deleted before this PR, same precedent as #2757/#2834/#2865's own harnesses) seeded `otel_metrics_exponential_histogram`-shaped rows, lowered a real `query_range` `sum(<selector>)` through `promql.NativeExpHistogramMergeLowerer`, emitted the **actual** SQL via `chsql.Emit`, ran it, and read peak memory from `system.query_log` after `SYSTEM FLUSH LOGS`.

Two axes, isolated the same way #2865's own instant multi-group calibration did:

**Group-count axis** (fixed width 160, no `by()`/`without()`, one series per step):

| steps | total rows | peak memory |
|---|---|---|
| 100 | 100 | 67.1 MiB |
| 500 | 500 | 303.9 MiB |
| 600 | 600 | 364.0 MiB |
| 700 | 700 | 424.1 MiB |
| 1,000 | 1,000 | 604.4 MiB |

**Rows-per-group axis** (fixed 100 steps, series per step grows):

| steps | rows/step | total rows | peak memory |
|---|---|---|---|
| 100 | 10 | 1,000 | 68.8 MiB |
| 100 | 50 | 5,000 | 325.9 MiB |
| 100 | 60 | 6,000 | 389.6 MiB |
| 100 | 80 | 8,000 | 521.4 MiB |
| 100 | 100 | 10,000 | 534.2 MiB |

Both axes are far steeper than instant mode's own (~0.6 MiB/step here vs ~0.01 MiB/group there) — real overhead from `chplan.RangeBucketFanout`'s own per-row arrayJoin fan-out, which the instant path never pays. This confirms the issue's own prediction that range mode needs its own ceiling rather than reusing instant's 40,000/200,000.

- `maxHistogramMergeSumMapRangeGroupCountGuard = 600` (pinned at the measured 364.0 MiB checkpoint, ~35.5% of the 1024 MiB `CERBERUS_CH_QUERY_MAX_MEMORY` default — the same margin discipline every other guard in this file uses).
- `maxHistogramMergeSumMapRangeTotalRowCountGuard = 6_000` (pinned at the measured 389.6 MiB checkpoint, ~38.0%).

Both boundaries were verified to actually fire/admit at real ClickHouse execution (`exp_histogram_merge_summap_bound_range_chdb_test.go`), not just pinned as arithmetic.

**Flagged for a future session**: around ~1,400 steps (well above the 600 ceiling this PR ships), repeated measurements at an *identical* step count were nondeterministic — sometimes following the same ~0.6 MiB/step trend (~850 MiB), sometimes settling into a much cheaper ~0.043 MiB/step trend, and *always* the cheaper trend for every larger step count tried (2,000 through 40,000, fully reproducible). This sits well outside the ceiling shipped here and doesn't affect this PR's safety, but is undiagnosed (plausibly a ClickHouse plan-selection threshold, e.g. aggregation-in-order eligibility) and documented in `exp_histogram_merge_summap_bound.go`'s "Range-mode calibration" section rather than silently smoothed over.

## Tests

- `exp_histogram_merge_summap_range_chdb_test.go` — chDB differential proof (range-mode fold vs sumMap): no-grouping, `by(route)`, `without(route)`, and an explicit `avg by(route)` case (issue's own "confirm avg() generalizes for free" item, verified rather than assumed).
- `exp_histogram_merge_summap_bound_range_chdb_test.go` — proves the new range-mode guard actually fires (group-count overflow, total-row-count overflow) and stays silent on legitimate data, and that the existing per-group width² check still ORs in.
- `test/spec/promql/exp_histogram_merge_summap_range_multigroup.txtar` — TXTAR fixture pinning `sum by(route)` over a `query_range` request with a per-anchor scale-negotiation change, mirroring `exp_histogram_merge_summap_multigroup.txtar`'s instant sibling.
- `just test-unit` — green (see CI).

Closes #3027
Closes #2865
