### PR TITLE
docs(actuals): document Tracker's in-memory-only scope as intentional

### DIFF
--- a/internal/actuals/tracker.go
+++ b/internal/actuals/tracker.go
@@ -169,13 +169,13 @@ type state struct {
 //     plus a background flush goroutine, exactly like optcorpus.Sink's own
 //     writers), never a synchronous write on that path.
 //
-// This is a deliberate scope boundary, not an oversight: if Config.EntryTTL
-// is later raised well past today's 30m default, or the feature graduates
-// out of dark-by-default and operators report losing alerting state across
-// routine deploys as a real operational pain point, that is the trigger to
-// revisit — build a Tracker-specific sink mirroring optcorpus.Sink's
-// buffered-channel-plus-background-flush shape, not to retrofit a
-// synchronous write into RecordActual.
+// This is a deliberate scope boundary, not an oversight: were Config.EntryTTL
+// ever raised well past today's 30m default, or the feature to graduate out
+// of dark-by-default with operators reporting real pain from losing
+// alerting state across routine deploys, a Tracker-specific sink mirroring
+// optcorpus.Sink's buffered-channel-plus-background-flush shape would earn
+// its cost at that point — never a synchronous write retrofitted into
+// RecordActual.
 type Tracker struct {
 	cfg Config
 

--- a/internal/actuals/tracker.go
+++ b/internal/actuals/tracker.go
@@ -120,6 +120,62 @@ type state struct {
 // Tracker is the bounded, in-process predicted-vs-actual drift tracker (this
 // package's own doc). Safe for concurrent use. The zero value is not usable;
 // construct with NewTracker.
+//
+// # Durability is intentionally NOT provided (issue #3036)
+//
+// Tracker's state is a plain in-memory map (states below): every shape's
+// calibration history — including any shape currently drift-alerting — is
+// lost on every process restart or deploy. Unlike internal/optcorpus, which
+// persists its query-outcome corpus to a JSONL file or a ClickHouse table
+// (optcorpus.Sink) precisely because that corpus is expensive to
+// re-accumulate (it joins system.query_log rows against dispatch-time
+// records over a long observation window), Tracker deliberately has no
+// durable-sink counterpart. This was evaluated against that same design —
+// the pattern issue #3036 names as the one to mirror — and rejected for
+// this type specifically, for three compounding reasons:
+//
+//  1. The tracked state is CHEAP to rebuild. Config.MinObservations
+//     defaults to 2 and Config.EMAAlpha defaults to 0.2: a shape regains a
+//     trusted verdict (CalibrationFactor ok, DriftReport.Alerting
+//     meaningful) after just two fresh RecordActual calls post-restart, and
+//     its EMA re-converges to within a few percent of its pre-restart value
+//     within roughly 5-10 observations (2-3 alpha=0.2 half-lives) — a matter
+//     of minutes of ordinary traffic for any shape common enough for its
+//     calibration to matter. A shape too rare to see two observations in a
+//     reasonable window was never going to accumulate meaningful evidence
+//     between deploys either way.
+//  2. Config.EntryTTL (default 30m) ALREADY caps how long any state is
+//     trusted, restart or not. A shape not queried again within EntryTTL is
+//     treated as expired and re-seeded from scratch by getOrCreateLocked
+//     regardless of whether the process restarted in between. Persisting
+//     across a restart would only ever help the narrow intersection "a
+//     restart happens" AND "within 30 minutes of that shape's last query" —
+//     a strictly smaller win than the TTL already discards on its own
+//     timescale, for a feature this package's own anti-autotune stance
+//     (see the package doc) already treats as advisory rather than
+//     authoritative.
+//  3. The feature ships DARK by default (Config.Enabled defaults to false —
+//     see Config's own doc). No production deployment depends today on
+//     drift continuity surviving a rollout, so paying a durable sink's
+//     ongoing cost now — a background flush goroutine, a buffered channel
+//     sized against burst writes, a JSONL or CH-table schema, boot wiring in
+//     cmd/cerberus, and restart-recovery test coverage, all mirroring
+//     optcorpus's own nontrivial machinery built for a fundamentally
+//     heavier join-and-batch problem — would buy correctness insurance for a
+//     value nobody is yet relying on. RecordActual is additionally called
+//     synchronously from the query-response hot path
+//     (internal/chclient/progress.go's flush()); any sink added later MUST
+//     preserve that non-blocking discipline (an internal buffered channel
+//     plus a background flush goroutine, exactly like optcorpus.Sink's own
+//     writers), never a synchronous write on that path.
+//
+// This is a deliberate scope boundary, not an oversight: if Config.EntryTTL
+// is later raised well past today's 30m default, or the feature graduates
+// out of dark-by-default and operators report losing alerting state across
+// routine deploys as a real operational pain point, that is the trigger to
+// revisit — build a Tracker-specific sink mirroring optcorpus.Sink's
+// buffered-channel-plus-background-flush shape, not to retrofit a
+// synchronous write into RecordActual.
 type Tracker struct {
 	cfg Config
 


### PR DESCRIPTION
## Summary

- `internal/actuals.Tracker` is purely in-process/ephemeral, unlike `internal/optcorpus`'s durable
  sink. Investigated whether it should gain a JSONL/CH-table sink mirroring `optcorpus.Sink`, or
  whether the in-memory-only scope should be documented as intentional instead (both are acceptable
  resolutions per #3036).
- Chose **option (b): document as intentional**, not build a sink. The evidence: `Config`'s own
  defaults make the tracked state cheap to rebuild (`MinObservations=2`, `EMAAlpha=0.2` — a shape
  regains a trusted verdict within 2 fresh observations and its EMA re-converges within ~5-10);
  `Config.EntryTTL` (30m) already discards any state not refreshed within that window, restart or
  not, so persistence would only help the narrow "restart + within 30m of last query for that exact
  shape" case; and the feature ships dark by default (`Config.Enabled=false`), so no deployment today
  depends on drift continuity surviving a rollout. `optcorpus.Sink`'s own machinery (buffered channel
  + background flush goroutine, JSONL/CH-table schema, boot wiring) is real complexity built for a
  heavier problem (joining async `system.query_log` rows against dispatch-time records) that this
  bounded, single-map tracker doesn't need yet.
- Added a substantial "Durability is intentionally NOT provided" section to `Tracker`'s own
  type-level doc comment in `internal/actuals/tracker.go`, laying out the three reasons above and the
  concrete triggers that would change the call (raised `EntryTTL`, the feature graduating off
  dark-by-default with operators reporting real pain from lost continuity).

## Test plan

- [x] `just test-unit` passes
- [x] `go test -race -run '^TestTracker' ./internal/actuals/...` passes
- [x] `go build ./internal/actuals/...` and `gofumpt -l` clean (doc-comment-only change, no new code
      paths)
- [ ] `just lint` — not run locally per repo invariant 5 (golangci-lint in an agent worktree is not
      evidence); CI is authoritative

## Notes for reviewers

No functional change — this PR is a design-decision record, not new code. See
`internal/actuals/tracker.go`'s `Tracker` doc comment for the full reasoning trail.

Closes #3036
