### PR TITLE
feat(schema): retire the legacy idx_lower_body tokenbf index

### DIFF
--- a/cmd/cerberus/cmd_schema.go
+++ b/cmd/cerberus/cmd_schema.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tsouza/cerberus/internal/deltaprefix"
 	"github.com/tsouza/cerberus/internal/downsampletier"
 	"github.com/tsouza/cerberus/internal/migrateverify"
+	"github.com/tsouza/cerberus/internal/schema/ddl"
 	"github.com/tsouza/cerberus/internal/schemaboot"
 )
 
@@ -65,6 +66,7 @@ func newSchemaCmd() *cobra.Command {
 		newSchemaDownsampleTierBackfillCmd(),
 		newSchemaDownsampleTierRebuildCmd(),
 		newSchemaDownsampleTierVerifyCmd(),
+		newSchemaRetireIdxLowerBodyCmd(),
 	)
 	return cmd
 }
@@ -727,4 +729,96 @@ func unionDownsampleTierMetricNames(rep downsampletier.Report) map[string]struct
 		out[name] = struct{}{}
 	}
 	return out
+}
+
+// retireIdxLowerBodyInputs carries newSchemaRetireIdxLowerBodyCmd's resolved
+// flags to runRetireIdxLowerBody.
+type retireIdxLowerBodyInputs struct {
+	dryRun bool
+}
+
+// newSchemaRetireIdxLowerBodyCmd builds `cerberus schema
+// retire-idx-lower-body` — the one-time, operator-run ALTER TABLE DROP INDEX
+// that retires the legacy idx_lower_body tokenbf_v1 skip index on a logs
+// table already upgraded to carry idx_body_text (cerberus issue #2773's
+// additive text-index feature), the follow-up cerberus issue #2839 asked
+// for.
+//
+// Live-measured against ClickHouse 26.6 before this verb was written (see
+// internal/schema/ddl.DropLegacyBodyTokenBFIndexSQL's doc comment for the
+// full numbers): idx_lower_body prunes ZERO parts/granules for the exact
+// `lower(Body) LIKE '%tok%'` conjunct shape cerberus's LogQL line-filter
+// prefilter emits (chopt text_index_line_filter) — identical to a table
+// with no index at all — while idx_body_text alone already provides the
+// real pruning (a ~244x rows-read reduction in the measured case). Retiring
+// idx_lower_body removes pure write-path bloom-filter-maintenance overhead
+// for zero read-path loss on an upgraded table.
+//
+// Deliberately its OWN verb, not folded into the server's boot-time
+// auto-create DDL apply: dropping an index a running deployment's queries
+// might still be planning against is a real production-cluster decision an
+// operator makes deliberately, once idx_body_text has been live and
+// MATERIALIZE'd for a confidence period — see docs/operations.md's runbook
+// step. Mirrors delta-prefix-backfill / downsample-tier-rebuild's own
+// "operator runs this once, deliberately, with --dry-run to preview first"
+// shape.
+func newSchemaRetireIdxLowerBodyCmd() *cobra.Command {
+	var in retireIdxLowerBodyInputs
+	cmd := &cobra.Command{
+		Use:   "retire-idx-lower-body",
+		Short: "Drop the legacy idx_lower_body tokenbf_v1 index on an upgraded logs table",
+		Long: "Retires the legacy idx_lower_body tokenbf_v1(32768, 3, 0) skip index\n" +
+			"(the pre-#2773 index) on a logs table that has already been upgraded to\n" +
+			"carry idx_body_text (CERBERUS_CH_OPTIMIZATIONS=full_text_index, cerberus\n" +
+			"issue #2773). Live-measured against ClickHouse 26.6: idx_lower_body\n" +
+			"prunes ZERO parts/granules for the `lower(Body) LIKE '%tok%'` conjunct\n" +
+			"shape cerberus's LogQL line-filter prefilter emits (chopt\n" +
+			"text_index_line_filter) — identical to a table with no index at all —\n" +
+			"while idx_body_text alone already provides the real pruning. Run this\n" +
+			"only once idx_body_text has been live and MATERIALIZE'd for a\n" +
+			"confidence period on this deployment — see docs/operations.md's runbook\n" +
+			"step. DESTRUCTIVE-ish: dropping and re-adding the index later requires a\n" +
+			"full re-backfill via `ALTER TABLE ... MATERIALIZE INDEX`, since ADD INDEX\n" +
+			"is metadata-only for new parts.",
+		Example:       "  cerberus schema retire-idx-lower-body --dry-run",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRetireIdxLowerBody(cmd, in)
+		},
+	}
+	f := cmd.Flags()
+	f.BoolVar(&in.dryRun, "dry-run", false, "print the ALTER TABLE DROP INDEX statement without executing it")
+	return cmd
+}
+
+func runRetireIdxLowerBody(cmd *cobra.Command, in retireIdxLowerBodyInputs) error {
+	cfg, err := config.FromEnv()
+	if err != nil {
+		return fmt.Errorf("load config from environment: %w", err)
+	}
+	ddlCfg, err := schemaboot.DDLConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("resolve schema DDL config: %w", err)
+	}
+	stmt := ddl.DropLegacyBodyTokenBFIndexSQL(ddlCfg)
+
+	if in.dryRun {
+		fmt.Fprintln(cmd.OutOrStdout(), stmt)
+		return nil
+	}
+
+	client, err := chclient.New(cfg.ClickHouse)
+	if err != nil {
+		return fmt.Errorf("connect ClickHouse: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if err := client.Conn().Exec(context.Background(), stmt); err != nil {
+		return fmt.Errorf("drop idx_lower_body: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "dropped idx_lower_body on %s.%s (idempotent: IF EXISTS)\n",
+		ddlCfg.Database, ddlCfg.Tables.Logs)
+	return nil
 }

--- a/cmd/cerberus/cmd_schema_test.go
+++ b/cmd/cerberus/cmd_schema_test.go
@@ -53,7 +53,7 @@ func TestSchema_HelpExitsCleanToStdout(t *testing.T) {
 // every schema subcommand's -h exits 0 with usage on stdout and nothing on
 // stderr.
 func TestSchema_SubcommandHelpExitsClean(t *testing.T) {
-	for _, sc := range []string{"delta-prefix-backfill", "delta-prefix-verify"} {
+	for _, sc := range []string{"delta-prefix-backfill", "delta-prefix-verify", "retire-idx-lower-body"} {
 		var out, errOut bytes.Buffer
 		if err := runSchema([]string{sc, "-h"}, &out, &errOut); err != nil {
 			t.Errorf("run %s -h should exit cleanly, got: %v", sc, err)
@@ -75,7 +75,7 @@ func TestSchema_RootUsageListsSubcommands(t *testing.T) {
 		t.Fatalf("run -h: %v", err)
 	}
 	usage := out.String()
-	for _, name := range []string{"delta-prefix-backfill", "delta-prefix-verify"} {
+	for _, name := range []string{"delta-prefix-backfill", "delta-prefix-verify", "retire-idx-lower-body"} {
 		if !strings.Contains(usage, name) {
 			t.Errorf("root usage should list subcommand %q, got:\n%s", name, usage)
 		}
@@ -181,6 +181,43 @@ func TestDeltaPrefixBackfill_NotOptedInIsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "DeltaPrefixTable") {
 		t.Errorf("error should name the missing DeltaPrefixTable, got: %v", err)
+	}
+}
+
+// TestRetireIdxLowerBody_DryRunPrintsSQLWithoutConnecting confirms --dry-run
+// prints the rendered ALTER TABLE DROP INDEX statement to stdout and returns
+// no error WITHOUT ever needing a live ClickHouse connection — mirrors
+// TestDeltaPrefixBackfill_DryRunPrintsSQLWithoutConnecting.
+func TestRetireIdxLowerBody_DryRunPrintsSQLWithoutConnecting(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := runSchema([]string{"retire-idx-lower-body", "--dry-run"}, &out, &errOut)
+	if err != nil {
+		t.Fatalf("dry-run should not error: %v (stderr: %s)", err, errOut.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := "ALTER TABLE default.otel_logs DROP INDEX IF EXISTS idx_lower_body"
+	if got != want {
+		t.Errorf("dry-run output = %q; want %q", got, want)
+	}
+}
+
+// TestRetireIdxLowerBody_DryRunHonorsTableOverride confirms the verb reads
+// the SAME CERBERUS_SCHEMA_LOGS_TABLE override every query-answering path
+// reads, rather than hard-coding "otel_logs" — a mismatch here would drop
+// the index on the wrong table (or silently no-op via IF EXISTS on a table
+// that was never the operator's real logs table).
+func TestRetireIdxLowerBody_DryRunHonorsTableOverride(t *testing.T) {
+	t.Setenv("CERBERUS_SCHEMA_LOGS_TABLE", "logs_v2")
+	t.Setenv("CERBERUS_CH_DATABASE", "otel")
+	var out, errOut bytes.Buffer
+	err := runSchema([]string{"retire-idx-lower-body", "--dry-run"}, &out, &errOut)
+	if err != nil {
+		t.Fatalf("dry-run should not error: %v (stderr: %s)", err, errOut.String())
+	}
+	got := strings.TrimSpace(out.String())
+	want := "ALTER TABLE otel.logs_v2 DROP INDEX IF EXISTS idx_lower_body"
+	if got != want {
+		t.Errorf("dry-run output = %q; want %q", got, want)
 	}
 }
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2224,10 +2224,13 @@ mode, so this reproduces the default rather than widening that builder's
 contract for one index type.
 
 **Retiring the now-redundant legacy `idx_lower_body` tokenbf index on an
-upgraded existing table is explicitly out of scope of this feature** —
-dropping an index a running deployment's queries may still be planning
-against is a real production-cluster risk this render-time DDL apply should
-not take unilaterally. Tracked as a follow-up issue.
+upgraded existing table is out of scope of THIS feature's own render-time DDL
+apply** — dropping an index a running deployment's queries may still be
+planning against is a real production-cluster decision no boot-time DDL
+apply should take unilaterally. `cerberus schema retire-idx-lower-body`
+(cerberus issue #2839) is the dedicated, operator-run follow-up; see
+"Retiring the legacy `idx_lower_body` tokenbf index" below for the runbook
+and the live measurement establishing it is safe.
 
 ##### One-time `MATERIALIZE INDEX` back-fill runbook
 
@@ -2288,6 +2291,84 @@ strictly ordered (26.4 > 26.2), so a server can satisfy one without the
 other, and the rewrite is a harmless (if pointless) no-op on any table that
 carries no text index at all — every LIKE conjunct just evaluates against
 the same undexed `lower(Body)` scan the row predicate already pays for.
+Live-confirmed against a real ClickHouse 26.6 server rather than assumed
+(cerberus issue #2839): a 2,002,000-row logs-shaped table with ONLY the
+legacy `idx_lower_body` tokenbf_v1 index (no text index at all) reads
+2,002,000 rows for a `lower(Body) LIKE '%peer%'` query — byte-identical to a
+table with no index whatsoever — confirming the rewrite is genuinely inert,
+not merely assumed inert, on that shape. The same probe is also the
+definitive answer to a narrower question the tokenbf_v1 branch's own history
+left open: whether `idx_lower_body`, specifically, could still prune THIS
+exact `lower(Body) LIKE '%tok%'` conjunct shape once it exists — see
+"Retiring the legacy `idx_lower_body` tokenbf index" immediately below.
+
+##### Retiring the legacy `idx_lower_body` tokenbf index (cerberus issue #2839)
+
+`idx_lower_body`'s pre-#2773 `tokenbf_v1(32768, 3, 0)` shape indexes
+`lower(Body)` — the exact column expression the `text_index_line_filter`
+prefilter above conjuncts against with `LIKE '%tok%'`. That similarity is
+worth stating plainly because it is the one honest reason this repo did not
+simply take the "`tokenbf_v1` provides zero benefit" claim on faith: a
+bloom-filter index over the SAME expression a new predicate shape targets is
+exactly the situation where "no predicate cerberus emits matches this index
+type" claims deserve a live check rather than a re-statement.
+
+Live-measured against a real ClickHouse 26.6 server (not chDB — index
+pruning is genuine server-planner behavior chDB does not reliably model): a
+2,002,000-row logs-shaped table (`idx_lower_body` tokenbf_v1(32768, 3, 0)
+GRANULARITY 8, `idx_body_text` text(tokenizer = 'splitByNonAlpha')
+GRANULARITY 100000000, 2,000 rows containing the word "peer" clustered into
+one narrow time window, matching a realistic incident-log shape) against
+`lower(Body) LIKE '%peer%'` — the exact conjunct shape
+`text_index_line_filter`'s prefilter emits:
+
+| Indexes present                      | `EXPLAIN indexes=1` Parts/Granules pruned  | rows read | query time |
+| ------------------------------------ | ------------------------------------------ | --------- | ---------- |
+| neither                              | 24/24, 255/255 (no pruning)                | 2,002,000 | 191 ms     |
+| `idx_lower_body` alone               | 24/24, 255/255 (no pruning)                | 2,002,000 | 254 ms     |
+| `idx_body_text` alone                | 1/24, 1/255                                | 8,192     | 142 ms     |
+| both (the post-#2773 upgraded shape) | 1/24, 1/255 (identical to text-only)       | 8,192     | 182 ms     |
+
+`idx_lower_body` alone is byte-for-byte identical to no index at all for
+this predicate — confirmed not to be a broken or misconfigured index by the
+same probe: `hasToken(lower(Body), 'peer')` and `lower(Body) = 'peer'`
+against the SAME `idx_lower_body`-only table both DO prune (5/24 parts,
+35/255 granules) — `tokenbf_v1` works exactly as documented for
+token-equality-shaped predicates, it is specifically the `LIKE '%needle%'`
+substring shape cerberus's line-filter prefilter emits that it cannot
+answer. `idx_body_text` alone already accounts for the FULL pruning benefit
+in the "both" row; `idx_lower_body` contributes nothing incremental once
+`idx_body_text` exists. This confirms both #2839's own "zero query-time
+benefit" claim and this document's "harmless (if pointless) no-op" sentence
+above hold up under a real-server check, not just as a re-stated assumption
+— `idx_lower_body` is confirmed dead weight on an upgraded deployment: real
+write-path bloom-filter-maintenance cost on every insert/merge, for zero
+read-path benefit on the one predicate shape it was built to accelerate.
+
+**Runbook** — `cerberus schema retire-idx-lower-body` (chsql's
+`AlterTableDropIndex` Frag, `internal/schema/ddl.DropLegacyBodyTokenBFIndexSQL`)
+renders/executes:
+
+```sql
+ALTER TABLE <db>.otel_logs DROP INDEX IF EXISTS idx_lower_body;
+```
+
+Preview it first with `--dry-run`. Like every other schema-mutation verb in
+this section (`delta-prefix-backfill`, `downsample-tier-rebuild`, and the
+`full_text_index` DDL feature's own `ADD INDEX` above), this is an
+operator-run, one-time ALTER — **not** something cerberus applies
+automatically at boot: dropping an index a running deployment's own queries
+might still be planning against (for a predicate shape this measurement did
+not probe) is a real production-cluster decision, never one a render-time
+DDL apply should make unilaterally. Run it only once `idx_body_text` has
+been live and `MATERIALIZE`'d (see the back-fill runbook above) for a
+confidence period on this deployment. `DROP INDEX` is metadata-only —
+ClickHouse discards the index's on-disk bloom-filter blocks for every part
+in the background; there is no equivalent of `MATERIALIZE INDEX` for a drop.
+Re-adding `idx_lower_body` later (there is no reason to, but if an operator
+ever needs the tokenbf_v1 shape back for some OTHER predicate) needs a full
+`ADD INDEX` + `MATERIALIZE INDEX` re-backfill, since the drop discards the
+existing granule data.
 
 **Unverified ClickHouse 26.6 claims — do not build on these without
 re-verifying against a real 26.6+ instance.** `multiSearchAny` inside the

--- a/internal/chsql/ddl.go
+++ b/internal/chsql/ddl.go
@@ -1158,6 +1158,78 @@ func (a *AddIndexBuilder) SQL() string {
 	return RenderDDL(a.frag())
 }
 
+// --- ALTER TABLE ... DROP INDEX surface ---
+//
+// DropIndexBuilder renders
+// `ALTER TABLE [<db>.]<table> [ON CLUSTER x] DROP INDEX IF EXISTS <name>`,
+// the statement that retires a ClickHouse data-skipping index a table
+// carries — the inverse of AddIndexBuilder above. Unlike ADD INDEX, this is
+// deliberately NOT part of any boot-time DDL apply path: dropping an index a
+// running deployment's queries might still be planning against is a real
+// production-cluster decision an operator makes deliberately (cerberus
+// issue #2839's `cerberus schema retire-idx-lower-body` verb is the current
+// caller), never something rendered on every server start the way
+// AddIndexBuilder's callers are. DROP INDEX is metadata-only — ClickHouse
+// discards the index's on-disk data for every part in the background; no
+// separate MATERIALIZE step applies to a drop the way one does to an add.
+//
+// Like the other DDL builders it binds no positional `?` values, so SQL
+// renders through RenderDDL.
+
+// DropIndexBuilder builds an ALTER TABLE DROP INDEX statement.
+type DropIndexBuilder struct {
+	database string // "" => unqualified table reference
+	table    string
+	name     string
+	cluster  string // "" => no ON CLUSTER clause
+}
+
+// AlterTableDropIndex starts a DROP INDEX builder retiring the data-skipping
+// index named <name> from [<database>.]<table>. An empty database emits no
+// qualifier, so a table the connection's own database owns is referenced
+// bare. The rendered statement always carries IF EXISTS, mirroring
+// AddIndexBuilder's own IF NOT EXISTS — an operator re-running the verb
+// against a table that has already had the index dropped gets a clean
+// no-op, not a client-visible "unknown index" error.
+func AlterTableDropIndex(database, table, name string) *DropIndexBuilder {
+	return &DropIndexBuilder{database: database, table: table, name: name}
+}
+
+// OnCluster adds an `ON CLUSTER <name>` clause so the ALTER replicates the
+// same way the CREATE statements do under a classic ON CLUSTER deployment.
+// A Replicated database replicates the DDL itself and needs no clause.
+func (a *DropIndexBuilder) OnCluster(name string) *DropIndexBuilder {
+	a.cluster = name
+	return a
+}
+
+// frag assembles the statement from typed pieces: keyword tokens via
+// ddlToken, bare database/table/index identifiers via BareIdent, and the
+// optional ON CLUSTER clause via the typed constructor — no raw token is
+// written here.
+func (a *DropIndexBuilder) frag() Frag {
+	return func(b *Builder) {
+		ddlToken("ALTER TABLE ")(b)
+		if a.database != "" {
+			BareIdent(a.database)(b)
+			ddlToken(".")(b)
+		}
+		BareIdent(a.table)(b)
+		if a.cluster != "" {
+			ddlToken(" ")(b)
+			OnCluster(a.cluster)(b)
+		}
+		ddlToken(" DROP INDEX IF EXISTS ")(b)
+		BareIdent(a.name)(b)
+	}
+}
+
+// SQL renders the ALTER TABLE DROP INDEX statement to ClickHouse text via
+// RenderDDL (which asserts the no-positional-bindings DDL invariant).
+func (a *DropIndexBuilder) SQL() string {
+	return RenderDDL(a.frag())
+}
+
 // --- ALTER TABLE ... ADD STATISTICS surface ---
 //
 // AddStatisticsBuilder renders

--- a/internal/chsql/ddl_test.go
+++ b/internal/chsql/ddl_test.go
@@ -607,6 +607,41 @@ func TestAlterTableAddIndex_RejectsNonPositiveGranularity(t *testing.T) {
 	}
 }
 
+// TestAlterTableDropIndex pins the DROP INDEX statement: the fully-qualified
+// (or bare) <db>.<table>, the idempotent IF EXISTS guard, the index name,
+// and the optional ON CLUSTER clause. The statement carries no positional
+// args.
+func TestAlterTableDropIndex(t *testing.T) {
+	cases := []struct {
+		name string
+		stmt *DropIndexBuilder
+		want string
+	}{
+		{
+			"unqualified_table",
+			AlterTableDropIndex("", "otel_logs", "idx_lower_body"),
+			"ALTER TABLE otel_logs DROP INDEX IF EXISTS idx_lower_body",
+		},
+		{
+			"qualified_table",
+			AlterTableDropIndex("otel", "otel_logs", "idx_lower_body"),
+			"ALTER TABLE otel.otel_logs DROP INDEX IF EXISTS idx_lower_body",
+		},
+		{
+			"on_cluster",
+			AlterTableDropIndex("otel", "otel_logs", "idx_lower_body").OnCluster("prod"),
+			"ALTER TABLE otel.otel_logs ON CLUSTER `prod` DROP INDEX IF EXISTS idx_lower_body",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.stmt.SQL(); got != tc.want {
+				t.Errorf("SQL() = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestAlterTableAddStatistics pins the ADD STATISTICS statement: the
 // fully-qualified (or bare) <db>.<table>, the idempotent IF NOT EXISTS
 // guard, the bare (no-parens) comma-separated column and TYPE lists, and the

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -1272,6 +1272,64 @@ func renderAddBodyTextIndex(cfg Config) string {
 	return stmt.SQL()
 }
 
+// legacyBodyTokenBFIndexName is the upstream OTel-CH exporter template's own
+// name (sqltemplates' logs_table.sql) for the pre-#2773 tokenbf_v1(32768, 3,
+// 0) skip index over lower(Body) — the SAME name idx_body_text's own doc
+// comment above describes the text-index branch as reusing on a FRESH
+// table (HasFullTextSearch's mutually-exclusive CREATE-time swap), but the
+// name an EXISTING, already-upgraded table's index still carries alongside
+// the separately-named idx_body_text. DropLegacyBodyTokenBFIndexSQL below is
+// the only caller.
+const legacyBodyTokenBFIndexName = "idx_lower_body"
+
+// DropLegacyBodyTokenBFIndexSQL renders the ALTER TABLE DROP INDEX statement
+// retiring the legacy idx_lower_body tokenbf_v1 skip index on an EXISTING
+// logs table that has already been upgraded to carry idx_body_text
+// (cerberus issue #2773) — cerberus issue #2839's retirement follow-up.
+//
+// Live-measured against ClickHouse 26.6 (2,002,000-row logs-shaped table,
+// idx_lower_body tokenbf_v1(32768, 3, 0) GRANULARITY 8 vs idx_body_text
+// text(tokenizer = 'splitByNonAlpha'), a `lower(Body) LIKE '%peer%'`
+// query — the EXACT conjunct shape internal/chsql's exprLineContent emits
+// for chopt text_index_line_filter, cerberus issue #2773): idx_lower_body
+// ALONE prunes ZERO parts/granules for this predicate shape — `EXPLAIN
+// indexes=1` reports the identical Parts 24/24, Granules 255/255 a table
+// with NO index at all reports, and read_rows is identical too (2,002,000
+// rows, a full scan, for both) — while idx_body_text ALONE (or the two
+// together, which perform identically to idx_body_text alone) prunes to
+// Parts 1/24, Granules 1/255, reading only 8,192 rows. A sanity check
+// against the SAME tokenbf_v1 index confirms it is not simply
+// misconfigured: `hasToken(lower(Body), 'peer')` and `lower(Body) = 'peer'`
+// both DO prune via idx_lower_body (Parts 5/24, Granules 35/255) — tokenbf_v1
+// works exactly as documented for token-equality-shaped predicates, it is
+// specifically the LIKE '%needle%' substring shape cerberus's line-filter
+// prefilter emits that it cannot answer. idx_lower_body is confirmed dead
+// weight on any deployment that has already upgraded to idx_body_text: it
+// costs real write-path bloom-filter-maintenance overhead on every
+// insert/merge for zero read-path benefit on the one predicate shape it
+// was built to accelerate.
+//
+// Deliberately NOT wired into Apply / RenderAll / applySignal — the same
+// "an operator runs this once, deliberately" posture
+// `cerberus schema delta-prefix-backfill` / `downsample-tier-rebuild` follow
+// (see cmd/cerberus/cmd_schema.go's `retire-idx-lower-body` verb, the only
+// caller): dropping an index a running deployment's queries might still be
+// planning against is a real production-cluster decision no render-time
+// boot-time DDL apply should make unilaterally, and this measurement's own
+// verdict — idx_lower_body helps nothing on THIS predicate shape — says
+// nothing about whether an operator's OWN queries lean on it some other
+// way this package cannot see. Run this only once idx_body_text has been
+// live and MATERIALIZE'd for a confidence period — see docs/operations.md's
+// runbook step.
+func DropLegacyBodyTokenBFIndexSQL(cfg Config) string {
+	cfg = cfg.withDefaults()
+	stmt := chsql.AlterTableDropIndex(cfg.Database, cfg.Tables.Logs, legacyBodyTokenBFIndexName)
+	if cfg.Cluster != "" {
+		stmt.OnCluster(cfg.Cluster)
+	}
+	return stmt.SQL()
+}
+
 const (
 	// temporalityIndexName is the ALTER TABLE ADD INDEX identifier for the
 	// AggregationTemporality skip index — see renderAddTemporalityIndex.

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -1280,7 +1280,7 @@ func renderAddBodyTextIndex(cfg Config) string {
 // name an EXISTING, already-upgraded table's index still carries alongside
 // the separately-named idx_body_text. DropLegacyBodyTokenBFIndexSQL below is
 // the only caller.
-const legacyBodyTokenBFIndexName = "idx_lower_body"
+const legacyBodyTokenBFIndexName = "idx_lower_body" //nolint:gosec // G101: an index NAME (tokenbf_v1 skip index), not a credential.
 
 // DropLegacyBodyTokenBFIndexSQL renders the ALTER TABLE DROP INDEX statement
 // retiring the legacy idx_lower_body tokenbf_v1 skip index on an EXISTING

--- a/internal/schema/ddl/text_index_test.go
+++ b/internal/schema/ddl/text_index_test.go
@@ -73,6 +73,45 @@ func TestRenderAddBodyTextIndex_ExactSQL(t *testing.T) {
 	}
 }
 
+// TestDropLegacyBodyTokenBFIndexSQL_ExactSQL pins the ALTER TABLE DROP INDEX
+// statement cerberus issue #2839's `cerberus schema retire-idx-lower-body`
+// verb renders/executes to retire the legacy idx_lower_body tokenbf_v1
+// index on an upgraded existing table — see that function's doc comment for
+// the live ClickHouse 26.6 measurement establishing the index provides zero
+// query-time benefit for the exact predicate shape it was built to
+// accelerate.
+func TestDropLegacyBodyTokenBFIndexSQL_ExactSQL(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			"default",
+			Config{}.withDefaults(),
+			"ALTER TABLE default.otel_logs DROP INDEX IF EXISTS idx_lower_body",
+		},
+		{
+			"on_cluster",
+			Config{Cluster: "prod"}.withDefaults(),
+			"ALTER TABLE default.otel_logs ON CLUSTER `prod` DROP INDEX IF EXISTS idx_lower_body",
+		},
+		{
+			"custom_database_and_table",
+			Config{Database: "otel", Tables: Tables{Logs: "logs_v2"}}.withDefaults(),
+			"ALTER TABLE otel.logs_v2 DROP INDEX IF EXISTS idx_lower_body",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DropLegacyBodyTokenBFIndexSQL(tt.cfg)
+			if got != tt.want {
+				t.Errorf("DropLegacyBodyTokenBFIndexSQL() =\n  %s\nwant:\n  %s", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestRenderSignal_TextIndexEnabled pins the version-gate contract at the
 // render layer, mirroring TestRenderSignal_TraceIDProjectionEnabled:
 // TextIndexEnabled=false renders NO idx_body_text statement at all — not a


### PR DESCRIPTION
## Summary

- **Independently measured, against a real ClickHouse 26.6 server (not chDB), whether `idx_lower_body`'s tokenbf_v1 index still provides pruning benefit for the exact `lower(Body) LIKE '%tok%'` conjunct shape #2773's `text_index_line_filter` prefilter emits.** Verdict: **retirement confirmed safe.** `idx_lower_body` prunes ZERO parts/granules for that predicate shape — byte-identical `read_rows` to a table with no index at all — while `idx_body_text` (the GA full-text index from #2773) alone already provides the full pruning benefit (a real-server sanity check with `hasToken()`/`=` confirms `idx_lower_body` itself is not misconfigured — it prunes fine for token-equality predicates, just not for `LIKE`).
- Ships the full M5 exit-criterion-3 deliverable in one PR:
  1. `chsql.AlterTableDropIndex` — a typed `DropIndexBuilder` Frag rendering `ALTER TABLE ... DROP INDEX IF EXISTS <name>` (`internal/chsql/ddl.go`), mirroring the existing `AlterTableAddIndex` builder.
  2. `ddl.DropLegacyBodyTokenBFIndexSQL` (`internal/schema/ddl/ddl.go`) composing the statement for the logs table.
  3. `cerberus schema retire-idx-lower-body` (`--dry-run` supported) — an operator-run, one-time verb, deliberately **not** wired into the boot-time auto-create DDL apply (same posture as `delta-prefix-backfill` / `downsample-tier-rebuild`).
  4. Exact-rendered-statement tests at both the chsql and schema/ddl layers, plus CLI dry-run tests.
- Corrects `docs/operations.md`: adds the measured numbers (table below) confirming both #2839's "zero query-time benefit" claim and the existing "harmless (if pointless) no-op" sentence hold under a real-server check, and adds a runbook step for the new verb.

## Measurement (ClickHouse 26.6.4, 2,002,000-row logs-shaped table)

Query: `lower(Body) LIKE '%peer%'` — the exact conjunct `internal/chsql`'s `exprLineContent` emits for chopt `text_index_line_filter`.

| Indexes present | `EXPLAIN indexes=1` pruning | rows read | query time |
| --- | --- | --- | --- |
| neither | 24/24 parts, 255/255 granules (none) | 2,002,000 | 191 ms |
| `idx_lower_body` alone | 24/24 parts, 255/255 granules (none) | 2,002,000 | 254 ms |
| `idx_body_text` alone | 1/24 parts, 1/255 granules | 8,192 | 142 ms |
| both (post-#2773 upgraded shape) | 1/24 parts, 1/255 granules (identical to text-only) | 8,192 | 182 ms |

Sanity check that `idx_lower_body` itself works: `hasToken(lower(Body), 'peer')` and `lower(Body) = 'peer'` against the SAME index both prune (5/24 parts, 35/255 granules) — `tokenbf_v1` is not broken, it simply cannot answer a `LIKE '%needle%'` substring predicate.

## Test plan

- [x] `go test -race ./internal/chsql/... ./internal/schema/... ./cmd/cerberus/...` — green locally.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean (no raw SQL token writes).
- [x] `npx markdownlint-cli2 docs/operations.md` — clean.
- [x] Real-ClickHouse 26.6 measurement backing the retirement verdict (see above) — reproduced independently, including a sanity check ruling out a misconfigured/broken index as the explanation.
- [ ] CI green (lint / build / spec / property / coverage-floor / etc.)

Closes #2839

🤖 Generated with [Claude Code](https://claude.com/claude-code)
