### PR TITLE
docs(chopt): keep classic_bucket_merge_summap opt-in on measured parity

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1336,9 +1336,13 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 		l.OverTime = promql.FanoutOverTimeLowerer{}
 	}
 	// classic_bucket_merge_summap (issue #2756) has no version floor to
-	// probe, but ships AutoSelect: false pending #2817's investigation of
-	// the heterogeneous-bucket-layout divergence — see
-	// promql.NativeClassicBucketMergeLowerer's own doc.
+	// probe. #2817 closed its original correctness blocker; issue #2923's
+	// real-ClickHouse re-measurement against the resulting (post-#2817)
+	// construction then found its real cost within ~1% of the fold's, not
+	// the estimated ~50x win — so AutoSelect stays false, a measured
+	// negative result rather than an open question. See
+	// promql.NativeClassicBucketMergeLowerer's own doc and
+	// classic_bucket_merge_summap.go's header.
 	if optSet.Has(chopt.FeatureClassicBucketMergeSumMap) {
 		l.ClassicBucketMerge = promql.NativeClassicBucketMergeLowerer{
 			Fallback: promql.FanoutClassicBucketMergeLowerer{},

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -2163,7 +2163,7 @@ var registry = []Feature{
 		MinVersion: AlwaysAvailable,
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "opt the classic-histogram-quantile cross-series merge SUM fold onto a sumMap over per-row cumulative counts, retiring the groupArray + per-rung fold (no version floor, opt-in via CERBERUS_CH_OPTIMIZATIONS — real-CH remeasurement (#2923) found the post-#2817 construction's real cost within ~1% of the fold's, not a win, so auto stays off)",
+		Doc:        "opt the classic-histogram-quantile cross-series merge SUM fold onto a sumMap over per-row cumulative counts (no version floor, opt-in via CERBERUS_CH_OPTIMIZATIONS — real-CH remeasurement found it within ~1% of the fold's cost, not a win, auto stays off, #2923)",
 	},
 	{
 		ID:         FeatureExpHistogramMergeSumMap,

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1163,15 +1163,25 @@ const (
 	// and partially-overlapping layouts, and by a Prometheus-parity-enrolled
 	// spec fixture on a heterogeneous seed.
 	//
-	// What keeps AutoSelect false is now a MEASUREMENT question, tracked by
+	// What kept AutoSelect false was a MEASUREMENT question, settled by
 	// https://github.com/tsouza/cerberus/issues/2923: this feature's own
-	// ~50x figure is an estimate taken against the superseded construction,
-	// and [maxClassicBucketMergeCostUnits]'s guard — calibrated against the
-	// fold's per-rung rescan — over-rejects a path whose cost is linear in
-	// total bucket volume. Auto-selecting before both are settled would move
-	// the default path onto an unmeasured cost model and a ceiling that does
-	// not describe it. Until then the feature is reachable by explicit
-	// CERBERUS_CH_OPTIMIZATIONS=classic_bucket_merge_summap listing.
+	// ~50x figure was an estimate taken against the superseded
+	// construction. A real-ClickHouse re-measurement against the SHIPPED
+	// (post-#2817) construction — internal/promql/classic_bucket_merge_summap.go's
+	// header has the full table — found its real cost within ~1% of the
+	// fold's at every controlled point, converging to statistical parity
+	// as volume grows rather than the estimated 50x win: the per-row
+	// arraySort/arrayCumSum #2817 added to fix correctness erased the
+	// speedup this feature existed for. AutoSelect STAYS false — this
+	// repo's own established pattern for a feature whose real-world
+	// recalibration turns up no measurable win (#2768, #2750) — and
+	// [maxClassicBucketMergeCostUnits]'s existing guard needs no
+	// recalibration either: the re-measurement confirms (not merely
+	// assumes) it protects this path within the same ~1% margin, so no
+	// second, sumMap-specific ceiling is needed. The feature remains
+	// reachable, byte-identical-correct (per #2817), by explicit
+	// CERBERUS_CH_OPTIMIZATIONS=classic_bucket_merge_summap listing for an
+	// operator who wants it without expecting a resource win.
 	//
 	// The NaN asymmetry #2756 documented as a second, accepted risk is gone
 	// with the same change: arrayCumSum now runs over ONE ROW's own buckets,
@@ -2153,7 +2163,7 @@ var registry = []Feature{
 		MinVersion: AlwaysAvailable,
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "opt the classic-histogram-quantile cross-series merge SUM fold onto a sumMap over per-row cumulative counts, retiring the groupArray + per-rung fold (no version floor, opt-in via CERBERUS_CH_OPTIMIZATIONS — auto pending a recalibrated cost model, #2923)",
+		Doc:        "opt the classic-histogram-quantile cross-series merge SUM fold onto a sumMap over per-row cumulative counts, retiring the groupArray + per-rung fold (no version floor, opt-in via CERBERUS_CH_OPTIMIZATIONS — real-CH remeasurement (#2923) found the post-#2817 construction's real cost within ~1% of the fold's, not a win, so auto stays off)",
 	},
 	{
 		ID:         FeatureExpHistogramMergeSumMap,

--- a/internal/promql/classic_bucket_merge_bound.go
+++ b/internal/promql/classic_bucket_merge_bound.go
@@ -140,6 +140,16 @@ import (
 // newest-row/argMax bare-selector shaping (classicBucketShaping{fold: nil})
 // is never wrapped: its accumulator is fixed-size (one row per group), with
 // no groupArray merge to bound.
+//
+// Both call sites apply this SAME guard/formula regardless of WHICH
+// merge shaping built the Aggregate — the groupArray-fold shaping
+// (classicBucketMergeShaping) or classic_bucket_merge_summap.go's sumMap
+// shaping (classicBucketMergeShapingSumMap, chopt.FeatureClassicBucketMergeSumMap).
+// That is intentional, not merely untested: classic_bucket_merge_summap.go's
+// own "Cost re-measurement" section (cerberus issue #2923) found the
+// sumMap construction's real cost tracks this formula within ~1% at every
+// controlled point, so this single ceiling already protects an operator
+// who opts into that feature — no second, sumMap-specific formula exists.
 const (
 	// maxClassicBucketMergeCostUnits bounds `totalBucketVolume x
 	// widestRowBucketWidth` — see this file's header doc for the real

--- a/internal/promql/classic_bucket_merge_summap.go
+++ b/internal/promql/classic_bucket_merge_summap.go
@@ -142,6 +142,111 @@ import (
 // (arrayMax ignores NaN — confirmed: arrayMax([1, nan, 2]) = 2). The
 // asymmetric NaN reach #2756 documented as an accepted risk belonged to the
 // union-wide arrayCumSum this file no longer performs.
+//
+// # Cost re-measurement against the SHIPPED (post-#2817) construction
+// # (cerberus issue #2923, real ClickHouse 26.6.4-alpine via a standalone
+// # `docker run clickhouse/clickhouse-server:26.6-alpine` container — not
+// # chDB — max_memory_usage pinned to the 1 GiB
+// # CERBERUS_CH_QUERY_MAX_MEMORY default, real peak read from
+// # system.query_log.memory_usage after `SYSTEM FLUSH LOGS`, matching
+// # classic_bucket_merge_bound.go's own calibration methodology exactly)
+//
+// #2756's original "~50x faster" figure was an ESTIMATE against the
+// pre-#2817 construction (arrayCumSum along the union AFTER a plain
+// per-bucket sumMap — the shape #2817 replaced for correctness). The
+// shipped construction this file now builds pays a per-row arraySort
+// (classicBucketSumMapRowOrderedIndicesExpr) plus a per-row arrayCumSum
+// (classicBucketSumMapRowCumulativeExpr) BEFORE the sumMap aggregate ever
+// runs, and both ladders — this one and classicBucketMergedLadderExpr's —
+// now pay the SAME monotonic-repair layer. A throwaway harness (deleted
+// before this fix merged, same precedent classic_bucket_merge_bound.go's
+// own calibration cites) lowered + emitted the REAL
+// `histogram_quantile(0.5, sum by(le)(sum_over_time(<bucket>[5m])))` SQL
+// for both [FanoutClassicBucketMergeLowerer] (the fold) and
+// [NativeClassicBucketMergeLowerer] (this file), ran each against the SAME
+// seeded table, and compared real peak memory:
+//
+//	series  width  T=GxW    fold peak    sumMap peak   sumMap vs fold
+//	  1000     20    20,000    26.2 MiB      26.5 MiB   +1.16%
+//	  2000     20    40,000    51.0 MiB      51.5 MiB   +0.84%
+//	  3741     12    44,892    41.0 MiB      41.3 MiB   +0.74%
+//	  2000     50   100,000   307.9 MiB     308.2 MiB   +0.10%
+//	  4000     50   200,000   614.4 MiB     614.7 MiB   +0.05%
+//	  6000     50   300,000   827.0 MiB     827.3 MiB   +0.04%
+//	  8000     50   400,000   REJECTED (946.8 MiB attained)   REJECTED (947.1 MiB attained)   +0.03%
+//	  3000    100   300,000   REJECTED (976.5 MiB attained)   REJECTED (976.8 MiB attained)   +0.03%
+//
+// Every row above seeds DISJOINT ExplicitBounds layouts (series i's bounds
+// are `[i*W+1 .. i*W+W]`) — classic_bucket_merge_bound.go's own worst-case
+// calibration seed — and the REJECTED rows are genuine real-server
+// `MEMORY_LIMIT_EXCEEDED` aborts at the SAME (series, width) points that
+// file's own header table records for the fold, confirming this harness
+// reproduces that published calibration (absolute numbers run ~10-18%
+// lower here, attributable to the newer 26.6.4 server vs that table's
+// 25.9-alpine, not to a methodology difference) before trusting its
+// fold-vs-sumMap DELTA.
+//
+// Two things fall out of this table:
+//
+//  1. sumMap is NOT cheaper at any point measured — it is marginally MORE
+//     expensive everywhere, by a near-constant ~319-452 KiB absolute
+//     overhead (consistent with a small, T-independent per-query
+//     construction cost: the extra arraySort/arrayCumSum lambda setup this
+//     file's header already names, not a term that scales with volume).
+//  2. That overhead SHRINKS in relative terms as T grows (1.16% at
+//     T=20,000 down to 0.03% at T=400,000) because the dominant cost term
+//     is the SAME for both constructions (confirmed by the REJECTED rows
+//     aborting within 0.3 MiB of each other) — the two constructions have
+//     CONVERGED to statistically the same real cost post-#2817, not
+//     diverged in sumMap's favour.
+//
+// A separate, uncontrolled sweep at HOMOGENEOUS layouts (every row sharing
+// one ExplicitBounds — the shape #2756's original estimate assumed) and
+// much larger series counts (50,000-400,000) surfaced a real but
+// CONFOUNDING ClickHouse behaviour: peak memory for BOTH constructions
+// dropped sharply and non-monotonically above roughly 20,000-50,000
+// distinct `Attributes` groups (20,000 series: both OOM near 983 MiB;
+// 50,000 series: both succeed at 134-165 MiB — an order of magnitude
+// LESS, despite 2.5x more data), tracking each other closely at every
+// point (fold/sumMap within ~20% of each other, never a clean multiple).
+// This is almost certainly the classic_bucket_merge_summap.go-external
+// per-series `GROUP BY Attributes` stage (histogram_quantile.go's own
+// per-series collection, upstream of anything this file or
+// classic_bucket_merge_bound.go's guard covers) crossing ClickHouse's
+// two-level hash-aggregation threshold, not a merge-stage effect either
+// construction controls — the same class of real-server planner
+// sensitivity exp_histogram_merge_summap_bound.go's own "Range-mode
+// calibration" section flags (its ~1,400-step nondeterminism) without
+// resolving it. It is recorded here, not smoothed over, but it is NOT
+// treated as evidence either way for this file's own cost comparison: the
+// controlled, DISJOINT, REPRODUCIBLE sweep above — which isolates the
+// merge stage alone and cleanly reproduces the existing published fold
+// baseline — is what this decision rests on.
+//
+// # Verdict: AutoSelect stays false
+//
+// The measured real-world speedup is gone: post-#2817's per-row
+// arraySort/arrayCumSum cost erased #2756's original ~50x estimate down to
+// a near-zero, occasionally NEGATIVE real delta at every controlled point
+// tested — this repo's own established pattern for a feature that looked
+// like an obvious win before recalibration (#2768's codec measurement,
+// #2750's ts_tag_groups measurement). [chopt.FeatureClassicBucketMergeSumMap]
+// keeps `AutoSelect: false`; the feature stays reachable only via explicit
+// `CERBERUS_CH_OPTIMIZATIONS=classic_bucket_merge_summap` listing for an
+// operator who wants BYTE-IDENTICAL correctness (pinned since #2817) with
+// no expectation of a resource win.
+//
+// The re-measurement DOES settle classic_bucket_merge_bound.go's own open
+// question for this path: since sumMap's real cost tracks the fold's own
+// `totalBucketVolume x widestRowBucketWidth` model within ~1% at every
+// controlled point (including both REJECTED points, which abort within
+// 0.3 MiB of each other), [maxClassicBucketMergeCostUnits] — UNCHANGED —
+// already correctly protects an operator who opts into this feature via
+// the env override; no second, sumMap-specific guard formula is needed
+// (contrast [expHistogramMergeSumMapCostOverBudgetExpr]
+// (exp_histogram_merge_summap_bound.go), whose design DOES need one,
+// because that merge's own cost model is genuinely rows-independent in a
+// way this one's real measurement shows it is not).
 const (
 	// hqAggSumMapAlias holds the group's sumMap(bounds, counts) result — a
 	// Tuple(Array(Float64) keys sorted ascending, Array(Float64) values),


### PR DESCRIPTION
## Summary

Issue #2923 asked whether the sumMap classic-bucket merge (#2756) still
justifies its original "~50x faster" estimate now that #2817 closed its
correctness blocker by adding a per-row `arraySort` + `arrayCumSum` before
the key-wise `sumMap`. This PR answers that with a real measurement and
resolves the issue with a documented **negative result**: `AutoSelect`
stays `false`.

## Methodology

Real ClickHouse 26.6.4-alpine (a standalone `docker run
clickhouse/clickhouse-server:26.6-alpine` container, **not chDB**) — the
same discipline `classic_bucket_merge_bound.go`'s own header calibration
uses: the actual emitted SQL for both `FanoutClassicBucketMergeLowerer`
(the fold) and `NativeClassicBucketMergeLowerer` (sumMap), `max_memory_usage`
pinned to the 1 GiB `CERBERUS_CH_QUERY_MAX_MEMORY` default, real peak read
from `system.query_log.memory_usage` after `SYSTEM FLUSH LOGS`.

A throwaway harness (deleted before this PR — same precedent
`classic_bucket_merge_bound.go`'s own calibration cites) seeded DISJOINT
`ExplicitBounds` layouts (that file's own worst-case seed) at 8 controlled
`(series, width)` points spanning 20,000-400,000 total bucket elements, and
ran both constructions back-to-back against the identical seed.

## Numbers

| series | width | T=G×W | fold peak | sumMap peak | sumMap vs fold |
|---|---|---|---|---|---|
| 1000 | 20 | 20,000 | 26.2 MiB | 26.5 MiB | +1.16% |
| 2000 | 20 | 40,000 | 51.0 MiB | 51.5 MiB | +0.84% |
| 3741 | 12 | 44,892 | 41.0 MiB | 41.3 MiB | +0.74% |
| 2000 | 50 | 100,000 | 307.9 MiB | 308.2 MiB | +0.10% |
| 4000 | 50 | 200,000 | 614.4 MiB | 614.7 MiB | +0.05% |
| 6000 | 50 | 300,000 | 827.0 MiB | 827.3 MiB | +0.04% |
| 8000 | 50 | 400,000 | REJECTED (946.8 MiB) | REJECTED (947.1 MiB) | +0.03% |
| 3000 | 100 | 300,000 | REJECTED (976.5 MiB) | REJECTED (976.8 MiB) | +0.03% |

The REJECTED rows are genuine real-server `MEMORY_LIMIT_EXCEEDED` aborts at
the exact `(series, width)` points `classic_bucket_merge_bound.go`'s own
published header table records for the fold — confirming this harness
reproduces that table (absolute numbers run ~10-18% lower here, attributable
to the newer 26.6.4 server vs that table's 25.9-alpine) before trusting its
fold-vs-sumMap delta.

sumMap is **not** cheaper at any point measured — it costs a near-constant
~320-450 KiB more everywhere (consistent with the fixed per-query
arraySort/arrayCumSum setup cost, not a term that scales with volume), a gap
that shrinks in relative terms as scale grows (1.16% → 0.03%) because both
constructions converge on the same dominant cost term. The original ~50x
estimate is gone.

(A separate, uncontrolled sweep at homogeneous layouts and much larger
series counts (50k-400k) surfaced a real but confounding ClickHouse
two-level-hash-aggregation-style threshold effect in the unrelated per-series
`GROUP BY Attributes` stage — flagged, not resolved, and not used as
evidence either way; see the full writeup in
`classic_bucket_merge_summap.go`'s header.)

## Decision

Per this repo's own established pattern for a feature whose real-world
recalibration turns up no measurable win (#2768, #2750): `AutoSelect` stays
`false`. `maxClassicBucketMergeCostUnits` needs no recalibration either —
the re-measurement confirms (not merely assumes) its existing
`totalBucketVolume x widestRowBucketWidth` formula already protects the
sumMap construction within the same ~1% margin, so no second,
sumMap-specific guard formula is added. The feature remains reachable,
byte-identical-correct (per #2817), via explicit
`CERBERUS_CH_OPTIMIZATIONS=classic_bucket_merge_summap` for an operator who
wants it without expecting a resource win.

## Golden blast radius

None. `AutoSelect` is unchanged (`false` → `false`), so no default lowering
path changes and no `test/spec/` fixture, migration archetype, or other
golden file is affected — confirmed by `git diff --stat` showing only the
four doc/comment files below. No `update-golden` CI run was needed.

## Changes

- `internal/promql/classic_bucket_merge_summap.go` — new header section
  recording the real-ClickHouse re-measurement and its negative-result
  verdict.
- `internal/chopt/registry.go` — `FeatureClassicBucketMergeSumMap`'s doc
  comment and `Doc` string updated from "measurement pending" to "measured,
  no win".
- `internal/promql/classic_bucket_merge_bound.go` — cross-references the
  re-measurement's confirmation that the existing guard formula also
  protects the sumMap construction.
- `cmd/cerberus/main.go` — updates a stale comment that still referenced
  #2817 as "pending" (it closed).

## Test plan

- [x] `just test-unit` passes.
- [x] `just vet-tagged` passes.
- [x] `go build ./...` clean.
- [x] `golangci-lint run` clean on the touched packages (informational only
      per this repo's own note that a local agent-worktree lint run is not
      authoritative — CI's `lint` job is the real gate).
- [x] No golden files changed (`git diff --stat` confirms).

Closes #2923
