### PR TITLE
fix(chsql): delete VectorJoin roleOne's redundant StepAligned max(TimeUnix)

### DIFF
--- a/.github/scripts/forbid-verbatim-concat.mjs
+++ b/.github/scripts/forbid-verbatim-concat.mjs
@@ -59,8 +59,8 @@ import process from 'node:process';
 const KNOWN_GOOD = new Set([
   // Category 1 — synthetic single-letter join alias + fixed punctuation.
   'internal/chsql/structural_join.go:556', // starExceptKeys: verbatim(side+".*")
-  'internal/chsql/vector_join.go:858',     // qualColFrag: verbatim(side+".")
-  'internal/chsql/vector_join.go:872',     // aliasedFrag: verbatim(" AS "+bareAlias)
+  'internal/chsql/vector_join.go:886',     // qualColFrag: verbatim(side+".")
+  'internal/chsql/vector_join.go:900',     // aliasedFrag: verbatim(" AS "+bareAlias)
 
   // Category 2 — tracked pre-existing debt, not yet fixed.
   // These two are already fixed by #2297 / PR #2319 (open, converts both to

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -188,6 +188,40 @@ var plans = map[string]chplan.Node{
 		TimestampColumn:  "TimeUnix",
 		ValueColumn:      "Value",
 	},
+	// vector_join_on_step_aligned: `on(...)` subset match in StepAligned
+	// (range) mode — CardOneToOne with a subset match key puts BOTH sides
+	// on roleOne's StepAligned arm (cerberus issue #2818). Pins that the
+	// per-side aggregation reads TimeUnix directly as its GROUP BY key
+	// rather than computing a redundant max(TimeUnix) over it.
+	"vector_join_on_step_aligned": &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpAdd,
+		Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
+		StepAligned:      true,
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	},
+	// vector_join_group_left_step_aligned: `group_left(...)` in
+	// StepAligned (range) mode — left is roleMany, right is roleOne
+	// (cerberus issue #2818). Exercises roleMany's and roleOne's
+	// StepAligned arms side by side in the same emitted query: roleMany's
+	// plain-column TimeUnix read (pre-existing) and roleOne's identical
+	// read (this fix — previously a redundant max(TimeUnix) aggregate).
+	"vector_join_group_left_step_aligned": &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpAdd,
+		Card:             chplan.CardManyToOne,
+		Include:          []string{"job"},
+		StepAligned:      true,
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	},
 
 	// StructuralJoin — TraceQL `>` (parent_of).
 	"structural_join_child": &chplan.StructuralJoin{

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -225,18 +225,31 @@ func (e *emitter) joinSideFrag(match chplan.VectorMatch, metricNameCol, attrsCol
 	// -> argAndMax(Value, TimeUnix) collapse (chopt.FeatureArgAndMaxFusion,
 	// cerberus issue #2764) onto exactly the non-derived, non-StepAligned
 	// "latest sample" shape: roleMany's default switch arm below and
-	// roleOne's non-derived else arm are the only two that pair the two
+	// roleOne's non-StepAligned else arm are the only two that pair the two
 	// aggregates over identical (Value, TimeUnix) arguments today.
 	//
-	// roleOne's else arm ALSO runs when j.StepAligned is true (its
-	// aggMaxAs/argMaxAs pairing is unconditional there — only `derived`
-	// branches away from it) and pairs the identical two aggregates, so it
-	// is technically fusable too; it is deliberately excluded here to keep
-	// this change scoped to the "instant-mode latest-sample" shape the
-	// issue names, matching roleMany's StepAligned arm (a separate switch
-	// case with no argMax/max pairing at all) rather than reading
-	// roleOne's broader StepAligned reach as in-scope. Tracked as a
-	// follow-up: https://github.com/tsouza/cerberus/issues/2818.
+	// roleOne's StepAligned arm is EXCLUDED here for a different reason than
+	// "out of scope": it has nothing to fuse in the first place. Cerberus
+	// issue #2818 originally proposed widening this gate to also fuse
+	// roleOne's StepAligned arm, on the premise that its max(TimeUnix) +
+	// argMax(Value, TimeUnix) pairing was a fusable duplicate of the
+	// instant-mode shape. Investigating that proposal found the opposite: `derived`
+	// is false whenever j.StepAligned is true (the `!j.StepAligned &&` guard
+	// above), and roleOne's StepAligned GROUP BY already includes
+	// TimestampColumn as a key (see groupFrags below) — so every row in a
+	// StepAligned roleOne group shares one identical TimeUnix by
+	// construction, and max(TimeUnix) over that group is just the group key
+	// restated. There is no second aggregate for argAndMax to fuse with; the
+	// honest fix is to delete the redundant max(TimeUnix) aggregate and
+	// project the GROUP BY key column directly (see the switch below), which
+	// this change does. argMaxAs(Value, TimeUnix) stays a real aggregate:
+	// it is still picking which Value goes with the (possibly tied)
+	// TimeUnix, and matchCheckGuardFrag's uniqueness HAVING guards only
+	// Attributes uniqueness — it throws AFTER aggregation and does not make
+	// a genuine TimeUnix tie within one (match-key, anchor) group
+	// well-defined beforehand, so argMax's own (CH-documented,
+	// non-deterministic-among-ties) tie-break still governs which Value
+	// survives a tie.
 	fuseValueTimestamp := j.ArgAndMaxFusion && !derived && !j.StepAligned
 	inner := NewQuery().From(sub)
 	if role == roleMany {
@@ -304,15 +317,30 @@ func (e *emitter) joinSideFrag(match chplan.VectorMatch, metricNameCol, attrsCol
 		// Step-aligned joins extend the match key with TimeUnix so
 		// each (match-key, anchor) gets its own row and the throwIf
 		// uniqueness guard fires per-anchor rather than across the
-		// full per-step matrix. The selector keeps argMax /
-		// max(TimeUnix) for symmetry with instant mode — within a
-		// single (match-key, anchor) group all rows share the same
-		// TimeUnix by construction.
+		// full per-step matrix.
 		groupFrags := []Frag{matchKeyGroupExprFrag(j.Match, j.AttributesColumn)}
 		if j.StepAligned {
 			groupFrags = append(groupFrags, Col(j.TimestampColumn))
 		}
-		if derived {
+		switch {
+		case j.StepAligned:
+			// TimeUnix is already a GROUP BY key here (groupFrags above),
+			// so every row in a (match-key, anchor) group shares one
+			// identical TimeUnix by construction — max(TimeUnix) over
+			// that group would just restate the group key. Select it
+			// directly instead of aggregating, matching roleMany's
+			// identical StepAligned arm above. argMax(Value, TimeUnix)
+			// stays a real aggregate: it still picks which Value goes
+			// with that TimeUnix when two rows of the same series are
+			// tied on it (see
+			// TestVectorJoinRoleOneStepAligned_TiedTimestamp_ChDB).
+			inner.Select(
+				joinMetricNameFrag(j),
+				As(Call("argMax", canonicalMatchKeyFrag(Col(j.AttributesColumn)), Col(j.TimestampColumn)), joinAlias(j.AttributesColumn)),
+				As(Col(j.TimestampColumn), joinAlias(j.TimestampColumn)),
+				argMaxAs(j.ValueColumn, j.TimestampColumn, joinAlias(j.ValueColumn)),
+			).GroupBy(groupFrags...).Having(matchCheckGuardFrag(j.AttributesColumn))
+		case derived:
 			// Range-vector operand: no TimeUnix to argMax by. The
 			// instant operand is already one row per series, so any()
 			// picks the representative Attributes/Value and the
@@ -323,13 +351,13 @@ func (e *emitter) joinSideFrag(match chplan.VectorMatch, metricNameCol, attrsCol
 				joinTimestampFrag(j),
 				aggAnyAs(j.ValueColumn, joinAlias(j.ValueColumn)),
 			).GroupBy(groupFrags...).Having(matchCheckGuardFrag(j.AttributesColumn))
-		} else if fuseValueTimestamp {
+		case fuseValueTimestamp:
 			inner.Select(
 				joinMetricNameFrag(j),
 				As(Call("argMax", canonicalMatchKeyFrag(Col(j.AttributesColumn)), Col(j.TimestampColumn)), joinAlias(j.AttributesColumn)),
 				argAndMaxAs(j.ValueColumn, j.TimestampColumn, joinArgAndMaxAlias),
 			).GroupBy(groupFrags...).Having(matchCheckGuardFrag(j.AttributesColumn))
-		} else {
+		default:
 			inner.Select(
 				joinMetricNameFrag(j),
 				As(Call("argMax", canonicalMatchKeyFrag(Col(j.AttributesColumn)), Col(j.TimestampColumn)), joinAlias(j.AttributesColumn)),

--- a/internal/chsql/vector_join_stepaligned_redundant_max_chdb_test.go
+++ b/internal/chsql/vector_join_stepaligned_redundant_max_chdb_test.go
@@ -1,0 +1,174 @@
+//go:build chdb
+
+// chDB-backed proof for cerberus issue #2818's actual resolution: deleting
+// the redundant max(TimeUnix) aggregate from VectorJoin's roleOne
+// StepAligned arm (internal/chsql/vector_join.go's joinSideFrag) is safe,
+// and argMax(Value, TimeUnix)'s own tie-break — not
+// matchCheckGuardFrag's uniqueness HAVING, which fires AFTER aggregation
+// and guards only Attributes uniqueness — governs which Value survives a
+// genuine TimeUnix tie within one (match-key, anchor) group.
+package chsql_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+const (
+	vectorJoinStepAlignedRedundantMaxLeftTable  = "vector_join_stepaligned_redundant_max_left"
+	vectorJoinStepAlignedRedundantMaxRightTable = "vector_join_stepaligned_redundant_max_right"
+)
+
+// TestVectorJoinRoleOneStepAligned_TiedTimestamp_ChDB seeds a
+// group_left(instance) join (left=roleMany, right=roleOne) with
+// StepAligned=true. The right ("one") side carries a "tied" series with
+// TWO rows sharing the exact same TimeUnix but different Values — the
+// scenario matchCheckGuardFrag's HAVING throwIf does NOT resolve, since it
+// guards only Attributes uniqueness and fires after aggregation completes,
+// not before. It asserts:
+//
+//   - The query executes and returns exactly one row per series (the
+//     group-key read did not break the per-side aggregation or the JOIN).
+//   - The joined TimeUnix equals the shared tied timestamp exactly — the
+//     now-direct group-key read reports the same value the deleted
+//     max(TimeUnix) aggregate would have (trivially, since every row in
+//     the group already shared it), pinning that the rewrite changed
+//     nothing observable for the timestamp axis.
+//   - The joined Value falls within the genuinely-tied candidate set,
+//     proving argMax(Value, TimeUnix) still executes correctly and picks
+//     an actual tied row rather than erroring or returning a value outside
+//     the tied set.
+func TestVectorJoinRoleOneStepAligned_TiedTimestamp_ChDB(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(chsqltest.MetricsSeedDDL(vectorJoinStepAlignedRedundantMaxLeftTable)); err != nil {
+		t.Fatalf("create left seed table: %v", err)
+	}
+	if _, err := db.Exec(chsqltest.MetricsSeedDDL(vectorJoinStepAlignedRedundantMaxRightTable)); err != nil {
+		t.Fatalf("create right seed table: %v", err)
+	}
+
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tiedTS := start.Add(90 * time.Second)
+	normalTS := start.Add(30 * time.Second)
+
+	type sample struct {
+		series   string
+		instance string
+		ts       time.Time
+		value    float64
+	}
+	seedTable := func(table string, rows []sample) {
+		for i, s := range rows {
+			insert := fmt.Sprintf(
+				"INSERT INTO %s (MetricName, Attributes, TimeUnix, Value) VALUES ('m', map('series', '%s', 'instance', '%s'), toDateTime64('%s', 9), %v)",
+				table, s.series, s.instance, s.ts.Format("2006-01-02 15:04:05.000000000"), s.value,
+			)
+			if _, err := db.Exec(insert); err != nil {
+				t.Fatalf("seed %s row %d: %v", table, i, err)
+			}
+		}
+	}
+	// Left ("many") side: one row per series, matching on the bare series
+	// label so it survives group_left's Attributes overlay unchanged.
+	seedTable(vectorJoinStepAlignedRedundantMaxLeftTable, []sample{
+		{"normal", "left-inst", normalTS, 1},
+		{"tied", "left-inst", tiedTS, 1},
+	})
+	// Right ("one") side: the "tied" series carries two rows at the exact
+	// same TimeUnix — same Attributes (same series+instance), different
+	// Value, a genuine argMax tie the StepAligned GROUP BY (match-key,
+	// TimeUnix) does not itself disambiguate.
+	seedTable(vectorJoinStepAlignedRedundantMaxRightTable, []sample{
+		{"normal", "right-inst", normalTS, 100},
+		{"tied", "right-inst", tiedTS, 1000},
+		{"tied", "right-inst", tiedTS, 2000}, // same TimeUnix as the row above
+	})
+
+	plan := &chplan.VectorJoin{
+		Left:  &chplan.Scan{Table: vectorJoinStepAlignedRedundantMaxLeftTable},
+		Right: &chplan.Scan{Table: vectorJoinStepAlignedRedundantMaxRightTable},
+		Op:    chplan.OpAdd,
+		// on(series): the two sides deliberately carry different
+		// `instance` values (left-inst / right-inst) so the match key
+		// must be reduced to `series` alone — matching group_left's
+		// typical real-world shape (matching on a shared identity label,
+		// not the full label set).
+		Match:            chplan.VectorMatch{On: true, Labels: []string{"series"}},
+		Card:             chplan.CardManyToOne, // left=roleMany, right=roleOne
+		Include:          []string{"instance"},
+		StepAligned:      true,
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	rows := vectorJoinStepAlignedRedundantMaxRows(t, db, sql, args)
+	if len(rows) != 2 {
+		t.Fatalf("row count = %d, want 2 (one per series); rows=%v\nSQL: %s", len(rows), rows, sql)
+	}
+
+	tiedCandidates := map[float64]bool{1001: true, 2001: true} // L(1) + R(1000|2000)
+	for _, r := range rows {
+		switch r.series {
+		case "normal":
+			if !r.timestamp.Equal(normalTS) {
+				t.Errorf("series %q: TimeUnix = %s, want %s", r.series, r.timestamp, normalTS)
+			}
+			if r.value != 101 {
+				t.Errorf("series %q: Value = %v, want 101", r.series, r.value)
+			}
+		case "tied":
+			if !r.timestamp.Equal(tiedTS) {
+				t.Errorf("series %q: TimeUnix = %s, want %s (the shared tied timestamp — the deleted max(TimeUnix) restated nothing else)", r.series, r.timestamp, tiedTS)
+			}
+			if !tiedCandidates[r.value] {
+				t.Errorf("series %q: Value %v is not one of argMax's tied candidates %v", r.series, r.value, tiedCandidates)
+			}
+		default:
+			t.Errorf("unexpected series %q", r.series)
+		}
+	}
+}
+
+type vectorJoinStepAlignedRedundantMaxRow struct {
+	series    string
+	timestamp time.Time
+	value     float64
+}
+
+func vectorJoinStepAlignedRedundantMaxRows(t *testing.T, db *sql.DB, query string, args []any) []vectorJoinStepAlignedRedundantMaxRow {
+	t.Helper()
+	q := "SELECT Attributes['series'], TimeUnix, Value FROM (" + query + ") ORDER BY 1"
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		t.Fatalf("query: %v\nSQL: %s", err, q)
+	}
+	defer rows.Close()
+	var out []vectorJoinStepAlignedRedundantMaxRow
+	for rows.Next() {
+		var r vectorJoinStepAlignedRedundantMaxRow
+		if err := rows.Scan(&r.series, &r.timestamp, &r.value); err != nil {
+			t.Fatalf("scan row: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration: %v", err)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].series < out[j].series })
+	return out
+}

--- a/internal/chsql/vector_join_stepaligned_redundant_max_test.go
+++ b/internal/chsql/vector_join_stepaligned_redundant_max_test.go
@@ -1,0 +1,85 @@
+package chsql_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestEmitVectorJoin_RoleOneStepAligned_NoRedundantMax pins cerberus issue
+// #2818's actual resolution: roleOne's StepAligned arm ("one" side of
+// group_left/group_right, or either side of an on()/ignoring()-reduced
+// one-to-one match, in range mode) no longer computes max(TimeUnix) as a
+// separate aggregate. TimeUnix is already a GROUP BY key in that arm (the
+// StepAligned match key is (match-key, TimeUnix)), so every row within one
+// group carries the identical TimeUnix value — max(TimeUnix) over that
+// group was always just the group key restated. The fix reads the column
+// directly instead, matching roleMany's identical StepAligned arm.
+// argMax(Value, TimeUnix) is untouched: it is still choosing which Value
+// goes with that TimeUnix (relevant under a genuine tie — see
+// TestVectorJoinRoleOneStepAligned_TiedTimestamp_ChDB).
+func TestEmitVectorJoin_RoleOneStepAligned_NoRedundantMax(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.VectorJoin{
+		Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+		Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+		Op:               chplan.OpAdd,
+		Card:             chplan.CardManyToOne, // left=roleMany, right=roleOne
+		Include:          []string{"instance"},
+		StepAligned:      true,
+		MetricNameColumn: "MetricName",
+		AttributesColumn: "Attributes",
+		TimestampColumn:  "TimeUnix",
+		ValueColumn:      "Value",
+	}
+
+	sql := emitJoin(t, plan)
+
+	if strings.Contains(sql, "max(`TimeUnix`)") {
+		t.Errorf("roleOne StepAligned emit must NOT contain a redundant max(TimeUnix); got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "argMax(`Value`, `TimeUnix`)") {
+		t.Errorf("roleOne StepAligned emit must still contain argMax(Value, TimeUnix); got:\n%s", sql)
+	}
+	// The plain group-key read renders as `_join_TimeUnix` AS aliased
+	// TimeUnix, the same shape roleMany's StepAligned arm already uses.
+	if !strings.Contains(sql, "`TimeUnix` AS `_join_TimeUnix`") {
+		t.Errorf("roleOne StepAligned emit must select the bare TimeUnix group-key column; got:\n%s", sql)
+	}
+}
+
+// TestEmitVectorJoin_RoleOneStepAligned_ArgAndMaxFusionInert pins that
+// ArgAndMaxFusion has nothing to act on in roleOne's StepAligned arm either
+// way — the redundant max(TimeUnix) this PR deletes was never fusable
+// (there is no second aggregate to fuse argMax with once max(TimeUnix) is
+// gone), so the emitted SQL is byte-identical regardless of the flag.
+func TestEmitVectorJoin_RoleOneStepAligned_ArgAndMaxFusionInert(t *testing.T) {
+	t.Parallel()
+
+	planWith := func(fused bool) *chplan.VectorJoin {
+		return &chplan.VectorJoin{
+			Left:             &chplan.Scan{Table: "otel_metrics_gauge"},
+			Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+			Op:               chplan.OpAdd,
+			Card:             chplan.CardManyToOne,
+			Include:          []string{"instance"},
+			StepAligned:      true,
+			ArgAndMaxFusion:  fused,
+			MetricNameColumn: "MetricName",
+			AttributesColumn: "Attributes",
+			TimestampColumn:  "TimeUnix",
+			ValueColumn:      "Value",
+		}
+	}
+
+	fusedSQL := emitJoin(t, planWith(true))
+	unfusedSQL := emitJoin(t, planWith(false))
+	if fusedSQL != unfusedSQL {
+		t.Errorf("roleOne StepAligned emit must be byte-identical regardless of ArgAndMaxFusion:\nfused:\n%s\nunfused:\n%s", fusedSQL, unfusedSQL)
+	}
+	if strings.Contains(fusedSQL, "argAndMax") {
+		t.Errorf("roleOne StepAligned emit must never contain argAndMax; got:\n%s", fusedSQL)
+	}
+}

--- a/test/spec/chsql/vector_join_group_left_step_aligned.txtar
+++ b/test/spec/chsql/vector_join_group_left_step_aligned.txtar
@@ -1,0 +1,11 @@
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = ""
+[3] string = ""
+-- chplan --
+VectorJoin op=+ match=default card=many-to-one include=[job] stepAligned
+  Scan(otel_metrics_gauge)
+  Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapConcat(L.`Attributes`, mapFilter((k, v) -> k IN (?), R.`Attributes`)) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, mapSort(`Attributes`) AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY mapSort(`Attributes`), `TimeUnix`)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, argMax(mapSort(`Attributes`), `TimeUnix`) AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY mapSort(`Attributes`), `TimeUnix` HAVING throwIf(uniqExact(mapSort(`Attributes`)) > 1, 'many-to-many matching not allowed: matching labels must be unique on one side') = 0)) AS R ON mapSort(L.`Attributes`) = mapSort(R.`Attributes`) AND L.`TimeUnix` = R.`TimeUnix`

--- a/test/spec/chsql/vector_join_on_step_aligned.txtar
+++ b/test/spec/chsql/vector_join_on_step_aligned.txtar
@@ -1,0 +1,15 @@
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = ""
+[3] string = "job"
+[4] string = ""
+[5] string = "job"
+[6] string = "job"
+[7] string = "job"
+-- chplan --
+VectorJoin op=+ match=on(job) card=one-to-one stepAligned
+  Scan(otel_metrics_gauge)
+  Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> k IN (?), L.`Attributes`) AS `Attributes`, L.`TimeUnix` AS `TimeUnix`, (L.`Value` + R.`Value`) AS `Value` FROM (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, argMax(mapSort(`Attributes`), `TimeUnix`) AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT * FROM `otel_metrics_gauge`) GROUP BY mapSort(mapFilter((k, v) -> k IN (?), `Attributes`)), `TimeUnix` HAVING throwIf(uniqExact(mapSort(`Attributes`)) > 1, 'many-to-many matching not allowed: matching labels must be unique on one side') = 0)) AS L INNER JOIN (SELECT `_join_MetricName` AS `MetricName`, `_join_Attributes` AS `Attributes`, `_join_TimeUnix` AS `TimeUnix`, `_join_Value` AS `Value` FROM (SELECT ? AS `_join_MetricName`, argMax(mapSort(`Attributes`), `TimeUnix`) AS `_join_Attributes`, `TimeUnix` AS `_join_TimeUnix`, argMax(`Value`, `TimeUnix`) AS `_join_Value` FROM (SELECT * FROM `otel_metrics_sum`) GROUP BY mapSort(mapFilter((k, v) -> k IN (?), `Attributes`)), `TimeUnix` HAVING throwIf(uniqExact(mapSort(`Attributes`)) > 1, 'many-to-many matching not allowed: matching labels must be unique on one side') = 0)) AS R ON L.`Attributes`[?] = R.`Attributes`[?] AND L.`TimeUnix` = R.`TimeUnix`


### PR DESCRIPTION
## Summary

Cerberus issue #2818 proposed extending #2764's argAndMax fusion
(`argMax(Value, TimeUnix)` + `max(TimeUnix)` → `argAndMax(Value, TimeUnix)`)
to `VectorJoin`'s roleOne StepAligned arm (the "one" side of
`group_left`/`group_right`, or either side of an `on()`/`ignoring()`-reduced
one-to-one match, in range mode).

Investigating that proposal found the honest resolution is the opposite of
the issue's own title: `derived` and `StepAligned` are mutually exclusive by
construction (`internal/chsql/vector_join.go:223`'s `!j.StepAligned && ...`
guard), and roleOne's StepAligned `GROUP BY` already includes
`TimestampColumn` as a key (`groupFrags` in `joinSideFrag`). So every row in
a StepAligned roleOne group shares one identical `TimeUnix` value by
construction, and the pre-existing `max(TimeUnix)` aggregate there was
always just the group key restated — a wasted computation, not a fusion
target.

## Changes

- `internal/chsql/vector_join.go`: roleOne's StepAligned arm now reads
  `TimeUnix` directly as the `GROUP BY` key column instead of computing
  `max(TimeUnix)` — matching roleMany's identical StepAligned arm, which
  already did this. `argMax(Value, TimeUnix)` is untouched: it still picks
  which `Value` goes with that `TimeUnix` when two rows of the same series
  are tied on it.
- Rewrote the stale comment block (previously framing this as a "follow-up:
  #2818" fusion-widening item) to explain the group-key-restated insight and
  the actual fix.
- `internal/chsql/vector_join_stepaligned_redundant_max_test.go`: pins the
  redundant `max(TimeUnix)` is gone from the emitted SQL, and that
  `ArgAndMaxFusion` is inert on this arm either way (nothing left to fuse).
- `internal/chsql/vector_join_stepaligned_redundant_max_chdb_test.go`: a
  chDB test with a genuinely tied-timestamp seed (two rows of the same
  series sharing one `TimeUnix`, different `Value`) on the roleOne side of
  a `group_left` StepAligned join. `matchCheckGuardFrag`'s uniqueness
  `HAVING` guards only `Attributes` uniqueness and fires **after**
  aggregation, so it does not itself make the tie well-defined —
  `argMax`'s own (ClickHouse-documented, non-deterministic-among-ties)
  tie-break governs which `Value` survives. The test pins that the query
  executes correctly and the surviving `Value` falls within the genuinely
  tied candidate set.
- `internal/chsql/emit_test.go` + `test/spec/chsql/vector_join_on_step_aligned.txtar` +
  `test/spec/chsql/vector_join_group_left_step_aligned.txtar`: two new
  TXTAR fixtures covering the arm — one over `on(...)` (both sides
  roleOne), one over `group_left(...)` (left roleMany, right roleOne) —
  regenerated via the `update-golden.yml` CI workflow.

## Test plan

- [x] `go test -race -run '^TestVectorJoin|^TestLower|^TestEmitVectorJoin|^TestMatchKeyFrags' ./internal/chsql/... ./internal/promql/...`
- [x] `go test -tags chdb -run 'ArgAndMaxFusion|StepAligned' ./internal/chsql/...` (including the new tied-timestamp test)
- [x] `node .github/scripts/forbid-sql-raw.mjs`
- [x] `just test-unit` (pre-golden-regen: only the two new empty fixtures
      failed with "missing section", as expected before the CI regen)
- [x] Goldens regenerated via `update-golden.yml`

Closes #2818
