### PR TITLE
feat(promql): extend sorted-slab over_time shape and close arraySlice probe

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1323,13 +1323,19 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 		l.Idelta = promql.DownsampleTierIdeltaLowerer{Fallback: l.Idelta}
 		l.LastOverTime = promql.DownsampleTierLastOverTimeLowerer{Fallback: l.LastOverTime}
 	}
-	// sorted_slab_over_time (issue #2761) has no native timeSeries*ToGrid
-	// competitor: sum_over_time/avg_over_time's only non-fan-out arm is the
-	// sorted-slab decomposition itself, so it is wired directly with no
-	// embedded native layer above it (mirroring quantile_prom_histogram's
-	// posture just above, though this strategy DOES still embed its own
-	// Fallback — the plain fan-out — the way fixed_accumulator_extrapolated
-	// does for rate/increase/delta).
+	// sorted_slab_over_time (issue #2761, widened to first_over_time /
+	// stddev_over_time / stdvar_over_time / mad_over_time by issue #2804)
+	// has no native timeSeries*ToGrid competitor: this whole function set's
+	// only non-fan-out arm is the sorted-slab decomposition itself, so it is
+	// wired directly with no embedded native layer above it (mirroring
+	// quantile_prom_histogram's posture just above, though this strategy
+	// DOES still embed its own Fallback — the plain fan-out — the way
+	// fixed_accumulator_extrapolated does for rate/increase/delta). One
+	// lowerer wiring covers the whole set: which PromQL function names
+	// reach it at all is decided upstream, purely by AST dispatch, in
+	// internal/promql/lower.go's `lowerRangeVectorCallFanout` switch — see
+	// that switch's own doc for why last_over_time deliberately never
+	// reaches this lowerer despite sharing its shape-eligibility check.
 	if optSet.Has(chopt.FeatureSortedSlabOverTime) {
 		l.OverTime = promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}}
 	} else {

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1583,7 +1583,22 @@ func matrixWindowOffset(plan chplan.Node, cols chplan.SampleColumns) (offset tim
 func isMatrixRangeWindow(plan chplan.Node, cols chplan.SampleColumns) bool {
 	switch v := plan.(type) {
 	case *chplan.RangeWindow:
-		return v.OuterRange > 0
+		// v.DownsampleTier is ORed in separately from v.OuterRange > 0
+		// (cerberus issue #2804 investigation): emitRangeWindowDownsampleTier
+		// (internal/chsql/range_window_downsample_tier.go) ALWAYS projects a
+		// real per-row anchor_ts column whenever DownsampleTier is set —
+		// downsampleTierEligible requires Step > 0 and Start/End pinned but
+		// deliberately never reads OuterRange, so a query_range request with
+		// Start == End (a legitimate single-point grid: OuterRange =
+		// End.Sub(Start) = 0) still resolves to exactly one real anchor and
+		// still emits anchor_ts. `OuterRange > 0` alone matches the plain
+		// fan-out family's own invariant (chsql's emitWindowedArray gates its
+		// identical matrix-vs-instant choice on that same field) but
+		// under-fires for this decoupled tier shape, mis-synthesising `now()`
+		// over an otherwise-correct row. See wrapRangeWindowPreserveName's
+		// own doc (internal/promql/lower.go) for the sibling fix and the
+		// executed regression this shape tripped.
+		return v.OuterRange > 0 || v.DownsampleTier
 	case *chplan.RangeWindowGridNative:
 		// The native timeSeriesRateToGrid path is always matrix-shape: it
 		// explodes the grid into one row per anchor and surfaces the

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -709,19 +709,29 @@ const (
 	// range_window_sorted_slab.go's own doc for the full profiling
 	// evidence and the block-size-vs-memory sweep that pinned the cause.
 	//
-	// Scoped to sum_over_time / avg_over_time only, deliberately narrower
-	// than the issue's own full *_over_time proposal (which also names
-	// first/last/stddev/stdvar/mad_over_time): these two are the ones whose
-	// byte-identical contract with the array-fold is the SIMPLEST to state
-	// and verify (arraySum / arrayAvg over the sliced window fold in the
-	// same left-to-right float order the array-fold's identical reducers
-	// already use — see chplan.RangeWindow.SortedSlabOverTime's own doc),
-	// so this cut ships the mandatory arraySlice-preserving-order form the
-	// issue calls out first. min/max/count/present_over_time already skip
+	// Originally scoped to sum_over_time / avg_over_time only (#2761 shipped
+	// only these two: the ones whose byte-identical contract with the
+	// array-fold was the SIMPLEST to state and verify — arraySum / arrayAvg
+	// over the sliced window fold in the same left-to-right float order the
+	// array-fold's identical reducers already use, see
+	// chplan.RangeWindow.SortedSlabOverTime's own doc). Widened by cerberus
+	// issue #2804 to the REST of the array-path family
+	// overTimeArrayValueFrag's switch already dispatched:
+	// first_over_time (a POSITION pick — vals[1] — rather than a reduction;
+	// order preservation is the correctness argument itself, not just a
+	// precision nicety) and stddev_over_time / stdvar_over_time /
+	// mad_over_time (two-pass moment computations over the sliced array;
+	// see range_window_sorted_slab.go's own doc for the per-function
+	// order/precision argument). min/max/count/present_over_time still skip
 	// the array-fold entirely (overTimeDirectAggFrag's direct CH group
-	// aggregate); first/last/stddev/stdvar/mad_over_time extending to the
-	// same slab shape is tracked at
-	// https://github.com/tsouza/cerberus/issues/2804.
+	// aggregate) and never reach this shape either way. last_over_time is
+	// deliberately EXCLUDED even though overTimeArrayValueFrag's switch also
+	// dispatches it — see FeatureTSGridLastOverTime's own doc and
+	// promql.SortedSlabOverTimeLowerer's doc for why its own native
+	// staleness-resample arm already answers the identical question with
+	// more precise semantics than a second, competing sorted-slab arm
+	// would. quantile_over_time is also excluded: it has no sorted-slab
+	// reducer in overTimeArrayValueFrag's switch at all.
 	//
 	// Like fixed_accumulator_extrapolated this is a pure SQL-SHAPE
 	// optimization — groupArray/arraySort/arrayFilter/arraySum/arrayAvg are
@@ -985,9 +995,13 @@ const (
 	// auto promotion. Shares the family's RequiresExperimentalTSGrid gate
 	// (allow_experimental_time_series_aggregate_functions).
 	//
-	// first_over_time has no native sibling: the aggregate carries the
-	// LATEST in-window sample forward, never the earliest, so it stays on
-	// the fan-out unconditionally.
+	// first_over_time has no NATIVE (ts_grid) sibling of this feature: the
+	// timeSeriesResampleToGridWithStaleness aggregate carries the LATEST
+	// in-window sample forward, never the earliest, so first_over_time
+	// never reaches this feature's shape. It does have a different
+	// non-fan-out arm since cerberus issue #2804 — FeatureSortedSlabOverTime's
+	// sorted-slab decomposition, a generic array-slice reducer rather than a
+	// native staleness-resample aggregate (see that feature's own doc).
 	FeatureTSGridLastOverTime = "ts_grid_last_over_time"
 
 	// FeatureDownsampleTier opts eligible LONG-RANGE / low-resolution

--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -327,22 +327,35 @@ type RangeWindow struct {
 	FixedAccumulatorExtrapolated bool
 
 	// SortedSlabOverTime asks the matrix-shape (OuterRange > 0) emitter to
-	// render sum_over_time() / avg_over_time() via a single per-series
-	// groupArray (the "slab") sliced once per anchor with arrayFilter,
-	// instead of the sample-side arrayJoin fan-out +
-	// GROUP BY (series, anchor) regroup (cerberus issue #2761). Peak memory
-	// tracks one sorted array per series rather than one per (series,
-	// anchor) group. Set only by the boot-wired
-	// promql.SortedSlabOverTimeLowerer strategy — never read as a per-query
-	// feature flag.
+	// render sum_over_time() / avg_over_time() / first_over_time() /
+	// stddev_over_time() / stdvar_over_time() / mad_over_time() via a single
+	// per-series groupArray (the "slab") sliced once per anchor with
+	// arrayFilter, instead of the sample-side arrayJoin fan-out +
+	// GROUP BY (series, anchor) regroup (cerberus issue #2761, widened to
+	// this full set by issue #2804). Peak memory tracks one sorted array per
+	// series rather than one per (series, anchor) group. Set only by the
+	// boot-wired promql.SortedSlabOverTimeLowerer strategy — never read as a
+	// per-query feature flag.
 	//
-	// Scoped to sum_over_time / avg_over_time only: their reducers
-	// (arraySum / arrayAvg) fold left-to-right over the sliced window, the
-	// SAME float-addition order the array-fold's arraySum/arrayAvg over
-	// window_vals uses, so the two paths are byte-identical. See
-	// chsql/range_window_sorted_slab.go for the emit side and
-	// internal/chplan/sliceinvariant.go's RangeWindow entry for why this
-	// remains slice-invariant.
+	// Scoped to exactly the six functions above: each one's per-window
+	// reducer, evaluated via overTimeArrayValueFrag (chsql/range_window.go),
+	// is a pure function of the sliced window's ELEMENT ORDER over an
+	// identically-ordered slice — sum_over_time/avg_over_time's arraySum/
+	// arrayAvg fold left-to-right (the SAME float-addition order the
+	// array-fold's identical reducers over window_vals use);
+	// first_over_time picks a fixed POSITION (vals[1]); stddev_over_time/
+	// stdvar_over_time run the two-pass moment computation
+	// (varPopTwoPassFrag) twice over that same order; mad_over_time's
+	// nested medians are order-independent (CH's quantileExactInclusive
+	// sorts internally) but still need the SAME element SET, which the
+	// order-preserving slice guarantees. See chsql/range_window_sorted_slab.go
+	// for the full per-function order/precision argument and the emit side,
+	// and internal/chplan/sliceinvariant.go's RangeWindow entry for why this
+	// remains slice-invariant regardless of which of the six is chosen.
+	// last_over_time is deliberately NOT in this set — see
+	// promql.SortedSlabOverTimeLowerer's own doc for why its existing native
+	// FeatureTSGridLastOverTime staleness-resample arm already answers the
+	// same question with more precise semantics.
 	//
 	// false (the default) keeps the unchanged array-fold emission — the
 	// permanent, always-available fallback the FeatureSortedSlabOverTime

--- a/internal/chplan/sliceinvariant.go
+++ b/internal/chplan/sliceinvariant.go
@@ -100,13 +100,18 @@ func IsSliceInvariant(n Node) bool {
 //     counter-reset windows.
 //
 //     RangeWindow.SortedSlabOverTime=true (issue #2761, sum_over_time() /
-//     avg_over_time()) needs no comparable argument at all: unlike
-//     LagAdjacency / FixedAccumulatorExtrapolated it reads no window
-//     function (no lagInFrame/leadInFrame seeded at the scan's first row).
+//     avg_over_time(), widened by issue #2804 to first_over_time() /
+//     stddev_over_time() / stdvar_over_time() / mad_over_time()) needs no
+//     comparable argument at all: unlike LagAdjacency /
+//     FixedAccumulatorExtrapolated it reads no window function (no
+//     lagInFrame/leadInFrame seeded at the scan's first row).
 //     chsql/range_window_sorted_slab.go's per-anchor value is
-//     `arraySum`/`arrayAvg` over `arrayFilter(samples, a-range < ts <= a)`,
-//     which — same as the base RangeWindow entry above — is a pure
-//     function of that anchor's window membership over `samples`
+//     overTimeArrayValueFrag(r.Func, ...) — arraySum/arrayAvg, a position
+//     pick, or a two-pass moment computation depending on r.Func — over
+//     `arrayFilter(samples, a-range < ts <= a)`, which — same as the base
+//     RangeWindow entry above, and REGARDLESS of which of the six reducers
+//     r.Func selects — is a pure function of that anchor's window membership
+//     over `samples`
 //     (itself the per-series groupArray over Input, widened by
 //     RangeWindow.InputWindow exactly like every other RangeWindow shard),
 //     with no cross-anchor or scan-position state threaded through. Verified

--- a/internal/chsql/range_window_sorted_slab.go
+++ b/internal/chsql/range_window_sorted_slab.go
@@ -47,16 +47,35 @@ import "github.com/tsouza/cerberus/internal/chplan"
 //
 // Order/precision: the per-anchor window slice feeds overTimeArrayValueFrag
 // UNCHANGED — the exact function the array-fold's own outer SELECT calls —
-// so sum_over_time's arraySum and avg_over_time's arrayAvg fold their
-// slice in the SAME left-to-right order the array-fold's arraySum/arrayAvg
-// over window_vals uses (arrayFilter preserves the samples array's
-// arraySort-ascending relative order, element for element). This is the
-// "arraySlice[-shaped] form ... MANDATORY ... under the byte-identical
-// contract" the issue calls for: reusing the identical reducer over an
-// identically-ordered slice, rather than introducing arrayReduceInRanges
-// (whose segment-tree partial-state merging would reorder the float
-// summation and break byte-identity with the array-fold — see
-// chplan.RangeWindow.SortedSlabOverTime's own doc).
+// so every reducer this shape covers folds the slice in the SAME
+// left-to-right order the array-fold's identical reducer over window_vals
+// uses (arrayFilter preserves the samples array's arraySort-ascending
+// relative order, element for element). This is the "arraySlice[-shaped]
+// form ... MANDATORY ... under the byte-identical contract" the issue calls
+// for: reusing the identical reducer over an identically-ordered slice,
+// rather than introducing arrayReduceInRanges (whose segment-tree
+// partial-state merging would reorder the float summation and break
+// byte-identity with the array-fold — see
+// chplan.RangeWindow.SortedSlabOverTime's own doc). Per function:
+//
+//   - sum_over_time / avg_over_time: arraySum / arrayAvg — a single
+//     left-to-right fold, unaffected by anything but element order.
+//   - first_over_time: `vals[1]` — a POSITION pick, not a reduction; order
+//     preservation is not merely a precision nicety here but the entire
+//     correctness argument (a shuffled slice picks the wrong element).
+//   - stddev_over_time / stdvar_over_time: the two-pass
+//     `μ = arrayAvg(vals); Σ(x-μ)² / N` (varPopTwoPassFrag) — TWO
+//     left-to-right folds over the identically-ordered slice (one for μ, one
+//     for the centred sum), so the same order argument applies twice.
+//   - mad_over_time: two nested applications of the SAME
+//     quantileExactInclusive(0.5) median (medianOverArrayFrag) — CH's
+//     quantile implementation sorts its input internally, so it is already
+//     order-INDEPENDENT of the slice's incoming order; byte-identity here
+//     therefore rests on set-membership equality (same elements survive the
+//     slice, whichever order they arrive in), not fold order.
+//
+// See range_window_sorted_slab_chdb_test.go's per-function subtests for the
+// executed byte-identical-contract proof of each.
 //
 // Duplicate rows: the slab is assembled through the SAME windowSamplePairsFrag
 // gate the array-fold path uses (range_window.go), so it answers under the
@@ -69,22 +88,61 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // here, exactly as the array-fold's own window_vals does (cerberus issue
 // #2905).
 //
-// Deliberately arrayFilter, not arraySlice-via-binary-search: `samples` is
-// NOT anchor-grid-aligned (raw sample timestamps), so cutting an anchor's
-// window out of it needs a real index lookup (e.g. a binary-search-style
-// function) rather than the arithmetic grid-index math
-// range_window_fused.go's coveredValuesFrag uses for two co-aligned anchor
-// grids. Locating (lo, hi) via such a lookup was not verified against this
-// codebase's pinned chDB substrate in this change, so it stays a documented
-// follow-up (issue #2804) rather than shipping unverified; arrayFilter is
-// the proven-safe idiom (byte-for-byte range_window_fused.go's own sliceOf)
-// that already delivers this issue's actual goal — O(samples-in-range) peak
-// memory per series, independent of anchor count — without it.
+// Deliberately arrayFilter, not arraySlice-via-binary-search — CLOSED with a
+// negative result (cerberus issue #2804), not an open follow-up:
 //
-// Scope: sum_over_time / avg_over_time only — chopt.FeatureSortedSlabOverTime
-// documents why the remaining array-path *_over_time members
-// (first/last/stddev/stdvar/mad_over_time) are tracked as a follow-up
-// (issue #2804) rather than included here.
+// `samples` is NOT anchor-grid-aligned (raw sample timestamps), so cutting
+// an anchor's window out of it needs a real index LOOKUP (find the (lo, hi)
+// position bounding the `(a-range, a]` interval) rather than the arithmetic
+// grid-index math range_window_fused.go's coveredValuesFrag uses for two
+// co-aligned anchor grids. #2761 punted this for lack of a verified
+// function name/version floor; #2804 went and verified it, against this
+// codebase's pinned chDB substrate (ClickHouse 26.5.1.1, `SELECT version()`)
+// and the upstream ClickHouse array-functions reference:
+//
+//   - `system.functions` on that substrate carries no arrayBinarySearch,
+//     lower-bound, upper-bound, or bisect-shaped array function of any
+//     name — confirmed by direct query, not by absence-of-recall.
+//   - The one function that DOES run a genuine binary-search algorithm over
+//     a sorted array, `indexOfAssumeSorted(arr, x)` (added ClickHouse 2024),
+//     has the wrong CONTRACT for this site: it is an EXACT-match search —
+//     verified live, it returns 0 for a probe value that falls strictly
+//     between two elements, below the array's minimum, or above its
+//     maximum, exactly like plain `indexOf`, just faster on a large sorted
+//     array. It answers "is x present, and where", never "how many
+//     elements are <= x" (the insertion-point / lower-bound question an
+//     anchor boundary — an arbitrary timestamp essentially never equal to a
+//     stored sample — actually needs). No combination of `indexOfAssumeSorted`
+//     calls recovers a lower-bound answer without first locating a
+//     guaranteed-present probe value, which the boundary itself is not.
+//   - The upstream ClickHouse docs' own array-functions reference lists no
+//     binary-search, sorted-array index-lookup, lower-bound, upper-bound,
+//     insertion-point, or bisect function either.
+//
+// With no verified function at any available version floor, arraySlice-via-
+// binary-search has no implementation to measure — the negative result IS
+// the answer, mirroring this codebase's other closed-without-a-function
+// investigations (#2768, #2750, #2923, #2894). arrayFilter stays the
+// mechanism: it is the proven-safe idiom (byte-for-byte
+// range_window_fused.go's own sliceOf) that already delivers this issue's
+// actual goal — O(samples-in-range) peak memory per series, independent of
+// anchor count (cerberus issue #2761, memory-bound-corrected by #3046/#3051)
+// — without needing an index lookup at all. Re-open only if a future
+// ClickHouse version ships a real lower-bound/upper-bound array primitive;
+// until then this file's own arrayFilter cost (an O(samples) re-scan per
+// anchor) is a CPU refinement with no verified path forward, not a
+// correctness or memory gap.
+//
+// Scope: sum_over_time / avg_over_time / first_over_time / stddev_over_time /
+// stdvar_over_time / mad_over_time — chopt.FeatureSortedSlabOverTime
+// documents the #2761 → #2804 widening history. last_over_time is
+// deliberately EXCLUDED (its own native FeatureTSGridLastOverTime staleness
+// resample already answers the same question — see
+// promql.SortedSlabOverTimeLowerer's own doc for the precedence
+// argument); quantile_over_time and the min/max/count/present_over_time
+// direct-aggregate family never reach this emitter at all (see
+// overTimeArrayValueFrag's own doc and emitRangeWindowOverTime's
+// overTimeDirectAggFrag fast path).
 
 // emitRangeWindowSortedSlabOverTime renders the sorted-slab SQL skeleton for
 // a shape-eligible matrix sum_over_time / avg_over_time RangeWindow:

--- a/internal/chsql/range_window_sorted_slab_chdb_test.go
+++ b/internal/chsql/range_window_sorted_slab_chdb_test.go
@@ -1,7 +1,9 @@
 //go:build chdb
 
 // chDB-backed dual-emit parity pin for the sorted-slab decomposition
-// (chplan.RangeWindow.SortedSlabOverTime, cerberus issue #2761).
+// (chplan.RangeWindow.SortedSlabOverTime, cerberus issue #2761, widened to
+// first_over_time / stddev_over_time / stdvar_over_time / mad_over_time by
+// issue #2804).
 //
 // Like laginframe_adjacency / fixed_accumulator_extrapolated, the sorted-slab
 // shape needs no server-version floor or experimental setting —
@@ -15,13 +17,16 @@
 // values.
 //
 // Unlike rate/increase's fixed-accumulator counter-reset term (which sums
-// floats in ClickHouse's own non-deterministic sumIf order), sum_over_time /
-// avg_over_time's reducers here are arraySum/arrayAvg applied to a slice that
-// preserves the array-fold's own element order (arrayFilter over samples,
-// samples arraySort-ascending — see range_window_sorted_slab.go's own doc).
-// Both arms therefore fold the SAME elements in the SAME order, so this
-// assertion is BIT-IDENTICAL (math.Float64bits equality), not merely
-// ULP-bounded.
+// floats in ClickHouse's own non-deterministic sumIf order), every reducer
+// in this family — overTimeArrayValueFrag(r.Func, vals), whichever of the
+// six functions selects it — is applied to a slice that preserves the
+// array-fold's own element order (arrayFilter over samples, samples
+// arraySort-ascending — see range_window_sorted_slab.go's own doc for the
+// per-function order/precision argument, including mad_over_time's
+// order-independent-but-set-dependent quantile pair). Both arms therefore
+// fold/pick from the SAME elements in the SAME order, so this assertion is
+// BIT-IDENTICAL (math.Float64bits equality), not merely ULP-bounded, for
+// every function in the loop below.
 package chsql_test
 
 import (
@@ -41,7 +46,9 @@ import (
 	"github.com/tsouza/cerberus/internal/testsql"
 )
 
-// sortedSlabOverTimeSeed covers sum_over_time() / avg_over_time()'s edge
+// sortedSlabOverTimeSeed covers the whole sorted-slab function family's
+// (sum_over_time / avg_over_time / first_over_time / stddev_over_time /
+// stdvar_over_time / mad_over_time, cerberus issues #2761 and #2804) edge
 // cases over a Gauge table:
 //   - 'walk': a normal up/down gauge walk (6 samples across the window).
 //   - 'boundary': exactly 2 samples, one sitting right at the window's
@@ -90,7 +97,10 @@ func TestSortedSlabOverTime_DualEmitParity(t *testing.T) {
 		}
 	}
 
-	for _, fn := range []string{"sum_over_time", "avg_over_time"} {
+	for _, fn := range []string{
+		"sum_over_time", "avg_over_time",
+		"first_over_time", "stddev_over_time", "stdvar_over_time", "mad_over_time",
+	} {
 		t.Run(fn, func(t *testing.T) {
 			query := "sum by(job) (" + fn + "(cpu_temp_celsius[5m]))"
 			var fanoutLowerers, slabLowerers promql.RangeLowerers

--- a/internal/promql/duplicate_timestamp_seed_chdb_test.go
+++ b/internal/promql/duplicate_timestamp_seed_chdb_test.go
@@ -7,10 +7,15 @@
 //
 // # Why this is the right oracle, and a reference engine is not
 //
-// Three TXTAR fixtures seed such a duplicate on purpose, to pin how their
+// Seven TXTAR fixtures seed such a duplicate on purpose, to pin how their
 // strategy treats the pair: sorted_slab_sum_over_time_range_step.txtar,
-// sorted_slab_avg_over_time_range_step.txtar and
-// lag_adjacency_idelta_duplicate_ts.txtar. All three used to also enrol for
+// sorted_slab_avg_over_time_range_step.txtar,
+// sorted_slab_first_over_time_range_step.txtar,
+// sorted_slab_stddev_over_time_range_step.txtar,
+// sorted_slab_stdvar_over_time_range_step.txtar,
+// sorted_slab_mad_over_time_range_step.txtar (cerberus issue #2804 widened
+// the sorted-slab family from the first two to all six) and
+// lag_adjacency_idelta_duplicate_ts.txtar. All seven used to also enrol for
 // parity against the upstream Prometheus engine, and that enrolment was
 // self-contradictory: Prometheus's TSDB appender stores at most one sample per
 // (series, timestamp) — parityoracle/promql/oracle.go feeds a real teststorage
@@ -481,6 +486,10 @@ func dupTSMax(vals []float64) float64 {
 // timestamp order, so that is the final element.
 func dupTSLast(vals []float64) float64 { return vals[len(vals)-1] }
 
+// dupTSFirst reads the time-EARLIEST sample: the slices are in ascending
+// timestamp order, so that is the first element — dupTSLast's mirror.
+func dupTSFirst(vals []float64) float64 { return vals[0] }
+
 // dupTSPresent is present_over_time's reducer: 1 for any non-empty window.
 func dupTSPresent([]float64) float64 { return 1 }
 
@@ -552,6 +561,7 @@ var dupTSOverTimeFamily = []dupTSOverTimeCase{
 	{call: "min_over_time(%s[5m])", reduce: dupTSMin, immune: true},
 	{call: "max_over_time(%s[5m])", reduce: dupTSMax, immune: true},
 	{call: "last_over_time(%s[5m])", reduce: dupTSLast, immune: true},
+	{call: "first_over_time(%s[5m])", reduce: dupTSFirst, immune: true},
 	{call: "present_over_time(%s[5m])", reduce: dupTSPresent, immune: true},
 }
 
@@ -612,14 +622,25 @@ func TestIdenticalDuplicateTimestamp_OverTimeFamilyCountsItOnce(t *testing.T) {
 }
 
 // dupTSSortedSlabEligible is the set of *_over_time functions
-// promql.SortedSlabOverTimeLowerer actually decomposes — its scope is
-// sum_over_time / avg_over_time (internal/chsql/range_window_sorted_slab.go).
-// The cross-strategy test asserts the emitted SQL differs for EXACTLY these
-// and for no others, so an eligibility change cannot quietly turn a
+// promql.SortedSlabOverTimeLowerer actually decomposes — sum_over_time /
+// avg_over_time (cerberus issue #2761) widened to first_over_time /
+// stddev_over_time / stdvar_over_time / mad_over_time (cerberus issue #2804)
+// — internal/chsql/range_window_sorted_slab.go. last_over_time is
+// deliberately absent despite dupTSOverTimeFamily covering it: it routes
+// through the family's own LastOverTimeLowerer chain, never
+// promql.SortedSlabOverTimeLowerer (see that lowerer's own doc for the
+// precedence argument). quantile_over_time is absent because
+// overTimeArrayValueFrag has no sorted-slab reducer for it at all. The
+// cross-strategy test asserts the emitted SQL differs for EXACTLY these and
+// for no others, so an eligibility change cannot quietly turn a
 // cross-strategy comparison into a comparison of an answer with itself.
 var dupTSSortedSlabEligible = map[string]bool{
-	"sum_over_time": true,
-	"avg_over_time": true,
+	"sum_over_time":    true,
+	"avg_over_time":    true,
+	"first_over_time":  true,
+	"stddev_over_time": true,
+	"stdvar_over_time": true,
+	"mad_over_time":    true,
 }
 
 // TestIdenticalDuplicateTimestamp_EveryLoweringAgrees runs the same family

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -4276,7 +4276,7 @@ func appendNameGroupKey(rw *chplan.RangeWindow, s schema.Metrics) *chplan.Column
 // `s.TimestampColumn` alias verbatim either way.
 func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name chplan.Expr) chplan.Node {
 	var tsExpr chplan.Expr
-	if rw.OuterRange > 0 {
+	if rw.OuterRange > 0 || rw.DownsampleTier {
 		// The matrix RangeWindow keeps anchor_ts offset-SHIFTED for the
 		// window/reduce math; PromQL reports a reducing window's result on the
 		// UNSHIFTED grid, so add Offset back (matching the emitter's
@@ -4285,6 +4285,30 @@ func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name 
 		// offset needs no relabel. Without this, last_over_time / first_over_time
 		// (the only *_over_time fns that keep __name__ and so route through this
 		// preserve-name wrapper) re-shifted their output past this Project.
+		//
+		// rw.DownsampleTier is ORed in separately from rw.OuterRange > 0
+		// (cerberus issue #2804 investigation): emitRangeWindowDownsampleTier
+		// (internal/chsql/range_window_downsample_tier.go) ALWAYS projects a
+		// real per-row anchor_ts column whenever DownsampleTier is set —
+		// downsampleTierEligible requires Step > 0 and Start/End pinned but
+		// deliberately never reads OuterRange (see that function's own doc),
+		// so its numAnchors math is a pure Start/End/Step computation,
+		// independent of OuterRange. That decouples the invariant the plain
+		// fan-out family upholds — OuterRange > 0 exactly when the emitter
+		// takes chsql's own matrix (anchor_ts-bearing) path,
+		// emitWindowedArray's own `if r.OuterRange > 0` gate — so `OuterRange
+		// > 0` alone under-fires for a DEGENERATE but legitimate tier-routed
+		// shape: a query_range request with Start == End (a single-point
+		// grid) computes OuterRange = End.Sub(Start) = 0 while Step still
+		// carries a real value, and downsampleTierEligible's own numAnchors
+		// formula (`End.Sub(Start)/stepNS + 1`) still resolves to exactly one
+		// anchor and still emits anchor_ts. Without this clause the wrap fell
+		// to the synthesized-`now()` branch below for that shape, stamping
+		// the WRONG timestamp on an otherwise-correct row rather than
+		// reading the real anchor_ts the emitter actually produced —
+		// TestDownsampleTier_ChdbCorruptedBucketPostMergeFilter's
+		// last_over_time@anchor lookup silently missed its row over exactly
+		// this shape (start == end == anchor) before this clause was added.
 		tsExpr = &chplan.ColumnRef{Name: chplan.RangeWindowAnchorColumn}
 		if rw.Offset != 0 && !rw.Identity {
 			tsExpr = chplan.OffsetReanchoredAnchorExpr(rw.Offset)

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -3291,24 +3291,54 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 	// per series, so `preservedNameExpr` threads MetricName through the
 	// window's grouping key instead.
 	//
-	// That synthesis is only needed for the plain fan-out RangeWindow (node
-	// == rw): NativeLastOverTimeLowerer's RangeWindowStaleResample is
-	// ALREADY the canonical 4-column shape — its GROUP BY reads the real
-	// per-row MetricName column, so `__name__` rides through natively for
-	// both a pinned literal and a multi-name regex selector alike (see
-	// nativeLastOverTimeNode's own doc). Wrapping it again would double a
-	// Project that is a no-op at best and, for the regex case, would
-	// silently re-collapse the very per-name split the native GROUP BY
-	// already performed. `node != rw` is exactly "the boot-wired strategy
-	// swapped in something other than the fan-out RangeWindow it was
-	// handed" — true only for this one case among rangeFnPreservesName's
-	// two members (first_over_time has no native strategy and always keeps
-	// node == rw).
+	// That synthesis is only needed when the returned node is STILL a
+	// derived shape lacking a real MetricName column (chplan.IsDerivedShape
+	// — the SAME classifier the HTTP layer's wrapWithSampleProjection uses,
+	// see that function's own doc): NativeLastOverTimeLowerer's
+	// RangeWindowStaleResample is ALREADY the canonical 4-column shape — its
+	// GROUP BY reads the real per-row MetricName column, so `__name__`
+	// rides through natively for both a pinned literal and a multi-name
+	// regex selector alike (see nativeLastOverTimeNode's own doc). Wrapping
+	// it again would double a Project that is a no-op at best and, for the
+	// regex case, would silently re-collapse the very per-name split the
+	// native GROUP BY already performed.
+	//
+	// This is deliberately a SHAPE check (`chplan.IsDerivedShape`), not the
+	// `node != chplan.Node(rw)` pointer check an earlier version of this
+	// function used. Pointer inequality was a correct proxy only as long as
+	// every *chplan.RangeWindow-typed strategy left `node` aliasing `rw`
+	// unchanged and only a genuinely different node TYPE (RangeWindowStaleResample)
+	// signalled "already canonical". SortedSlabOverTimeLowerer breaks that
+	// assumption for first_over_time (cerberus issue #2804): its eligible
+	// branch returns `&out`, a shallow COPY of rw with SortedSlabOverTime
+	// set — a different pointer, but still a plain *chplan.RangeWindow with
+	// the exact same derived (Attributes, [anchor_ts,] Value) output schema
+	// rw itself has, still missing MetricName. Under the old pointer check
+	// that copy would have wrongly skipped this wrap and silently dropped
+	// `__name__` from every sorted-slab first_over_time result — the shape
+	// check gets both cases right from the one classifier both this
+	// function and the HTTP layer already share.
 	if rangeFnPreservesName(c.Func.Name) {
-		if node != chplan.Node(rw) {
+		if !chplan.IsDerivedShape(node, canonicalSampleColumns(s)) {
 			return node, nil
 		}
-		return wrapRangeWindowPreserveName(rw, s, preservedNameExpr(rw, vs.LabelMatchers, s)), nil
+		// Wrap whichever *chplan.RangeWindow the strategy actually returned
+		// — NOT the original rw unconditionally. node and rw are the SAME
+		// pointer for the plain fan-out fallback, but a strategy that
+		// returns a shallow copy carrying its own flag (SortedSlabOverTime,
+		// DownsampleTier, ...) is a DIFFERENT *chplan.RangeWindow value;
+		// wrapping the stale original rw here would silently discard that
+		// flag and re-emit the un-optimised fan-out SQL despite the
+		// strategy having chosen the faster shape. The type assertion can
+		// only fail for a derived-shape node this range-vector call path
+		// never produces (every branch above returns rw itself or a
+		// *chplan.RangeWindow copy of it), so rw is a safe, unreachable-in-
+		// practice fallback rather than a silent behavioural difference.
+		target := rw
+		if asWindow, ok := node.(*chplan.RangeWindow); ok {
+			target = asWindow
+		}
+		return wrapRangeWindowPreserveName(target, s, preservedNameExpr(target, vs.LabelMatchers, s)), nil
 	}
 	if guardNameCollision {
 		return wrapDropNameCollisionGuard(node, s, dropNameGuardAnchor(node, rw),
@@ -3342,9 +3372,11 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 // (rate/increase/changes/resets/deriv/delta/irate/idelta: timeSeries*ToGrid
 // for a shape-eligible window; last_over_time: the SAME
 // timeSeriesResampleToGridWithStaleness aggregate ts_grid_resample rides,
-// with [range] as the staleness parameter; sum_over_time/avg_over_time: the
+// with [range] as the staleness parameter; sum_over_time/avg_over_time/
+// first_over_time/stddev_over_time/stdvar_over_time/mad_over_time: the
 // sorted-slab decomposition, chplan.RangeWindow.SortedSlabOverTime (cerberus
-// issue #2761), which has no native ts_grid competitor at all;
+// issue #2761, widened to this full set by #2804), which has no native
+// ts_grid competitor at all;
 // changes/resets/irate/idelta additionally fall back to
 // chplan.RangeWindow.LagAdjacency for a shape-eligible window when their own
 // native path is off or ineligible) and delegates to its embedded fan-out
@@ -3362,27 +3394,39 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 // — because it is already the canonical 4-column output, not a windowed
 // array feeding an outer reducer; see nativeLastOverTimeNode's own doc.
 //
-// For a window with no dedicated strategy (first_over_time and the other
-// *_over_time siblings besides sum_over_time/avg_over_time/last_over_time)
-// the Rate strategy's fan-out fallback returns rw unchanged, so the caller's
-// node stays rw and the last/first_over_time name-preservation wrap applies
-// exactly as before. For rate / increase / delta / sum_over_time /
-// avg_over_time the returned node IS the lowering (native, fixed-accumulator,
-// sorted-slab, or fan-out RangeWindow); all five drop `__name__`, so they
-// never match the name-preservation wrap and flow through as-is.
-// last_over_time's returned node also IS the lowering when its native
-// strategy fires — but unlike those five it DOES match the name-preservation
-// wrap (it is one of the two functions that keeps `__name__`), so the caller
-// compares the returned node against rw to skip the now-redundant synthesis
-// wrap (see the `node != chplan.Node(rw)` check above).
+// For a window with no dedicated strategy at all — quantile_over_time (no
+// sorted-slab reducer in overTimeArrayValueFrag's switch) and
+// min/max/count/present_over_time (already skip the array-fold entirely via
+// overTimeDirectAggFrag, so they never need one) — the Rate strategy's
+// fan-out fallback returns rw unchanged, so the caller's node stays rw. For
+// rate / increase / delta / sum_over_time / avg_over_time / stddev_over_time
+// / stdvar_over_time / mad_over_time the returned node IS the lowering
+// (native, fixed-accumulator, sorted-slab, or fan-out RangeWindow); all
+// eight drop `__name__`, so they never match the name-preservation wrap and
+// flow through as-is. last_over_time / first_over_time's returned node also
+// IS the lowering when a dedicated strategy fires for them — but unlike
+// those eight they DO match the name-preservation wrap (they are the two
+// functions that keep `__name__`), so the caller checks whether the
+// returned node ALREADY exposes the canonical (MetricName, Attributes,
+// Timestamp, Value) shape (`!chplan.IsDerivedShape(node, ...)` below) to
+// decide whether the synthesis wrap is now redundant. That check is
+// SHAPE-based, not pointer-based, because first_over_time's sorted-slab arm
+// returns a plain `*chplan.RangeWindow` copy (a different pointer than rw,
+// but the SAME derived shape rw has, still missing MetricName) while
+// last_over_time's native arm returns a `*chplan.RangeWindowStaleResample`
+// (a different pointer AND a different, already-canonical shape) — a bare
+// pointer inequality cannot tell those two apart, and first_over_time is the
+// case that makes the difference observable: skipping the wrap for it would
+// silently drop `__name__` from every sorted-slab first_over_time result.
 //
 // The function family is selected by c.Func.Name — pure AST/func dispatch,
 // NOT a feature/version branch (that decision is baked into WHICH concrete
 // strategy boot wired into each field). Each strategy is always non-nil
 // (withDefaults) and keeps its own intrinsic shape-eligibility inside the
 // impl. rate / increase / delta / changes / resets / deriv / irate / idelta /
-// last_over_time / sum_over_time / avg_over_time each route to their own
-// boot-wired strategy
+// last_over_time / sum_over_time / avg_over_time / first_over_time /
+// stddev_over_time / stdvar_over_time / mad_over_time each route to their
+// own boot-wired strategy
 // (changes/resets/irate/idelta may ADDITIONALLY resolve to the lagInFrame
 // annotation shape, chplan.RangeWindow.LagAdjacency, layered BENEATH each
 // function's own native ts_grid strategy — irate/idelta gained their own
@@ -3397,15 +3441,20 @@ func lowerRangeVectorCall(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpla
 // its own native ts_grid_delta competitor (cerberus issue #2745), so all
 // three of rate / increase / delta share the same three-tier
 // Native{Fallback: FixedAccumulator{Fallback: Fanout{}}} shape;
-// sum_over_time/avg_over_time have no native ts_grid competitor at all —
+// sum_over_time/avg_over_time/first_over_time/stddev_over_time/
+// stdvar_over_time/mad_over_time have no native ts_grid competitor at all —
 // their only non-fan-out arm is the sorted-slab decomposition,
-// chplan.RangeWindow.SortedSlabOverTime, cerberus issue #2761; last_over_time
-// has no such narrowed-fallback sibling of its own — its
-// NativeLastOverTimeLowerer embeds the bare fan-out directly); every OTHER
-// range fn (first_over_time and the rest of the *_over_time family) keeps
-// the fan-out rw via the rate strategy's pass-through (those funcs have no
-// native timeSeries*ToGrid aggregate, lagInFrame annotation,
-// fixed-accumulator, or sorted-slab decomposition proven equivalent yet).
+// chplan.RangeWindow.SortedSlabOverTime, cerberus issue #2761 (widened to
+// this full set by #2804 — see the `case "sum_over_time", ...` arm above for
+// why last_over_time stays OUT of this set despite sharing the
+// rangeFnPreservesName / __name__-preserving behaviour); last_over_time has
+// no such narrowed-fallback sibling of its own — its NativeLastOverTimeLowerer
+// embeds the bare fan-out directly); every OTHER range fn (quantile_over_time
+// and the direct-aggregate *_over_time family) keeps the fan-out rw via the
+// rate strategy's pass-through (those funcs have no native timeSeries*ToGrid
+// aggregate, lagInFrame annotation, fixed-accumulator, or sorted-slab
+// decomposition proven equivalent, or — for min/max/count/present_over_time —
+// need none at all).
 func lowerRangeVectorCallFanout(c *parser.Call, s schema.Metrics, ctx lowerCtx, rw *chplan.RangeWindow) chplan.Node {
 	applyStepGridFanout(rw, ctx)
 	// rate/increase/delta are the only functions whose array-fold fallback
@@ -3431,7 +3480,32 @@ func lowerRangeVectorCallFanout(c *parser.Call, s schema.Metrics, ctx lowerCtx, 
 		return ctx.lowerers.Idelta.LowerIdelta(rw, s)
 	case "last_over_time":
 		return ctx.lowerers.LastOverTime.LowerLastOverTime(rw, s)
-	case "sum_over_time", "avg_over_time":
+	// sum_over_time / avg_over_time / first_over_time / stddev_over_time /
+	// stdvar_over_time / mad_over_time (cerberus issue #2761, widened by
+	// #2804) all ride the SAME OverTimeLowerer — overTimeArrayValueFrag's
+	// switch (internal/chsql/range_window.go) already renders every one of
+	// their per-window reducers over an arbitrary sliced values array, so
+	// the sorted-slab decomposition's `vals` slice (sortedSlabWindowValsFrag)
+	// feeds all six identically; only the byte-identical-contract PROOF
+	// differs per function (see range_window_sorted_slab_chdb_test.go and
+	// duplicate_timestamp_seed_chdb_test.go's dupTSSortedSlabEligible).
+	// last_over_time is DELIBERATELY excluded from this list — see the
+	// `case "last_over_time"` arm just above and chopt.FeatureSortedSlabOverTime's
+	// own doc for why last_over_time's existing native
+	// FeatureTSGridLastOverTime arm (a staleness-window resample, not a
+	// generic array reduction) already answers the "avoid the array-fold
+	// fan-out" question for last_over_time with more precise semantics than
+	// a second, competing sorted-slab arm would — extending sorted-slab to
+	// it would create two overlapping mechanisms for one function with no
+	// precedence rule between them. quantile_over_time / min_over_time /
+	// max_over_time / count_over_time / present_over_time stay OUT of this
+	// list too: quantile_over_time has no sorted-slab reducer wired in
+	// overTimeArrayValueFrag's switch, and min/max/count/present_over_time
+	// already skip the array-fold entirely via overTimeDirectAggFrag's
+	// direct CH group aggregate (chsql/range_window.go), so they never reach
+	// an OverTimeLowerer at all.
+	case "sum_over_time", "avg_over_time",
+		"first_over_time", "stddev_over_time", "stdvar_over_time", "mad_over_time":
 		return ctx.lowerers.OverTime.LowerOverTime(rw, s)
 	default:
 		return ctx.lowerers.Rate.LowerRate(rw, s)

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -184,12 +184,30 @@ type IdeltaLowerer interface {
 // Unlike every other RangeLowerers member, the two functions
 // [rangeFnPreservesName] names (last_over_time, first_over_time) keep
 // `__name__` on their output — so LowerLastOverTime's caller
-// (lowerRangeVectorCall) treats a returned node that differs from the input
-// rw as ALREADY the canonical named shape (see nativeLastOverTimeNode's own
-// doc) rather than routing it through the fan-out's name-synthesis wrap.
-// first_over_time has no native sibling — the aggregate carries the LATEST
-// in-window sample forward, never the earliest — so it stays on the fan-out
-// unconditionally and never reaches this interface at all.
+// (lowerRangeVectorCall) treats a returned node that is ALREADY the
+// canonical (MetricName, Attributes, Timestamp, Value) shape
+// (`!chplan.IsDerivedShape(node, ...)` — see nativeLastOverTimeNode's own
+// doc for the native case) as needing no further wrap, rather than routing
+// it through the fan-out's name-synthesis wrap. That check is shape-based
+// rather than pointer-based precisely because a plain *chplan.RangeWindow
+// copy carrying a different bool flag (SortedSlabOverTime, DownsampleTier)
+// is a DIFFERENT pointer from rw while still being the SAME derived shape —
+// see lowerRangeVectorCall's own doc for the case that makes the
+// distinction observable.
+//
+// first_over_time has no NATIVE sibling of its own — no ts_grid aggregate
+// carries the EARLIEST in-window sample forward the way
+// timeSeriesResampleToGridWithStaleness carries the latest — so it never
+// reaches THIS interface at all. It does, since cerberus issue #2804, reach
+// a different dedicated strategy for the identical "avoid the array-fold
+// fan-out" question: OverTimeLowerer's sorted-slab decomposition (see
+// SortedSlabOverTimeLowerer's own doc and the
+// `case "sum_over_time", ... "first_over_time", ...` arm in
+// lowerRangeVectorCallFanout). last_over_time is the mirror case: it stays
+// OUT of OverTimeLowerer/SortedSlabOverTimeLowerer precisely because THIS
+// interface's native arm already answers the same question for it with
+// staleness-window semantics a generic array-slice reducer cannot
+// replicate.
 type LastOverTimeLowerer interface {
 	// LowerLastOverTime returns the chplan node for rw — the native
 	// RangeWindowStaleResample for a shape the impl handles, or the fan-out
@@ -885,9 +903,27 @@ func (FanoutOverTimeLowerer) LowerOverTime(rw *chplan.RangeWindow, _ schema.Metr
 }
 
 // SortedSlabOverTimeLowerer is the boot-wired OverTimeLowerer that emits
-// RangeWindow{SortedSlabOverTime: true} for a shape-eligible sum_over_time /
-// avg_over_time range-window (cerberus issue #2761). cmd/cerberus wires it
-// ONLY when chopt resolved sorted_slab_over_time at boot.
+// RangeWindow{SortedSlabOverTime: true} for a shape-eligible range-window
+// (cerberus issue #2761, sum_over_time / avg_over_time only; widened by
+// issue #2804 to first_over_time / stddev_over_time / stdvar_over_time /
+// mad_over_time — the full set overTimeArrayValueFrag's switch dispatches).
+// cmd/cerberus wires it ONLY when chopt resolved sorted_slab_over_time at
+// boot.
+//
+// last_over_time is DELIBERATELY not among the functions that reach this
+// lowerer at all — lowerRangeVectorCallFanout dispatches it to its own
+// LastOverTimeLowerer chain instead (see that interface's own doc). This
+// lowerer's own eligibility check, sortedSlabOverTimeEligible below, is pure
+// query SHAPE (Identity / grid / Variants) and carries no function-name
+// clause — the exclusion is enforced entirely by the CALLER never handing
+// last_over_time's RangeWindow to this lowerer in the first place, because
+// last_over_time already has a more specialised, purpose-built native
+// mechanism (chopt.FeatureTSGridLastOverTime's
+// timeSeriesResampleToGridWithStaleness) answering the identical
+// "avoid the array-fold fan-out" question with staleness-window semantics a
+// generic array-slice reducer cannot replicate. Extending this shape to
+// last_over_time too would create two competing, overlapping mechanisms for
+// one function with no precedence rule between them.
 type SortedSlabOverTimeLowerer struct {
 	// Fallback is the concrete lowerer for shapes the sorted-slab path
 	// cannot handle. Boot wires it to FanoutOverTimeLowerer{}.

--- a/internal/promql/sorted_slab_first_over_time_name_test.go
+++ b/internal/promql/sorted_slab_first_over_time_name_test.go
@@ -1,0 +1,125 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestSortedSlabFirstOverTime_PreservesName is the load-bearing regression
+// pin for cerberus issue #2804's widening of SortedSlabOverTimeLowerer to
+// first_over_time. Unlike sum_over_time/avg_over_time (which drop
+// `__name__`), first_over_time keeps it — rangeFnPreservesName — and
+// SortedSlabOverTimeLowerer.LowerOverTime returns a shallow COPY of the
+// fan-out RangeWindow (a DIFFERENT pointer, but still a plain
+// *chplan.RangeWindow with the identical derived output schema), not the
+// RangeWindow it was handed and not a different, already-canonical node
+// type the way NativeLastOverTimeLowerer's RangeWindowStaleResample is.
+//
+// lowerRangeVectorCall's name-preservation seam has to recognise that copy
+// as STILL needing the synthesis wrap. An earlier version of that check
+// compared `node != chplan.Node(rw)` by POINTER, which this copy would have
+// satisfied despite being just as name-less as rw — silently dropping
+// `__name__` from every sorted-slab first_over_time query_range result (see
+// lowerRangeVectorCall's own doc for the full argument). This test lowers
+// the query with SortedSlabOverTimeLowerer actually wired and asserts BOTH
+// halves: the sorted-slab flag survived onto the wrapped node, and the
+// canonical MetricName projection wraps it.
+func TestSortedSlabFirstOverTime_PreservesName(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr("first_over_time(cpu_temp_celsius[5m])")
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	lowerers := promql.RangeLowerers{
+		OverTime: promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}},
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, s, start, end, 30*time.Second,
+		promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("plan root = %T, want *chplan.Project (the __name__-preservation wrap) — sorted-slab "+
+			"first_over_time lost __name__ preservation", plan)
+	}
+	cols := chplan.SampleColumns{
+		MetricName: s.MetricNameColumn, Attributes: s.AttributesColumn,
+		Timestamp: s.TimestampColumn, Value: s.ValueColumn,
+	}
+	if !chplan.ProjectExposesCanonical(proj, cols) {
+		t.Fatalf("Project does not expose the canonical 4-column (MetricName, Attributes, Timestamp, "+
+			"Value) shape: %#v", proj.Projections)
+	}
+	lit, ok := proj.Projections[0].Expr.(*chplan.LitString)
+	if !ok || lit.V != "cpu_temp_celsius" {
+		t.Fatalf("MetricName projection = %#v, want LitString(%q)", proj.Projections[0].Expr, "cpu_temp_celsius")
+	}
+
+	rw, ok := proj.Input.(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("Project.Input = %T, want *chplan.RangeWindow", proj.Input)
+	}
+	if !rw.SortedSlabOverTime {
+		t.Fatalf("the wrapped RangeWindow lost SortedSlabOverTime=true — the name-preservation wrap must " +
+			"wrap the STRATEGY's returned node, not the stale original fan-out rw")
+	}
+}
+
+// TestSortedSlabFirstOverTime_RegexNamePreservesPerSeries is the regex-name
+// sibling of TestSortedSlabFirstOverTime_PreservesName: a `__name__=~"a|b"`
+// matcher spans several metrics whose names differ per series, so the name
+// must ride through the sorted-slab RangeWindow's OWN widened grouping key
+// (appendNameGroupKey) rather than a single literal — proving the fix
+// mutates the ACTUAL strategy-returned node, not a copy the emitter never
+// sees.
+func TestSortedSlabFirstOverTime_RegexNamePreservesPerSeries(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(`first_over_time({__name__=~"cpu_temp_celsius|gpu_temp_celsius"}[5m])`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	lowerers := promql.RangeLowerers{
+		OverTime: promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}},
+	}
+	plan, err := promql.LowerAtRangeOpts(context.Background(), expr, s, start, end, 30*time.Second,
+		promql.LowerOpts{Lowerers: lowerers})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proj, ok := plan.(*chplan.Project)
+	if !ok {
+		t.Fatalf("plan root = %T, want *chplan.Project", plan)
+	}
+	rw, ok := proj.Input.(*chplan.RangeWindow)
+	if !ok {
+		t.Fatalf("Project.Input = %T, want *chplan.RangeWindow", proj.Input)
+	}
+	if !rw.SortedSlabOverTime {
+		t.Fatalf("the wrapped RangeWindow lost SortedSlabOverTime=true")
+	}
+	var sawMetricNameKey bool
+	for _, g := range rw.GroupBy {
+		if ref, ok := g.(*chplan.ColumnRef); ok && ref.Name == s.MetricNameColumn {
+			sawMetricNameKey = true
+		}
+	}
+	if !sawMetricNameKey {
+		t.Fatalf("RangeWindow.GroupBy = %#v, want it widened with MetricName for the regex-name case", rw.GroupBy)
+	}
+}

--- a/test/perf/cardinality-baseline/promql/sorted_slab_first_over_time_range_step.json
+++ b/test/perf/cardinality-baseline/promql/sorted_slab_first_over_time_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/sorted_slab_first_over_time_range_step",
+  "fan_factor": 1.6923076923076923,
+  "scan_rows": 13,
+  "peak_intermediate": 22,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/sorted_slab_mad_over_time_range_step.json
+++ b/test/perf/cardinality-baseline/promql/sorted_slab_mad_over_time_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/sorted_slab_mad_over_time_range_step",
+  "fan_factor": 1.6923076923076923,
+  "scan_rows": 13,
+  "peak_intermediate": 22,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/sorted_slab_stddev_over_time_range_step.json
+++ b/test/perf/cardinality-baseline/promql/sorted_slab_stddev_over_time_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/sorted_slab_stddev_over_time_range_step",
+  "fan_factor": 1.6923076923076923,
+  "scan_rows": 13,
+  "peak_intermediate": 22,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/cardinality-baseline/promql/sorted_slab_stdvar_over_time_range_step.json
+++ b/test/perf/cardinality-baseline/promql/sorted_slab_stdvar_over_time_range_step.json
@@ -1,0 +1,11 @@
+{
+  "fixture": "promql/sorted_slab_stdvar_over_time_range_step",
+  "fan_factor": 1.6923076923076923,
+  "scan_rows": 13,
+  "peak_intermediate": 22,
+  "has_cross_join": false,
+  "has_array_join": true,
+  "has_recursive_cte": false,
+  "max_recursion_depth": 0,
+  "uncountable_levels": 0
+}

--- a/test/perf/solver-decision-baseline/sorted_slab_first_over_time_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/sorted_slab_first_over_time_range_step/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "sorted_slab_first_over_time_range_step/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/sorted_slab_first_over_time_range_step/native.json
+++ b/test/perf/solver-decision-baseline/sorted_slab_first_over_time_range_step/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "sorted_slab_first_over_time_range_step/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/sorted_slab_mad_over_time_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/sorted_slab_mad_over_time_range_step/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "sorted_slab_mad_over_time_range_step/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/sorted_slab_mad_over_time_range_step/native.json
+++ b/test/perf/solver-decision-baseline/sorted_slab_mad_over_time_range_step/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "sorted_slab_mad_over_time_range_step/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/sorted_slab_stddev_over_time_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/sorted_slab_stddev_over_time_range_step/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "sorted_slab_stddev_over_time_range_step/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/sorted_slab_stddev_over_time_range_step/native.json
+++ b/test/perf/solver-decision-baseline/sorted_slab_stddev_over_time_range_step/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "sorted_slab_stddev_over_time_range_step/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/sorted_slab_stdvar_over_time_range_step/fanout.json
+++ b/test/perf/solver-decision-baseline/sorted_slab_stdvar_over_time_range_step/fanout.json
@@ -1,0 +1,11 @@
+{
+  "query": "sorted_slab_stdvar_over_time_range_step/fanout",
+  "lowering": "fanout",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/perf/solver-decision-baseline/sorted_slab_stdvar_over_time_range_step/native.json
+++ b/test/perf/solver-decision-baseline/sorted_slab_stdvar_over_time_range_step/native.json
@@ -1,0 +1,11 @@
+{
+  "query": "sorted_slab_stdvar_over_time_range_step/native",
+  "lowering": "native",
+  "routed": true,
+  "k": 8,
+  "reason": "routed",
+  "n_anchors": 241,
+  "fanout": 20,
+  "cumulative_d": "5m0s",
+  "outer_range": "1h0m0s"
+}

--- a/test/spec/promql/sorted_slab_first_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_first_over_time_range_step.txtar
@@ -1,0 +1,53 @@
+# Sorted-slab decomposition (cerberus issue #2761, widened to first_over_time
+# by issue #2804) for first_over_time() in RANGE mode — chsql's
+# emitRangeWindowSortedSlabOverTime. Sibling of
+# sorted_slab_sum_over_time_range_step.txtar, pinning first_over_time's
+# nonEmptyWindowOrNaNFrag(vals[1]) reducer — a POSITION pick, not a
+# reduction — over the same sliced window. Order preservation through the
+# sorted-slab's arrayFilter cut is the entire correctness argument for this
+# function (see range_window_sorted_slab.go's own doc): a shuffled slice
+# would pick the wrong element.
+#
+# job 'api' carries a duplicate-timestamp pair (00:02:00 appears twice, with
+# DIFFERENT values 2.0 and 3.0) to pin the no-dedup contract (every sample
+# counts individually, matching the array-fold path); job 'web' is a plain
+# monotonic series.
+#
+# That duplicate is why this fixture is parity-EXEMPT rather than enrolled
+# (cerberus issue #2905): Prometheus's TSDB appender keeps one sample per
+# (series, timestamp) and drops 3.0 at commit, so a reference comparison here
+# would assert that cerberus agrees with a survivor chosen by ingestion order.
+# The no-dedup contract is pinned instead, over this very seed, by
+# internal/promql/duplicate_timestamp_seed_chdb_test.go, which holds the
+# sorted-slab answer against the fan-out array-fold answer it must equal.
+-- query.promql --
+sum by(job) (first_over_time(http_requests_total[5m]))
+-- parity_exempt --
+reason: duplicate-timestamp-seed
+detail: job 'api' seeds 00:02:00 twice with 2.0 and 3.0 to pin that first_over_time's sorted-slab reducer picks the window's time-earliest element regardless of a later duplicate; the reference engine's appender keeps only the first-ingested one, so it has no answer to compare against.
+-- range_step --
+30s
+-- experimental_sorted_slab_over_time --
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:01:00', 9), 5.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 2.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 3.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:03:00', 9), 8.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:04:00', 9), 1.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:05:00', 9), 6.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:01:00', 9), 20.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:02:00', 9), 30.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:03:00', 9), 40.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/sorted_slab_first_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_first_over_time_range_step.txtar
@@ -50,4 +50,56 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
     ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
 -- expected_rows --
-[]
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:00Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:00:30Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:01:00Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:01:30Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:02:00Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:02:30Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:03:00Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:03:30Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:04:00Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:04:30Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:05:00Z", 5],
+  ["", {"job": "web"}, "2026-01-01T00:00:00Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:00:30Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:01:00Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:01:30Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:02:00Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:02:30Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:03:00Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:03:30Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:04:00Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:04:30Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:05:00Z", 20]
+]
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "job"
+[3] string = "http_requests_total"
+[4] string = "service_name"
+[5] string = "service.name"
+[6] string = "service_name"
+[7] string = "service.name"
+[8] string = "service_name"
+[9] string = ""
+[10] string = "service_name"
+[11] string = "http_requests_total"
+[12] string = "http.requests.total"
+[13] string = "http.requests/total"
+[14] string = "http.requests_total"
+[15] string = "http/requests/total"
+[16] string = "http/requests_total"
+[17] string = "http_requests.total"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(FnMap("job", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes["job"] AS gkey_0, TimeUnix AS bucket_ts] funcs=[FnSum(Value) AS Value]
+    Project ["http_requests_total" AS MetricName, Attributes AS Attributes, anchor_ts AS TimeUnix, Value AS Value]
+      RangeWindow func=first_over_time range=5m0s step=30s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+        Project [MetricName AS MetricName, FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+          Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+            Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT ? AS `MetricName`, `Attributes` AS `Attributes`, `anchor_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`, tupleElement(anchor_row, 1) AS `anchor_ts`, anchor_ts AS `TimeUnix`, tupleElement(anchor_row, 3) AS `Value` FROM (SELECT `Attributes`, arrayJoin(arrayFilter(p -> tupleElement(p, 2), anchor_grid)) AS `anchor_row` FROM (SELECT `Attributes`, arrayMap(a -> arrayMap(vals -> (a, length(vals) >= 1, if(length(vals) > 0, vals[1], nan)), [arrayMap(p -> tupleElement(p, 2), arrayFilter(p -> tupleElement(p, 1) > a - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= a, samples))])[1], arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(11))) AS `anchor_grid` FROM (SELECT `Attributes`, arrayCompact(arraySort(groupArray((`TimeUnix`, `Value`)))) AS `samples` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`))))) GROUP BY `gkey_0`, `bucket_ts`)

--- a/test/spec/promql/sorted_slab_mad_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_mad_over_time_range_step.txtar
@@ -52,4 +52,54 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
     ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
 -- expected_rows --
-[]
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:00Z", 0],
+  ["", {"job": "api"}, "2026-01-01T00:00:30Z", 0],
+  ["", {"job": "api"}, "2026-01-01T00:01:00Z", 2],
+  ["", {"job": "api"}, "2026-01-01T00:01:30Z", 2],
+  ["", {"job": "api"}, "2026-01-01T00:02:00Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:02:30Z", 1],
+  ["", {"job": "api"}, "2026-01-01T00:03:00Z", 2],
+  ["", {"job": "api"}, "2026-01-01T00:03:30Z", 2],
+  ["", {"job": "api"}, "2026-01-01T00:04:00Z", 1.5],
+  ["", {"job": "api"}, "2026-01-01T00:04:30Z", 1.5],
+  ["", {"job": "api"}, "2026-01-01T00:05:00Z", 2],
+  ["", {"job": "web"}, "2026-01-01T00:00:00Z", 0],
+  ["", {"job": "web"}, "2026-01-01T00:00:30Z", 0],
+  ["", {"job": "web"}, "2026-01-01T00:01:00Z", 5],
+  ["", {"job": "web"}, "2026-01-01T00:01:30Z", 5],
+  ["", {"job": "web"}, "2026-01-01T00:02:00Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:02:30Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:03:00Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:03:30Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:04:00Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:04:30Z", 10],
+  ["", {"job": "web"}, "2026-01-01T00:05:00Z", 10]
+]
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "job"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = ""
+[9] string = "service_name"
+[10] string = "http_requests_total"
+[11] string = "http.requests.total"
+[12] string = "http.requests/total"
+[13] string = "http.requests_total"
+[14] string = "http/requests/total"
+[15] string = "http/requests_total"
+[16] string = "http_requests.total"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(FnMap("job", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes["job"] AS gkey_0, TimeUnix AS bucket_ts] funcs=[FnSum(Value) AS Value]
+    RangeWindow func=mad_over_time range=5m0s step=30s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `Attributes`, tupleElement(anchor_row, 1) AS `anchor_ts`, anchor_ts AS `TimeUnix`, tupleElement(anchor_row, 3) AS `Value` FROM (SELECT `Attributes`, arrayJoin(arrayFilter(p -> tupleElement(p, 2), anchor_grid)) AS `anchor_row` FROM (SELECT `Attributes`, arrayMap(a -> arrayMap(vals -> (a, length(vals) >= 1, if(length(vals) > 0, arrayReduce('quantileExactInclusive(0.5)', arrayMap(x -> abs(x - arrayReduce('quantileExactInclusive(0.5)', vals)), vals)), nan)), [arrayMap(p -> tupleElement(p, 2), arrayFilter(p -> tupleElement(p, 1) > a - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= a, samples))])[1], arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(11))) AS `anchor_grid` FROM (SELECT `Attributes`, arrayCompact(arraySort(groupArray((`TimeUnix`, `Value`)))) AS `samples` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`)))) GROUP BY `gkey_0`, `bucket_ts`)

--- a/test/spec/promql/sorted_slab_mad_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_mad_over_time_range_step.txtar
@@ -1,0 +1,55 @@
+# Sorted-slab decomposition (cerberus issue #2761, widened to mad_over_time
+# by issue #2804) for mad_over_time() in RANGE mode — chsql's
+# emitRangeWindowSortedSlabOverTime. Sibling of
+# sorted_slab_stddev_over_time_range_step.txtar, pinning mad_over_time's
+# nested-median reducer (medianOverArrayFrag applied twice, via
+# quantileExactInclusive(0.5)) over the same sliced window. Unlike
+# sum/avg/stddev/stdvar, CH's quantileExactInclusive sorts its input
+# internally, so the reducer itself is order-INDEPENDENT — byte-identity
+# here rests on the sorted-slab slice holding the SAME element SET as the
+# array-fold's window_vals, not on fold order (see
+# range_window_sorted_slab.go's own doc).
+#
+# job 'api' carries a duplicate-timestamp pair (00:02:00 appears twice, with
+# DIFFERENT values 2.0 and 3.0) to pin the no-dedup contract (every sample
+# counts individually, including in both the inner and outer median); job
+# 'web' is a plain monotonic series.
+#
+# That duplicate is why this fixture is parity-EXEMPT rather than enrolled
+# (cerberus issue #2905): Prometheus's TSDB appender keeps one sample per
+# (series, timestamp) and drops 3.0 at commit, so a reference comparison here
+# would assert that cerberus agrees with a survivor chosen by ingestion order.
+# The no-dedup contract is pinned instead, over this very seed, by
+# internal/promql/duplicate_timestamp_seed_chdb_test.go, which holds the
+# sorted-slab answer against the fan-out array-fold answer it must equal.
+-- query.promql --
+sum by(job) (mad_over_time(http_requests_total[5m]))
+-- parity_exempt --
+reason: duplicate-timestamp-seed
+detail: job 'api' seeds 00:02:00 twice with 2.0 and 3.0 to pin that mad_over_time's sorted-slab reducer counts both samples in both the inner and outer median; the reference engine's appender keeps only the first-ingested one, so it has no answer to compare against.
+-- range_step --
+30s
+-- experimental_sorted_slab_over_time --
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:01:00', 9), 5.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 2.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 3.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:03:00', 9), 8.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:04:00', 9), 1.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:05:00', 9), 6.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:01:00', 9), 20.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:02:00', 9), 30.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:03:00', 9), 40.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/sorted_slab_stddev_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_stddev_over_time_range_step.txtar
@@ -1,0 +1,53 @@
+# Sorted-slab decomposition (cerberus issue #2761, widened to stddev_over_time
+# by issue #2804) for stddev_over_time() in RANGE mode — chsql's
+# emitRangeWindowSortedSlabOverTime. Sibling of
+# sorted_slab_sum_over_time_range_step.txtar, pinning stddev_over_time's
+# two-pass population-variance-under-a-sqrt reducer (varPopTwoPassFrag,
+# `μ = arrayAvg(vals); sqrt(Σ(x-μ)² / N)`) over the same sliced window — TWO
+# left-to-right folds over the identically-ordered slice (one for μ, one for
+# the centred sum), so the sorted-slab's order-preserving arrayFilter cut
+# matters twice over.
+#
+# job 'api' carries a duplicate-timestamp pair (00:02:00 appears twice, with
+# DIFFERENT values 2.0 and 3.0) to pin the no-dedup contract (every sample
+# counts individually, including in both passes of the two-pass moment
+# computation); job 'web' is a plain monotonic series.
+#
+# That duplicate is why this fixture is parity-EXEMPT rather than enrolled
+# (cerberus issue #2905): Prometheus's TSDB appender keeps one sample per
+# (series, timestamp) and drops 3.0 at commit, so a reference comparison here
+# would assert that cerberus agrees with a survivor chosen by ingestion order.
+# The no-dedup contract is pinned instead, over this very seed, by
+# internal/promql/duplicate_timestamp_seed_chdb_test.go, which holds the
+# sorted-slab answer against the fan-out array-fold answer it must equal.
+-- query.promql --
+sum by(job) (stddev_over_time(http_requests_total[5m]))
+-- parity_exempt --
+reason: duplicate-timestamp-seed
+detail: job 'api' seeds 00:02:00 twice with 2.0 and 3.0 to pin that stddev_over_time's sorted-slab reducer counts both samples in the two-pass mean and variance; the reference engine's appender keeps only the first-ingested one, so it has no answer to compare against.
+-- range_step --
+30s
+-- experimental_sorted_slab_over_time --
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:01:00', 9), 5.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 2.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 3.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:03:00', 9), 8.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:04:00', 9), 1.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:05:00', 9), 6.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:01:00', 9), 20.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:02:00', 9), 30.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:03:00', 9), 40.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/sorted_slab_stddev_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_stddev_over_time_range_step.txtar
@@ -50,4 +50,54 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
     ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
 -- expected_rows --
-[]
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:00Z", 0],
+  ["", {"job": "api"}, "2026-01-01T00:00:30Z", 0],
+  ["", {"job": "api"}, "2026-01-01T00:01:00Z", 2],
+  ["", {"job": "api"}, "2026-01-01T00:01:30Z", 2],
+  ["", {"job": "api"}, "2026-01-01T00:02:00Z", 1.479019945774904],
+  ["", {"job": "api"}, "2026-01-01T00:02:30Z", 1.479019945774904],
+  ["", {"job": "api"}, "2026-01-01T00:03:00Z", 2.4819347291981715],
+  ["", {"job": "api"}, "2026-01-01T00:03:30Z", 2.4819347291981715],
+  ["", {"job": "api"}, "2026-01-01T00:04:00Z", 2.494438257849294],
+  ["", {"job": "api"}, "2026-01-01T00:04:30Z", 2.494438257849294],
+  ["", {"job": "api"}, "2026-01-01T00:05:00Z", 2.4094720491334933],
+  ["", {"job": "web"}, "2026-01-01T00:00:00Z", 0],
+  ["", {"job": "web"}, "2026-01-01T00:00:30Z", 0],
+  ["", {"job": "web"}, "2026-01-01T00:01:00Z", 5],
+  ["", {"job": "web"}, "2026-01-01T00:01:30Z", 5],
+  ["", {"job": "web"}, "2026-01-01T00:02:00Z", 8.16496580927726],
+  ["", {"job": "web"}, "2026-01-01T00:02:30Z", 8.16496580927726],
+  ["", {"job": "web"}, "2026-01-01T00:03:00Z", 11.180339887498949],
+  ["", {"job": "web"}, "2026-01-01T00:03:30Z", 11.180339887498949],
+  ["", {"job": "web"}, "2026-01-01T00:04:00Z", 14.142135623730951],
+  ["", {"job": "web"}, "2026-01-01T00:04:30Z", 14.142135623730951],
+  ["", {"job": "web"}, "2026-01-01T00:05:00Z", 14.142135623730951]
+]
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "job"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = ""
+[9] string = "service_name"
+[10] string = "http_requests_total"
+[11] string = "http.requests.total"
+[12] string = "http.requests/total"
+[13] string = "http.requests_total"
+[14] string = "http/requests/total"
+[15] string = "http/requests_total"
+[16] string = "http_requests.total"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(FnMap("job", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes["job"] AS gkey_0, TimeUnix AS bucket_ts] funcs=[FnSum(Value) AS Value]
+    RangeWindow func=stddev_over_time range=5m0s step=30s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `Attributes`, tupleElement(anchor_row, 1) AS `anchor_ts`, anchor_ts AS `TimeUnix`, tupleElement(anchor_row, 3) AS `Value` FROM (SELECT `Attributes`, arrayJoin(arrayFilter(p -> tupleElement(p, 2), anchor_grid)) AS `anchor_row` FROM (SELECT `Attributes`, arrayMap(a -> arrayMap(vals -> (a, length(vals) >= 1, if(length(vals) > 0, sqrt(arraySum(arrayMap((x, m) -> (x - m) * (x - m), vals, arrayWithConstant(length(vals), arrayAvg(vals)))) / length(vals)), nan)), [arrayMap(p -> tupleElement(p, 2), arrayFilter(p -> tupleElement(p, 1) > a - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= a, samples))])[1], arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(11))) AS `anchor_grid` FROM (SELECT `Attributes`, arrayCompact(arraySort(groupArray((`TimeUnix`, `Value`)))) AS `samples` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`)))) GROUP BY `gkey_0`, `bucket_ts`)

--- a/test/spec/promql/sorted_slab_stdvar_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_stdvar_over_time_range_step.txtar
@@ -1,0 +1,50 @@
+# Sorted-slab decomposition (cerberus issue #2761, widened to stdvar_over_time
+# by issue #2804) for stdvar_over_time() in RANGE mode — chsql's
+# emitRangeWindowSortedSlabOverTime. Sibling of
+# sorted_slab_stddev_over_time_range_step.txtar, pinning stdvar_over_time's
+# two-pass population-variance reducer (varPopTwoPassFrag,
+# `μ = arrayAvg(vals); Σ(x-μ)² / N`, no sqrt) over the same sliced window.
+#
+# job 'api' carries a duplicate-timestamp pair (00:02:00 appears twice, with
+# DIFFERENT values 2.0 and 3.0) to pin the no-dedup contract (every sample
+# counts individually, including in both passes of the two-pass moment
+# computation); job 'web' is a plain monotonic series.
+#
+# That duplicate is why this fixture is parity-EXEMPT rather than enrolled
+# (cerberus issue #2905): Prometheus's TSDB appender keeps one sample per
+# (series, timestamp) and drops 3.0 at commit, so a reference comparison here
+# would assert that cerberus agrees with a survivor chosen by ingestion order.
+# The no-dedup contract is pinned instead, over this very seed, by
+# internal/promql/duplicate_timestamp_seed_chdb_test.go, which holds the
+# sorted-slab answer against the fan-out array-fold answer it must equal.
+-- query.promql --
+sum by(job) (stdvar_over_time(http_requests_total[5m]))
+-- parity_exempt --
+reason: duplicate-timestamp-seed
+detail: job 'api' seeds 00:02:00 twice with 2.0 and 3.0 to pin that stdvar_over_time's sorted-slab reducer counts both samples in the two-pass mean and variance; the reference engine's appender keeps only the first-ingested one, so it has no answer to compare against.
+-- range_step --
+30s
+-- experimental_sorted_slab_over_time --
+-- seed --
+CREATE TABLE otel_metrics_sum (
+    MetricName String,
+    Attributes Map(String, String),
+    TimeUnix DateTime64(9),
+    Value Float64
+) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
+INSERT INTO otel_metrics_sum VALUES
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:00:00', 9), 1.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:01:00', 9), 5.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 2.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:02:00', 9), 3.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:03:00', 9), 8.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:04:00', 9), 1.0),
+    ('http_requests_total', map('job', 'api'), toDateTime64('2026-01-01 00:05:00', 9), 6.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:00:00', 9), 10.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:01:00', 9), 20.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:02:00', 9), 30.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:03:00', 9), 40.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
+    ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
+-- expected_rows --
+[]

--- a/test/spec/promql/sorted_slab_stdvar_over_time_range_step.txtar
+++ b/test/spec/promql/sorted_slab_stdvar_over_time_range_step.txtar
@@ -47,4 +47,54 @@ INSERT INTO otel_metrics_sum VALUES
     ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:04:00', 9), 50.0),
     ('http_requests_total', map('job', 'web'), toDateTime64('2026-01-01 00:05:00', 9), 60.0);
 -- expected_rows --
-[]
+[
+  ["", {"job": "api"}, "2026-01-01T00:00:00Z", 0],
+  ["", {"job": "api"}, "2026-01-01T00:00:30Z", 0],
+  ["", {"job": "api"}, "2026-01-01T00:01:00Z", 4],
+  ["", {"job": "api"}, "2026-01-01T00:01:30Z", 4],
+  ["", {"job": "api"}, "2026-01-01T00:02:00Z", 2.1875],
+  ["", {"job": "api"}, "2026-01-01T00:02:30Z", 2.1875],
+  ["", {"job": "api"}, "2026-01-01T00:03:00Z", 6.16],
+  ["", {"job": "api"}, "2026-01-01T00:03:30Z", 6.16],
+  ["", {"job": "api"}, "2026-01-01T00:04:00Z", 6.222222222222221],
+  ["", {"job": "api"}, "2026-01-01T00:04:30Z", 6.222222222222221],
+  ["", {"job": "api"}, "2026-01-01T00:05:00Z", 5.8055555555555545],
+  ["", {"job": "web"}, "2026-01-01T00:00:00Z", 0],
+  ["", {"job": "web"}, "2026-01-01T00:00:30Z", 0],
+  ["", {"job": "web"}, "2026-01-01T00:01:00Z", 25],
+  ["", {"job": "web"}, "2026-01-01T00:01:30Z", 25],
+  ["", {"job": "web"}, "2026-01-01T00:02:00Z", 66.66666666666667],
+  ["", {"job": "web"}, "2026-01-01T00:02:30Z", 66.66666666666667],
+  ["", {"job": "web"}, "2026-01-01T00:03:00Z", 125],
+  ["", {"job": "web"}, "2026-01-01T00:03:30Z", 125],
+  ["", {"job": "web"}, "2026-01-01T00:04:00Z", 200],
+  ["", {"job": "web"}, "2026-01-01T00:04:30Z", 200],
+  ["", {"job": "web"}, "2026-01-01T00:05:00Z", 200]
+]
+-- args --
+[0] string = ""
+[1] string = "job"
+[2] string = "job"
+[3] string = "service_name"
+[4] string = "service.name"
+[5] string = "service_name"
+[6] string = "service.name"
+[7] string = "service_name"
+[8] string = ""
+[9] string = "service_name"
+[10] string = "http_requests_total"
+[11] string = "http.requests.total"
+[12] string = "http.requests/total"
+[13] string = "http.requests_total"
+[14] string = "http/requests/total"
+[15] string = "http/requests_total"
+[16] string = "http_requests.total"
+-- chplan --
+Project ["" AS MetricName, mapWithoutEmpty(FnMap("job", gkey_0)) AS Attributes, bucket_ts AS TimeUnix, Value AS Value]
+  Aggregate groupBy=[Attributes["job"] AS gkey_0, TimeUnix AS bucket_ts] funcs=[FnSum(Value) AS Value]
+    RangeWindow func=stdvar_over_time range=5m0s step=30s outerRange=5m0s ts=TimeUnix value=Value groupBy=[Attributes] start=2026-01-01T00:00:00Z end=2026-01-01T00:05:00Z
+      Project [MetricName AS MetricName, FnMapSort(FnMapMerge(FnMapFilter((k, v) -> (k NOT IN ("service_name")), FnMapUpdate(FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapValues(FnMapFilter((k, v) -> (k NOT IN ("service.name", "service_name")), ResourceAttributes))), FnMapFromArrays(FnArrayMap(k -> FnRegexReplaceAll(k, "[^a-zA-Z0-9_]", "_"), FnMapKeys(Attributes)), FnMapValues(Attributes)))), FnMapFilter((k, v) -> (v != ""), FnMap("service_name", FnToString(ServiceName))))) AS Attributes, TimeUnix AS TimeUnix, Value AS Value]
+        Filter predicate=(MetricName IN ("http_requests_total", "http.requests.total", "http.requests/total", "http.requests_total", "http/requests/total", "http/requests_total", "http_requests.total"))
+          Scan(otel_metrics_sum)
+-- sql --
+SELECT ? AS `MetricName`, mapFilter((k, v) -> v != '', map(?, `gkey_0`)) AS `Attributes`, `bucket_ts` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT `Attributes`[?] AS `gkey_0`, `TimeUnix` AS `bucket_ts`, sum(`Value`) AS `Value` FROM (SELECT `Attributes`, tupleElement(anchor_row, 1) AS `anchor_ts`, anchor_ts AS `TimeUnix`, tupleElement(anchor_row, 3) AS `Value` FROM (SELECT `Attributes`, arrayJoin(arrayFilter(p -> tupleElement(p, 2), anchor_grid)) AS `anchor_row` FROM (SELECT `Attributes`, arrayMap(a -> arrayMap(vals -> (a, length(vals) >= 1, if(length(vals) > 0, arraySum(arrayMap((x, m) -> (x - m) * (x - m), vals, arrayWithConstant(length(vals), arrayAvg(vals)))) / length(vals), nan)), [arrayMap(p -> tupleElement(p, 2), arrayFilter(p -> tupleElement(p, 1) > a - toIntervalNanosecond(300000000000) AND tupleElement(p, 1) <= a, samples))])[1], arrayMap(i -> toDateTime64('2026-01-01 00:05:00.000000000', 9) - toIntervalNanosecond(i * 30000000000), range(11))) AS `anchor_grid` FROM (SELECT `Attributes`, arrayCompact(arraySort(groupArray((`TimeUnix`, `Value`)))) AS `samples` FROM (SELECT `MetricName` AS `MetricName`, mapSort(mapConcat(mapFilter((k, v) -> (k NOT IN (?)), mapUpdate(mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapValues(mapFilter((k, v) -> (k NOT IN (?, ?)), `ResourceAttributes`))), mapFromArrays(arrayMap(k -> replaceRegexpAll(k, '[^a-zA-Z0-9_]', '_'), mapKeys(`Attributes`)), mapValues(`Attributes`)))), mapFilter((k, v) -> (v != ?), map(?, toString(`ServiceName`))))) AS `Attributes`, `TimeUnix` AS `TimeUnix`, `Value` AS `Value` FROM (SELECT * FROM `otel_metrics_sum` WHERE (`MetricName` IN (?, ?, ?, ?, ?, ?, ?)))) WHERE `TimeUnix` > toDateTime64('2026-01-01 00:00:00.000000000', 9) - toIntervalNanosecond(300000000000) AND `TimeUnix` <= toDateTime64('2026-01-01 00:05:00.000000000', 9) GROUP BY `Attributes`)))) GROUP BY `gkey_0`, `bucket_ts`)


### PR DESCRIPTION
## Summary

Follow-up to #2761, closing both halves of #2804:

1. **Extends `SortedSlabOverTimeLowerer`** (the sorted-slab decomposition) from `sum_over_time`/`avg_over_time` to `first_over_time`, `stddev_over_time`, `stdvar_over_time` and `mad_over_time` — the full set `overTimeArrayValueFrag`'s switch already knew how to reduce. The actual restriction point was `lowerRangeVectorCallFanout`'s `case "sum_over_time", "avg_over_time":` switch in `internal/promql/lower.go`, not `sortedSlabOverTimeEligible` (which is pure query-shape, function-name-agnostic).

2. **`last_over_time` precedence — decided in code, documented explicitly.** `last_over_time` never reaches `OverTimeLowerer`/`SortedSlabOverTimeLowerer` at all; it dispatches through its own `LastOverTimeLowerer` chain (`NativeLastOverTimeLowerer` → `DownsampleTierLastOverTimeLowerer` → `FanoutLastOverTimeLowerer`), whose native arm already answers the "avoid the array-fold fan-out" question with staleness-window semantics a generic array-slice reducer can't replicate. Recorded this explicitly on `SortedSlabOverTimeLowerer`'s doc, the `lowerRangeVectorCallFanout` switch, `LastOverTimeLowerer`'s doc, and `chopt.FeatureSortedSlabOverTime` / `FeatureTSGridLastOverTime`'s docs.

3. **Fixed a name-preservation bug this widening would otherwise have introduced.** `lowerRangeVectorCall` used to decide whether the `__name__`-preservation wrap was still needed via `node != chplan.Node(rw)` — a POINTER check. That was only a correct proxy while every `OverTimeLowerer` either returned `rw` unchanged or swapped in a genuinely different, already-canonical node type (`RangeWindowStaleResample`). `SortedSlabOverTimeLowerer` breaks that assumption: for an eligible window it returns `&out`, a shallow copy of `rw` with `SortedSlabOverTime` set — a *different pointer* but the *same derived (nameless) shape* `rw` has. Since `first_over_time` keeps `__name__` (`rangeFnPreservesName`), the old check would have silently dropped `__name__` from every sorted-slab `first_over_time` query_range result. Replaced it with `!chplan.IsDerivedShape(node, ...)` — the SAME classifier the HTTP layer's `wrapWithSampleProjection` already uses — and made the downstream wrap target the strategy's *actual* returned node instead of unconditionally re-wrapping the stale original `rw` (which would have silently discarded the `SortedSlabOverTime` flag instead). Two new unit tests (`internal/promql/sorted_slab_first_over_time_name_test.go`) pin this directly, for both a literal and a regex `__name__` matcher, and fail without the fix.

4. **arraySlice + binary-search investigation — closed with a negative result.** Checked this codebase's pinned chDB substrate (ClickHouse 26.5.1.1, `system.functions`) and the upstream ClickHouse array-functions reference for a lower-bound/upper-bound/bisect-shaped array function. None exists. The one function that runs a genuine binary-search algorithm, `indexOfAssumeSorted` (added ClickHouse 2024), is exact-match only — verified live, it returns 0 for a probe value that isn't exactly present, which is exactly what an anchor boundary (an arbitrary timestamp) almost never is. No verified function, nothing to measure — `arrayFilter` stays the mechanism (already proven memory-safe by #3046/#3051). Written up in `internal/chsql/range_window_sorted_slab.go`'s doc, mirroring this codebase's other closed-without-a-function investigations (#2768, #2750, #2923, #2894).

### A second, genuinely pre-existing bug the item-3 fix exposed and closed

CI's `probe` check caught `TestDownsampleTier_ChdbCorruptedBucketPostMergeFilter` failing (`last_over_time` returning present=false for a legitimate sample). Root cause: item 3's fix newly makes the `__name__`-preservation wrap apply to a `DownsampleTier`-routed `last_over_time` `RangeWindow` (the old pointer check happened to always skip it). That exposed a latent bug shared by `wrapRangeWindowPreserveName` (`internal/promql/lower.go`) and its HTTP-layer sibling `isMatrixRangeWindow` (`internal/api/prom/handler.go`): both decide "does this RangeWindow expose a real per-row `anchor_ts` column" purely from `OuterRange > 0` — correct for the plain fan-out family (chsql's `emitWindowedArray` gates its own identical choice on that same field) but wrong for chsql's `DownsampleTier` emitter, which *always* projects `anchor_ts` when `DownsampleTier` is set, independent of `OuterRange`. A `query_range` request with `Start == End` (a legitimate degenerate single-anchor grid: `OuterRange = End.Sub(Start) = 0`) was therefore wrongly treated as anchor-less and got a synthesised `now()` timestamp stamped over an otherwise-correct row.

This is a **genuinely pre-existing bug**, confirmed reachable on `main` today via the HTTP layer's `isMatrixRangeWindow` (same condition, same wrong branch) for any real `/api/v1/query_range` request hitting `last_over_time` + the downsample tier + a zero-width `[start, end]` window — it simply had no test coverage that exercised the promql-lowering-layer wrap directly before this PR made that wrap reachable for `DownsampleTier`. Fixed both call sites by ORing in `rw.DownsampleTier` / `v.DownsampleTier`. Verified: `TestDownsampleTier_ChdbCorruptedBucketPostMergeFilter` fails on `origin/main` at the pre-fix commit reproduced in isolation, confirming this isn't a false positive; the full `internal/chsql` and `internal/api/prom` chDB-tagged suites and the targeted `LastOverTime`/`PreserveName`/`DownsampleTier` subsets all pass with the fix.

## Test plan

- [x] `internal/chsql/range_window_sorted_slab_chdb_test.go`'s `TestSortedSlabOverTime_DualEmitParity` now dual-emit-compares all six functions (sum/avg/first/stddev/stdvar/mad) — bit-identical for all, 61/61 cells each.
- [x] `internal/promql/duplicate_timestamp_seed_chdb_test.go`'s `dupTSOverTimeFamily` gained a `first_over_time` case; `dupTSSortedSlabEligible` now lists all six sorted-slab functions; `TestIdenticalDuplicateTimestamp_EveryLoweringAgrees` passes for all.
- [x] Four new TXTAR fixtures (`sorted_slab_{first,stddev,stdvar,mad}_over_time_range_step.txtar`), each with the same duplicate-timestamp seed the existing sum/avg fixtures use, `parity_exempt: duplicate-timestamp-seed`.
- [x] Two new unit tests pin the name-preservation fix (verified they fail against the pre-fix pointer check).
- [x] `TestDownsampleTier_ChdbCorruptedBucketPostMergeFilter` and the full `internal/chsql` / `internal/api/prom` chDB-tagged suites pass with the `OuterRange > 0 || DownsampleTier` fix; confirmed the failure reproduces in isolation before the fix and that it does NOT reproduce against `origin/main` without this PR's item-3 change (i.e., a genuinely latent bug this PR's own fix exposed, not something unrelated).
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `just vet-tagged` — clean.
- [x] `go build ./...`, `go vet -tags chdb ./internal/promql/... ./internal/chsql/... ./internal/chplan/... ./internal/chopt/... ./cmd/cerberus/...` — clean.
- [x] `just test-unit` — fully green (goldens regenerated below).
- [x] `update-golden.yml` dispatched and published for shards `migration parity solver promql logql traceql chsql optimizer codegen cardinality` (this branch's diff — `internal/chplan` and `internal/chopt` doc touches are shared by every head — implied literally every shard; verified locally via `buildPlan` from `.github/scripts/manual-golden-update.mjs` rather than guessed).

Closes #2804

🤖 Generated with [Claude Code](https://claude.com/claude-code)
