### PR TITLE
test(chopttest): wire sorted_slab_over_time and fixed_accumulator_extrapolated

### DIFF
--- a/internal/chopttest/lowerers.go
+++ b/internal/chopttest/lowerers.go
@@ -88,19 +88,31 @@ func BuildRangeLowerers(set chopt.EnabledSet) promql.RangeLowerers {
 	// cmd/cerberus/main.go's nativeRangeLowerers exactly.
 	tsGridInstant := set.Has(chopt.FeatureTSGridInstant)
 
+	// fixed_accumulator_extrapolated layers BENEATH rate/increase/delta's own
+	// native ts_grid strategy, exactly like laginframe_adjacency layers
+	// inside irate/idelta below — mirrors cmd/cerberus/main.go's
+	// nativeRangeLowerers exactly (cerberus issue #2760).
+	var rateFallback promql.RateLowerer = promql.FanoutRateLowerer{}
+	var increaseFallback promql.IncreaseLowerer = promql.FanoutIncreaseLowerer{}
+	var deltaFallback promql.DeltaLowerer = promql.FanoutDeltaLowerer{}
+	if set.Has(chopt.FeatureFixedAccumulatorExtrapolated) {
+		rateFallback = promql.FixedAccumulatorRateLowerer{Fallback: rateFallback}
+		increaseFallback = promql.FixedAccumulatorIncreaseLowerer{Fallback: increaseFallback}
+		deltaFallback = promql.FixedAccumulatorDeltaLowerer{Fallback: deltaFallback}
+	}
 	if set.Has(chopt.FeatureTSGridRange) {
 		l.Rate = promql.NativeRateLowerer{
-			Fallback:   promql.FanoutRateLowerer{},
+			Fallback:   rateFallback,
 			Recollapse: set.Has(chopt.FeatureTSGridRecollapse),
 			Instant:    tsGridInstant,
 		}
 	} else {
-		l.Rate = promql.FanoutRateLowerer{}
+		l.Rate = rateFallback
 	}
 	if set.Has(chopt.FeatureTSGridIncrease) {
-		l.Increase = promql.NativeIncreaseLowerer{Fallback: promql.FanoutIncreaseLowerer{}}
+		l.Increase = promql.NativeIncreaseLowerer{Fallback: increaseFallback}
 	} else {
-		l.Increase = promql.FanoutIncreaseLowerer{}
+		l.Increase = increaseFallback
 	}
 	if set.Has(chopt.FeatureTSGridResample) {
 		l.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{}}
@@ -128,9 +140,9 @@ func BuildRangeLowerers(set chopt.EnabledSet) promql.RangeLowerers {
 		l.PredictLinear = promql.FanoutPredictLinearLowerer{}
 	}
 	if set.Has(chopt.FeatureTSGridDelta) {
-		l.Delta = promql.NativeDeltaLowerer{Fallback: promql.FanoutDeltaLowerer{}}
+		l.Delta = promql.NativeDeltaLowerer{Fallback: deltaFallback}
 	} else {
-		l.Delta = promql.FanoutDeltaLowerer{}
+		l.Delta = deltaFallback
 	}
 
 	// irate/idelta: laginframe_adjacency layers BENEATH their own native
@@ -185,6 +197,16 @@ func BuildRangeLowerers(set chopt.EnabledSet) promql.RangeLowerers {
 		l.LastOverTime = promql.NativeLastOverTimeLowerer{Fallback: promql.FanoutLastOverTimeLowerer{}}
 	} else {
 		l.LastOverTime = promql.FanoutLastOverTimeLowerer{}
+	}
+
+	// sorted_slab_over_time (issue #2761, widened by issue #2804) has no
+	// native timeSeries*ToGrid competitor of its own — it is wired directly
+	// with its plain fan-out as its own embedded Fallback, mirroring
+	// cmd/cerberus/main.go's nativeRangeLowerers exactly.
+	if set.Has(chopt.FeatureSortedSlabOverTime) {
+		l.OverTime = promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}}
+	} else {
+		l.OverTime = promql.FanoutOverTimeLowerer{}
 	}
 
 	return l

--- a/test/perf/perf-smoke-baseline.json
+++ b/test/perf/perf-smoke-baseline.json
@@ -2,23 +2,28 @@
   "sentinels": [
     {
       "name": "native_histogram_quantile",
-      "max_of_n_bytes": 206521201,
-      "ceiling_bytes": 309781801
+      "max_of_n_bytes": 206521793,
+      "ceiling_bytes": 309782689
     },
     {
       "name": "spill_high_cardinality_groupby",
-      "max_of_n_bytes": 667298209,
+      "max_of_n_bytes": 661798373,
       "ceiling_bytes": 805306368
     },
     {
       "name": "compare_memory_bound",
-      "max_of_n_bytes": 682442721,
+      "max_of_n_bytes": 682295113,
       "ceiling_bytes": 805306368
     },
     {
       "name": "join_spill_vector_join",
-      "max_of_n_bytes": 449714870,
-      "ceiling_bytes": 674572305
+      "max_of_n_bytes": 449714078,
+      "ceiling_bytes": 674571117
+    },
+    {
+      "name": "sorted_slab_over_time_memory_bound",
+      "max_of_n_bytes": 89771133,
+      "ceiling_bytes": 134656699
     }
   ]
 }

--- a/test/perf/smoke/realch_perfsmoke_integration_test.go
+++ b/test/perf/smoke/realch_perfsmoke_integration_test.go
@@ -33,15 +33,26 @@
 // for FloorJoinSpill, whose mechanism chopt gates behind a 26.4 server. Each
 // constant's own comment carries the why.
 //
-// # Two boot-resolved axes, one of them wired
+// # Two boot-resolved axes, and two kinds of lane
 //
 // Both handlers carry the per-query engine.SettingsRules a real deployment
 // resolves at boot (chopttest.BuildSettingsRules, cerberus issue #2820) —
 // without it Engine.Settings stays at its zero value, which applies NOTHING,
 // and no sentinel here could measure a settings-rule mechanism at all. The
 // OTHER boot-resolved axis, the native ts_grid_* RangeLowerers table, stays at
-// prom.New's fan-out-only zero value; wiring it into this lane is issue
-// #2487's own scope.
+// prom.New's fan-out-only zero value on every floor's BASE ("auto") lane;
+// wiring it there is issue #2487's own scope.
+//
+// A sentinel whose mechanism is opt-in-only — AutoSelect: false and, unlike
+// join_spill, carrying NO chopt version floor at all — cannot be reached by
+// "auto" on any server, so cerberus issue #3050 adds a SECOND kind of lane,
+// distinct from smoke.ServerFloor's server-CAPABILITY tiering: one extra
+// prom.Handler / tempo.Handler pair per distinct explicit
+// CERBERUS_CH_OPTIMIZATIONS listing a floor's own sentinels declare
+// (Sentinel.Optimizations), with BOTH boot-resolved axes wired from that
+// listing's own resolved chopt.EnabledSet. See startSentinelLane's own doc
+// for the construction and sentinelLane.muxFor for how a sentinel picks
+// its lane.
 //
 // Gated behind the `integration` build tag (Docker required); wired into the
 // already-required strict-scan CI lane via `just perf-smoke-integration`.
@@ -174,12 +185,35 @@ const joinSpillSeriesCount = 4_000
 var sentinelWindowEnd = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 
 // sentinelLane is one floor's fully-wired substrate: the connection its
-// query_log is read through, the mux its sentinels are issued against, and
-// the query_log reader their memory is measured with.
+// query_log is read through, the mux(es) its sentinels are issued against,
+// and the query_log reader their memory is measured with.
+//
+// muxes is keyed by Sentinel.Optimizations: "" is the base "auto"-resolved
+// lane every pre-existing sentinel runs against, and any other key is an
+// opt-in-only lane startSentinelLane builds specifically for a sentinel
+// whose mechanism needs an explicit CERBERUS_CH_OPTIMIZATIONS listing
+// "auto" itself never turns on (cerberus issue #3050) — see
+// muxFor's own doc.
 type sentinelLane struct {
 	conn      driver.Conn
-	mux       *http.ServeMux
+	muxes     map[string]*http.ServeMux
 	logSource *optcorpus.CHQueryLogSource
+}
+
+// muxFor returns the ServeMux sentinel must be driven against: its own
+// opt-in lane if Sentinel.Optimizations names one, otherwise the floor's
+// base "auto" lane. Fatals loudly rather than silently falling back — a
+// missing lane means startSentinelLane and this corpus have drifted, and a
+// silent fallback to the base lane would make an opt-in-only sentinel pass
+// vacuously against the fan-out path it exists to move past.
+func (l sentinelLane) muxFor(t *testing.T, sentinel Sentinel) *http.ServeMux {
+	t.Helper()
+	mux, ok := l.muxes[sentinel.Optimizations]
+	if !ok {
+		t.Fatalf("%s: no lane wired for optimizations %q — startSentinelLane must build one for every "+
+			"distinct Sentinel.Optimizations value a floor's sentinels declare", sentinel.Name, sentinel.Optimizations)
+	}
+	return mux
 }
 
 func TestPerfSmokeRealCH(t *testing.T) {
@@ -220,10 +254,12 @@ func runSentinelFloor(
 	start, end time.Time, baseline perfSmokeBaseline, update bool, updated map[string]sentinelBound,
 ) {
 	t.Helper()
-	conn, mux, logSource := lane.conn, lane.mux, lane.logSource
+	conn, logSource := lane.conn, lane.logSource
 
 	for _, sentinel := range sentinels {
 		t.Run(sentinel.Name, func(t *testing.T) {
+			mux := lane.muxFor(t, sentinel)
+
 			// One untimed, unmeasured warm-up: startSentinelLane's
 			// OPTIMIZE ... FINAL pass leaves this sentinel's table's
 			// marks/data cold, and the FIRST query
@@ -368,22 +404,38 @@ func optimizeTableFinal(ctx context.Context, t *testing.T, client *chclient.Clie
 // handlers with the SAME two boot-resolved axes cmd/cerberus wires from a
 // chopt.EnabledSet.
 //
-// Only ONE of those two axes is wired here — the SettingsRules one
-// (chopttest.BuildSettingsRules). The RangeLowerers axis stays at prom.New's
-// zero value, which promql.RangeLowerers.withDefaults normalises to the
-// concrete fan-out impls, exactly as this lane has always run: wiring the
-// native ts_grid_* families into the OTHER real-CH lanes is issue #2487's own
-// scope, and flipping them here would silently re-calibrate every existing
-// sentinel's committed baseline as a side effect of a settings-rules change.
+// The base ("auto") lane wires only ONE of those two axes — the SettingsRules
+// one (chopttest.BuildSettingsRules). Its RangeLowerers axis stays at
+// prom.New's zero value, which promql.RangeLowerers.withDefaults normalises
+// to the concrete fan-out impls, exactly as this lane has always run: wiring
+// the native ts_grid_* families into the OTHER real-CH lanes is issue #2487's
+// own scope, and flipping them here would silently re-calibrate every
+// existing sentinel's committed baseline as a side effect of a
+// settings-rules change.
 //
 // Wiring SettingsRules is what closes issue #2820: prom.New / tempo.New leave
 // Engine.Settings at its zero value, which applies NOTHING, so before this
 // every SettingsRules mechanism — aggregation_in_order and condition_cache as
 // much as join_spill — was unreachable in this corpus regardless of the
 // server it ran against.
+//
+// Beyond the base lane, this function builds one ADDITIONAL lane per
+// distinct non-empty Sentinel.Optimizations value among floor's own
+// sentinels (cerberus issue #3050): a feature like
+// chopt.FeatureSortedSlabOverTime is AutoSelect: false and carries no chopt
+// version floor at all, so "auto" alone never activates it on ANY server —
+// the only way a sentinel reaches it is an explicit
+// CERBERUS_CH_OPTIMIZATIONS listing, resolved into its OWN chopt.EnabledSet,
+// its OWN chopttest.BuildSettingsRules, and — unlike the base lane — its OWN
+// chopttest.BuildRangeLowerers. Wiring RangeLowerers here does not touch the
+// base lane's own fan-out-only posture or re-calibrate any existing
+// sentinel's baseline: the opt-in lane is a SEPARATE prom.Handler /
+// tempo.Handler pair mounted on its own ServeMux, sharing only the
+// underlying ClickHouse connection.
 func startSentinelLane(ctx context.Context, t *testing.T, floor ServerFloor, start, end time.Time) sentinelLane {
 	t.Helper()
 
+	sentinels := SentinelsForFloor(floor)
 	image := perfSmokeCHImage
 	signals := []ddl.Signal{ddl.Metrics, ddl.Traces}
 	if floor == FloorJoinSpill {
@@ -422,7 +474,13 @@ func startSentinelLane(ctx context.Context, t *testing.T, floor ServerFloor, sta
 		}
 		t.Logf("seeded wide-attribute traces: %d rows, %d traces", traceRows, wideTraceCount)
 
-		tables = []string{"otel_metrics_exponential_histogram", "otel_metrics_sum", "otel_traces"}
+		gaugeRows, err := SeedSortedSlabOverTimeGauge(ctx, conn, SortedSlabOverTimeGaugeMetric, SortedSlabOverTimeSeriesCount, start, end)
+		if err != nil {
+			t.Fatalf("seed sorted-slab gauge: %v", err)
+		}
+		t.Logf("seeded sorted-slab gauge: %d rows, %d series", gaugeRows, SortedSlabOverTimeSeriesCount)
+
+		tables = []string{"otel_metrics_exponential_histogram", "otel_metrics_sum", "otel_traces", "otel_metrics_gauge"}
 	case FloorJoinSpill:
 		counterRows, err := SeedHighCardinalityCounter(ctx, conn, WideCounterMetric, joinSpillSeriesCount, start, end)
 		if err != nil {
@@ -468,11 +526,77 @@ func startSentinelLane(ctx context.Context, t *testing.T, floor ServerFloor, sta
 	tracesHandler.Engine.SetSettings(rules)
 	t.Logf("%s (%s): settings rules wired: %+v", floor, image, rules)
 
+	muxes := map[string]*http.ServeMux{"": mux}
+	for _, opt := range optInLaneKeys(sentinels) {
+		muxes[opt] = buildOptInLane(ctx, t, client, floor, image, opt, sentinels, metricsSchema, tracesSchema)
+	}
+
 	return sentinelLane{
 		conn:      conn,
-		mux:       mux,
+		muxes:     muxes,
 		logSource: optcorpus.NewCHQueryLogSource(conn, 30*time.Second, time.Hour),
 	}
+}
+
+// optInLaneKeys collects the distinct non-empty Sentinel.Optimizations
+// values among sentinels, in first-seen order — the set of additional lanes
+// startSentinelLane must build beyond the base "auto" one.
+func optInLaneKeys(sentinels []Sentinel) []string {
+	seen := make(map[string]bool, len(sentinels))
+	var keys []string
+	for _, s := range sentinels {
+		if s.Optimizations == "" || seen[s.Optimizations] {
+			continue
+		}
+		seen[s.Optimizations] = true
+		keys = append(keys, s.Optimizations)
+	}
+	return keys
+}
+
+// buildOptInLane resolves opt against client's real connected server,
+// asserts every sentinel that declares a RequiredFeature under this exact
+// Optimizations string actually resolved it enabled (the same
+// "activation, not just a 200" guard
+// TestNativeRangeLowerers_RealCH_Integration applies via its own
+// enabled.Has(family.Feature) check), then mounts a SEPARATE prom.Handler /
+// tempo.Handler pair — its own SettingsRules AND its own
+// chopttest.BuildRangeLowerers, both resolved from opt — on a fresh
+// ServeMux. Sharing client rather than opening a second connection: opt-in
+// features like chopt.FeatureSortedSlabOverTime carry no version floor, so
+// they need no server capability the base lane's own connection lacks.
+func buildOptInLane(
+	ctx context.Context, t *testing.T, client *chclient.Client, floor ServerFloor, image, opt string,
+	sentinels []Sentinel, metricsSchema schema.Metrics, tracesSchema schema.Traces,
+) *http.ServeMux {
+	t.Helper()
+
+	set := chopttest.ResolveEnabledSet(ctx, t, client, opt)
+	for _, s := range sentinels {
+		if s.Optimizations != opt || s.RequiredFeature == "" {
+			continue
+		}
+		if !set.Has(s.RequiredFeature) {
+			t.Fatalf("%s: chopt feature %q did NOT resolve enabled against optimizations %q on %s (%s) — "+
+				"this sentinel's own activation would be vacuous against a server or listing that cannot "+
+				"reach the mechanism at all", s.Name, s.RequiredFeature, opt, floor, image)
+		}
+	}
+
+	rules := chopttest.BuildSettingsRules(set, metricsSchema, tracesSchema, schema.DefaultOTelLogs())
+	lowerers := chopttest.BuildRangeLowerers(set)
+
+	metricsHandler := prom.New(client, metricsSchema, nil)
+	metricsHandler.Lowerers = lowerers
+	tracesHandler := tempo.New(client, tracesSchema, "v-perf-smoke", nil)
+	mux := http.NewServeMux()
+	metricsHandler.Mount(mux)
+	tracesHandler.Mount(mux)
+	metricsHandler.Engine.SetSettings(rules)
+	tracesHandler.Engine.SetSettings(rules)
+	t.Logf("%s (%s): opt-in lane %q wired: enabled=%v settings=%+v", floor, image, opt, set.IDs(), rules)
+
+	return mux
 }
 
 func startPerfSmokeCH(ctx context.Context, t *testing.T, image string) *chclient.Client {

--- a/test/perf/smoke/seed.go
+++ b/test/perf/smoke/seed.go
@@ -204,6 +204,86 @@ FROM numbers(%d)`,
 	return int64(totalSamples), nil
 }
 
+// --- Sorted-slab sentinel seed: sum_over_time() gauge at #3046's scale ----
+
+// sortedSlabGaugeScrapeInterval / sortedSlabGaugeRange size the seeded
+// sample density for the sorted-slab memory-bound sentinel
+// (sentinels.go's sorted_slab_over_time_memory_bound): a 60s cadence keeps
+// several genuine samples inside every anchor's 5m sum_over_time() window
+// (sortedSlabOverTimeRangeSelector), mirroring seedNativeLowererGauge's own
+// 30s-cadence choice for the identical reason — a degenerate 0-or-1-sample
+// window would not exercise the sorted-slab decomposition's real per-series
+// array-fold/arrayFilter work at all. sortedSlabGaugeRange matches the
+// sentinel's own [5m] selector so the seed extends far enough before the
+// query window's start for every anchor's window to have real preceding
+// samples.
+const (
+	sortedSlabGaugeScrapeInterval = 60 * time.Second
+	sortedSlabGaugeRange          = 5 * time.Minute
+)
+
+// sortedSlabGaugeValueModulus / sortedSlabGaugeValueBase shape the seeded
+// gauge waveform as a plausible bounded reading (e.g. a temperature-like
+// value in [20, 35)) rather than a flat series, mirroring
+// seedNativeLowererGauge's own oscillating-value rationale — sum_over_time()
+// /avg_over_time() over a flat series would still exercise the sorted-slab
+// shape mechanically, but a genuinely varying one makes the array-fold vs.
+// sorted-slab byte-identical-result claim (chopt.FeatureSortedSlabOverTime's
+// own doc) a real check rather than a degenerate one.
+const (
+	sortedSlabGaugeValueModulus = 15
+	sortedSlabGaugeValueBase    = 20
+)
+
+// SeedSortedSlabOverTimeGauge seeds the sorted-slab memory-bound sentinel's
+// fixture directly into the real otel_metrics_gauge table (created by
+// ddl.Apply against ddl.Metrics). It lays down seriesCount distinct
+// `instance` series of metric (sharing one constant `job` label, matching
+// the sentinel's own `sum by (job, instance)` grouping), each an
+// oscillating gauge sampled every sortedSlabGaugeScrapeInterval from
+// (start - sortedSlabGaugeRange) through end.
+//
+// seriesCount is NOT calibrated by a sweep against this fixture — it is the
+// EXACT cardinality cerberus#3046's own real-ClickHouse measurement
+// reproduced the sorted-slab shape's OOM at (sentinels.go's
+// SortedSlabOverTimeSeriesCount), re-seeded here rather than re-derived so
+// the sentinel's own claim to reproduce that exact incident is verifiable
+// by inspection.
+//
+// Returns the row count seeded.
+func SeedSortedSlabOverTimeGauge(ctx context.Context, conn driver.Conn, metric string, seriesCount int, start, end time.Time) (rows int64, err error) {
+	if seriesCount <= 0 {
+		return 0, fmt.Errorf("seed sorted-slab gauge: seriesCount must be positive, got %d", seriesCount)
+	}
+	seedStart := start.Add(-sortedSlabGaugeRange)
+	samplesPerSeries := int(end.Sub(seedStart)/sortedSlabGaugeScrapeInterval) + 1
+	if samplesPerSeries <= 0 {
+		return 0, fmt.Errorf("seed sorted-slab gauge: non-positive samplesPerSeries (start=%v end=%v)", start, end)
+	}
+	totalSamples := samplesPerSeries * seriesCount
+
+	insert := fmt.Sprintf(
+		`
+INSERT INTO otel_metrics_gauge
+    (MetricName, Attributes, ServiceName, TimeUnix, Value)
+SELECT
+    '%s' AS MetricName,
+    map('job', 'cerberus-smoke-sorted-slab', 'instance', concat('instance-', toString(number %% %d))) AS Attributes,
+    'cerberus-smoke' AS ServiceName,
+    toDateTime64(%d, 9) + toIntervalSecond(intDiv(number, %d) * %d) AS TimeUnix,
+    toFloat64(%d + (number %% %d)) AS Value
+FROM numbers(%d)`,
+		metric, seriesCount,
+		seedStart.Unix(), seriesCount, int(sortedSlabGaugeScrapeInterval/time.Second),
+		sortedSlabGaugeValueBase, sortedSlabGaugeValueModulus,
+		totalSamples,
+	)
+	if err := conn.Exec(ctx, insert); err != nil {
+		return 0, fmt.Errorf("seed sorted-slab gauge: %w\n%s", err, insert)
+	}
+	return int64(totalSamples), nil
+}
+
 // --- Sentinel 3 seed: wide-attribute traces -------------------------------
 
 // wideTraceAttrKeysPerMap is the number of distinct attribute keys seeded

--- a/test/perf/smoke/seed_test.go
+++ b/test/perf/smoke/seed_test.go
@@ -88,6 +88,22 @@ func TestSeedHighCardinalityCounter_RejectsNonPositiveSampleWindow(t *testing.T)
 	}
 }
 
+func TestSeedSortedSlabOverTimeGauge_RejectsNonPositiveSeriesCount(t *testing.T) {
+	start := time.Unix(0, 0)
+	end := start.Add(time.Hour)
+	if _, err := SeedSortedSlabOverTimeGauge(context.Background(), nil, SortedSlabOverTimeGaugeMetric, 0, start, end); err == nil {
+		t.Fatal("expected an error for a non-positive seriesCount")
+	}
+}
+
+func TestSeedSortedSlabOverTimeGauge_RejectsNonPositiveSampleWindow(t *testing.T) {
+	start := time.Unix(0, 3600)
+	end := start.Add(-2 * time.Hour)
+	if _, err := SeedSortedSlabOverTimeGauge(context.Background(), nil, SortedSlabOverTimeGaugeMetric, 1, start, end); err == nil {
+		t.Fatal("expected an error for a non-positive sample window")
+	}
+}
+
 func TestSeedWideAttributeTraces_RejectsNonPositiveTraceCount(t *testing.T) {
 	start := time.Unix(0, 0)
 	end := start.Add(time.Hour)

--- a/test/perf/smoke/sentinels.go
+++ b/test/perf/smoke/sentinels.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/tsouza/cerberus/internal/chopt"
 )
 
 // Metric names the seed builders write and the sentinel queries read. Kept
@@ -14,6 +16,10 @@ const (
 	NativeHistogramMetric = "cerberus_smoke_latency_exp_hist"
 	// WideCounterMetric is Sentinel 2's high-cardinality counter metric.
 	WideCounterMetric = "cerberus_smoke_wide_requests_total"
+	// SortedSlabOverTimeGaugeMetric is the sorted-slab memory-bound
+	// sentinel's gauge metric (cerberus issue #3050, closing #3046's
+	// PERF-SENTINEL-WAIVER).
+	SortedSlabOverTimeGaugeMetric = "cerberus_smoke_sorted_slab_gauge"
 )
 
 // sentinelWindow / sentinelStep size every sentinel's query_range grid: 1h at
@@ -31,6 +37,30 @@ const (
 // doc comment names as the methodology that measured the #2355/#2358
 // regression: "500 distinct series under a one-label GROUP BY".
 const NativeHistogramSeriesCount = 500
+
+// SortedSlabOverTimeSeriesCount / sortedSlabOverTimeAnchorCount reproduce
+// cerberus#3046's own OOM scale exactly: "500 series / 2h span / 15s step
+// (480 anchors) / 5m window" is the row #3046's own measurement table
+// singles out as "the closest to this repo's own #2429 resource-bound
+// calibration corpus... squarely inside what a production dashboard panel
+// runs" — the array-fold fan-out finished comfortably at 535 MiB there while
+// the UNFIXED sorted-slab shape OOMed a 6 GiB container outright.
+//
+// The sentinel below reaches the same 500-series/480-anchor shape WITHOUT
+// widening the shared outer query window every other FloorBase sentinel
+// runs against (sentinelWindow, 1h): anchor count is what
+// applySortedSlabOverTimeMemoryBound's per-anchor block-width fix actually
+// bounds (internal/chsql/range_window_sorted_slab.go's own doc — the
+// per-anchor arrayFilter intermediate is what a wide vectorized block
+// retains), not the wall-clock span a fixed anchor count is spread across,
+// so sentinelWindow/sortedSlabOverTimeAnchorCount reaches the identical
+// 480-anchor grid at a smaller step instead.
+const (
+	SortedSlabOverTimeSeriesCount   = 500
+	sortedSlabOverTimeAnchorCount   = 480
+	sortedSlabOverTimeSentinelStep  = sentinelWindow / sortedSlabOverTimeAnchorCount
+	sortedSlabOverTimeRangeSelector = "5m"
+)
 
 // ServerFloor names the ClickHouse capability tier a sentinel needs. The
 // corpus is not single-tier: chopt gates several SettingsRules mechanisms
@@ -82,6 +112,31 @@ const settingMaxBytesBeforeExternalJoin = "max_bytes_before_external_join"
 // of silently changing what production stamps.
 const joinSpillCapDenominator int64 = 2
 
+// OptInSortedSlabOverTime is the explicit CERBERUS_CH_OPTIMIZATIONS listing
+// the sorted-slab memory-bound sentinel must resolve chopt.EnabledSet
+// against. chopt.FeatureSortedSlabOverTime is AutoSelect: false and carries
+// NO chopt version floor (see its own registry doc) — the explicit opt-in
+// string is the ONLY thing standing between the harness's ordinary "auto"
+// resolution and this feature activating, never a newer server. This is a
+// SEPARATE axis from ServerFloor, which tiers by SERVER CAPABILITY: the
+// sorted-slab sentinel runs on FloorBase's own repo-wide pinned image, just
+// resolved against a different chopt.Config.Optimizations string
+// (startSentinelLane builds one additional lane per distinct
+// Sentinel.Optimizations value a floor's own sentinels declare).
+const OptInSortedSlabOverTime = "auto," + chopt.FeatureSortedSlabOverTime
+
+// settingMaxBlockSize mirrors internal/engine's own settingMaxBlockSize
+// (query_settings_rules.go), and wantSortedSlabOverTimeMaxBlockSize mirrors
+// its sortedSlabOverTimeMaxBlockSize — both re-derived here (never
+// imported: both are unexported) as a cross-check the same way
+// joinSpillCapDenominator re-derives spillCapDenominator above: if the
+// engine's own setting name or value moves, this sentinel's stamp assertion
+// goes red rather than silently asserting nothing.
+const (
+	settingMaxBlockSize                = "max_block_size"
+	wantSortedSlabOverTimeMaxBlockSize = "1"
+)
+
 // Sentinel describes one real-ClickHouse memory-bounding differential
 // target: an HTTP request against the mounted production handlers, built to
 // reach a specific plan shape and memory-bounding mechanism the #2364
@@ -108,6 +163,32 @@ type Sentinel struct {
 	// The zero value (FloorBase) is the repo-wide pinned image every
 	// pre-existing sentinel is calibrated against.
 	Floor ServerFloor
+	// Optimizations, when non-empty, is an explicit
+	// CERBERUS_CH_OPTIMIZATIONS listing this sentinel resolves its
+	// chopt.EnabledSet against, INSTEAD of the harness's own default
+	// "auto" resolution. It is a SEPARATE axis from Floor: Floor tiers by
+	// SERVER CAPABILITY (a version/allow_experimental_* floor a real
+	// deployment cannot opt around), while Optimizations exists for a
+	// feature like chopt.FeatureSortedSlabOverTime that carries no version
+	// floor at all and is AutoSelect: false purely as an unresolved perf
+	// tradeoff — "auto" alone never activates it, regardless of server
+	// version, only the explicit opt-in string does. The harness
+	// (startSentinelLane) builds one extra lane — its own SettingsRules
+	// AND promql.RangeLowerers, both resolved from THIS string — per
+	// distinct non-empty value among a floor's own sentinels, so every
+	// OTHER sentinel's calibrated baseline stays measured against the
+	// unmodified "auto" lane.
+	Optimizations string
+	// RequiredFeature, when non-empty, is the chopt feature id that must
+	// have resolved enabled in the EnabledSet Optimizations produced --
+	// checked once per opt-in lane at lane-build time, the same
+	// "activation, not just a 200" guard
+	// TestNativeRangeLowerers_RealCH_Integration already applies via its
+	// own enabled.Has(family.Feature) check. Without it a server that
+	// silently failed to resolve Optimizations (a typo, a version
+	// regression) would make this sentinel pass vacuously against the SAME
+	// fan-out path the mechanism exists to replace.
+	RequiredFeature string
 	// RequiredQuerySettings, when non-nil, returns the per-query ClickHouse
 	// settings the harness must find in system.query_log's Settings map for
 	// EVERY repeat of this sentinel, keyed by setting name and valued by the
@@ -218,6 +299,50 @@ var Sentinels = []Sentinel{
 			return map[string]string{
 				settingMaxBytesBeforeExternalJoin: strconv.FormatInt(memoryCapBytes/joinSpillCapDenominator, 10),
 			}
+		},
+	},
+	{
+		// Sorted-slab memory bound, opt-in-only: applySortedSlabOverTimeMemoryBound
+		// (query_settings_rules.go) stamps max_block_size=1 on any plan
+		// carrying a chplan.RangeWindow.SortedSlabOverTime node, but that
+		// node only exists once chopt.FeatureSortedSlabOverTime resolves
+		// enabled — "auto" alone never does (AutoSelect: false, see the
+		// feature's own registry doc), so this sentinel runs on its own
+		// OptInSortedSlabOverTime lane rather than the floor's default one.
+		//
+		// Reproduces cerberus#3046's own OOM scale exactly: 500 series,
+		// sum_over_time() over a 5m window at a 480-anchor grid — the row
+		// #3046's own measurement table names as "squarely inside what a
+		// production dashboard panel runs", where the UNFIXED sorted-slab
+		// shape OOMed a 6 GiB container while the array-fold it replaces
+		// finished at 535 MiB. See sortedSlabOverTimeAnchorCount's own doc
+		// for why the anchor count (not sentinelWindow's own 1h span) is
+		// what this sentinel reproduces exactly.
+		//
+		// RequiredQuerySettings is the load-bearing assertion, exactly
+		// like join_spill_vector_join above: max_block_size=1 is a
+		// RESULT-EQUIVALENT stamp (rows-per-block execution batching
+		// only), so a query that fits comfortably under the memory cap
+		// either way cannot distinguish "the bound fired" from "the rule
+		// was deleted" without reading system.query_log's Settings map
+		// back.
+		Name:            "sorted_slab_over_time_memory_bound",
+		Mechanism:       "applySortedSlabOverTimeMemoryBound (internal/engine/query_settings_rules.go) via chopt.FeatureSortedSlabOverTime",
+		Path:            "/api/v1/query_range",
+		Optimizations:   OptInSortedSlabOverTime,
+		RequiredFeature: chopt.FeatureSortedSlabOverTime,
+		Params: func(start, end time.Time) url.Values {
+			return url.Values{
+				"query": {
+					"sum by (job, instance) (sum_over_time(" +
+						SortedSlabOverTimeGaugeMetric + "[" + sortedSlabOverTimeRangeSelector + "]))",
+				},
+			}
+		},
+		Window: sentinelWindow,
+		Step:   sortedSlabOverTimeSentinelStep,
+		RequiredQuerySettings: func(memoryCapBytes int64) map[string]string {
+			return map[string]string{settingMaxBlockSize: wantSortedSlabOverTimeMaxBlockSize}
 		},
 	},
 }

--- a/test/perf/smoke/sentinels_test.go
+++ b/test/perf/smoke/sentinels_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tsouza/cerberus/internal/chopt"
 )
 
 // TestSentinels_Roster asserts every sentinel in the single source of truth
@@ -11,7 +13,7 @@ import (
 // broken request in the real-ClickHouse integration lane, where a driver
 // error is much more expensive to root-cause than this unit check.
 func TestSentinels_Roster(t *testing.T) {
-	const wantCount = 4
+	const wantCount = 5
 	if len(Sentinels) != wantCount {
 		t.Fatalf("len(Sentinels) = %d, want %d", len(Sentinels), wantCount)
 	}
@@ -92,6 +94,64 @@ func TestSentinels_JoinSpillStampIsAsserted(t *testing.T) {
 	for k, v := range want {
 		if got[k] != v {
 			t.Errorf("join_spill sentinel RequiredSettings[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// TestSentinels_SortedSlabOverTimeStampIsAsserted pins the one thing that
+// makes the sorted-slab sentinel falsifiable — it must require the
+// max_block_size=1 stamp applySortedSlabOverTimeMemoryBound (cerberus#3046)
+// stamps — plus the opt-in wiring that makes the sentinel actually REACH
+// that plan shape at all: chopt.FeatureSortedSlabOverTime is AutoSelect:
+// false, so without an explicit Optimizations listing and a RequiredFeature
+// activation guard, this sentinel would run against the harness's ordinary
+// "auto" lane and never build a chplan.RangeWindow.SortedSlabOverTime node
+// in the first place — a vacuous pass indistinguishable from the mechanism
+// never existing.
+func TestSentinels_SortedSlabOverTimeStampIsAsserted(t *testing.T) {
+	base := SentinelsForFloor(FloorBase)
+	var s *Sentinel
+	for i := range base {
+		if base[i].Name == "sorted_slab_over_time_memory_bound" {
+			s = &base[i]
+			break
+		}
+	}
+	if s == nil {
+		t.Fatalf("SentinelsForFloor(FloorBase) has no sorted_slab_over_time_memory_bound sentinel")
+	}
+
+	if s.Optimizations != OptInSortedSlabOverTime {
+		t.Errorf("sorted-slab sentinel Optimizations = %q, want %q — without the explicit opt-in "+
+			"listing the sentinel resolves against the harness's default \"auto\" lane, where "+
+			"AutoSelect:false keeps chopt.FeatureSortedSlabOverTime permanently off", s.Optimizations, OptInSortedSlabOverTime)
+	}
+	if s.RequiredFeature != chopt.FeatureSortedSlabOverTime {
+		t.Errorf("sorted-slab sentinel RequiredFeature = %q, want %q", s.RequiredFeature, chopt.FeatureSortedSlabOverTime)
+	}
+
+	query := s.Params(time.Unix(0, 0), time.Unix(0, 0).Add(sentinelWindow)).Get("query")
+	if !strings.Contains(query, "sum_over_time(") {
+		t.Errorf("sorted-slab sentinel query %q does not call sum_over_time(...)", query)
+	}
+	if !strings.Contains(query, SortedSlabOverTimeGaugeMetric) {
+		t.Errorf("sorted-slab sentinel query %q does not reference %s", query, SortedSlabOverTimeGaugeMetric)
+	}
+
+	if anchors := int(s.Window / s.Step); anchors != sortedSlabOverTimeAnchorCount {
+		t.Errorf("sorted-slab sentinel Window/Step = %v/%v -> %d anchors, want %d (cerberus#3046's own "+
+			"OOM reproduction scale)", s.Window, s.Step, anchors, sortedSlabOverTimeAnchorCount)
+	}
+
+	const cap1GiB int64 = 1 << 30
+	got := s.RequiredSettings(cap1GiB)
+	want := map[string]string{settingMaxBlockSize: wantSortedSlabOverTimeMaxBlockSize}
+	if len(got) != len(want) {
+		t.Fatalf("sorted-slab sentinel RequiredSettings = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("sorted-slab sentinel RequiredSettings[%q] = %q, want %q", k, got[k], v)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`internal/chopttest.BuildRangeLowerers` (the helper every real-ClickHouse
integration/perf test uses to wire `promql.RangeLowerers`) was missing two
branches `cmd/cerberus/main.go`'s own `nativeRangeLowerers` already carries:
`chopt.FeatureSortedSlabOverTime` → `RangeLowerers.OverTime`, and the
`chopt.FeatureFixedAccumulatorExtrapolated` fallback layering underneath
`rate()`/`increase()`/`delta()`. That left both of #2894's subjects
unreachable by any real-ClickHouse test in the repo, including the
`applySortedSlabOverTimeMemoryBound` mechanism #3046/#3051 just shipped —
this PR closes the `PERF-SENTINEL-WAIVER` #3046's own PR cited pending this
issue.

- `internal/chopttest.BuildRangeLowerers` now mirrors `main.go`'s
  `nativeRangeLowerers` field-for-field for both `OverTime` and the
  `FixedAccumulatorExtrapolated` fallback layering (same construction order,
  same fallback threading through `rate`/`increase`/`delta`).
- `test/perf/smoke`'s harness gains a second kind of lane, orthogonal to
  `smoke.ServerFloor`'s server-capability tiering: `Sentinel.Optimizations`
  names an explicit `CERBERUS_CH_OPTIMIZATIONS` listing a sentinel resolves
  against instead of the harness's default `"auto"`, and
  `startSentinelLane` builds one extra `prom.Handler`/`tempo.Handler` pair —
  wiring BOTH `chopttest.BuildSettingsRules` and, for the first time in this
  lane, `chopttest.BuildRangeLowerers` — per distinct value declared.
  `Sentinel.RequiredFeature` guards against a hollow pass if the listing
  ever fails to resolve. Every pre-existing sentinel is untouched: they keep
  running against the base `"auto"` lane exactly as before.
- Added `sorted_slab_over_time_memory_bound` to `test/perf/smoke/sentinels.go`:
  reproduces cerberus#3046's own OOM scale exactly (500 series, `sum_over_time()`
  over a 5m window at a 480-anchor grid) and asserts `max_block_size=1`
  lands in `system.query_log`'s Settings map for every repeat — the
  `RequiredQuerySettings` pattern `join_spill_vector_join` already
  established. New seed builder `SeedSortedSlabOverTimeGauge` in `seed.go`.
- `fixed_accumulator_extrapolated` carries no memory-bounding engine setting
  today (confirmed: no `internal/engine` settings rule references
  `FixedAccumulator` at all), so per the issue's own item 4 there is nothing
  to sentinel yet for it.

## Verification

Ran the new sentinel against real ClickHouse (testcontainers, Docker):
confirmed the `"auto,sorted_slab_over_time"` opt-in lane actually resolves
`chopt.FeatureSortedSlabOverTime` enabled, the query dispatches through the
sorted-slab shape, and `max_block_size=1` is present in `system.query_log`
for every repeat. Then ran `just update-perf-smoke-baseline` (Docker) to
calibrate: the new sentinel measured 89,771,133 bytes max-of-5 (8.4% of the
1 GiB cap), comfortably under the memory bound — confirming
`applySortedSlabOverTimeMemoryBound`'s fix holds at the exact scale that
OOMed before it. The 4 pre-existing sentinels shifted by <1% (ordinary
run-to-run measurement jitter).

`just test-unit` passes. The new integration-tagged sentinel/harness code is
gated behind the `integration` build tag like the rest of this package, so
it is not part of `test-unit`'s untagged `go test ./...` — it was verified
directly against real ClickHouse as described above, mirroring how this
repo's own perf-smoke lane is normally validated (CI's `strict-scan` job,
not the default dev loop).

## Test plan

- [x] `just test-unit` passes
- [x] `go vet -tags=integration ./test/perf/smoke/...` passes
- [x] New sentinel executed against real ClickHouse (testcontainers); confirmed
      the opt-in lane resolves `sorted_slab_over_time` and `max_block_size=1`
      is stamped in `system.query_log`
- [x] `just update-perf-smoke-baseline` run against real ClickHouse; diff
      reviewed (new entry + <1% jitter on existing sentinels)

Closes #3050

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
