### PR TITLE
fix(chopt): close the untracked optcorpus A/B deferral on two chopt features

### DIFF
--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -654,13 +654,24 @@ const (
 	// family needs — so it carries NO version gate (AlwaysAvailable) and no
 	// allow_experimental_* setting.
 	//
-	// AutoSelect is false, unlike laginframe_adjacency: the issue's own
-	// proposal calls for an optcorpus A/B pass before promoting this to
-	// auto-selected (the reset-correction term's summation runs in
-	// ClickHouse's own non-deterministic aggregation order, unlike the
-	// array-fold's strict time-ordered fold — proven algebraically
-	// equivalent and verified bit-identical on the dual-emit parity corpus,
-	// but not yet fielded). Reachable only via an explicit
+	// AutoSelect is false, unlike laginframe_adjacency — NOT pending
+	// measurement (cerberus#2894 ran the optcorpus A/B and closed that gap):
+	// the reset-correction term's summation runs in ClickHouse's own
+	// non-deterministic aggregation order, unlike the array-fold's strict
+	// time-ordered fold — proven algebraically equivalent and verified
+	// bit-identical on the dual-emit parity corpus. But a real ClickHouse
+	// 26.6.4.55 optcorpus A/B (query_range rate()/increase(), 2,200 series,
+	// 1h span / 60 anchors / 5m window — matching #2429's own
+	// resource-bound calibration scale) measured this shape reading HALF
+	// the source rows and ~20% fewer bytes at roughly neutral wall-clock
+	// (within ~10%), but at ~1.8-2x the incumbent array-fold's PEAK MEMORY
+	// (six concurrent per-group accumulators — count/min/max/argMin/
+	// argMax/sumIf — against the array-fold's single groupArrayIf pass).
+	// Trading a real memory increase for no consistent wall-clock win is
+	// not worth the OOM-risk uplift on every default rate/increase/delta
+	// query_range request, so this stays opt-in — a measured "no", not an
+	// unfinished "pending" (see #2768 and #2750 for this repo's other
+	// negative-result precedent). Reachable only via an explicit
 	// CERBERUS_CH_OPTIMIZATIONS=fixed_accumulator_extrapolated listing.
 	//
 	// Scope: eligible for a temporality-bearing counter window too — the
@@ -706,10 +717,27 @@ const (
 	// all long-standing ClickHouse primitives — so it carries NO version gate
 	// (AlwaysAvailable) and no allow_experimental_* setting.
 	//
-	// AutoSelect is false, mirroring fixed_accumulator_extrapolated: pending
-	// an optcorpus A/B pass before promoting to auto-selected. Reachable
-	// only via an explicit CERBERUS_CH_OPTIMIZATIONS=sorted_slab_over_time
-	// listing.
+	// AutoSelect is false — NOT pending measurement (cerberus#2894 ran the
+	// optcorpus A/B and closed that gap), and more decisively so than
+	// fixed_accumulator_extrapolated's sibling finding: a real ClickHouse
+	// 26.6.4.55 A/B found this shape's own "peak memory is O(samples-in-
+	// range) per series, independent of anchor count" design claim (see
+	// this file's own doc above) does NOT hold in practice. At typical
+	// anchor density (60-240 anchors) it used 6-9x the incumbent array-
+	// fold's peak memory for no wall-clock win; at 500 series / 480
+	// anchors / 5m window — inside #2429's own resource-bound calibration
+	// scale (3,740 real series) — it OOMed a 6 GiB cap outright while the
+	// array-fold it exists to replace finished comfortably at 535 MiB.
+	// Only at extreme anchor density (1,440+ anchors, well past any
+	// query_range panel step this codebase's own perf corpus samples) does
+	// it become faster, and even there at 2.6x the array-fold's own
+	// (already elevated) memory. A shape whose OWN motivating case can OOM
+	// where the incumbent does not must not reach the default path — a
+	// measured "no", not an unfinished "pending" (see #2768 and #2750 for
+	// this repo's other negative-result precedent). The apparent gap
+	// between the design's O(samples) claim and the measured behavior is
+	// tracked as a follow-up investigation at #3046. Reachable only via an
+	// explicit CERBERUS_CH_OPTIMIZATIONS=sorted_slab_over_time listing.
 	FeatureSortedSlabOverTime = "sorted_slab_over_time"
 
 	// FeatureTSGridGroupArray swaps the fan-out window-assembly idiom's
@@ -2101,14 +2129,18 @@ var registry = []Feature{
 		MinVersion: AlwaysAvailable,
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "opt eligible query_range rate/increase/delta shapes onto per-(series, anchor) fixed-size aggregates (count/min/max/argMin/argMax/sumIf), retiring the array-fold fan-out (no version floor, opt-in via CERBERUS_CH_OPTIMIZATIONS pending optcorpus A/B)",
+		Doc: "opt eligible query_range rate/increase/delta shapes onto per-(series, anchor) fixed-size aggregates (count/min/max/argMin/argMax/sumIf), retiring the array-fold fan-out " +
+			"(no version floor, opt-in only via CERBERUS_CH_OPTIMIZATIONS — a real-CH 26.6.4.55 optcorpus A/B measured half the source rows/~20% fewer bytes at roughly neutral " +
+			"wall-clock but ~1.8-2x the incumbent array-fold's peak memory, so auto never picks it; see #2894)",
 	},
 	{
 		ID:         FeatureSortedSlabOverTime,
 		MinVersion: AlwaysAvailable,
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "opt eligible query_range sum_over_time/avg_over_time shapes onto a per-series sorted-slab groupArray sliced per anchor, retiring the arrayJoin fan-out + per-(series, anchor) regroup (no version floor, opt-in via CERBERUS_CH_OPTIMIZATIONS pending optcorpus A/B)",
+		Doc: "opt eligible query_range sum_over_time/avg_over_time shapes onto a per-series sorted-slab groupArray sliced per anchor, retiring the arrayJoin fan-out + per-(series, anchor) regroup " +
+			"(no version floor, opt-in only via CERBERUS_CH_OPTIMIZATIONS — a real-CH 26.6.4.55 optcorpus A/B found its claimed O(samples)-per-series memory bound does not hold in practice: " +
+			"6-9x the incumbent's memory at typical anchor density, and it OOMed a 6GiB cap at 500 series/480 anchors where the array-fold held at 535MiB, so auto never picks it; see #2894, follow-up #3046)",
 	},
 	{
 		ID:                         FeatureTSGridGroupArray,


### PR DESCRIPTION
## Summary

Closes the untracked "pending optcorpus A/B" deferral on two shipped `chopt`
features (`fixed_accumulator_extrapolated`, `sorted_slab_over_time`) by
actually running that A/B against a real ClickHouse server and recording the
result in each `Doc` string.

## Methodology

Lowered the same PromQL query twice through the real `promql` -> `chplan` ->
`chsql` pipeline — once with the incumbent array-fold lowerer
(`FanoutRateLowerer` / `FanoutIncreaseLowerer` / `FanoutOverTimeLowerer`),
once with the candidate (`FixedAccumulatorRateLowerer` /
`FixedAccumulatorIncreaseLowerer` / `SortedSlabOverTimeLowerer`) — and ran
both against a **real ClickHouse 26.6.4.55** server (Docker, distinct ports,
memory-capped) rather than chDB, per the issue's stated preference. Cost was
read back from `system.query_log` (`read_rows`, `read_bytes`,
`query_duration_ms`, `memory_usage`), median of 3 runs per shape. Correctness
was already pinned by this repo's existing dual-emit parity chDB tests
(`range_window_fixed_accumulator_chdb_test.go`,
`range_window_sorted_slab_chdb_test.go`), so this A/B measured cost only.

## Results

**`fixed_accumulator_extrapolated`** (`rate()`/`increase()`, 2,200 series, 1h
span / 60 anchors / 5m window — matching #2429's own resource-bound
calibration scale): reads half the source rows and ~20% fewer bytes at
roughly neutral wall-clock (within ~10%), but at **~1.8-2x** the incumbent's
peak memory (six concurrent per-group accumulators vs. one `groupArrayIf`
pass). Consistent at both a small scale (80 series) and this
production-representative scale.

**`sorted_slab_over_time`** (`sum_over_time()`/`avg_over_time()`): its own
design doc claims peak memory is O(samples-in-range) per series, independent
of anchor count. Measured against real ClickHouse, that claim does **not**
hold:

| series | anchors | fan-out mem | sorted-slab mem | fan-out ms | slab ms |
| ------ | ------- | ----------- | ---------------- | ---------- | ------- |
| 2,200  | 60      | 247 MiB     | 1.59 GiB (~6.4x)  | 905        | 1,908   |
| 500    | 240     | 166 MiB     | 1.42 GiB (~8.8x)  | 1,611      | 1,647   |
| 500    | 480     | 535 MiB     | **OOM** (6 GiB cap, code 241) | 1,271 | n/a |
| 50     | 1,440   | 1.98 GiB    | 5.09 GiB (~2.6x, 3x faster) | 13,900 | 4,700 |

The 500-series/480-anchor row sits inside #2429's own calibration corpus
scale (3,740 real series) — squarely production-representative — and is
where sorted-slab OOMs a 6 GiB cap while the array-fold it exists to replace
finishes comfortably at 535 MiB. Only at extreme anchor density (far past
any panel step this repo's perf corpus samples) does it become faster, and
even there at a higher absolute memory cost than the array-fold's own
(already elevated) usage.

## Decision

**Both stay `AutoSelect: false`.** Neither flips, so there is no default-SQL
blast radius and no golden regeneration is required — verified via `git
diff` against nothing beyond `internal/chopt/registry.go`, and confirmed
`registry_test.go` / `resolve_test.go` still pass unchanged. This matches
this repo's own precedent for a measured "no" being a complete answer (#2768:
codecs measured worse than incumbent; #2750: `ts_tag_groups` measured slower
at low cardinality) rather than a lesser one — the acceptance criterion "if
it flips to auto, pin a reachability test" therefore doesn't apply to either
feature.

Filed and triaged same-turn: [#3046](https://github.com/tsouza/cerberus/issues/3046)
(milestone M4, sub-issue of epic #2758) — the apparent gap between
`sorted_slab_over_time`'s O(samples)-per-series design intent and its
measured real-ClickHouse behavior, as a follow-up investigation.

## Verification

- `go test -race ./internal/chopt/...` — pass.
- `just test-unit` — full pass (race-detected unit + spec suite + vet-tagged).
- `grep -n "pending optcorpus" internal/chopt/registry.go` — no matches.
- Line lengths checked against the repo's 280-char `lll` limit.
- The one-off benchmark harness used to run the A/B was never committed (built,
  run, and deleted from the worktree before this commit).

Closes #2894
