### PR TITLE
docs(traceql,logql): correct refuted claims in #2039/#1956 tracking text

### DIFF
--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -1626,10 +1626,21 @@ duration_gt_dynamic_attribute
 # NOT repointed at a real numeric attribute (e.g. `span.child.index`):
 # doing so exposed a genuine, separate divergence — reference Tempo
 # returns 0 traces for `duration > span.child.index` (an Int-typed
-# attribute) while cerberus returns 100, so cerberus's per-row
-# coercion is over-eager relative to Tempo's real per-row typing rule.
-# See #2039, which tracks that divergence on its own; fixing it is out
-# of scope for this PR's static-validation subject.
+# attribute) while cerberus returns 100. That is NOT cerberus
+# over-eager coercion: #2039's own investigation root-caused it to a
+# proven defect in reference Tempo's live storage/search pushdown path
+# (`BinaryOperation.execute`, `pkg/traceql/ast_execute.go` L365-414 at
+# the pinned compat commit) — Tempo's own canonical evaluator and its
+# `TestBinaryOperationsWorkAcrossNumberTypes` unit test both allow a
+# mixed numeric/duration comparison like this one to match, so the
+# live reference's zero-trace answer contradicts Tempo's own semantics
+# and tests. Cerberus's 100-trace answer is the one consistent with
+# Tempo's documented evaluator; it is not something to "fix" to agree
+# with the buggy reference. See #2039, which tracks the divergence and
+# cites the blocking external tracker, grafana/tempo#7774 — invariant
+# 7 forbids emulating the broken reference here, so this case stays
+# pointed at `span.budget_ns` (empty vs. empty on both backends) until
+# that upstream defect is resolved, not repointed at `child.index`.
 -- query --
 { duration > span.budget_ns }
 -- endpoint --


### PR DESCRIPTION
## Summary

Step 0 of milestone M5 (per epic #2892): correct two refuted/stale claims in
this repo's tracking text before anything else in the milestone starts, since
a stale body here is worse than a missing one — a future agent reading only
the wrong comment would "fix" cerberus into emulating a broken reference
backend, which invariant 7 forbids.

- **#2039** (`compatibility/tempo/driver/corpus/smoke.txtar`, the
  `duration_gt_dynamic_attribute` case): the comment blamed cerberus's
  per-row coercion as "over-eager" for the `duration > span.child.index`
  divergence. That root cause was disproved in #2039's own investigation
  thread months ago — the defect is in reference Tempo's own
  `BinaryOperation.execute` storage/search pushdown path
  (`pkg/traceql/ast_execute.go` L365-414), contradicted by Tempo's own
  evaluator and its `TestBinaryOperationsWorkAcrossNumberTypes` unit test.
  Cerberus's 100-trace answer is the one consistent with Tempo's documented
  semantics. Rewrote the comment to state this plainly and cite the real
  blocking tracker, `grafana/tempo#7774`.
- **#1956** (`label_replace` shared-capture-name guard): the issue body still
  cited catalogue file paths that don't exist
  (`internal__promql__label_fns.go.json` / `internal__logql__label_fns.go.json`
  instead of the real `...__labelReplaceAttributes.json` /
  `...__lowerLabelReplace.json`) and a witness query,
  `(?:(?P<dup>a?)|y)(?P<dup>b)`, that shipped code (PR #2147's negative-sibling
  probe) now **accepts** rather than rejects — verified directly against
  `Lower(...)` in `internal/promql`, not assumed. Replaced it with the
  witness the current pinned tests (`TestLowerLabelReplace_RejectsInexpressibleBackref`)
  and the actual catalogue JSON files use,
  `(?:(?P<dup>a?)|y)*(?P<dup>b)` (a repeated/reenterable alternation), which is
  confirmed still rejected today in both `internal/promql` and `internal/logql`.
  The "3 divergence entries vs. `max_entries: 2`" sub-claim from epic #2892
  turned out to already be stale/corrected — the current body doesn't state
  a count at all, and `divergence-ceiling.json` does read `max_entries: 2`
  against exactly 2 live catalogue entries, so no edit was needed there.

Both GitHub issue bodies (#2039, #1956) were rewritten out-of-tree via
`gh issue edit --body-file` to match, name their real blocking external
trackers (`grafana/tempo#7774`, `ClickHouse/ClickHouse#114733`), and record an
explicit re-check trigger.

No cerberus query-engine behavior changes. This is a documentation/record
correction only, verified against the current, unmodified test suite.

## Verification

- `go test -run '^TestSmokeCorpus_LoadsAndMeetsFloor$|^TestSmokeCorpus_TagEndpointCoverage$' ./compatibility/tempo/driver/...` — smoke.txtar still parses correctly after the comment rewrite.
- `go test -run '^TestLower$' ./internal/traceql/...` — `duration_gt_attr_type_mismatch` fixture still passes, confirming cerberus's current (correct) coercion behavior is unchanged and still pinned.
- `go test -run '^TestLowerLabelReplace_RejectsInexpressibleBackref$|^TestLowerLabelReplace_AcceptsSharedCaptureName$' ./internal/promql/... ./internal/logql/...` — both heads still draw the guard boundary exactly where the corrected issue body now says.
- Directly verified via a scratch lowering call (removed before commit) that the old, now-inaccurate witness `(?:(?P<dup>a?)|y)(?P<dup>b)` is accepted by current `Lower(...)`, confirming it is no longer a valid rejection witness.

## Test plan

- [x] `go test -run '^TestSmokeCorpus_LoadsAndMeetsFloor$|^TestSmokeCorpus_TagEndpointCoverage$' ./compatibility/tempo/driver/...`
- [x] `go test -run '^TestLower$' ./internal/traceql/...`
- [x] `go test -run '^TestLowerLabelReplace_RejectsInexpressibleBackref$|^TestLowerLabelReplace_AcceptsSharedCaptureName$' ./internal/promql/... ./internal/logql/...`
- [x] Issue #2039 body corrected (`gh issue edit`)
- [x] Issue #1956 body corrected (`gh issue edit`)

Both tracking issues (#2039, #1956) stay open pending their respective
upstream trackers; this PR only corrects their in-repo and issue-body text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sse3zjfiAaP27w82mWRBtU
