### PR TITLE
docs(chsql,chopt): record measured-negative verdict on ts-grid NaN-duplicate gate

### DIFF
--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -217,7 +217,18 @@ Notes:
   alias (below). Its native aggregate requires the experimental setting to be
   co-stamped on exactly the queries that emit the native node — and the engine
   co-stamps off the post-optimize plan, so the setting fires whether the
-  feature was reached via `auto` or explicit listing.
+  feature was reached via `auto` or explicit listing. It carries one KNOWN,
+  UNFIXED divergence: a duplicate `(series, timestamp)` pair where one sample
+  is NaN collapses inside the ClickHouse builtin in an order-DEPENDENT way,
+  unlike cerberus's own deterministic fan-out fold — tracked at
+  [#2798](https://github.com/tsouza/cerberus/issues/2798). An order-independent
+  scan-side gate exists and is sound, but
+  [#2924](https://github.com/tsouza/cerberus/issues/2924) measured it at a
+  ~2.1-2.4x wall-clock tax on this exact path even under the best-case ORDER BY
+  alignment, for no memory benefit, and closed without shipping it (see
+  `chsql.nativeTSGridFn`'s own "Verdict on the scan-order gate" doc for the
+  full measurement). The only remaining path is an upstream ClickHouse report,
+  which needs authorization this repo has not given.
 - **`ts_grid_resample`** is `experimental` in maturity but **auto-enabled** on
   a capable server (no legacy alias). It shares
   the `timeSeries*ToGrid` family floor (25.9) and the same experimental setting

--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -42,6 +42,17 @@ const (
 	// on the 25.8 chDB substrate. A 25.6 floor would auto-enable a path that
 	// systematically diverges from Prometheus on 25.6-25.8; 25.9 is the first
 	// release whose window is Prometheus-equivalent.
+	//
+	// KNOWN DIVERGENCE, NOT REPAIRABLE HERE — a duplicate (series, timestamp)
+	// pair where one sample is NaN collapses inside ClickHouse's own builtin in
+	// an order-DEPENDENT way (cerberus issue #2798), unlike cerberus's own
+	// array-fold fan-out. An order-independent scan-side gate exists and is
+	// sound, but was measured (cerberus issue #2924) at a ~2.1-2.4x wall-clock
+	// tax on this exact path even under the best-case ORDER BY alignment, for
+	// no memory benefit — see chsql.nativeTSGridFn's own "Verdict on the
+	// scan-order gate" section for the full measurement. Not shipped, gated or
+	// not; the only remaining path is an upstream report, which needs
+	// authorization this repo has not given.
 	FeatureTSGridRange = "ts_grid_range"
 
 	// FeatureTSGridResample opts the eligible range-mode instant-vector

--- a/internal/chsql/range_window_grid_native.go
+++ b/internal/chsql/range_window_grid_native.go
@@ -131,6 +131,70 @@ type nativeTSGridAgg struct {
 // which no NaN propagates into) and irate/idelta (trailing-pair folds, blind
 // to an interior NaN) break the premise a second and third way.
 //
+// # Verdict on the scan-order gate (cerberus issue #2924): rejected, measured
+//
+// A second repair — sound this time — exists: a window aggregate
+// (`max(isNaN(Value)) OVER (PARTITION BY <series keys>, <ts>)`) ahead of the
+// scan drops a finite row iff some row shares its (series, timestamp) and
+// carries a NaN, leaving the timeSeries*ToGrid fold nothing ambiguous to
+// collapse. It was not shipped, because its cost was measured and it is not
+// close to free even in the BEST case.
+//
+// Measured against a real ClickHouse 25.10.7.6 (above the family's 25.9
+// floor), one MergeTree table (ORDER BY (SeriesId, TimeUnix), matching the
+// production schema's (MetricName, Attributes, …, TimeUnix) shape for a
+// single-metric query with no relabeling), 2000 series x 2880 samples/series
+// (5.76M rows, 30s scrape interval over 24h), one representative
+// `rate(<counter>[5m])` query_range shape at a 60s step over the full day —
+// exactly emitRangeWindowGridNative's own two-level SQL, before and after
+// inserting the gate ahead of the inner GROUP BY. Each variant run 8x
+// end-to-end (clickhouse-client wall clock) plus once with query_id tagging
+// for a system.query_log cross-check:
+//
+//   - baseline (today's shape): 618-1090ms wall clock (median ~700ms);
+//     query_log query_duration_ms=775, memory_usage=453MiB.
+//   - gated, PARTITION BY key IDENTICAL to the table's physical ORDER BY (the
+//     best case the deployment can offer — no re-sort should be needed):
+//     1568-1764ms wall clock (median ~1660ms, EVERY rep slower than the
+//     baseline's slowest); query_log query_duration_ms=1769,
+//     memory_usage=447MiB.
+//   - gated, PARTITION BY key that does NOT match the physical order
+//     (`SeriesId % 37`, forcing a genuine resort): 1712-2337ms wall clock —
+//     close to, not dramatically worse than, the matching-order case.
+//
+// EXPLAIN PIPELINE confirms why the two gated cases are close: even the
+// order-matching case gets a Sorting step and a WindowTransform (ClickHouse
+// does not skip window-function bookkeeping just because the input already
+// satisfies the partition order); the mismatched case additionally gets an
+// 8-way PartialSortingTransform / MergeSortingTransform pair, and that extra
+// real sort is a SMALLER increment than the WindowTransform bookkeeping
+// itself. A control run — the identical two-level nesting with a plain
+// boolean filter swapped in for the window aggregate — reproduced the
+// baseline's own timing (median ~840ms), ruling out "one more subquery
+// level" as the cause and isolating the cost to the window function.
+//
+// Net: the gate adds roughly +130% wall-clock latency (2.1-2.4x) to the
+// flagship native rate() path, on EVERY query down that path, with no
+// memory benefit, even under the most favourable ORDER BY alignment a
+// deployment could have — to correctly resolve an edge case (two samples at
+// one series' exact timestamp with one of them NaN) real telemetry rarely
+// produces. This is this repo's own established pattern for a change that
+// looks like an obvious win before it is actually measured (see
+// classic_bucket_merge_summap.go's own "Verdict" section for the same
+// shape of finding) — the number kills it. No chopt feature is added for
+// this gate, opt-in or otherwise: a mandatory ~2x tax on the flagship native
+// path is not something worth carrying, gated or not, for a rarity this
+// narrow.
+//
+// The only remaining path is cerberus issue #2924's Option 1: the family's
+// own documentation states a NaN-loses rule it does not deliver, which is a
+// documented-contract violation upstream, not a cerberus modelling gap — but
+// reporting it needs a maintainer contact or triage path outside this
+// repository, and that requires explicit human authorization this issue does
+// not have. No such report has been filed or attempted. The divergence stays
+// tracked exactly where cerberus issue #2798 already pinned it; #2924 closes
+// on this measured negative result.
+//
 // StateFn / MergeFn name the aggregate's partial-state combinator pair, which
 // the deferred label-shaping shape (chplan.RangeWindowGridNative.Recollapse)
 // needs: the inner level emits <fn>ToGridState per RAW series and the middle


### PR DESCRIPTION
## Summary

- Cerberus issue #2924 asked whether an order-independent scan-side gate
  (`max(isNaN(Value)) OVER (PARTITION BY <series keys>, <ts>)` ahead of the
  scan) is worth shipping to remove the `timeSeries*ToGrid` NaN-duplicate-
  timestamp nondeterminism tracked by #2798. This PR is the measured answer:
  **no** — the cost is real and material, not a rounding error.
- Measured against a real ClickHouse 25.10.7.6 (5.76M rows, 2000 series, 30s
  scrape interval over 24h, `ORDER BY (SeriesId, TimeUnix)` — matching the
  production schema's `(MetricName, Attributes, …, TimeUnix)` shape for a
  single-metric query with no relabeling, i.e. the deployment's **best case**):
  a representative native `rate(<counter>[5m])` `query_range` shape at a 60s
  step over the full day went from a median ~700ms (8 reps, 618-1090ms) to a
  median ~1660ms (8 reps, 1568-1764ms) with the gate inserted — every gated
  rep slower than the baseline's slowest. `system.query_log` cross-check:
  `query_duration_ms` 775 → 1769 (+128%), `memory_usage` 453 MiB → 447 MiB (no
  memory cost, pure latency). EXPLAIN PIPELINE shows why: even the
  order-matching case pays a Sorting step + WindowTransform bookkeeping;
  forcing a genuine mismatch (partitioning by `SeriesId % 37`) only adds a
  little more (1712-2337ms) — the WindowTransform itself, not the sort, is the
  dominant added cost. A control (identical extra subquery nesting with a
  plain boolean filter instead of the window aggregate) reproduced the
  baseline's own timing, isolating the cost to the window function.
- Net: **+~130% wall-clock (2.1-2.4x) on the flagship native `rate()` path,
  on every query down that path**, with no memory benefit, even under the
  most favourable `ORDER BY` alignment a deployment could have — to correctly
  resolve an edge case (two samples at one series' exact timestamp, one NaN)
  real telemetry rarely produces. Not worth shipping, gated or not.
- The only remaining path is cerberus issue #2924's Option 1 (report the
  fold's documented-contract violation upstream to ClickHouse), which needs
  explicit human authorization this issue does not have. **No upstream
  report has been filed or attempted** — this PR does not touch or contact
  any third-party project.
- No code paths change. This PR records the measured-negative verdict where
  a future re-proposal of the same gate would look: `chsql.nativeTSGridFn`'s
  own doc comment (full measurement writeup), `chopt.FeatureTSGridRange`'s
  doc comment (cross-reference), and the hand-authored `ts_grid_range`
  section of `docs/clickhouse-optimizations.md`. #2798's own pins are
  unchanged — they still correctly characterise the (still-present)
  divergence.

## Test plan

- [x] `go build ./internal/chsql/... ./internal/chopt/...`
- [x] `go test ./internal/chsql/... ./internal/chopt/...`
- [x] `go vet ./internal/chsql/... ./internal/chopt/...`
- [x] `go run ./cmd/cerberus optdocs -doc docs/clickhouse-optimizations.md -check` (no drift — only the hand-authored prose changed, not the generated table)
- [x] `node .github/scripts/forbid-sql-raw.mjs`
- [x] `node .github/scripts/markdownlint-run.mjs` (0 issues)
- [x] Cost measurement executed against a real, disposable ClickHouse container (25.10.7.6) seeded and torn down for this PR only — see the doc comments for the full methodology and numbers.

Closes #2924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
