### PR TITLE
fix(routememo): wire MagnitudeFor into a corroboration-gated routing decision

### DIFF
--- a/docs/solver.md
+++ b/docs/solver.md
@@ -476,7 +476,7 @@ normalized `query_log` text.
   the normal route-A path; the outcome is still `Observe`d so corroboration
   bookkeeping progresses.
 - **`PreferB`** — route A has failed on this Key at least
-  `minCorroboratingFailures` (2) consecutive times with no intervening
+  `MinCorroboratingFailures` (2) consecutive times with no intervening
   success, and a route-B probe subsequently succeeded. The caller MAY memo-hit
   route B directly, subject to every other gate re-checked at dispatch time
   (eligibility, freshness, breaker, admission). A `PreferB` past its
@@ -487,7 +487,7 @@ normalized `query_log` text.
   resource failure. The caller stays on route A; no further probing is
   attempted until the entry ages out at the memo's TTL.
 
-Requiring `minCorroboratingFailures = 2` consecutive failures (not one) exists
+Requiring `MinCorroboratingFailures = 2` consecutive failures (not one) exists
 so a single transient rejection never mints a verdict on its own: probing
 route B is itself a real dispatch, and the memo's premise only holds if
 repeated failure is treated as real signal rather than noise from one bad
@@ -498,7 +498,7 @@ request.
 A `pressureTracker` (`internal/routememo/pressure.go`) records every resource
 failure's Key and timestamp, independent of which route produced it.
 `Memo.UnderPressure()` reports true once more than `pressureFailureThreshold`
-(`minCorroboratingFailures + 1` = 3) DISTINCT keys have shown a resource
+(`MinCorroboratingFailures + 1` = 3) DISTINCT keys have shown a resource
 failure within a pressure window. While under pressure, the memo admits no
 probe and no memo-hit dispatch — both fall back to route A — and `Observe`
 writes no verdict state at all; only the pressure tracker itself keeps
@@ -509,7 +509,7 @@ without the damper, one shared external cause would look like independent
 evidence against every one of those keys and stampede all of them into
 probing route B at once — exactly the wrong response to a cause that has
 nothing to do with any individual key's cost shape. `pressureFailureThreshold`
-is defined relative to `minCorroboratingFailures` specifically so a single hot
+is defined relative to `MinCorroboratingFailures` specifically so a single hot
 key's own corroboration count can never trip the damper by itself — tripping
 it takes failures spread across more than one key.
 
@@ -778,7 +778,7 @@ by construction.
 
 The issue's proposal names both the route memo and per-rung admission as
 seeding targets. Only per-rung admission is seeded. The route memo's
-`minCorroboratingFailures = 2` and its cluster-wide pressure damper (both
+`MinCorroboratingFailures = 2` and its cluster-wide pressure damper (both
 documented above) exist specifically to reject exactly the kind of single-
 shot, non-corroborated evidence a granule-resolution upper bound is: seeding
 `PreferB` from an estimate would let one advisory signal — not selectivity-
@@ -884,7 +884,7 @@ below), and its `DistinctSeries` is a field only this probe ever populates.
    reason `EXPLAIN ESTIMATE` is not: see "Why the failure-driven route memo
    is NOT seeded" above. A real bounded aggregate is still one non-drain
    observation, not the repeated real-traffic corroboration
-   `minCorroboratingFailures` + the pressure damper exist to require.
+   `MinCorroboratingFailures` + the pressure damper exist to require.
 
 ### Cost bound and scope (deliberately narrow)
 
@@ -1055,17 +1055,31 @@ whether or not the operator separately opted into it.
    safety argument as that mechanism's own doc: it can only ever DOWNGRADE
    an already-`PerRungPredictive` route, never promote or block one.
 4. **Route-memo priors with real magnitudes** (`internal/routememo/magnitude.go`,
-   `RecordActualMagnitude` / `MagnitudeFor`): a deliberately THIN hook —
-   see "Why the failure-driven route memo is NOT seeded" above for why the
-   memo's routing VERDICT is never touched by an advisory or actuals
-   signal. This hook adds a second, purely OBSERVATIONAL axis on top of an
-   ALREADY-LIVE verdict (it never creates, deletes, or changes
-   `LookupState`, eviction order, or TTL) — wired from
-   `per_rung_admission.go`'s existing `perRungObservingCursor.Close()`,
-   which already computes the identical `routememo.Key` for a per-rung
-   predictive route-B dispatch's own clean drain. Architecture the memo
-   supports for a future routing use; this landing makes no routing
-   decision from it.
+   `RecordActualMagnitude` / `MagnitudeFor`): a second, OBSERVATIONAL axis on
+   top of an already-live verdict — it never creates, deletes, or changes
+   `LookupState`, eviction order, or TTL by itself. This is NOT the same
+   thing "Why the failure-driven route memo is NOT seeded" above forbids:
+   that section is about seeding the VERDICT from a single-shot, external
+   ADVISORY signal (`EXPLAIN ESTIMATE`, the cardinality probe, a calibration
+   factor) with no real-dispatch corroboration behind it. The magnitude axis
+   is built entirely from the memo's OWN repeated, real route-B drains —
+   `RecordActualMagnitude` is fed from every clean drain across all three
+   route-B call sites (`internal/engine/route_memo_wiring.go`'s memo-hit,
+   first probe, and stale-`PreferB` re-validation, plus
+   `per_rung_admission.go`'s separate per-rung predictive cursor), so a
+   consumer that requires `MinCorroboratingFailures` independent readings
+   before trusting it is reading the SAME class of repeated real-traffic
+   evidence the verdict itself requires, just on a different axis.
+   `route_memo_wiring.go`'s `retryOnRouteAResourceFailure` is that consumer:
+   a stale-`PreferB` re-validation whose tracked magnitude is
+   well-corroborated AND trivially small (under
+   `routeMemoTrivialMagnitudeRowsPerAnchor` rows per anchor) declines the
+   automatic rescue-probe admission — the scarce dispatch-token budget goes
+   unspent rather than re-confirming a route whose own corroborated history
+   says it barely moves any data. It never touches a brand-new `Unknown`
+   key's first-ever probe (no magnitude reading can exist yet for a Key that
+   has never completed a route-B dispatch) and never demotes or evicts the
+   verdict itself — only whether THIS ONE rescue dispatch is attempted.
 
 ### Verified against a live server, not assumed
 

--- a/internal/engine/actuals_wiring.go
+++ b/internal/engine/actuals_wiring.go
@@ -24,8 +24,11 @@ import (
 //     (engine.go's classify) — "calibrate the solver's carrier-geometry
 //     cost model" without solver itself needing to import actuals at all.
 //  2. Route-memo priors with real magnitudes: routememo.Memo.
-//     RecordActualMagnitude (internal/routememo/magnitude.go), wired from
-//     per_rung_admission.go's existing perRungObservingCursor — see that
+//     RecordActualMagnitude (internal/routememo/magnitude.go), originally
+//     wired ONLY from per_rung_admission.go's perRungObservingCursor. Issue
+//     #3035 widened this to route_memo_wiring.go's own memo-hit / probe /
+//     re-validation drains too (fixing the single-source sampling bias)
+//     and gave MagnitudeFor a real routing consumer there — see that
 //     file's own doc.
 //  3. Per-rung admission tightening: reuses PerRungAdmissionLearner.
 //     SeedPriorFromEstimate (per_rung_admission.go, issue #2787's own

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2065,6 +2065,12 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 	budget := chclient.SampleBudgetFromContext(ctx)
 	if cur, info, usedDecision, key, ok := e.tryRouteMemoHit(ctx, lang.Name(), meta.ResponseShape, plan, decision, budget); ok {
 		result := e.buildRoutedCursorResult(meta, plan, lang.Name(), usedDecision, cur, info, "memo-hit")
+		// See routeMemoHitObserveDrainOutcome's own doc: issue #3035's
+		// sampling-bias fix, unlike Retry below (which only ever fires on a
+		// drain FAILURE) this hook is called UNCONDITIONALLY, so a memo-hit's
+		// clean drain is what feeds the magnitude EMA the most of any single
+		// route-B call site.
+		result.ObserveDrainOutcome = routeMemoHitObserveDrainOutcome(e.RouteMemo, key, cur)
 		result.Retry = func(retryCtx context.Context, drainErr error) (CursorResult, bool) {
 			// The verdict already existed before this dispatch (that is
 			// what made it a memo-hit); a clean drain needed no

--- a/internal/engine/route_memo_wiring.go
+++ b/internal/engine/route_memo_wiring.go
@@ -27,6 +27,59 @@ import (
 // memo-hit alike — regardless of what the memo has recorded for its Key.
 const liveEdgeFreshnessMarginSteps = 1
 
+// routeMemoTrivialMagnitudeRowsPerAnchor bounds "trivially small" for a
+// stale-PreferB re-validation's tracked magnitude (routememo.Memo.
+// MagnitudeFor), RELATIVE to the dispatch's own anchor count — mirroring
+// per_rung_admission.go's perRungCheapRowsPerAnchor per-anchor cheapness
+// reasoning (a composed route-B result averaging fewer than this many
+// output rows per anchor has too little data behind it, at any grid width,
+// to justify K-way contention). This is a SECOND, independent constant
+// rather than a shared one: per_rung_admission.go's own doc is explicit
+// that the per-rung learner and the failure-driven route memo are
+// deliberately independent mechanisms answering different questions (one
+// downgrades an already-eligible per-rung bypass; this one decides whether
+// a SCARCE rescue-dispatch token is worth spending re-confirming a route
+// memo verdict) — coupling their thresholds would make a future change to
+// either one silently retune the other.
+const routeMemoTrivialMagnitudeRowsPerAnchor = 20
+
+// recordRouteMemoMagnitude feeds cur's inspected-row count into memo's
+// magnitude EMA for key, on a CLEAN route-B drain only (callers gate on
+// drainErr == nil / a nil dispatch error before calling this) — see
+// routememo/magnitude.go's own doc. Guards the int64->uint64 conversion the
+// same way per_rung_admission.go's perRungObservingCursor already does:
+// Inspected() is documented non-negative on a clean drain, so the guard is
+// defensive, not expected to ever trip. A nil cur or nil memo is a no-op —
+// the former can't happen at either of this function's call sites but
+// costs nothing to guard against, the latter mirrors every other memo
+// method's own "unwired mechanism" contract.
+func recordRouteMemoMagnitude(memo *routememo.Memo, key routememo.Key, cur chclient.Cursor) {
+	if memo == nil || cur == nil {
+		return
+	}
+	if n := cur.Inspected(); n >= 0 {
+		memo.RecordActualMagnitude(key, uint64(n)) //nolint:gosec // G115 -- guarded by the >= 0 check above
+	}
+}
+
+// routeMemoHitObserveDrainOutcome builds a memo-hit CursorResult's
+// ObserveDrainOutcome hook (QueryPlanCursor's own call site) — a named,
+// directly testable function rather than an inline closure, since the
+// memo-hit's OTHER hook (Retry) already warranted one. The handler calls
+// this UNCONDITIONALLY with the real drain error (nil on the ordinary
+// clean finish), so a clean memo-hit drain — the SINGLE MOST common route-B
+// dispatch shape once a Key is established — is what closes issue #3035's
+// sampling-bias gap the widest: no verdict-state write happens (a clean
+// memo-hit needs no re-confirmation, unchanged from before this hook
+// existed), only the observational magnitude axis is fed.
+func routeMemoHitObserveDrainOutcome(memo *routememo.Memo, key routememo.Key, cur chclient.Cursor) func(drainErr error) {
+	return func(drainErr error) {
+		if drainErr == nil {
+			recordRouteMemoMagnitude(memo, key, cur)
+		}
+	}
+}
+
 // routeMemoActive reports whether the failure-driven route memo is wired
 // and has something to consult. A nil RouteMemo or a nil Solver both mean
 // the mechanism is off, matching e.classify's own "Solver nil -> no
@@ -285,6 +338,26 @@ func (e *Engine) retryOnRouteAResourceFailure(
 		telemetry.RecordRouteMemoHitSkipped(ctx, telemetry.RouteMemoDeclineBreakerOpen)
 		return nil, nil, nil, nil, false
 	}
+	// Snapshot whether THIS failure is heading into the stale-PreferB
+	// re-validation rescue (as opposed to a brand-new Unknown key's
+	// first-ever probe) BEFORE the atomic call below mutates state — purely
+	// to inform the magnitude-trivial decline right after it, never as a
+	// substitute for that call's own internal atomic staleness check (see
+	// its doc for why record-and-decide must stay one critical section).
+	// Reading it here cannot reintroduce that race: this is an ADDITIONAL,
+	// non-mutating read for a second, independent, dispatch-token-budget
+	// decision, not a second attempt at the state-transition decision
+	// itself — at worst a concurrent request makes this snapshot stale by
+	// the time the atomic call runs, which costs only dispatch-token
+	// efficiency, never a wrong answer (routememo never decides HOW route B
+	// computes its answer, only whether to try it).
+	preState, preStale := e.RouteMemo.Lookup(d.key)
+	magRows, magObservations, magOK := e.RouteMemo.MagnitudeFor(d.key)
+	trivialRevalidation := preState == routememo.PreferB && preStale &&
+		magOK && magObservations >= routememo.MinCorroboratingFailures &&
+		d.decision.NAnchors > 0 &&
+		magRows < float64(d.decision.NAnchors)*routeMemoTrivialMagnitudeRowsPerAnchor
+
 	// Record the failure AND decide probe admission atomically — see
 	// ObserveRouteAFailureAndMaybeBeginProbe's doc for why this must not be
 	// two separate calls (a stale PreferB entry's re-validation rescue
@@ -299,6 +372,21 @@ func (e *Engine) retryOnRouteAResourceFailure(
 		} else {
 			telemetry.RecordRouteMemoHitSkipped(ctx, telemetry.RouteMemoDeclineProbeNotAdmitted)
 		}
+		return nil, nil, nil, nil, false
+	}
+	if trivialRevalidation {
+		// The admission above already recorded the failure (corroboration
+		// / re-validation-clock bookkeeping progresses exactly as if this
+		// rescue had run) — only the DISPATCH itself is declined, giving
+		// the token straight back unspent rather than spending one of
+		// maxConcurrentRoutedDispatches re-confirming a route whose own
+		// well-corroborated history says it barely moves any data. A
+		// brand-new Unknown key's first-ever probe is never affected:
+		// MagnitudeFor has no reading for a key that has never once
+		// completed a route-B dispatch, so trivialRevalidation is always
+		// false there.
+		release()
+		telemetry.RecordRouteMemoHitSkipped(ctx, telemetry.RouteMemoDeclineTrivialMagnitude)
 		return nil, nil, nil, nil, false
 	}
 	dispatchDone := telemetry.ObserveRoutedDispatchInflight(ctx)
@@ -328,6 +416,16 @@ func (e *Engine) retryOnRouteAResourceFailure(
 			e.RouteMemo.Observe(key, routememo.RouteB, drainOutcome)
 			if drainOutcome == routememo.OutcomeSuccess {
 				telemetry.RecordRouteABSuccess(ctx, telemetry.RouteChoiceB)
+				// Observe above already landed (or refreshed) the PreferB
+				// verdict for key, so this magnitude reading lands on that
+				// SAME entry, never a doomed-to-be-replaced Unknown one —
+				// see recordRouteMemoMagnitude's own doc. This is the probe
+				// / stale-rescue half of the sampling-bias fix issue #3035
+				// describes: magnitude no longer comes ONLY from the
+				// per-rung predictive cursor (per_rung_admission.go), it
+				// also comes from every clean first-probe and re-validation
+				// drain the failure-driven route memo itself dispatches.
+				recordRouteMemoMagnitude(e.RouteMemo, key, cur)
 			}
 			release()
 			dispatchDone()

--- a/internal/engine/route_memo_wiring_test.go
+++ b/internal/engine/route_memo_wiring_test.go
@@ -900,6 +900,188 @@ func TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration(t *testing.T) {
 	}
 }
 
+// TestRetryOnRouteAResourceFailure_ObserveFnRecordsMagnitudeOnCleanProbe
+// pins the probe half of issue #3035's sampling-bias fix: a first-time
+// probe's CLEAN drain must feed the composed cursor's real Inspected()
+// count into the route memo's magnitude EMA for the SAME Key
+// observeFn(nil) just flipped to PreferB — not just the per-rung
+// predictive cursor's narrower dispatch path (per_rung_admission.go),
+// which is the ONLY thing that fed MagnitudeFor before this fix.
+func TestRetryOnRouteAResourceFailure_ObserveFnRecordsMagnitudeOnCleanProbe(t *testing.T) {
+	t.Parallel()
+	const rowsPerShard = 5
+	cq := &fakeSolverCursorClient{rows: rowsPerShard}
+	eng, memo := newMemoWiringEngine(t, cq)
+	plan := memoWiringEligiblePlan()
+	seed := memoWiringNotRoutedDecision(t)
+	ctx := context.Background()
+
+	// Two consecutive route-A resource failures earn the first probe (see
+	// TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration).
+	eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	cur, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	if !retried {
+		t.Fatal("did not retry on the 2nd consecutive route-A resource failure")
+	}
+	for cur.Next() {
+	}
+	if err := cur.Err(); err != nil {
+		t.Fatalf("fixture cursor drain error: %v", err)
+	}
+	observeFn(nil) // the caller's actual drain succeeded cleanly
+
+	d := eng.deriveRouteMemoDispatch(plan, seed, time.Now())
+	rows, obs, ok := memo.MagnitudeFor(d.key)
+	if !ok {
+		t.Fatal("expected a magnitude reading recorded from the probe's own clean drain")
+	}
+	if obs != 1 {
+		t.Errorf("magnitude observations = %d, want 1", obs)
+	}
+	if rows <= 0 {
+		t.Errorf("magnitude rows = %v, want a positive count reflecting the composed cursor's real drain", rows)
+	}
+}
+
+// TestRouteMemoHitObserveDrainOutcome_RecordsMagnitudeOnCleanDrainOnly pins
+// the memo-hit half of issue #3035's sampling-bias fix: unlike Retry (which
+// only ever fires on a drain FAILURE), this hook is called on EVERY memo-hit
+// drain, and must feed the magnitude EMA on a clean one while recording
+// nothing on a failed one (Retry, not this hook, owns that path, and a
+// partial/cancelled drain's Inspected() count is not trustworthy evidence —
+// mirrors perRungObservingCursor.Close's own "only a CLEAN drain is trusted
+// evidence" reasoning).
+func TestRouteMemoHitObserveDrainOutcome_RecordsMagnitudeOnCleanDrainOnly(t *testing.T) {
+	t.Parallel()
+	memo := routememo.New(time.Minute)
+	k := routememo.Key{RootKind: "*fixture.MemoHit"}
+	memo.Observe(k, routememo.RouteB, routememo.OutcomeSuccess)
+
+	cur := &perRungFakeCursor{inspected: 42}
+	hook := routeMemoHitObserveDrainOutcome(memo, k, cur)
+
+	hook(errors.New("boom"))
+	if _, _, ok := memo.MagnitudeFor(k); ok {
+		t.Fatal("recorded a magnitude reading from a FAILED drain")
+	}
+
+	hook(nil)
+	rows, obs, ok := memo.MagnitudeFor(k)
+	if !ok {
+		t.Fatal("expected a magnitude reading after a clean drain")
+	}
+	if obs != 1 || rows != 42 {
+		t.Errorf("MagnitudeFor = (%v, %d), want (42, 1)", rows, obs)
+	}
+}
+
+// TestRetryOnRouteAResourceFailure_TrivialMagnitudeDeclinesRevalidation pins
+// the routing-consumer half of issue #3035: a stale-PreferB re-validation
+// whose tracked magnitude is well-corroborated (MinCorroboratingFailures
+// readings) AND trivially small (well under
+// routeMemoTrivialMagnitudeRowsPerAnchor per anchor) must decline the
+// automatic rescue dispatch — giving the admitted token straight back
+// rather than spending it re-confirming a route whose own history says it
+// barely moves any data. Bookkeeping (the re-validation clock) still
+// progresses, exactly as an actually-dispatched rescue would have left it.
+func TestRetryOnRouteAResourceFailure_TrivialMagnitudeDeclinesRevalidation(t *testing.T) {
+	reader := installMemoWiringTelemetryReader(t)
+	cq := &fakeSolverCursorClient{rows: 2}
+	eng, memo := newMemoWiringEngine(t, cq)
+	plan := memoWiringEligiblePlan()
+	seed := memoWiringNotRoutedDecision(t)
+
+	fixedNow := memoWiringGridEnd.Add(2 * memoWiringGridStep)
+	memo.SetNowForTest(func() time.Time { return fixedNow })
+	d := eng.deriveRouteMemoDispatch(plan, seed, fixedNow)
+	if !d.eligible {
+		t.Fatalf("fixture plan must be structurally eligible")
+	}
+	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
+
+	// Corroborate a trivially small tracked magnitude — MinCorroboratingFailures
+	// readings, well below the per-anchor floor.
+	for i := 0; i < routememo.MinCorroboratingFailures; i++ {
+		memo.RecordActualMagnitude(d.key, 1)
+	}
+
+	// Cross the re-validation midpoint without crossing the TTL — this is
+	// now a stale-PreferB re-validation candidate.
+	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
+
+	before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineTrivialMagnitude]
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	if retried {
+		t.Fatal("retried a stale-PreferB re-validation despite a well-corroborated trivially small tracked magnitude")
+	}
+	after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineTrivialMagnitude]
+	if after != before+1 {
+		t.Errorf("trivial-magnitude skip count = %d, want %d", after, before+1)
+	}
+	if cq.opens.Load() != 0 {
+		t.Errorf("Executor cursor opens = %d, want 0 — the rescue dispatch must be declined, not merely under-observed", cq.opens.Load())
+	}
+	state, stale := memo.Lookup(d.key)
+	if state != routememo.PreferB || stale {
+		t.Errorf("verdict after a declined re-validation = (%v, stale=%v), want (PreferB, stale=false) — bookkeeping must still progress", state, stale)
+	}
+}
+
+// TestRetryOnRouteAResourceFailure_LargeMagnitudeStillRevalidates is the
+// trivial-magnitude gate's negative control: a LARGE, well-corroborated
+// tracked magnitude must not trip the gate — the re-validation rescue
+// dispatches exactly as it did before issue #3035.
+func TestRetryOnRouteAResourceFailure_LargeMagnitudeStillRevalidates(t *testing.T) {
+	t.Parallel()
+	cq := &fakeSolverCursorClient{rows: 2}
+	eng, memo := newMemoWiringEngine(t, cq)
+	plan := memoWiringEligiblePlan()
+	seed := memoWiringNotRoutedDecision(t)
+
+	fixedNow := memoWiringGridEnd.Add(2 * memoWiringGridStep)
+	memo.SetNowForTest(func() time.Time { return fixedNow })
+	d := eng.deriveRouteMemoDispatch(plan, seed, fixedNow)
+	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
+
+	for i := 0; i < routememo.MinCorroboratingFailures; i++ {
+		memo.RecordActualMagnitude(d.key, 5_000_000)
+	}
+	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
+
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	if !retried {
+		t.Fatal("declined a stale-PreferB re-validation despite a LARGE tracked magnitude — the trivial-magnitude gate must not over-trigger")
+	}
+	awaitDispatch(t, cq, "the re-validation rescue dispatch must still happen for a non-trivial magnitude")
+}
+
+// TestRetryOnRouteAResourceFailure_UnderCorroboratedMagnitudeStillRevalidates
+// is the trivial-magnitude gate's corroboration-floor control: a SINGLE
+// trivial-magnitude reading (below MinCorroboratingFailures) must not trip
+// the gate either — a single anomalous reading cannot, by itself, teach the
+// memo anything, the same discipline every other verdict transition in
+// this package already enforces.
+func TestRetryOnRouteAResourceFailure_UnderCorroboratedMagnitudeStillRevalidates(t *testing.T) {
+	t.Parallel()
+	cq := &fakeSolverCursorClient{rows: 2}
+	eng, memo := newMemoWiringEngine(t, cq)
+	plan := memoWiringEligiblePlan()
+	seed := memoWiringNotRoutedDecision(t)
+
+	fixedNow := memoWiringGridEnd.Add(2 * memoWiringGridStep)
+	memo.SetNowForTest(func() time.Time { return fixedNow })
+	d := eng.deriveRouteMemoDispatch(plan, seed, fixedNow)
+	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
+
+	memo.RecordActualMagnitude(d.key, 1)
+	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
+
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	if !retried {
+		t.Fatal("declined a stale-PreferB re-validation on a single, under-corroborated trivial-magnitude reading")
+	}
+}
+
 // TestRetryOnRouteAResourceFailure_NonResourceErrorNeverRetried pins
 // Major-6: a route-A failure classified as anything OTHER than a resource
 // failure (a timeout, a broken connection, a cancellation) must never

--- a/internal/routememo/concurrency_bound_test.go
+++ b/internal/routememo/concurrency_bound_test.go
@@ -35,11 +35,11 @@ func TestAmplificationBound_ConcurrentSameKeyFailuresCapAtDispatchBudget(t *test
 	k := testKey("hot-same-key")
 
 	// Sequentially drive the key to exactly the corroboration floor: after
-	// minCorroboratingFailures consecutive route-A resource failures with no
+	// MinCorroboratingFailures consecutive route-A resource failures with no
 	// intervening success, the key is admit-eligible (Unknown state,
-	// corroboration == minCorroboratingFailures) but no dispatch has been
+	// corroboration == MinCorroboratingFailures) but no dispatch has been
 	// admitted yet — plain Observe only records, it never admits.
-	for i := 0; i < minCorroboratingFailures; i++ {
+	for i := 0; i < MinCorroboratingFailures; i++ {
 		m.Observe(k, RouteA, OutcomeResourceFailure)
 	}
 

--- a/internal/routememo/magnitude.go
+++ b/internal/routememo/magnitude.go
@@ -8,16 +8,25 @@ import "time"
 // Verdict.corroboration) answers "should route B be tried for this Key" —
 // a pure outcome bit — and says nothing about HOW MUCH data a successful
 // route-B dispatch for that Key actually moved. RecordActualMagnitude adds
-// that second, purely OBSERVATIONAL axis without touching the outcome
-// axis at all: it never creates, deletes, or changes a Key's LookupState,
-// eviction order, or TTL, and no existing method's behavior changes by one
-// bit. Deliberately a THIN hook (this file's own doc names it as such,
-// mirroring issue #2789's own "the others can be thinner initial hooks"
-// allowance for its three non-primary consumers): the magnitude is recorded
-// for observability today (Stats-style callers, an operator dashboard,
-// internal/engine's actuals wiring), and is architecture the memo already
-// supports for a future routing use — but this file itself makes no routing
-// decision based on it.
+// that second axis without touching the outcome axis at all: it never
+// creates, deletes, or changes a Key's LookupState, eviction order, or TTL,
+// and no existing state-transition method's behavior changes by one bit —
+// this file writes only the magnitudeEMA*/magnitudeObservations fields.
+//
+// Originally a purely OBSERVATIONAL hook (issue #2789's own "the others can
+// be thinner initial hooks" allowance for its non-primary consumers): the
+// magnitude was recorded for observability only, with the memo's own doc
+// noting it "makes no routing decision based on it". Issue #3035 (split
+// from #2853) closed that gap on both ends: RecordActualMagnitude gained
+// production callers beyond per_rung_admission.go's narrow, single-route
+// perRungObservingCursor — internal/engine/route_memo_wiring.go now feeds it
+// from every clean route-B drain (memo-hit, first probe, and stale-PreferB
+// re-validation alike), and MagnitudeFor gained a real routing consumer
+// there too: a stale-PreferB re-validation whose tracked magnitude is
+// well-corroborated (MinCorroboratingFailures readings) AND trivially small
+// declines the automatic rescue-probe admission, corroboration-gated the
+// same way every other verdict transition in this package is. See that
+// file's own doc for the gate's exact shape and reasoning.
 //
 // Only a LIVE (unexpired) entry is updated — RecordActualMagnitude never
 // CREATES an entry, unlike every state-transition method in memo.go. A
@@ -57,10 +66,10 @@ func (m *Memo) RecordActualMagnitude(k Key, outputRows uint64) {
 }
 
 // MagnitudeFor returns k's tracked actual-magnitude EMA, or ok=false when
-// k has no live entry or no magnitude has ever been recorded for it (the
-// overwhelmingly common case today: RecordActualMagnitude has exactly one
-// caller, per_rung_admission.go's perRungObservingCursor, so most Keys
-// carry no magnitude reading at all).
+// k has no live entry or no magnitude has ever been recorded for it — still
+// the common case for a Key that has never once completed a clean route-B
+// drain (every fresh Unknown key, every BothFail key, and any PreferB key
+// whose only route-B dispatches so far were mid-drain failures).
 func (m *Memo) MagnitudeFor(k Key) (rows float64, observations int, ok bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/routememo/memo.go
+++ b/internal/routememo/memo.go
@@ -41,7 +41,7 @@ const (
 	// Observed so corroboration bookkeeping progresses.
 	Unknown LookupState = iota
 	// PreferB: route A has failed on this Key at least
-	// minCorroboratingFailures times with no intervening Success, and a
+	// MinCorroboratingFailures times with no intervening Success, and a
 	// route-B probe subsequently succeeded. The caller MAY memo-hit route B
 	// — subject to re-checking every structural/freshness/admission gate
 	// itself; Lookup makes no promise about any of those.
@@ -83,19 +83,26 @@ const (
 	// exactly today's (pre-memo) behavior.
 	maxConcurrentRoutedDispatches = 4
 
-	// minCorroboratingFailures is how many consecutive route-A
+	// MinCorroboratingFailures is how many consecutive route-A
 	// ResourceFailure observations (with no intervening Success) a Key
 	// needs before it becomes probe-eligible. A single transient resource
-	// rejection cannot, by itself, teach the memo anything.
-	minCorroboratingFailures = 2
+	// rejection cannot, by itself, teach the memo anything. Exported (unlike
+	// every other constant in this block) so a consumer outside this
+	// package can apply the SAME corroboration discipline to a DIFFERENT
+	// axis of evidence about the same Key — see
+	// internal/engine/route_memo_wiring.go's magnitude-trivial
+	// re-validation gate, which requires this many magnitude readings
+	// before trusting them, for exactly the same "one anomalous reading
+	// teaches nothing" reason.
+	MinCorroboratingFailures = 2
 
 	// pressureFailureThreshold is how many DISTINCT keys must show a fresh
 	// ResourceFailure within the pressure window before the environment is
-	// flagged under pressure. Defined relative to minCorroboratingFailures
+	// flagged under pressure. Defined relative to MinCorroboratingFailures
 	// so a single hot key's own corroboration count can never trip it
 	// alone — it takes failures spread across more keys than any one key
 	// could contribute.
-	pressureFailureThreshold = minCorroboratingFailures + 1
+	pressureFailureThreshold = MinCorroboratingFailures + 1
 )
 
 // Verdict is the memo's per-Key state. Unexported: callers only ever see it
@@ -252,7 +259,7 @@ func (m *Memo) BeginProbe(k Key) (release func(), ok bool) {
 		return noopRelease, false
 	}
 	v, live := m.getLiveLocked(k, now)
-	if !live || v.state != Unknown || v.corroboration < minCorroboratingFailures {
+	if !live || v.state != Unknown || v.corroboration < MinCorroboratingFailures {
 		return noopRelease, false
 	}
 	select {
@@ -332,7 +339,7 @@ func (m *Memo) ObserveRouteAFailureAndMaybeBeginProbe(k Key) (release func(), ok
 	// The original first-probe path: admit only a fresh Unknown entry that
 	// has now reached the corroboration floor.
 	v, live = m.getLiveLocked(k, now)
-	if !live || v.state != Unknown || v.corroboration < minCorroboratingFailures {
+	if !live || v.state != Unknown || v.corroboration < MinCorroboratingFailures {
 		return noopRelease, false, false
 	}
 	select {
@@ -400,7 +407,7 @@ func (m *Memo) observeRouteALocked(k Key, now time.Time, outcome Outcome) {
 // observeRouteAResourceFailureLocked applies the route-A resource-failure
 // state transition: create a fresh Unknown entry with corroboration=1 if
 // none exists; on an existing Unknown entry, bump corroboration (capped at
-// minCorroboratingFailures); on a live PreferB entry (necessarily the
+// MinCorroboratingFailures); on a live PreferB entry (necessarily the
 // stale-re-validation path — Lookup would not have let the caller route
 // through A otherwise), refresh createdAt without re-probing, since the
 // failing premise was just re-confirmed directly; a BothFail entry has no
@@ -424,7 +431,7 @@ func (m *Memo) observeRouteAResourceFailureLocked(k Key, now time.Time) {
 		m.touchLRULocked(k)
 	case BothFail:
 	case Unknown:
-		if v.corroboration < minCorroboratingFailures {
+		if v.corroboration < MinCorroboratingFailures {
 			v.corroboration++
 		}
 		m.touchLRULocked(k)
@@ -450,11 +457,11 @@ func (m *Memo) observeRouteBLocked(k Key, now time.Time, outcome Outcome) {
 		// dispatch re-derives eligibility and may probe again; the second
 		// consecutive one locks out. A success anywhere resets by replacing
 		// the entry outright.
-		if v, ok := m.entries[k]; ok && v.state != BothFail && v.corroboration+1 < minCorroboratingFailures {
+		if v, ok := m.entries[k]; ok && v.state != BothFail && v.corroboration+1 < MinCorroboratingFailures {
 			m.entries[k] = &Verdict{state: Unknown, createdAt: now, corroboration: v.corroboration + 1}
 			break
 		}
-		if _, ok := m.entries[k]; !ok && minCorroboratingFailures > 1 {
+		if _, ok := m.entries[k]; !ok && MinCorroboratingFailures > 1 {
 			m.entries[k] = &Verdict{state: Unknown, createdAt: now, corroboration: 1}
 			break
 		}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -107,6 +107,15 @@ const (
 	// met, or the shared dispatch-token semaphore full) — the wiring
 	// layer sees only the bool, so both collapse into one reason here.
 	RouteMemoDeclineProbeNotAdmitted = "probe-not-admitted"
+	// RouteMemoDeclineTrivialMagnitude is retryOnRouteAResourceFailure
+	// declining an admitted stale-PreferB re-validation rescue because
+	// Memo.MagnitudeFor reports a well-corroborated, trivially small
+	// tracked magnitude for the Key — the scarce rescue-dispatch token is
+	// released back unspent rather than spent re-confirming a route whose
+	// own history says it barely moves any data. Never fires for a Key's
+	// first-ever probe (MagnitudeFor has no reading yet for an Unknown
+	// key), only for a re-validation of an already-established verdict.
+	RouteMemoDeclineTrivialMagnitude = "trivial-magnitude"
 )
 
 // RouteChoice label values for AttrRouteChoice on RouteABSuccessTotal.


### PR DESCRIPTION
## Summary

`MagnitudeFor` had zero production callers, and `RecordActualMagnitude` was
reachable only from the per-rung predictive cursor
(`internal/engine/per_rung_admission.go`), sampling-biasing the magnitude
EMA toward whichever route that one mechanism happened to favor. Per the
M4 milestone's own definition of done, this closes the gap by choosing
option (a) — wiring `MagnitudeFor` into a real routing decision — after
confirming the design converges soundly (see reasoning below).

- **Sampling-bias fix**: `internal/engine/route_memo_wiring.go` now feeds
  `RecordActualMagnitude` from every CLEAN route-B drain it dispatches —
  the ordinary memo-hit (`routeMemoHitObserveDrainOutcome`, wired through
  `CursorResult.ObserveDrainOutcome`), a first-time probe, and a
  stale-`PreferB` re-validation (both via `retryOnRouteAResourceFailure`'s
  `observeFn`) — in addition to the pre-existing per-rung predictive cursor
  call site, which is left untouched (a separate, still-valid evidence
  source, not a duplicate).
- **Real routing consumer**: `retryOnRouteAResourceFailure` now reads
  `MagnitudeFor` before granting a stale-`PreferB` re-validation rescue. If
  the tracked magnitude is well-corroborated
  (`routememo.MinCorroboratingFailures` independent readings — exported
  from `routememo` for this cross-package reuse, replacing a duplicated
  unexported constant) AND trivially small (under a new
  `routeMemoTrivialMagnitudeRowsPerAnchor` per-anchor floor), the admitted
  rescue token is released back unspent instead of being spent
  re-confirming a route whose own corroborated history says it barely
  moves any data. Bookkeeping (the re-validation clock refresh) still
  happens exactly as before — only the dispatch itself is declined.
  A brand-new key's first-ever probe is never affected: `MagnitudeFor` has
  no reading until a key has already completed one successful route-B
  dispatch.

## Why option (a), not deletion

The design converges cleanly using only data already available at the
call site (`d.decision.NAnchors`, `MagnitudeFor`, the existing
corroboration/pressure gates `ObserveRouteAFailureAndMaybeBeginProbe`
already enforces) — no new race, no parallel weaker gate, no coupling to
the unrelated per-rung learner's own threshold. The gate sits strictly
*after* the atomic admission call, so it can only ever narrow an
already-admitted rescue, never bypass the pressure damper or the
corroboration floor.

## Test plan

- [x] `go test -race -run '^TestRouteMemo|^TestMagnitude|^TestPerRungAdmission|^TestTryRouteMemoHit|^TestRetryOnRouteAResourceFailure|^TestRecordActualMagnitude' ./internal/routememo/... ./internal/engine/...`
- [x] New tests: `TestRetryOnRouteAResourceFailure_ObserveFnRecordsMagnitudeOnCleanProbe`,
      `TestRouteMemoHitObserveDrainOutcome_RecordsMagnitudeOnCleanDrainOnly`,
      `TestRetryOnRouteAResourceFailure_TrivialMagnitudeDeclinesRevalidation`,
      `TestRetryOnRouteAResourceFailure_LargeMagnitudeStillRevalidates` (negative control),
      `TestRetryOnRouteAResourceFailure_UnderCorroboratedMagnitudeStillRevalidates` (negative control)
- [x] `just test-unit` — full tree, green

Closes #3035
