### PR TITLE
fix(solver): fold route-B's K per-shard actuals into one observation

### DIFF
--- a/internal/chclient/progress.go
+++ b/internal/chclient/progress.go
@@ -2,6 +2,7 @@ package chclient
 
 import (
 	"context"
+	"sync"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 
@@ -209,20 +210,156 @@ func (r *progressRecorder) onProfileEvents(events []clickhouse.ProfileEvent) {
 // observation (plus the latched peak memory) into it as the SourcePacket
 // fast path (issue #2789). Safe to call with a nil-progress recorder
 // (no-op).
+//
+// Issue #3033: when this recorder's ctx also carries a *ShardActualsFold
+// (route B, K > 1 shards — see WithShardActualsFold's own doc), flush does
+// NOT call tracker.RecordActual itself; it folds this shard's observation
+// into the shared accumulator instead, which performs the SINGLE
+// per-request RecordActual call once every shard has folded in. Route A,
+// and a route-B dispatch with no fold wired (k < 2, or actuals capture
+// off), are byte-unchanged: they still call tracker.RecordActual here,
+// directly, exactly as before this issue.
 func (r *progressRecorder) flush() {
 	if r == nil {
 		return
 	}
 	telemetry.RecordClickHouseProgress(r.ctx, r.ql, r.rows, r.bytes)
-	if r.shapeID != "" {
-		report, ok := r.tracker.RecordActual(r.shapeID, actuals.Actual{
-			ReadRows:   r.rows,
-			ReadBytes:  r.bytes,
-			PeakMemory: r.peakMemory,
-		}, actuals.SourcePacket)
-		if ok && report.HasPredicted {
-			telemetry.RecordEstimateDrift(r.ctx, report.Ratio, report.Alerting, actuals.SourcePacket.String())
-		}
+	if r.shapeID == "" {
+		return
+	}
+	actual := actuals.Actual{
+		ReadRows:   r.rows,
+		ReadBytes:  r.bytes,
+		PeakMemory: r.peakMemory,
+	}
+	if fold, ok := shardActualsFoldFromContext(r.ctx); ok {
+		fold.add(actual)
+		return
+	}
+	report, ok := r.tracker.RecordActual(r.shapeID, actual, actuals.SourcePacket)
+	if ok && report.HasPredicted {
+		telemetry.RecordEstimateDrift(r.ctx, report.Ratio, report.Alerting, actuals.SourcePacket.String())
+	}
+}
+
+// ShardActualsFold folds a route-B K-shard dispatch's per-shard actuals
+// captures into ONE per-request Actual observation before it reaches the
+// tracker (issue #3033). Without it, each of route-B's K shards' own
+// progressRecorder.flush() would call tracker.RecordActual independently —
+// K calls against the ONE un-sharded RecordPredicted prediction the whole
+// request made — corrupting the tracked EMA by roughly a factor of K.
+//
+// Folding rule:
+//   - ReadRows / ReadBytes: SUM across shards — each shard scanned a
+//     disjoint slice of the request's total.
+//   - PeakMemory: MAX across shards, never summed. onProfileEvents already
+//     latches the max PACKET within one shard's own dispatch; this is the
+//     same idea applied ACROSS shards — ClickHouse's own per-query
+//     MemoryTrackerPeakUsage is a single-process high-water mark, not
+//     additive across K independent queries.
+//
+// Construct with WithShardActualsFold, which wires the SAME
+// *ShardActualsFold pointer onto every shard's derived ctx via a context
+// value — mirroring actualsIntent's own "survives being shadowed by a
+// fresh recorder" shape (see WithProgressFor's doc) — so every shard's
+// flush() feeds the SAME accumulator regardless of which goroutine it runs
+// on. The driver invokes progress/ProfileEvents callbacks off-goroutine
+// (WithProgressFor's own doc), and the K shards' cursors can each complete
+// on a different goroutine, so every mutation below is guarded by mu.
+//
+// The shard whose add() call observes completed == k — necessarily the
+// LAST one, since completed only increases — performs the single
+// RecordActual (+ RecordEstimateDrift) call, inline, still holding mu. So
+// "exactly one call per request" is enforced by construction: no separate
+// finalize step exists for a caller to forget. A dispatch that never gets
+// all k shards to flush (e.g. a shard failed to even open its cursor, so
+// its own defer'd CloseCursor / progressRecorder.flush never runs) simply
+// never fires — recording a (k-1)-of-k partial sum would reintroduce the
+// very undercount class this fix exists to close, just at a smaller K.
+type ShardActualsFold struct {
+	// ctx is the per-request ctx WithShardActualsFold was called with — NOT
+	// any one shard's own derived ctx — so the single RecordEstimateDrift
+	// call this fold makes is request-scoped, like RecordPredicted's own
+	// call was, rather than tied to whichever shard happened to finish last.
+	ctx     context.Context
+	tracker *actuals.Tracker
+	shapeID string
+	k       int
+
+	mu         sync.Mutex
+	completed  int
+	rows       uint64
+	bytes      uint64
+	peakMemory uint64
+}
+
+type shardActualsFoldKeyType struct{}
+
+var shardActualsFoldKey = shardActualsFoldKeyType{}
+
+// WithShardActualsFold wires a fresh *ShardActualsFold onto ctx for a
+// route-B dispatch of k shards, so every shard's progressRecorder.flush()
+// (see that method's own "if fold, ok :=" branch) feeds the SAME
+// accumulator instead of calling tracker.RecordActual directly.
+//
+// Returns ctx UNCHANGED — no fold wired — when actuals capture is not
+// active for this dispatch (no actualsIntent on ctx yet; mirrors
+// WithActualsCapture's own fail-open posture) or k < 2 (route A, or a
+// degenerate single-shard route-B decision: exactly the shape that already
+// records correctly today, so folding would be pure overhead for zero
+// benefit). Callers MUST treat "no *ShardActualsFold on the returned ctx"
+// as "nothing to finalize" — there is no separate off-path to remember.
+//
+// Call this ONCE per dispatch, on the SAME ctx that gets threaded into
+// every shard's own derived context (solver.Executor.Execute's ctx
+// parameter, BEFORE any per-shard ctx is derived from it) — a fold wired
+// onto anything narrower than that would not reach every shard.
+func WithShardActualsFold(ctx context.Context, k int) context.Context {
+	intent, ok := actualsIntentFromContext(ctx)
+	if !ok || k < 2 {
+		return ctx
+	}
+	fold := &ShardActualsFold{ctx: ctx, tracker: intent.tracker, shapeID: intent.shapeID, k: k}
+	return context.WithValue(ctx, shardActualsFoldKey, fold)
+}
+
+// ShardActualsFoldFromContext returns the *ShardActualsFold WithShardActualsFold
+// wired onto ctx, if any. Exported for internal/solver's own tests, which
+// verify the Executor wires the SAME fold onto every shard's ctx (and wires
+// none at all for k < 2) without internal/solver importing internal/actuals
+// itself (its own dependency allowlist in .go-arch-lint.yml deliberately
+// omits it — the fold's tracker/Actual plumbing must stay inside chclient).
+func ShardActualsFoldFromContext(ctx context.Context) (*ShardActualsFold, bool) {
+	return shardActualsFoldFromContext(ctx)
+}
+
+func shardActualsFoldFromContext(ctx context.Context) (*ShardActualsFold, bool) {
+	f, ok := ctx.Value(shardActualsFoldKey).(*ShardActualsFold)
+	return f, ok
+}
+
+// add folds one shard's (rows, bytes, peakMemory) into the running totals —
+// see the type doc for the SUM/MAX split and the exactly-once completion
+// contract. Safe for concurrent use.
+func (f *ShardActualsFold) add(a actuals.Actual) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rows += a.ReadRows
+	f.bytes += a.ReadBytes
+	if a.PeakMemory > f.peakMemory {
+		f.peakMemory = a.PeakMemory
+	}
+	f.completed++
+	if f.completed != f.k {
+		return
+	}
+	report, ok := f.tracker.RecordActual(f.shapeID, actuals.Actual{
+		ReadRows:   f.rows,
+		ReadBytes:  f.bytes,
+		PeakMemory: f.peakMemory,
+	}, actuals.SourcePacket)
+	if ok && report.HasPredicted {
+		telemetry.RecordEstimateDrift(f.ctx, report.Ratio, report.Alerting, actuals.SourcePacket.String())
 	}
 }
 

--- a/internal/chclient/shard_actuals_fold_test.go
+++ b/internal/chclient/shard_actuals_fold_test.go
@@ -1,0 +1,175 @@
+package chclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+)
+
+// simulateShardFlush mimics runShard's own per-shard sequence
+// (internal/solver/executor.go): a SECOND WithProgressFor call on a
+// descendant of outerCtx (the one WithShardActualsFold was wired onto),
+// feeding it packet/ProfileEvents data, and flushing it exactly the way
+// rowsCursor.Close does at end-of-shard.
+func simulateShardFlush(outerCtx context.Context, rows, bytes, peakMemory uint64) {
+	shardCtx := WithProgressFor(outerCtx, "promql")
+	rec := recorderFromContext(shardCtx)
+	rec.onProgress(&clickhouse.Progress{Rows: rows, Bytes: bytes})
+	if peakMemory > 0 {
+		rec.onProfileEvents([]clickhouse.ProfileEvent{
+			{Name: profileEventMemoryTrackerPeakUsage, Value: int64(peakMemory)}, //nolint:gosec // G115 -- test fixture, always small positive values
+		})
+	}
+	rec.flush()
+}
+
+// TestShardActualsFold_SumsRowsBytesMaxesPeakMemory pins the folding rule
+// itself (issue #3033): ReadRows/ReadBytes SUM across shards, PeakMemory
+// MAXES — and exactly ONE RecordActual reaches the tracker for the whole
+// K-shard dispatch, not K.
+func TestShardActualsFold_SumsRowsBytesMaxesPeakMemory(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:agg;rw"
+	tracker.RecordPredicted(shape, 1000)
+
+	outer := WithProgressFor(context.Background(), "promql")
+	outer = WithActualsCapture(outer, tracker, shape)
+	outer = WithShardActualsFold(outer, 4)
+
+	fold, ok := shardActualsFoldFromContext(outer)
+	if !ok {
+		t.Fatal("expected a fold to be wired for a 4-shard dispatch with actuals capture on")
+	}
+
+	// Each shard scanned a disjoint slice of the total; peak memory readings
+	// are independent per-shard high-water marks.
+	simulateShardFlush(outer, 250, 2500, 1_000)
+	simulateShardFlush(outer, 300, 3000, 5_000) // the max
+	simulateShardFlush(outer, 200, 2000, 2_000)
+	simulateShardFlush(outer, 250, 2500, 3_000)
+
+	if fold.rows != 1000 || fold.bytes != 10000 || fold.peakMemory != 5000 {
+		t.Fatalf("expected SUM(rows)=1000 SUM(bytes)=10000 MAX(peakMemory)=5000, got rows=%d bytes=%d peakMemory=%d",
+			fold.rows, fold.bytes, fold.peakMemory)
+	}
+	if fold.completed != 4 {
+		t.Fatalf("expected all 4 shards to have folded in, got completed=%d", fold.completed)
+	}
+
+	report, ok := tracker.Snapshot(shape)
+	if !ok {
+		t.Fatal("expected the fold to have recorded exactly one actual into the tracker")
+	}
+	if report.Observations != 1 {
+		t.Fatalf("expected exactly ONE RecordActual for the whole 4-shard dispatch, got Observations=%d", report.Observations)
+	}
+	if report.ActualEMARows != 1000 {
+		t.Fatalf("expected the folded (summed) rows to reach the tracker, got ActualEMARows=%v", report.ActualEMARows)
+	}
+}
+
+// TestShardActualsFold_KShardDispatchRecordsComparableActualsToSingleShard is
+// the DoD test (issue #3033 / M4 exit criterion #1): dispatching the SAME
+// logical plan once via a K-shard route-B fan-out and once via a
+// single-shard dispatch must record COMPARABLE actuals — not off by a
+// factor of K. Before the fold existed, each of the K shards' flush() called
+// tracker.RecordActual directly with only ITS OWN fractional share, so the
+// K-shard tracker's EMA converged toward roughly totalRows/K instead of
+// totalRows; this test fails against that behavior and passes once shards
+// fold into ONE observation.
+func TestShardActualsFold_KShardDispatchRecordsComparableActualsToSingleShard(t *testing.T) {
+	const totalRows, totalBytes, peakMemory = 1000, 10_000, 5_000
+	const shapeSingle, shapeSharded = "cerb:single", "cerb:sharded"
+
+	// Single-shard dispatch (route-A shape): one recorder sees the WHOLE
+	// request in one flush, exactly as today.
+	singleTracker := actuals.NewTracker(actuals.DefaultConfig())
+	singleTracker.RecordPredicted(shapeSingle, totalRows)
+	singleCtx := WithProgressFor(context.Background(), "promql")
+	singleCtx = WithActualsCapture(singleCtx, singleTracker, shapeSingle)
+	simulateShardFlush(singleCtx, totalRows, totalBytes, peakMemory)
+
+	// K=4 route-B dispatch of the SAME total, split across 4 disjoint
+	// shards (mirroring the executor's own shard-composition contract:
+	// each shard scans a disjoint slice of the total).
+	shardedTracker := actuals.NewTracker(actuals.DefaultConfig())
+	shardedTracker.RecordPredicted(shapeSharded, totalRows)
+	shardedOuter := WithProgressFor(context.Background(), "promql")
+	shardedOuter = WithActualsCapture(shardedOuter, shardedTracker, shapeSharded)
+	shardedOuter = WithShardActualsFold(shardedOuter, 4)
+
+	shardRows := [4]uint64{250, 300, 200, 250}
+	shardBytes := [4]uint64{2500, 3000, 2000, 2500}
+	shardPeaks := [4]uint64{1000, 5000, 2000, 3000} // max is 5000, the peak the single dispatch itself saw
+	for i := 0; i < 4; i++ {
+		simulateShardFlush(shardedOuter, shardRows[i], shardBytes[i], shardPeaks[i])
+	}
+
+	singleReport, ok := singleTracker.Snapshot(shapeSingle)
+	if !ok {
+		t.Fatal("expected the single-shard dispatch to record an actual")
+	}
+	shardedReport, ok := shardedTracker.Snapshot(shapeSharded)
+	if !ok {
+		t.Fatal("expected the K-shard dispatch to record an actual")
+	}
+
+	if shardedReport.Observations != 1 {
+		t.Fatalf("expected the K-shard dispatch to record exactly ONE observation, got %d (the un-folded bug records K)",
+			shardedReport.Observations)
+	}
+	if singleReport.ActualEMARows != shardedReport.ActualEMARows {
+		t.Fatalf("expected the K-shard dispatch's folded rows to be COMPARABLE to the single-shard dispatch's, got single=%v sharded=%v (ratio=%v)",
+			singleReport.ActualEMARows, shardedReport.ActualEMARows, shardedReport.ActualEMARows/singleReport.ActualEMARows)
+	}
+}
+
+// TestShardActualsFold_RouteAUnaffected pins that a plain route-A dispatch —
+// no WithShardActualsFold call at all, exactly like every existing call site
+// before issue #3033 — behaves byte-identically: flush() still calls
+// tracker.RecordActual directly.
+func TestShardActualsFold_RouteAUnaffected(t *testing.T) {
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:routeA"
+	tracker.RecordPredicted(shape, 500)
+
+	ctx := WithProgressFor(context.Background(), "promql")
+	ctx = WithActualsCapture(ctx, tracker, shape)
+	// No WithShardActualsFold call — route A never makes one.
+	if _, ok := shardActualsFoldFromContext(ctx); ok {
+		t.Fatal("expected no fold on a route-A ctx")
+	}
+	rec := recorderFromContext(ctx)
+	rec.onProgress(&clickhouse.Progress{Rows: 500, Bytes: 5000})
+	rec.flush()
+
+	report, ok := tracker.Snapshot(shape)
+	if !ok || report.ActualEMARows != 500 || report.Observations != 1 {
+		t.Fatalf("expected route A's single flush to record directly into the tracker, got %+v (ok=%v)", report, ok)
+	}
+}
+
+// TestWithShardActualsFold_NoOpWithoutActualsIntentOrSingleShard pins both
+// no-op branches: no actualsIntent on ctx (feature off), and k < 2 (route A,
+// or a degenerate single-shard route-B decision that already records
+// correctly without folding).
+func TestWithShardActualsFold_NoOpWithoutActualsIntentOrSingleShard(t *testing.T) {
+	// No actuals capture at all.
+	ctx := WithProgressFor(context.Background(), "promql")
+	if got := WithShardActualsFold(ctx, 4); got != ctx {
+		t.Fatal("expected WithShardActualsFold to no-op when actuals capture is off")
+	}
+
+	// Actuals capture on, but k < 2.
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	ctx = WithActualsCapture(ctx, tracker, "cerb:agg;rw")
+	if got := WithShardActualsFold(ctx, 1); got != ctx {
+		t.Fatal("expected WithShardActualsFold to no-op for k < 2")
+	}
+	if _, ok := shardActualsFoldFromContext(WithShardActualsFold(ctx, 1)); ok {
+		t.Fatal("expected no fold wired for k < 2")
+	}
+}

--- a/internal/solver/executor.go
+++ b/internal/solver/executor.go
@@ -115,6 +115,18 @@ func (x *Executor) Execute(
 	}
 	k := len(d.Slices)
 
+	// Issue #3033: fold route-B's K shard actuals into ONE per-request
+	// RecordActual call. WithShardActualsFold reads whatever actualsIntent
+	// routeBExecCtx (internal/engine) already stamped on ctx before calling
+	// Execute (chclient.WithActualsCapture's own doc) and wires a fresh
+	// *chclient.ShardActualsFold onto ctx keyed to THIS dispatch's k — every
+	// shard's own derived ctx below inherits it by ordinary context nesting,
+	// so runShard's per-shard chclient.WithProgressFor call needs no changes
+	// at all. It is a no-op (ctx returned unchanged) when actuals capture is
+	// off or k < 2, so route A — and any k==1 caller of this function — is
+	// completely unaffected.
+	ctx = chclient.WithShardActualsFold(ctx, k)
+
 	// 6. HALF-OPEN PRE-FLIGHT — peek before emitting. A non-CLOSED breaker
 	// fails fast WITHOUT consuming the half-open probe (PeekBreakerState is
 	// read-only): a K-shard fan-out must never burn the single recovery

--- a/internal/solver/executor.go
+++ b/internal/solver/executor.go
@@ -86,6 +86,90 @@ type Executor struct {
 	Admit admitTopUp
 }
 
+// admitAndGate performs the Executor's two-stage weighted admission (step 2)
+// and the atomic global-connection-gate acquisition (step 3) as ONE unit:
+// the gate's own effective shard count (kEff) depends on the admission
+// result (pEff), and a gate-acquire failure must release the admission
+// top-up it already holds — the two steps share state in exactly the way
+// that makes splitting their RELEASE handles across two independent call
+// sites error-prone. Returns the admitted (kEff, pEff) pair, the two
+// idempotent release closures Execute must hand off to the shardCursor (or
+// call itself on an early return), and a non-nil err only when the gate
+// denied the request — already breaker-neutral (no CH connection was ever
+// opened) and with the admit top-up already released before returning.
+func (x *Executor) admitAndGate(ctx context.Context, k int) (kEff, pEff int, releaseGate, releaseAdmit func(), err error) {
+	// 2. TWO-STAGE WEIGHTED ADMISSION (degrade-don't-reject). The handler
+	// already charged weight 1; ask for (P-1) extra units. On a partial /
+	// zero grant we clamp effective P to 1+granted — down to sequential —
+	// and run. We NEVER 503 and NEVER proceed at full P.
+	pCfg := x.Cfg.Parallel
+	if pCfg < 1 {
+		pCfg = 1
+	}
+	pEff = pCfg
+	var admitRelease func()
+	if x.Admit != nil && pCfg > 1 {
+		granted, release := x.Admit.TryAcquireTopUp(ctx, pCfg-1)
+		admitRelease = release
+		pEff = 1 + granted
+		if pEff < pCfg {
+			recordParallelismClamped(ctx)
+		}
+	}
+	// admitRelease must run exactly once. If anything below fails before we
+	// hand ownership to the shardCursor, release here.
+	releaseAdmit = func() {
+		if admitRelease != nil {
+			admitRelease()
+			admitRelease = nil
+		}
+	}
+
+	// 3. ATOMIC GATE ACQUISITION — no hold-and-wait. K_eff = min(K, P_eff,
+	// gate/2). The gate/2 cap guarantees >=2 routed requests can always make
+	// progress. Acquire ALL K_eff slots in one call before opening any
+	// cursor; release them all at Close.
+	kEff = k
+	if pEff < kEff {
+		kEff = pEff
+	}
+	if x.Gate != nil && x.GateCap > 0 {
+		half := int(x.GateCap / 2)
+		if half < 1 {
+			half = 1
+		}
+		if half < kEff {
+			kEff = half
+		}
+	}
+	if kEff < 1 {
+		kEff = 1
+	}
+
+	var gateReleased atomic.Bool
+	releaseGate = func() {
+		if x.Gate != nil && gateReleased.CompareAndSwap(false, true) {
+			x.Gate.Release(int64(kEff))
+		}
+	}
+	if x.Gate != nil {
+		if aerr := x.Gate.Acquire(ctx, int64(kEff)); aerr != nil {
+			// Gate acquire honoured the request ctx (timeout / client
+			// cancel). No cursors opened; release the admit top-up and
+			// surface the ctx error. This is breaker-neutral: the Executor
+			// never opened a CH connection.
+			releaseAdmit()
+			return kEff, pEff, releaseGate, releaseAdmit, fmt.Errorf("solver: gate acquire: %w", aerr)
+		}
+	}
+
+	// effective concurrency cannot exceed the slots we hold.
+	if pEff > kEff {
+		pEff = kEff
+	}
+	return kEff, pEff, releaseGate, releaseAdmit, nil
+}
+
 // Execute emits, admits, gates, and dispatches a routed Decision, returning
 // a Cursor that concatenates the K shard streams oldest-first. The returned
 // Cursor owns the gate + admit releases and frees them on Close; callers
@@ -170,74 +254,12 @@ func (x *Executor) Execute(
 		info.ShardQueryIDs[i] = chclient.MintQueryID(ctx)
 	}
 
-	// 2. TWO-STAGE WEIGHTED ADMISSION (degrade-don't-reject). The handler
-	// already charged weight 1; ask for (P-1) extra units. On a partial /
-	// zero grant we clamp effective P to 1+granted — down to sequential —
-	// and run. We NEVER 503 and NEVER proceed at full P.
-	pCfg := x.Cfg.Parallel
-	if pCfg < 1 {
-		pCfg = 1
-	}
-	pEff := pCfg
-	var admitRelease func()
-	if x.Admit != nil && pCfg > 1 {
-		granted, release := x.Admit.TryAcquireTopUp(ctx, pCfg-1)
-		admitRelease = release
-		pEff = 1 + granted
-		if pEff < pCfg {
-			recordParallelismClamped(ctx)
-		}
-	}
-	// admitRelease must run exactly once. If anything below fails before we
-	// hand ownership to the shardCursor, release here.
-	releaseAdmit := func() {
-		if admitRelease != nil {
-			admitRelease()
-			admitRelease = nil
-		}
-	}
-
-	// 3. ATOMIC GATE ACQUISITION — no hold-and-wait. K_eff = min(K, P_eff,
-	// gate/2). The gate/2 cap guarantees >=2 routed requests can always make
-	// progress. Acquire ALL K_eff slots in one call before opening any
-	// cursor; release them all at Close.
-	kEff := k
-	if pEff < kEff {
-		kEff = pEff
-	}
-	if x.Gate != nil && x.GateCap > 0 {
-		half := int(x.GateCap / 2)
-		if half < 1 {
-			half = 1
-		}
-		if half < kEff {
-			kEff = half
-		}
-	}
-	if kEff < 1 {
-		kEff = 1
-	}
-
-	var gateReleased atomic.Bool
-	releaseGate := func() {
-		if x.Gate != nil && gateReleased.CompareAndSwap(false, true) {
-			x.Gate.Release(int64(kEff))
-		}
-	}
-	if x.Gate != nil {
-		if err := x.Gate.Acquire(ctx, int64(kEff)); err != nil {
-			// Gate acquire honoured the request ctx (timeout / client
-			// cancel). No cursors opened; release the admit top-up and
-			// surface the ctx error. This is breaker-neutral: the Executor
-			// never opened a CH connection.
-			releaseAdmit()
-			return nil, nil, fmt.Errorf("solver: gate acquire: %w", err)
-		}
-	}
-
-	// effective concurrency cannot exceed the slots we hold.
-	if pEff > kEff {
-		pEff = kEff
+	// 2. TWO-STAGE WEIGHTED ADMISSION and 3. ATOMIC GATE ACQUISITION —
+	// extracted to admitAndGate (its own doc explains why the two steps
+	// share one helper rather than living inline here).
+	kEff, pEff, releaseGate, releaseAdmit, err := x.admitAndGate(ctx, k)
+	if err != nil {
+		return nil, nil, err
 	}
 	info.Parallelism = pEff
 

--- a/internal/solver/shard_actuals_fold_wiring_test.go
+++ b/internal/solver/shard_actuals_fold_wiring_test.go
@@ -1,0 +1,123 @@
+package solver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// shardActualsFoldOfShards reads back the *chclient.ShardActualsFold each
+// shard's QueryCursor call actually observed on its own ctx, failing the
+// test if any shard never opened a cursor at all — mirrors
+// responseShapeOfShards' own doc for why that would make an "every shard
+// carries X" assertion vacuously true.
+func shardActualsFoldOfShards(t *testing.T, q *fakeQuerier, k int) []*chclient.ShardActualsFold {
+	t.Helper()
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	folds := make([]*chclient.ShardActualsFold, k)
+	for shard := 0; shard < k; shard++ {
+		shardCtx, ok := q.ctxByShard[shard]
+		if !ok {
+			t.Fatalf("shard %d never opened a cursor — nothing to assert about its ctx", shard)
+		}
+		fold, _ := chclient.ShardActualsFoldFromContext(shardCtx)
+		folds[shard] = fold
+	}
+	return folds
+}
+
+// TestExecute_WiresSameShardActualsFoldOntoEveryShard pins issue #3033's
+// wiring half: a K-shard routed dispatch with actuals capture active must
+// thread the SAME *chclient.ShardActualsFold accumulator onto every shard's
+// own ctx — not a fresh one per shard, which would defeat the fold entirely
+// and reproduce the exact K-way undercount this issue exists to close.
+func TestExecute_WiresSameShardActualsFoldOntoEveryShard(t *testing.T) {
+	const k = 4
+	q := newFakeQuerier(2)
+	cfg := testCfg()
+	cfg.Parallel = k // kEff == k, so every shard really does open a cursor
+	x := newExec(q, newFakeEmitter(), cfg, 32, newFakeBreaker(BreakerClosed), nil)
+
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	ctx := chclient.WithProgressFor(context.Background(), "promql")
+	ctx = chclient.WithActualsCapture(ctx, tracker, "cerb:agg;rw")
+
+	cur, _, err := x.Execute(ctx, "promql", makeDecision(k), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	defer cur.Close()
+	if _, err := drainAll(cur); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+
+	folds := shardActualsFoldOfShards(t, q, k)
+	first := folds[0]
+	if first == nil {
+		t.Fatal("expected a non-nil *ShardActualsFold on shard 0's ctx for a K>1 actuals-capturing dispatch")
+	}
+	for i, f := range folds {
+		if f != first {
+			t.Fatalf("expected shard %d to carry the SAME fold pointer as shard 0, got a different (or nil) one: %p vs %p", i, f, first)
+		}
+	}
+}
+
+// TestExecute_NoShardActualsFoldForSingleShardDecision pins the k<2 no-op:
+// a single-slice Decision (a degenerate route-B dispatch, or any test that
+// exercises Execute directly with k==1) must not carry a fold at all — it
+// already records correctly without one, and chclient.WithShardActualsFold's
+// own doc says as much.
+func TestExecute_NoShardActualsFoldForSingleShardDecision(t *testing.T) {
+	q := newFakeQuerier(2)
+	x := newExec(q, newFakeEmitter(), testCfg(), 32, newFakeBreaker(BreakerClosed), nil)
+
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	ctx := chclient.WithProgressFor(context.Background(), "promql")
+	ctx = chclient.WithActualsCapture(ctx, tracker, "cerb:agg;rw")
+
+	cur, _, err := x.Execute(ctx, "promql", makeDecision(1), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	defer cur.Close()
+	if _, err := drainAll(cur); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+
+	folds := shardActualsFoldOfShards(t, q, 1)
+	if folds[0] != nil {
+		t.Fatal("expected no fold wired onto a single-shard dispatch's ctx")
+	}
+}
+
+// TestExecute_NoShardActualsFoldWithoutActualsCapture pins the other no-op:
+// a routed K-shard dispatch with actuals capture OFF (no WithActualsCapture
+// call at all — the overwhelmingly common case, since the feature defaults
+// off) must not wire a fold either.
+func TestExecute_NoShardActualsFoldWithoutActualsCapture(t *testing.T) {
+	const k = 3
+	q := newFakeQuerier(2)
+	cfg := testCfg()
+	cfg.Parallel = k
+	x := newExec(q, newFakeEmitter(), cfg, 32, newFakeBreaker(BreakerClosed), nil)
+
+	cur, _, err := x.Execute(context.Background(), "promql", makeDecision(k), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	defer cur.Close()
+	if _, err := drainAll(cur); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+
+	folds := shardActualsFoldOfShards(t, q, k)
+	for i, f := range folds {
+		if f != nil {
+			t.Fatalf("expected no fold on shard %d's ctx with actuals capture off", i)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`internal/chclient/progress.go`'s `WithProgressFor` correctly gives each of a route-B sharded
dispatch's K shards its own fresh `progressRecorder` (issue #2789's fix). But each shard's recorder
independently called `tracker.RecordActual` from its own `flush()` (on that shard's cursor Close) —
so a K-shard dispatch made K independent `RecordActual` calls, each carrying only that shard's own
fractional `(rows, bytes, peakMemory)`, against the ONE un-sharded `RecordPredicted` prediction the
whole request made. This corrupted `internal/actuals.Tracker`'s EMA (and everything downstream —
`CalibrationFactor`, the per-rung admission actuals-driven seed) by roughly a factor of K.

## Fix

`chclient.ShardActualsFold` (new, `internal/chclient/progress.go`) accumulates every shard's
observation into ONE per-request total:

- `ReadRows` / `ReadBytes`: **summed** across shards (each shard scanned a disjoint slice of the
  total).
- `PeakMemory`: **maxed** across shards, never summed (`onProfileEvents` already latches the max
  packet within one shard's own dispatch; this applies the same idea across shards).

`solver.Executor.Execute` wires a fresh fold onto `ctx` via `chclient.WithShardActualsFold(ctx, k)`
right after computing `k := len(d.Slices)`. Because every shard's own `ctx` is derived from that
same `ctx` (through `causeCtx` → `gctx` → each shard's `pctx`), the fold rides along by ordinary
context nesting — `runShard`'s existing per-shard `chclient.WithProgressFor` call needed **no
changes at all**.

`progressRecorder.flush()` now checks for a fold on its own `ctx`: if present, it feeds its
`(rows, bytes, peakMemory)` into the shared accumulator instead of calling `tracker.RecordActual`
directly. The shard whose `add()` call observes `completed == k` — necessarily the last one, since
`completed` only increases — performs the single `RecordActual` (+ `RecordEstimateDrift`) call,
inline, still holding the accumulator's mutex. So "exactly one call per request" is enforced by
construction, with no separate finalize step for a caller to forget.

`WithShardActualsFold` is a no-op (returns `ctx` unchanged) when actuals capture isn't active for
the dispatch, or `k < 2` — so **route A is completely unaffected**, and it still calls
`tracker.RecordActual` directly exactly as before.

A dispatch that never gets all `k` shards to flush (e.g. a shard failed to even open its cursor)
simply never fires — recording a partial `(k-1)-of-k` sum would reintroduce the same undercount
class this fix exists to close, just at a smaller K.

## Tests

- `internal/chclient/shard_actuals_fold_test.go`:
  - `TestShardActualsFold_SumsRowsBytesMaxesPeakMemory` — pins the SUM/MAX folding rule and that
    exactly ONE `RecordActual` reaches the tracker for a 4-shard dispatch.
  - `TestShardActualsFold_KShardDispatchRecordsComparableActualsToSingleShard` — the DoD test: the
    same total dispatched once as 4 shards and once as a single shard record **comparable**
    (here, exactly equal) `ActualEMARows`. Verified this fails against the pre-fix behavior: with
    `progressRecorder.flush()`'s fold branch disabled, this test reports the K-shard dispatch
    recording 4 independent observations instead of 1, with the folded values reading as zero.
  - `TestShardActualsFold_RouteAUnaffected` / `TestWithShardActualsFold_NoOpWithoutActualsIntentOrSingleShard`
    — the no-op contracts.
- `internal/solver/shard_actuals_fold_wiring_test.go` — proves `Executor.Execute` threads the
  **same** `*chclient.ShardActualsFold` pointer onto every shard's own `ctx` for a K-shard
  actuals-capturing dispatch, and wires none at all for `k == 1` or with actuals capture off.

`just test-unit` passes.

Closes #3033
