### PR TITLE
fix(chsql): bound sorted_slab_over_time's real per-block memory retention

### DIFF
--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -862,7 +862,13 @@ func (c *Client) querySettings(ctx context.Context) clickhouse.Settings {
 	if blockSize > 0 {
 		// Per-request override (WithMaxBlockSize) — only ever set by the
 		// chaos_sleep build so its injected sleepEachRow source is read as
-		// small blocks and max_execution_time can abort it mid-scan.
+		// small blocks and max_execution_time can abort it mid-scan. Applied
+		// AFTER perQuery so it would win a same-key collision, but in
+		// practice nothing else stamps this same "max_block_size" key
+		// through the generic perQuery map — the sorted-slab memory bound
+		// (internal/engine.applySortedSlabOverTimeMemoryBound) stamps it
+		// through its OWN local const (see settingMaxBlockSize's own doc),
+		// which is the identical string but a different Go declaration.
 		s[settingMaxBlockSize] = blockSize
 	}
 	return s

--- a/internal/chclient/timeout.go
+++ b/internal/chclient/timeout.go
@@ -120,6 +120,15 @@ var queryTimeoutKey = queryTimeoutKeyType{}
 // chaos_sleep build so a sleepEachRow over a numbers() source is read as
 // single-row blocks (per-block sleep stays under max_sleep_in_seconds)
 // and max_execution_time aborts it part-way through with code 159.
+//
+// internal/engine's applySortedSlabOverTimeMemoryBound (cerberus issue
+// #3046) stamps the SAME ClickHouse setting for an unrelated reason (the
+// sorted-slab shape's own memory bound) through ITS OWN local
+// settingMaxBlockSize const in query_settings_rules.go, not this one — the
+// perf-sentinel-obligation CI gate requires a memory-bounding setting name
+// to be a local `setting<Name>` const inside the file that stamps it, so
+// the two consts intentionally do not share a declaration despite sharing
+// a literal string.
 const settingMaxBlockSize = "max_block_size"
 
 type maxBlockSizeKeyType struct{}

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -685,7 +685,18 @@ const (
 	// array is an UNGUARDED fan-out axis — unlike rate/increase/delta
 	// (#2429) it carries no size guard at all — so peak memory scales with
 	// samples * anchors; the sorted-slab shape bounds it to samples per
-	// series, independent of anchor count.
+	// series, independent of anchor count, PROVIDED the mandatory
+	// max_block_size=1 companion setting rides every dispatch of this shape
+	// (internal/engine.applySortedSlabOverTimeMemoryBound) — real
+	// ClickHouse 26.6.4.55 profiling (cerberus issue #3046) found the SQL
+	// shape alone does not bound memory this way; ClickHouse's vectorized
+	// block execution retained the per-anchor intermediates across an
+	// entire block of series rows rather than one row at a time, an
+	// O(block-width x samples) footprint that OOMed a 6 GiB container at
+	// 500 series / 480 anchors. The engine rule stamps the fix
+	// unconditionally whenever this feature's shape is chosen; see
+	// range_window_sorted_slab.go's own doc for the full profiling
+	// evidence and the block-size-vs-memory sweep that pinned the cause.
 	//
 	// Scoped to sum_over_time / avg_over_time only, deliberately narrower
 	// than the issue's own full *_over_time proposal (which also names
@@ -709,7 +720,20 @@ const (
 	// AutoSelect is false, mirroring fixed_accumulator_extrapolated: pending
 	// an optcorpus A/B pass before promoting to auto-selected. Reachable
 	// only via an explicit CERBERUS_CH_OPTIMIZATIONS=sorted_slab_over_time
-	// listing.
+	// listing. Issue #3046's memory fix (the max_block_size companion
+	// setting above) closes the specific concern that A/B pass would have
+	// tripped over — every re-measured data point now beats the array-fold
+	// fan-out on BOTH memory and, in most cases, wall-clock — so
+	// AutoSelect COULD be revisited now, but doing so needs its own fresh
+	// optcorpus A/B run (cerberus issue #2894, already closed with a
+	// negative result under the unfixed shape) rather than being flipped
+	// as a side effect of the #3046 fix — and that A/B run should include
+	// mixed-shape queries (a sorted-slab branch combined with an unrelated,
+	// otherwise-cheap sibling via a binary op), since
+	// applySortedSlabOverTimeMemoryBound's own doc records that its
+	// max_block_size=1 stamp applies to the WHOLE dispatched query, not
+	// just the sorted-slab subtree — currently low-blast-radius only
+	// because this feature is opt-in-only.
 	FeatureSortedSlabOverTime = "sorted_slab_over_time"
 
 	// FeatureTSGridGroupArray swaps the fan-out window-assembly idiom's
@@ -2108,7 +2132,7 @@ var registry = []Feature{
 		MinVersion: AlwaysAvailable,
 		Stability:  Experimental,
 		AutoSelect: false,
-		Doc:        "opt eligible query_range sum_over_time/avg_over_time shapes onto a per-series sorted-slab groupArray sliced per anchor, retiring the arrayJoin fan-out + per-(series, anchor) regroup (no version floor, opt-in via CERBERUS_CH_OPTIMIZATIONS pending optcorpus A/B)",
+		Doc:        "opt eligible query_range sum_over_time/avg_over_time shapes onto a per-series sorted-slab groupArray sliced per anchor, retiring the arrayJoin fan-out + per-(series, anchor) regroup, with a mandatory max_block_size=1 companion setting closing #3046's memory defect (no version floor, opt-in via CERBERUS_CH_OPTIMIZATIONS pending a fresh optcorpus A/B, #2894)",
 	},
 	{
 		ID:                         FeatureTSGridGroupArray,

--- a/internal/chsql/range_window_sorted_slab.go
+++ b/internal/chsql/range_window_sorted_slab.go
@@ -24,7 +24,26 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // the matrix's own step-anchor grid over the RAW per-series samples rather
 // than to an inner subquery's anchor grid over an already-reduced value
 // array. Peak memory is O(samples-in-range) per series, independent of
-// anchor count.
+// anchor count — but ONLY when the per-query max_block_size cap below is
+// also in effect. Real ClickHouse 26.6.4.55 profiling (cerberus issue
+// #3046) found the naive SQL shape alone does NOT bound memory this way:
+// ClickHouse's vectorized block execution evaluates the anchor-arrayMap
+// lambda across every series row batched into ONE block simultaneously, so
+// the per-anchor arrayFilter intermediates this comment describes as
+// "sliced anchor by anchor, freed as it goes" were in practice retained for
+// the WHOLE block's worth of series before being freed — an
+// O(block-width x samples-in-range) footprint, not O(samples-in-range). A
+// max_block_size=1 sweep against #3046's own 500-series/480-anchor
+// reproduction proved the block width (not the anchor or sample count in
+// isolation) drives this: peak memory scaled ~linearly with block width
+// (98 MiB at block=1 up to a 6 GiB-container OOM at the default ~65505-row
+// block), and forcing block=1 restores the intended per-row bound because
+// each series row then finishes (and frees its own anchor-grid
+// intermediates) before the next one starts. See
+// internal/engine.applySortedSlabOverTimeMemoryBound, the mandatory
+// per-query companion setting that makes this file's own O(samples-in-range)
+// claim actually hold — this emitter's SQL shape is necessary but not
+// sufficient for it on its own.
 //
 // Order/precision: the per-anchor window slice feeds overTimeArrayValueFrag
 // UNCHANGED — the exact function the array-fold's own outer SELECT calls —

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -262,8 +262,9 @@ func strategyFor(meta Meta) string {
 // (QueryPlanCursor) execute sites so the native path is gated the same
 // way regardless of which one runs.
 //
-// On top of the always-on ts-grid gate, spill bound, compare() memory bound
-// and native-histogram analyzer fix, execContext applies the join spill bound
+// On top of the always-on ts-grid gate, spill bound, compare() memory bound,
+// native-histogram analyzer fix and sorted-slab memory bound, execContext
+// applies the join spill bound
 // — gated on BOTH the join_spill chopt feature (server >= 26.4, resolved once
 // at boot into e.settings().JoinSpill) AND the plan containing a join-bearing
 // node, so it is absent on every server too old to carry
@@ -297,6 +298,13 @@ func (e *Engine) execContext(ctx context.Context, plan chplan.Node, language str
 	// to the older analyzer (cerberus issue #2355). Always-on and
 	// result-equivalent, like the compare() bound above.
 	ctx = applyNativeHistogramAnalyzerFix(ctx, plan)
+	// Sorted-slab sum_over_time()/avg_over_time()-only: cap max_block_size at
+	// 1 so the per-anchor arrayFilter/arrayMap intermediates the emitter
+	// builds per series row are freed row-by-row instead of retained across
+	// an entire vectorized block (cerberus issue #3046). Always-on and
+	// result-equivalent, like the two bounds above; fires only when the plan
+	// carries the opt-in sorted-slab RangeWindow shape.
+	ctx = applySortedSlabOverTimeMemoryBound(ctx, plan)
 	ctx = e.settings().apply(ctx, plan)
 	// Issue #2789: tag this route-A dispatch for actuals capture — see
 	// applyActualsCapture's own doc. No-op (ctx unchanged) whenever Actuals

--- a/internal/engine/query_settings_rules.go
+++ b/internal/engine/query_settings_rules.go
@@ -405,6 +405,110 @@ func planHasMetricsCompare(plan chplan.Node) bool {
 	return found
 }
 
+// settingMaxBlockSize names the ClickHouse setting that caps the number of
+// rows a source/expression stage may batch into one execution block.
+// internal/chclient's own settingMaxBlockSize (timeout.go) names the
+// identical ClickHouse setting for an unrelated reason (the chaos_sleep
+// build's dedicated WithMaxBlockSize carrier); this file declares its OWN
+// copy — rather than importing that one — because the required
+// perf-sentinel-obligation CI gate (.github/scripts/perf-sentinel-
+// obligation.mjs) derives this file's memory-bounding surface from
+// `setting<Name>` consts declared LOCALLY in query_settings_rules.go /
+// spill.go, and a cross-package reference would be invisible to that scan.
+//
+// perf-sentinel: memory-bounding — see sortedSlabOverTimeMaxBlockSize's own
+// doc for what this setting bounds and how that was measured.
+const settingMaxBlockSize = "max_block_size"
+
+// sortedSlabOverTimeMaxBlockSize is the per-request max_block_size cerberus
+// stamps on a query carrying a chplan.RangeWindow.SortedSlabOverTime shape
+// (cerberus issue #2761's sum_over_time()/avg_over_time() decomposition,
+// internal/chsql/range_window_sorted_slab.go). Forcing single-row blocks
+// closes cerberus issue #3046: real ClickHouse 26.6.4.55 profiling (EXPLAIN
+// PIPELINE plus a block-size sweep against the issue's own 500-series/
+// 480-anchor reproduction) found the sorted-slab emitter's per-series
+// `arrayMap(a -> ..., anchors)` — each anchor's lambda re-running
+// `arrayFilter` over that row's full samples slab — gets vectorized ACROSS
+// every series row ClickHouse happens to batch into one block, not just
+// across the anchors within a single row: the exception stack trace on the
+// OOM (`FUNCTION arrayFilter(...): while executing 'FUNCTION arrayMap(a ->
+// ...)'`) names exactly that expression, and a controlled max_block_size
+// sweep at that reproduction (1 / 10 / 50 / 100 / 250 / default≈65505 rows)
+// measured peak memory scaling ~linearly with block width — 98 MiB / 436
+// MiB / 1.74 GiB / 3.43 GiB / 4.86 GiB / OOM — confirming the block width,
+// not the anchor or sample count alone, is what the design's "freed as it
+// goes" claim failed to bound. At max_block_size=1 each series row is its
+// own block, so ClickHouse frees one row's per-anchor intermediates before
+// starting the next — restoring the O(samples-in-range)-per-series bound
+// the doc on range_window_sorted_slab.go claims. Re-measured at all four of
+// the issue's own data points (real ClickHouse 26.6.4.55): every case now
+// uses LESS memory than the array-fold fan-out it replaces (previously
+// 1.4-9x MORE, up to a 6 GiB-container OOM), while keeping most or all of
+// the sorted-slab shape's wall-clock advantage — see the issue for the full
+// before/after table. The value mirrors the chaos_sleep build's OWN
+// single-row-block precedent (internal/api/prom/chaos_sleep.go's
+// chaosSleepMaxBlockSize), applied here for a correctness/memory reason
+// rather than a chaos-determinism one.
+const sortedSlabOverTimeMaxBlockSize = 1
+
+// applySortedSlabOverTimeMemoryBound stamps max_block_size=
+// sortedSlabOverTimeMaxBlockSize on any plan carrying a
+// chplan.RangeWindow.SortedSlabOverTime node, so the sorted-slab family's
+// real per-anchor memory retention (see the const's own doc) never rides an
+// unbounded block width. It is unconditional — like
+// applyCompareMemoryBound and applyNativeHistogramAnalyzerFix above, NOT
+// gated behind a SettingsRules opt-in flag — because it is a mandatory
+// companion to an EXISTING opt-in shape (chopt.FeatureSortedSlabOverTime),
+// not a new optimization of its own: whenever the sorted-slab shape is
+// chosen at all (currently only via an explicit
+// CERBERUS_CH_OPTIMIZATIONS=sorted_slab_over_time listing), it must carry
+// this bound. The setting is RESULT-EQUIVALENT (rows-per-block execution
+// batching only), so stamping it never changes the query's answer.
+//
+// Known scope tradeoff, deliberately accepted rather than left
+// undocumented: max_block_size is a per-QUERY ClickHouse setting, not
+// scoped to a subquery, and planHasSortedSlabOverTime's WalkDeep matches a
+// sorted-slab RangeWindow ANYWHERE in the plan — so a query that combines a
+// sorted-slab branch with an unrelated, otherwise-cheap-to-stream sibling
+// (e.g. a binary op between a sorted-slab sum_over_time() and a large
+// fan-out/native rate() on the other side) pays single-row blocks for the
+// WHOLE statement, not just the sorted-slab subtree. There is no
+// ClickHouse setting that scopes max_block_size to one subquery. This
+// mirrors the tradeoff applySpillSettings and applyCompareMemoryBound
+// already accept in this same file (a memory-safety stamp that costs
+// throughput on the query as a whole rather than only the shape that needs
+// it) — an OOM (total query failure) is strictly worse than a slower
+// success, so unconditional is still the right default. The blast radius
+// is bounded today by chopt.FeatureSortedSlabOverTime's own AutoSelect:
+// false posture (opt-in only), so no production traffic mixes this
+// pattern yet; whoever revisits AutoSelect (see the feature's own doc)
+// should re-examine this tradeoff against real mixed-shape query traffic
+// first.
+func applySortedSlabOverTimeMemoryBound(ctx context.Context, plan chplan.Node) context.Context {
+	if !planHasSortedSlabOverTime(plan) {
+		return ctx
+	}
+	return chclient.WithQuerySetting(ctx, settingMaxBlockSize, sortedSlabOverTimeMaxBlockSize)
+}
+
+// planHasSortedSlabOverTime reports whether plan contains a
+// *chplan.RangeWindow node with SortedSlabOverTime set anywhere in its
+// tree. The sweep is chplan.WalkDeep, matching planHasMetricsCompare /
+// planHasNativeHistogramMerge, so a sorted-slab RangeWindow nested inside a
+// scalar-binding subtree (an Expr slot Walk does not follow) is still
+// found.
+func planHasSortedSlabOverTime(plan chplan.Node) bool {
+	found := false
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		if rw, ok := n.(*chplan.RangeWindow); ok && rw.SortedSlabOverTime {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 // applyNativeHistogramAnalyzerFix stamps enable_analyzer=0 on a query whose
 // plan reaches the native (exponential) histogram merge/window-fold machinery
 // — histogram_quantile.go's promHistogramKahanSum and the deeply-nested

--- a/internal/engine/query_settings_rules_test.go
+++ b/internal/engine/query_settings_rules_test.go
@@ -290,6 +290,77 @@ func TestApplyCompareMemoryBound_NonCompareStampsNeither(t *testing.T) {
 	}
 }
 
+// TestApplySortedSlabOverTimeMemoryBound_SortedSlabStampsMaxBlockSize — a
+// plan carrying a chplan.RangeWindow with SortedSlabOverTime set gets
+// max_block_size=1 stamped (cerberus issue #3046: real ClickHouse profiling
+// found the sorted-slab shape's per-anchor intermediates are retained
+// across an entire vectorized block of series rows, not freed row-by-row,
+// unless the block width is forced to 1).
+func TestApplySortedSlabOverTimeMemoryBound_SortedSlabStampsMaxBlockSize(t *testing.T) {
+	// wantSortedSlabMaxBlockSize is the LITERAL single-row block width the
+	// #3046 measurement validated (see sortedSlabOverTimeMaxBlockSize's own
+	// doc), not a reference to the const under test: computing the
+	// expectation from sortedSlabOverTimeMaxBlockSize itself would pass
+	// under any value that const happened to hold, including one the
+	// measurement never validated.
+	const wantSortedSlabMaxBlockSize = 1
+
+	plan := &chplan.RangeWindow{
+		Input:              &chplan.Scan{Table: "otel_metrics_sum"},
+		SortedSlabOverTime: true,
+	}
+
+	ctx := applySortedSlabOverTimeMemoryBound(context.Background(), plan)
+
+	if got, want := settingValue(ctx, settingMaxBlockSize), wantSortedSlabMaxBlockSize; got != want {
+		t.Errorf("max_block_size = %v; want %v", got, want)
+	}
+}
+
+// TestApplySortedSlabOverTimeMemoryBound_NonSortedSlabStampsNothing — a
+// RangeWindow that does NOT carry SortedSlabOverTime (the default
+// array-fold fan-out shape) never gets max_block_size narrowed: that shape
+// does not carry #3046's per-anchor memory retention, and narrowing its
+// block width would only cost throughput for no benefit.
+func TestApplySortedSlabOverTimeMemoryBound_NonSortedSlabStampsNothing(t *testing.T) {
+	plan := &chplan.RangeWindow{Input: &chplan.Scan{Table: "otel_metrics_sum"}}
+
+	ctx := applySortedSlabOverTimeMemoryBound(context.Background(), plan)
+
+	if got := settingValue(ctx, settingMaxBlockSize); got != nil {
+		t.Errorf("non-sorted-slab plan: max_block_size = %v; want absent", got)
+	}
+}
+
+// TestApplySortedSlabOverTimeMemoryBound_NestedStampsMaxBlockSize — a
+// sorted-slab RangeWindow nested inside a scalar-binding subtree (an Expr
+// slot chplan.Walk does not follow) is still found, mirroring
+// TestApplyNativeHistogramAnalyzerFix_NestedStampsDisabled — the sweep is
+// chplan.WalkDeep.
+func TestApplySortedSlabOverTimeMemoryBound_NestedStampsMaxBlockSize(t *testing.T) {
+	// Literal, not sortedSlabOverTimeMaxBlockSize — see the sibling
+	// wantSortedSlabMaxBlockSize's own doc for why.
+	const wantSortedSlabMaxBlockSize = 1
+
+	inner := &chplan.RangeWindow{
+		Input:              &chplan.Scan{Table: "otel_metrics_sum"},
+		SortedSlabOverTime: true,
+	}
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Projections: []chplan.Projection{{
+			Expr:  &chplan.ScalarSubquery{Input: inner},
+			Alias: "Value",
+		}},
+	}
+
+	ctx := applySortedSlabOverTimeMemoryBound(context.Background(), plan)
+
+	if got, want := settingValue(ctx, settingMaxBlockSize), wantSortedSlabMaxBlockSize; got != want {
+		t.Errorf("max_block_size = %v; want %v", got, want)
+	}
+}
+
 // TestApplyNativeHistogramAnalyzerFix_QuantileStampsDisabled — a plan whose
 // root is chplan.HistogramQuantileNative (histogram_quantile() over a native
 // histogram, e.g. cerberus issue #2355's


### PR DESCRIPTION
## Problem

cerberus#2894's real-ClickHouse A/B measurement found `sorted_slab_over_time`
(cerberus#2761's `sum_over_time()`/`avg_over_time()` decomposition,
`internal/chsql/range_window_sorted_slab.go`) does not actually deliver the
O(samples-in-range)-per-series, anchor-count-independent peak memory its own
doc comment claims: at 500 series / 480 anchors — inside this repo's own
#2429 calibration scale — the array-fold fan-out it exists to replace
finished at 535 MiB while sorted-slab OOMed a 6 GiB container attempting an
880 MiB allocation on top of an already-4.32 GiB resident set.

## Investigation

Real ClickHouse 26.6.4.55 in Docker (matching the issue's own server
version), reproducing the issue's 500-series/480-anchor OOM directly against
the emitted SQL shape (not chDB — a real-server memory-profiling question).

`EXPLAIN PIPELINE` showed the sorted-slab query collapses to a single
`ExpressionTransform` stage after the per-series `GROUP BY`, which evaluates
the whole `arrayMap(a -> ..., anchors)` expression across every row batched
into ONE ClickHouse execution block — not just across the anchors within a
single row. The OOM's own exception stack trace names exactly that
expression (`FUNCTION arrayFilter(...): while executing 'FUNCTION
arrayMap(a -> ...)'`).

A controlled `max_block_size` sweep at the same reproduction confirmed it:
peak memory scales ~linearly with block width.

| max_block_size | peak memory |
| --- | --- |
| 1 | 98 MiB |
| 10 | 436 MiB |
| 50 | 1.74 GiB |
| 100 | 3.43 GiB |
| 250 | 4.86 GiB |
| default (~65505) | OOM (matches the issue exactly) |

This **confirms** the issue's own leading hypothesis: ClickHouse's
vectorized block execution retains the per-anchor intermediates across the
whole block of series rows, not freed row-by-row as the "one slab, sliced
anchor by anchor, freed as it goes" design intended.

## Fix

`internal/engine/query_settings_rules.go` gains
`applySortedSlabOverTimeMemoryBound`, an always-on (not opt-in) engine rule
that stamps `max_block_size=1` on any dispatched query whose plan carries a
`chplan.RangeWindow.SortedSlabOverTime` shape — forcing each series row to
finish (and free its own anchor-grid intermediates) before the next one
starts, restoring the O(samples-in-range)-per-series bound the design
intended. It is unconditional, mirroring `applyCompareMemoryBound` /
`applyNativeHistogramAnalyzerFix` in the same file: a mandatory companion to
an *existing* opt-in shape, not a new optimization of its own.

Re-measured at all four of the issue's own data points, real ClickHouse
26.6.4.55:

| series | span | step (anchors) | window | fan-out mem | sorted-slab mem (before) | sorted-slab mem (fixed) |
| --- | --- | --- | --- | --- | --- | --- |
| 2,200 | 1h | 1m (61) | 5m | 87 MiB | 398 MiB | **8.89 MiB** |
| 500 | 1h | 15s (241) | 5m | 187 MiB | 1.34 GiB | **12.79 MiB** |
| 500 | 2h | 15s (481) | 5m | 438 MiB | OOM | **98.30 MiB** |
| 50 | 2h | 5s (1,441) | 30m | 1.59 GiB | 4.74 GiB | **198.48 MiB** |

(Absolute numbers differ from the issue's own table — this reproduction
uses a simplified single-column table rather than the full OTel
Attributes-map schema — but the qualitative pattern, and the OOM itself,
reproduce exactly.)

Every case now uses **less** memory than the array-fold fan-out it
replaces (previously 1.4-9x more, up to the container OOM), while keeping
most or all of the sorted-slab shape's wall-clock advantage — in the
extreme-anchor-density case it is both 24x less memory AND 3.7x faster than
before.

## Known tradeoff, deliberately accepted and documented

`max_block_size` is a per-QUERY ClickHouse setting, not scoped to a
subquery, and `planHasSortedSlabOverTime`'s `WalkDeep` matches a
sorted-slab `RangeWindow` anywhere in the plan — so a query that combines
a sorted-slab branch with an unrelated, otherwise-cheap sibling (e.g. a
binary op between a sorted-slab `sum_over_time()` and a large fan-out/
native `rate()` on the other side) pays single-row blocks for the WHOLE
statement, not just the sorted-slab subtree. There is no ClickHouse
setting that scopes `max_block_size` to one subquery. This mirrors the
tradeoff `applySpillSettings`/`applyCompareMemoryBound` already accept in
the same file (a memory-safety stamp that costs throughput on the query as
a whole) — an OOM is strictly worse than a slower success. The blast
radius is bounded today by `FeatureSortedSlabOverTime`'s own
`AutoSelect: false` posture (opt-in only, no production traffic mixes this
pattern yet); documented in both `applySortedSlabOverTimeMemoryBound`'s own
doc comment and the registry's `AutoSelect` note as something whoever
revisits `AutoSelect` needs to re-examine against real mixed-shape traffic
first.

Doc comments in `range_window_sorted_slab.go` and `internal/chopt/registry.go`
(`FeatureSortedSlabOverTime`) are corrected: the O(samples-in-range) claim
now states it holds only together with this settings-rule companion.

`FeatureSortedSlabOverTime` stays `AutoSelect: false` in this PR — the
memory defect this issue tracked is fixed, so the flag *could* be
revisited, but that needs its own fresh optcorpus A/B run
(cerberus#2894, already closed with a negative result under the unfixed
shape) rather than being flipped as a side effect of this fix.

## Dependency: #2804

cerberus#2804 ("Extend #2761's sorted-slab `*_over_time` shape: remaining
functions + arraySlice index lookup") is currently held pending this
investigation's outcome. With the memory defect fixed, #2804 can proceed —
whoever picks it up next should extend `applySortedSlabOverTimeMemoryBound`'s
`planHasSortedSlabOverTime` coverage (or confirm the existing `WalkDeep`
sweep already covers it) as each additional `*_over_time` member adopts the
sorted-slab shape, since the memory retention this PR fixes is a property of
the shared SQL SHAPE (`arrayMap` over anchors, `arrayFilter` over the
per-series slab), not specific to `sum`/`avg`.

## Follow-up filed: #3050

`internal/chopttest.BuildRangeLowerers` (the helper every real-ClickHouse
integration/perf test uses) does not wire `RangeLowerers.OverTime` at all —
a pre-existing gap, not introduced here — so no integration/perf-smoke test
can currently exercise `chopt.FeatureSortedSlabOverTime`
(`cerberus_ch_optimizations=sorted_slab_over_time` is unreachable through
that helper), and the perf-smoke harness's `ServerFloor` tiering has no lane
for a non-version-gated, purely opt-in feature like this one. Filed as
cerberus#3050 (sub-issue of the fan-out-reduction epic #2758), citing the
gap that makes this PR's own `applySortedSlabOverTimeMemoryBound` mechanism
currently uncoverable by a real-ClickHouse sentinel.

PERF-SENTINEL-WAIVER: #3050

## Testing

- `just test-unit` passes (race-detected unit + spec suite, plus
  vet-tagged).
- New unit tests in `internal/engine/query_settings_rules_test.go` pin
  `applySortedSlabOverTimeMemoryBound`'s stamp/no-stamp/nested-plan
  behavior.
- No `test/spec` goldens changed — this PR touches only a per-query
  ClickHouse SETTINGS stamp at the dispatch layer, never the emitted SQL
  text `chsql.Emit` produces, so `just update-golden` is not needed.
- `node .github/scripts/forbid-sql-raw.mjs` clean (no raw SQL touched).
- `go run ./cmd/cerberus optdocs -doc docs/clickhouse-optimizations.md`
  produces no diff (only `Doc` field prose changed, not the generated
  structural table).

Closes #3046
