### PR TITLE
fix(engine): stop per-rung admission's actuals seed from renewing a stale decline

### DIFF
--- a/internal/engine/actuals_per_rung_test.go
+++ b/internal/engine/actuals_per_rung_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"testing"
+	"time"
 
 	"github.com/tsouza/cerberus/internal/actuals"
 )
@@ -57,11 +58,18 @@ func TestMaybeSeedPerRungAdmissionFromActuals_SeedsOnLowCorroboratedActuals(t *t
 		t.Fatal("a single seed must not immediately decline the bypass")
 	}
 
-	// A second seed call (mirroring a second request for the same shape)
-	// reaches perRungEvidenceMinObservations and declines the bypass.
+	// A second, IMMEDIATE seed call (mirroring the very next request for the
+	// same shape, still inside the freshness window) must now be a no-op —
+	// issue #3034's own fix: reseeding an already-fresh entry is exactly
+	// what kept a decline's TTL from ever lapsing. Corroboration toward an
+	// actual decline must come from evidence spread out in time (a real
+	// Observe(), or a seed after the previous one has genuinely gone stale —
+	// see TestMaybeSeedPerRungAdmissionFromActuals_DoesNotReseedAFreshEntry),
+	// never from calling the seed twice in the same instant.
 	e.maybeSeedPerRungAdmissionFromActuals(plan, shape, decision)
-	if !e.PerRungAdmission.ShouldDeclineBypass(key) {
-		t.Fatal("expected the per-rung bypass to be declined after two corroborating seeds")
+	if e.PerRungAdmission.ShouldDeclineBypass(key) {
+		t.Fatal("a second immediate seed call on an already-fresh entry must not itself decline the bypass — " +
+			"the guard must have skipped it, not corroborated it")
 	}
 }
 
@@ -104,5 +112,80 @@ func TestMaybeSeedPerRungAdmissionFromActuals_NoSeedWhenNotCheap(t *testing.T) {
 	key := shapeKey(plan, decision)
 	if e.PerRungAdmission.ShouldDeclineBypass(key) {
 		t.Fatal("expected no seeding when the actual EMA is not cheap relative to anchor count")
+	}
+}
+
+// TestMaybeSeedPerRungAdmissionFromActuals_DoesNotReseedAFreshEntry is the
+// direct regression test for issue #3034's own bug: before the fix, this
+// hook called PerRungAdmissionLearner.SeedPriorFromEstimate — and therefore
+// record's own unconditional `st.lastObserved = time.Now()` — on EVERY
+// request whose actuals EMA still looked cheap, regardless of whether the
+// learner already held a fresh verdict. That indefinitely renewed
+// perRungEvidenceTTL and made a decline permanent, because the seed alone
+// (no real per-rung dispatch ever runs again once declined) was the only
+// thing still touching the entry. This asserts the literal mechanism the
+// bug hinged on — lastObserved and consecutiveCheap after repeated,
+// immediate seed calls — is provably unchanged from the first call, then
+// confirms the guard still reseeds correctly once the entry genuinely goes
+// stale.
+func TestMaybeSeedPerRungAdmissionFromActuals_DoesNotReseedAFreshEntry(t *testing.T) {
+	plan := perRungTestPlan()
+	decision := perRungTestDecision()
+	tracker := actuals.NewTracker(actuals.DefaultConfig())
+	const shape = "cerb:agg"
+	for i := 0; i < perRungEvidenceMinObservations; i++ {
+		if _, ok := tracker.RecordActual(shape, actuals.Actual{ReadRows: 100}, actuals.SourcePacket); !ok {
+			t.Fatal("RecordActual should succeed")
+		}
+	}
+	e := &Engine{PerRungAdmission: NewPerRungAdmissionLearner(), Actuals: tracker}
+	key := shapeKey(plan, decision)
+
+	e.maybeSeedPerRungAdmissionFromActuals(plan, shape, decision)
+	e.PerRungAdmission.mu.Lock()
+	firstObservedAt := e.PerRungAdmission.states[key].lastObserved
+	firstStreak := e.PerRungAdmission.states[key].consecutiveCheap
+	e.PerRungAdmission.mu.Unlock()
+
+	// Simulate the seed firing again on "effectively every request" while
+	// the entry is still fresh — the pre-fix behavior this hook's own doc
+	// now warns against.
+	for i := 0; i < 5; i++ {
+		e.maybeSeedPerRungAdmissionFromActuals(plan, shape, decision)
+	}
+
+	e.PerRungAdmission.mu.Lock()
+	laterObservedAt := e.PerRungAdmission.states[key].lastObserved
+	laterStreak := e.PerRungAdmission.states[key].consecutiveCheap
+	e.PerRungAdmission.mu.Unlock()
+
+	if !laterObservedAt.Equal(firstObservedAt) {
+		t.Fatal("repeated seed calls on an already-fresh entry kept refreshing lastObserved — " +
+			"this is exactly issue #3034's bug: an indefinitely self-renewing seed never lets " +
+			"perRungEvidenceTTL lapse, so a decline can never relax")
+	}
+	if laterStreak != firstStreak {
+		t.Fatalf("repeated seed calls on an already-fresh entry changed consecutiveCheap %d -> %d, want unchanged",
+			firstStreak, laterStreak)
+	}
+
+	// Now let the entry genuinely go stale (no seed calls in between,
+	// mirroring perRungEvidenceTTL passing with no traffic) and confirm the
+	// guard correctly steps aside once there is nothing fresh to protect —
+	// the seed mechanism must still work when a reseed is actually due.
+	e.PerRungAdmission.mu.Lock()
+	e.PerRungAdmission.states[key].lastObserved = time.Now().Add(-perRungEvidenceTTL - time.Minute)
+	e.PerRungAdmission.mu.Unlock()
+
+	if e.PerRungAdmission.hasFreshEntry(key) {
+		t.Fatal("fixture setup: expected the entry to read as stale before the next seed attempt")
+	}
+	e.maybeSeedPerRungAdmissionFromActuals(plan, shape, decision)
+	e.PerRungAdmission.mu.Lock()
+	postStaleObservedAt := e.PerRungAdmission.states[key].lastObserved
+	e.PerRungAdmission.mu.Unlock()
+	if !postStaleObservedAt.After(firstObservedAt) {
+		t.Fatal("a seed call on a genuinely stale entry must still reseed — the guard only skips an " +
+			"already-fresh entry, it must never permanently disable seeding for a shape")
 	}
 }

--- a/internal/engine/actuals_wiring.go
+++ b/internal/engine/actuals_wiring.go
@@ -130,8 +130,32 @@ func (e *Engine) calibrateEstimate(shapeID string, est *solver.ScanEstimate) *so
 // Observe/ShouldDeclineBypass already require) — a single anomalous
 // actuals reading must never seed a prior any more than a single real
 // drain would.
+//
+// Issue #3034: also a no-op when e.PerRungAdmission already holds a FRESH
+// entry for this shape (hasFreshEntry — the SAME "already holds a verdict"
+// gate explain_estimate_wiring.go's hasExistingVerdict uses before spending
+// its own advisory round trip). This hook re-runs on effectively every
+// request of a shape whose route-A actuals EMA still looks cheap, so
+// without this guard it would call SeedPriorFromEstimate — and therefore
+// record's unconditional st.lastObserved = time.Now() — forever, on a
+// decline that a genuinely one-directional signal (this hook only ever
+// seeds cheap=true) can never itself reverse. That indefinitely renews
+// ShouldDeclineBypass's own perRungEvidenceTTL and makes a decline
+// permanent: the TTL can never lapse, the solver's next fresh
+// PerRungPredictive=true prediction never reaches an un-declined dispatch,
+// and wrapPerRungObserver — the only path that calls a REAL Observe — never
+// fires again for this shape. Skipping the reseed once fresh evidence
+// already exists (of EITHER polarity — a real decline is exactly as valid
+// a reason to skip as a real non-decline) lets the TTL expire naturally,
+// which is what actually lets a stale decline relax: see
+// PerRungAdmissionLearner.ShouldDeclineBypass's own doc for what an expired
+// entry means to the next admission check.
 func (e *Engine) maybeSeedPerRungAdmissionFromActuals(plan chplan.Node, shapeID string, baseline *solver.Decision) {
 	if e.PerRungAdmission == nil || e.Actuals == nil || shapeID == "" || baseline == nil || baseline.NAnchors <= 0 {
+		return
+	}
+	key := shapeKey(plan, baseline)
+	if e.PerRungAdmission.hasFreshEntry(key) {
 		return
 	}
 	report, ok := e.Actuals.Snapshot(shapeID)
@@ -142,7 +166,7 @@ func (e *Engine) maybeSeedPerRungAdmissionFromActuals(plan chplan.Node, shapeID 
 	if int64(report.ActualEMARows) >= int64(baseline.NAnchors)*perRungCheapRowsPerAnchor { //nolint:gosec // G115
 		return
 	}
-	e.PerRungAdmission.SeedPriorFromEstimate(shapeKey(plan, baseline), true)
+	e.PerRungAdmission.SeedPriorFromEstimate(key, true)
 }
 
 // recordEstimateDriftFromQueryLog forwards one query_log-sourced

--- a/internal/engine/per_rung_admission_test.go
+++ b/internal/engine/per_rung_admission_test.go
@@ -272,6 +272,80 @@ func TestWrapPerRungObserver_RecordsOnlyOnACleanDrain(t *testing.T) {
 	}
 }
 
+// --- issue #3034: declined shapes gain a reachable relax path --------------
+
+// TestPerRungAdmission_DeclinedShapeRelaxesOnceEvidenceGoesStale is the
+// end-to-end regression test for issue #3034: a shape that declines the
+// per-rung bypass must gain a REAL, evidence-driven path back to
+// eligibility — not merely a TTL entry that some other mechanism keeps
+// renewing forever. This declines a shape with two real, clean Observe()
+// calls (exactly what wrapPerRungObserver feeds from a real per-rung
+// dispatch), confirms refinePerRungAdmission downgrades it, ages the
+// evidence past perRungEvidenceTTL with NO further calls in between
+// (mirroring perRungEvidenceTTL passing with no seed traffic), and confirms
+// the SAME Decision — a fresh PerRungPredictive=true prediction, exactly
+// what the solver recomputes on every request independent of the learner's
+// own state — now reaches dispatch un-declined, which is what lets
+// wrapPerRungObserver wrap a real cursor and call a real Observe() again.
+func TestPerRungAdmission_DeclinedShapeRelaxesOnceEvidenceGoesStale(t *testing.T) {
+	t.Parallel()
+	l := NewPerRungAdmissionLearner()
+	plan := perRungTestPlan()
+	key := perRungTestKey()
+
+	l.Observe(key, 1, perRungTestNAnchors)
+	l.Observe(key, 1, perRungTestNAnchors)
+	if !l.ShouldDeclineBypass(key) {
+		t.Fatal("fixture setup: expected decline-worthy evidence")
+	}
+
+	e := &Engine{PerRungAdmission: l}
+	decision := perRungTestDecision()
+	if refined, routed := e.refinePerRungAdmission(plan, decision, true); routed || refined.PerRungPredictive {
+		t.Fatal("fixture setup: expected the declined shape to route A before aging the evidence")
+	}
+
+	// Age the evidence past perRungEvidenceTTL with NO seed/Observe calls in
+	// between — same-package direct field access, exactly like this file's
+	// own TestPerRungAdmissionLearner_StaleEvidenceIsIgnored.
+	l.mu.Lock()
+	l.states[key].lastObserved = time.Now().Add(-perRungEvidenceTTL - time.Minute)
+	l.mu.Unlock()
+
+	if l.ShouldDeclineBypass(key) {
+		t.Fatal("evidence past perRungEvidenceTTL must relax the decline")
+	}
+
+	// The solver computes PerRungPredictive fresh on every request
+	// (refinePerRungAdmission's own doc), so the next request for this
+	// shape presents the SAME un-declined Decision again — confirm it now
+	// passes through un-declined, reaching wrapPerRungObserver for a real
+	// Observe() on the next dispatch.
+	refined, routed := e.refinePerRungAdmission(plan, perRungTestDecision(), true)
+	if !routed || !refined.PerRungPredictive {
+		t.Fatal("a relaxed decline must let the solver's fresh PerRungPredictive prediction through un-declined")
+	}
+
+	// Confirm the relaxed decision genuinely reaches a real Observe() again:
+	// wrapPerRungObserver must wrap (not pass through) this cursor, and a
+	// clean drain through it must be able to move the streak off zero,
+	// closing the self-confirming loop issue #3034 describes.
+	clean := &perRungFakeCursor{inspected: 1}
+	wrapped := wrapPerRungObserver(clean, l, nil, plan, refined)
+	if wrapped == chclient.Cursor(clean) {
+		t.Fatal("wrapPerRungObserver must wrap a relaxed, un-declined PerRungPredictive decision, not pass it through")
+	}
+	if err := wrapped.Close(); err != nil {
+		t.Fatalf("Close returned an unexpected error: %v", err)
+	}
+	l.mu.Lock()
+	streak := l.states[key].consecutiveCheap
+	l.mu.Unlock()
+	if streak == 0 {
+		t.Fatal("a real clean drain through the relaxed decision did not reach Observe()")
+	}
+}
+
 func TestWrapPerRungObserver_DoubleCloseRecordsOnce(t *testing.T) {
 	t.Parallel()
 	l := NewPerRungAdmissionLearner()


### PR DESCRIPTION
## Summary

`PerRungAdmissionLearner`'s decline was self-confirming: once
`refinePerRungAdmission` declined a per-rung bypass, `wrapPerRungObserver`
stopped observing that shape (it only wraps a cursor when
`decision.PerRungPredictive` is still true), so the only path that could
ever reverse a decline — `Observe()` — never ran again. The existing
`perRungEvidenceTTL` (30m) was supposed to be the escape valve, but
`maybeSeedPerRungAdmissionFromActuals` called
`PerRungAdmissionLearner.SeedPriorFromEstimate` unconditionally on
effectively every request whose route-A actuals EMA still looked cheap —
and `SeedPriorFromEstimate` funnels into the same `record()` helper
`Observe()` uses, which sets `st.lastObserved = time.Now()`
unconditionally on every call. The TTL could never lapse as long as route
A kept looking cheap, which it always does once B is declined (B is what
would otherwise surface a real drain).

## Fix

`per_rung_admission.go` already carries the exact right constraint for
this, built for an analogous problem: `hasFreshEntry` — "used only by
`explain_estimate_wiring.go`'s `ScanEstimateAdvisor` to decide whether this
learner already holds SOME verdict for key (of either polarity) before
spending an advisory EXPLAIN ESTIMATE round trip on it". This applies the
same guard to `maybeSeedPerRungAdmissionFromActuals`: it now skips seeding
entirely when `e.PerRungAdmission.hasFreshEntry(key)` is already true, and
only proceeds when the shape has no fresh verdict (of either polarity).

With the guard in place: a shape whose actuals stay genuinely cheap forever
still re-confirms its decline (correctly, since it's still cheap) but only
once per TTL window instead of on every request. Once the shape's real
usage stops looking cheap — route A keeps executing and reporting its own
actual read-rows via the pre-existing drift-capture hook regardless of
whether B ever dispatches — the next request after the stale entry's TTL
lapses skips the reseed, `ShouldDeclineBypass` reports no evidence, the
solver's fresh `PerRungPredictive=true` prediction reaches dispatch
un-declined, and `wrapPerRungObserver` wraps a real cursor again, feeding a
genuine `Observe()`.

## Diagnosis check against the dispatched analysis

- The `hasFreshEntry` diagnosis matched exactly: reusing it as the pre-seed
  gate is the entire fix, no new mechanism needed.
- `wrapPerRungObserver` needed **no direct change**. Tracing the call
  ordering in `Engine.classify` confirmed `maybeSeedPerRungAdmissionFromActuals`
  always runs (as part of `classify()`) strictly before the request's own
  `refinePerRungAdmission`/dispatch step, for every request of a shape. So
  once the guard stops the seed from renewing an already-fresh entry, TTL
  expiry naturally reopens the route the very next time the shape's actuals
  genuinely stop looking cheap — the existing `decision.PerRungPredictive`
  gate on `wrapPerRungObserver` was already the correct trigger; it just
  never got reached because the seed never let the TTL lapse.

## Tests

- `TestMaybeSeedPerRungAdmissionFromActuals_DoesNotReseedAFreshEntry` — the
  direct regression test for the bug: asserts `lastObserved` and
  `consecutiveCheap` are unchanged after repeated immediate seed calls on
  an already-fresh entry (this would fail against the pre-fix code), then
  confirms the guard still reseeds once the entry is genuinely stale.
- `TestMaybeSeedPerRungAdmissionFromActuals_SeedsOnLowCorroboratedActuals`
  updated: a second *immediate* seed call is now correctly a no-op rather
  than corroborating straight to a decline (corroboration now has to come
  from evidence spread out in time — a real `Observe()`, or a seed after
  the previous entry has gone stale).
- `TestPerRungAdmission_DeclinedShapeRelaxesOnceEvidenceGoesStale` — the
  end-to-end relax test: declines a shape via two real `Observe()` calls,
  confirms `refinePerRungAdmission` downgrades it, ages the evidence past
  `perRungEvidenceTTL` with no further calls in between, confirms
  `ShouldDeclineBypass` now reports false, confirms the solver's fresh
  `PerRungPredictive=true` decision reaches dispatch un-declined, and
  confirms `wrapPerRungObserver` wraps (not passes through) that decision
  and a clean drain through it reaches a real `Observe()` again.

Ran the same-package direct-field-access convention this file's own
`TestPerRungAdmissionLearner_StaleEvidenceIsIgnored` already established for
TTL simulation, rather than adding a `SetNowForTest` clock-injection seam —
the package already has an adequate, precedented way to control
`lastObserved` for tests without adding new production-visible surface for
it.

`just test-unit` passes.

Closes #3034
