### PR TITLE
docs(chopt): close M5's batched substrate probe (#2822, #2827, #2837, #2838) all negative

### DIFF
--- a/docs/clickhouse-optimizations.md
+++ b/docs/clickhouse-optimizations.md
@@ -748,20 +748,29 @@ against the live server rather than assume it from documentation alone, no
 `chopt` feature is registered for either family: it would be machinery
 duplicating what the server already does unconditionally.
 
-**A genuinely open question this audit surfaced, not resolved by it**: the
-issue's own "fan-out-heavy wide scans vs point lookups" framing implies the
-OPPOSITE tuning direction might pay off — deliberately RAISING the
-remote-filesystem concurrent-read thresholds (toward the local-disk
-defaults) on a detected narrow, highly-selective point-lookup shape, to
-avoid the coordination overhead of spinning up concurrent S3 fetches for a
-read that only touches a handful of granules. That is a real, plausible
-optimization, but — unlike the two settings families above — it needs an
-optcorpus A/B pass against representative point-lookup and wide-scan query
-shapes to earn adoption, the same bar `fixed_accumulator_extrapolated` and
-`sorted_slab_over_time` were held to before their own AutoSelect posture was
-decided. Tracked at
-[cerberus#2827](https://github.com/tsouza/cerberus/issues/2827), not
-attempted in this PR.
+**The follow-up question this audit surfaced — settled negative
+(cerberus issue #2827).** The issue's own "fan-out-heavy wide scans vs
+point lookups" framing implied the OPPOSITE tuning direction might pay
+off: deliberately RAISING the remote-filesystem concurrent-read thresholds
+(toward the local-disk defaults, 163840 rows / 240 MiB) on a detected
+narrow, highly-selective point-lookup shape, to avoid the coordination
+overhead of spinning up concurrent S3 fetches for a read that only touches
+a handful of granules. Benchmarked directly against a real ClickHouse 26.8
+server backed by a live MinIO (S3-compatible) disk — 20M rows, a single
+`id = <literal>` point-lookup shape, `clickhouse-benchmark` over 2,000
+distinct random-id queries per configuration with the mark cache dropped
+between runs: the default (`0`/`0`, max concurrency) and the raised
+local-disk-matching thresholds measured statistically indistinguishable
+throughput (83.577 vs 83.655 QPS, a ~0.1% gap, well inside run-to-run
+noise). Smaller repeated trials (500 queries x 3) leaned the OPPOSITE
+direction from the hypothesis — raised thresholds ~2-3% SLOWER, not
+faster. A single-key point lookup only ever touches on the order of one
+granule regardless of the concurrent-read threshold, so there is no
+coordination overhead this setting family removes for that shape on real
+S3-backed storage: the threshold governs whether a read gets SPLIT into
+concurrent sub-ranges, and a read this narrow has nothing left to split
+either way. No `chopt` feature is adopted; #2827 is closed with this
+evidence rather than left open.
 
 **Local filesystem cache** (`enable_filesystem_cache` + the server-side
 cache disk) IS adopted by this issue, but as documented operator guidance

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2021,11 +2021,23 @@ the codec swap:
   adopted; Value / Sum keep `ZSTD(1)`, unchanged.
 
 See the codec-tuning PR (cerberus issue #2768) for the full benchmark
-transcript and measured numbers. Cerberus issue #2822 tracks the one
-candidate the issue explicitly deferred rather than benchmarked here:
-experimental ALP for Value/Sum, earmarked for a future `>= 26.8` version
-floor (its 26.8 Float32 arithmetic change is a live on-disk decode-compat
-risk below that floor).
+transcript and measured numbers.
+
+**NOT adopted — Value / Sum Float64, ALP codec (cerberus issue #2822):**
+this third Value/Sum candidate was originally deferred rather than
+benchmarked, on the premise that it needed a `>= 26.8` version-floor bump
+to resolve a Float32 arithmetic decode-compat risk in ALP's 26.8 release.
+That premise was corrected when #2822 closed: no floor bump was needed
+(chopt already ships per-feature floors — e.g. `full_text_index` at 26.2 —
+well above the 24.8 global `min_clickhouse`), and the cited Float32
+decode-compat risk never applied, since every targeted column (Value, Sum)
+is Float64, not Float32. Benchmarked directly against the same real
+production-shaped samples on live ClickHouse 26.6/26.7/26.8 servers, ALP
+measured dramatically worse than even Gorilla/FPC above — the histogram
+Sum column compressed to ~99.9% of its uncompressed size (essentially no
+compression) versus ZSTD(1)'s ~11x, and the counter Value column to ~19%
+of uncompressed versus ZSTD(1)'s ~2.7%, consistently across all three
+versions. ALP is not adopted; Value / Sum keep `ZSTD(1)`, unchanged.
 
 All codecs used above are supported at ClickHouse >= 22.9, well under this
 repo's 24.8 version floor (`docs/toolchain.md`), so — like `ADD PROJECTION`
@@ -2370,18 +2382,59 @@ ever needs the tokenbf_v1 shape back for some OTHER predicate) needs a full
 `ADD INDEX` + `MATERIALIZE INDEX` re-backfill, since the drop discards the
 existing granule data.
 
-**Unverified ClickHouse 26.6 claims — do not build on these without
-re-verifying against a real 26.6+ instance.** `multiSearchAny` inside the
-skip-index analyzer and a dedicated posting-list segment cache were both
-raised as possible 26.6 extras. Live-probed against a real ClickHouse
-26.6.3.62 server: `multiSearchAny(Body, [...])` produced NO skip-index entry
-in `EXPLAIN indexes=1` at all (full granule scan, unlike `hasAnyTokens` /
-`hasAllTokens` / `hasToken`, which all pruned correctly) — this claim did
-NOT hold on the probed build. `use_text_index_postings_cache` DOES exist as
-a real setting on 26.6.3.62, defaulting to `0` (off) — its existence is
-confirmed, but no benchmark evidence was gathered on its actual effect.
-Neither claim is relied on by `text_index_line_filter`. See the follow-up
-issue this PR files for someone with continued 26.6+ access to settle these.
+**Re-verified ClickHouse 26.6-26.8 claims (cerberus issue #2838) — both
+REFUTED / no realized win, confirmed across three live server versions.**
+`multiSearchAny` inside the skip-index analyzer and a dedicated posting-list
+segment cache were both raised as possible 26.6 extras and originally only
+probed on one 26.6.3.62 build. Re-verified against real ClickHouse
+26.6.4.55, 26.7.6.57, and 26.8.2.7 servers (Docker `clickhouse/clickhouse-
+server`), each seeded with 20M realistic log rows and an `idx_lower_body`
+text index:
+
+- **`multiSearchAny` stays out of the skip index on every probed build,
+  including 26.8.** `EXPLAIN indexes=1` on `multiSearchAny(lower(Body),
+  [...])` produced no `Skip` entry and a full granule scan (`Granules:
+  612/612` and `2442/2442` across two differently-sized test tables) on all
+  three versions, while `hasAnyTokens` on the identical predicate correctly
+  pruned to the matching granules only (and even resolved to a trivial
+  index-only count on 26.8). This is the real production consumer LogQL's
+  own or-filter chains would hit: chained `|=`/`or` alternates
+  (`internal/logql/lower.go`'s `lowerLineFilterChain`) lower to an `OpOr`
+  tree of per-alternate `position(Body, ?) > 0` predicates — the exact shape
+  a working `multiSearchAny` skip-index collapse would target — and it does
+  not fire at any tested version. The original refutation was not a
+  26.6.3-specific gap; it holds through 26.8.
+- **`use_text_index_postings_cache=1` measured no win** on a chained
+  multi-stage AND predicate matching cerberus's own emitted
+  `text_index_line_filter` shape (`lower(Body) LIKE '%tok%' AND
+  position(Body, ?) > 0`, ANDed across 2-3 stages) run repeatedly against
+  the identical predicate — the cache's best case. Across repeated
+  `clickhouse-benchmark` trials on ClickHouse 26.8 it was consistently at or
+  slightly below the `0` (off) baseline (e.g. 27.1 vs 26.3 QPS on a 3-stage
+  chain, 12.7 vs 12.4 QPS on a 2-stage chain) — no realized throughput or
+  latency win to justify stamping it.
+
+Neither is relied on by `text_index_line_filter`, and neither warrants a new
+`chopt` feature: #2838 closed both findings negative with this evidence.
+
+**`text_index_posting_list_apply_mode=lazy` (cerberus issue #2837) —
+measured no win, closed negative.** `lazy` is default-off (`materialize`) on
+26.6/26.7 and becomes the server default at 26.8. Benchmarked explicitly
+stamping `text_index_posting_list_apply_mode=lazy` (plus
+`allow_experimental_text_index_lazy_apply=1` where required) against the
+unchanged `materialize` default, on the same 3-stage chained-AND workload,
+across repeated trials on both 26.6 and 26.7: `lazy` measured slightly
+WORSE than `materialize` on both (26.6: ~22.4 vs ~23.1 QPS averaged across 3
+trials; 26.7: ~25.4 vs ~25.8 QPS), never a consistent win. On 26.8, where
+`lazy` is already the default, explicitly stamping it is a no-op by
+definition — "no chopt feature ships whose stamp merely duplicates what the
+server already defaults to." `text_index_density_threshold` (the lever
+`lazy` mode uses internally to pick leapfrog-intersection vs brute-force
+bitmap) was also swept from `0.01` to `0.9` on 26.8 against the same
+workload and moved throughput by less than the run-to-run noise floor
+already established by the trials above (~2-4%) — no version default-flip
+backs it either, so there is no floor at which to gate a feature even if a
+real effect existed. Neither setting warrants a `chopt` feature.
 
 ### DELTA-prefix aggregate table + backfill (cerberus issue #2389)
 

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -2280,23 +2280,24 @@ func renderTracesCreateTsView(cfg Config) string {
 //     neither is adopted; Value / Sum keep ZSTD(1), unchanged.
 //
 // A third candidate for the same Value/Sum columns — the experimental ALP
-// (Adaptive Lossless floating-Point) codec — was deferred to a follow-up
-// (cerberus issue #2822) rather than benchmarked here, on the premise that
-// it needed a >= 26.8 version-floor bump to resolve a Float32 arithmetic
-// decode-compat risk in ALP's 26.8 release. That premise did not survive
-// scrutiny when #2822 was closed: no floor bump was needed (chopt already
-// ships per-feature floors — e.g. full_text_index at 26.2 — well above the
-// 24.8 global min_clickhouse), and the cited Float32 decode-compat risk
-// never applied in the first place, since every targeted column (Value,
-// Sum) is Float64, not Float32. On the actual question — does ALP beat
-// ZSTD(1) on this data — #2822 measured it directly against real
-// production-shaped samples (the same #2411 corpus this issue used) on
-// live ClickHouse 26.6/26.7/26.8 servers: ALP was dramatically WORSE than
-// even Gorilla/FPC above, compressing the histogram Sum column to ~99.9%
-// of its uncompressed size (essentially no compression at all, versus
-// ZSTD(1)'s ~11x) and the counter Value column to ~19% of uncompressed
-// (versus ZSTD(1)'s ~2.7%, a ~7x gap) — consistent across all three
-// versions. ALP is not adopted; Value / Sum keep ZSTD(1), unchanged.
+// (Adaptive Lossless floating-Point) codec — was raised and tracked
+// separately (cerberus issue #2822) instead of being benchmarked here, on
+// the premise that it needed a >= 26.8 version-floor bump to resolve a
+// Float32 arithmetic decode-compat risk in ALP's 26.8 release. Resolved in
+// #2822: that premise did not hold up — no floor bump was needed (chopt
+// already ships per-feature floors — e.g. full_text_index at 26.2 — well
+// above the 24.8 global min_clickhouse), and the cited Float32
+// decode-compat risk never applied in the first place, since every
+// targeted column (Value, Sum) is Float64, not Float32. On the actual
+// question — does ALP beat ZSTD(1) on this data — #2822 measured it
+// directly against real production-shaped samples (the same #2411 corpus
+// this issue used) on live ClickHouse 26.6/26.7/26.8 servers: ALP was
+// dramatically WORSE than even Gorilla/FPC above, compressing the
+// histogram Sum column to ~99.9% of its uncompressed size (essentially no
+// compression at all, versus ZSTD(1)'s ~11x) and the counter Value column
+// to ~19% of uncompressed (versus ZSTD(1)'s ~2.7%, a ~7x gap) — consistent
+// across all three versions. ALP is not adopted; Value / Sum keep
+// ZSTD(1), unchanged.
 //
 // Two candidates DID measure a real, safe win and are adopted below:
 //

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -2279,6 +2279,25 @@ func renderTracesCreateTsView(cfg Config) string {
 //     regressed — Gorilla 27%-2182% larger, FPC 84%-2662% larger — so
 //     neither is adopted; Value / Sum keep ZSTD(1), unchanged.
 //
+// A third candidate for the same Value/Sum columns — the experimental ALP
+// (Adaptive Lossless floating-Point) codec — was deferred to a follow-up
+// (cerberus issue #2822) rather than benchmarked here, on the premise that
+// it needed a >= 26.8 version-floor bump to resolve a Float32 arithmetic
+// decode-compat risk in ALP's 26.8 release. That premise did not survive
+// scrutiny when #2822 was closed: no floor bump was needed (chopt already
+// ships per-feature floors — e.g. full_text_index at 26.2 — well above the
+// 24.8 global min_clickhouse), and the cited Float32 decode-compat risk
+// never applied in the first place, since every targeted column (Value,
+// Sum) is Float64, not Float32. On the actual question — does ALP beat
+// ZSTD(1) on this data — #2822 measured it directly against real
+// production-shaped samples (the same #2411 corpus this issue used) on
+// live ClickHouse 26.6/26.7/26.8 servers: ALP was dramatically WORSE than
+// even Gorilla/FPC above, compressing the histogram Sum column to ~99.9%
+// of its uncompressed size (essentially no compression at all, versus
+// ZSTD(1)'s ~11x) and the counter Value column to ~19% of uncompressed
+// (versus ZSTD(1)'s ~2.7%, a ~7x gap) — consistent across all three
+// versions. ALP is not adopted; Value / Sum keep ZSTD(1), unchanged.
+//
 // Two candidates DID measure a real, safe win and are adopted below:
 //
 //   - Logs Body (String): ZSTD(3) measured ~1.3%-1.8% smaller than ZSTD(1)


### PR DESCRIPTION
## Summary

M5's own description called out four issues — #2822, #2827, #2837, #2838 — as **one container
session, not four**, because they all depend on a real ClickHouse >= 26.6 server the repo's own
`chdb_substrate` (pinned at 26.5) cannot answer. This PR is that one session: three real ClickHouse
servers (26.6.4.55, 26.7.6.57, 26.8.2.7, via Docker) plus a real MinIO S3-compatible disk for the
point-lookup probe, seeded with realistic data, all four questions answered with measured evidence.

**All four close negative.** Per M5's own framing, this is a successful outcome: ClickHouse's own
defaults were already correctly tuned for cerberus's shapes in every case, and one candidate (ALP)
measured dramatically worse than the incumbent. No new `chopt` feature ships.

### #2822 — ALP codec for Value/Sum: not adopted

Corrected both gating premises before measuring (M5 exit criterion 2): no `versions.yaml` floor
bump was needed (chopt already ships per-feature floors above the 24.8 global min), and every
targeted column (`Value`, `Sum`) is `Float64`, so the cited Float32 decode-compat risk never
applied. Measured anyway, against the same real production-shaped samples #2768 used
(`test/perf/nightly/testdata/samples/`), replicated 10x, on all three server versions:

| Column | ZSTD(1) | ALP | Verdict |
| --- | --- | --- | --- |
| histogram `Sum` | ~9.39 MB (~11.2x compression) | ~105.3 MB (~1.0006x — essentially none) | ALP ~11x LARGER |
| counter `Value` | ~2.95 MB (~36.3x compression) | ~20.3 MB (~5.3x) | ALP ~6.9x LARGER |

Worse than even the Gorilla/FPC candidates #2768 already rejected for the same columns. Not
adopted; `Value`/`Sum` keep `ZSTD(1)`.

### #2827 — point-lookup concurrent-read threshold: not adopted

Real ClickHouse 26.8 backed by a live MinIO S3 disk, 20M rows, single `id = <literal>` lookups.
`clickhouse-benchmark` over 2,000 distinct random ids: default (`0`/`0`, max concurrency) vs raised
to local-disk defaults (163840 rows / 240 MiB) measured **83.577 vs 83.655 QPS** — statistically
indistinguishable. Smaller trials leaned the opposite direction from the hypothesis (raised was
~2-3% slower). A single-key lookup only ever touches ~1 granule regardless of the threshold, so
there's nothing for the setting to split either way. Not adopted.

### #2837 — `text_index_posting_list_apply_mode=lazy`: not adopted

`lazy` measured slightly WORSE than the `materialize` default on both 26.6 (~22.4 vs ~23.1 QPS
avg, 3 trials) and 26.7 (~25.4 vs ~25.8 QPS avg) — never a consistent win where it isn't yet the
default. On 26.8, where it IS the default, stamping it explicitly is a no-op by definition.
`text_index_density_threshold` was also swept (0.01 → 0.9) with no reproducible effect beyond
run-to-run noise. Not adopted.

### #2838 — `multiSearchAny` / postings cache re-verification: both negative

- **`multiSearchAny` confirmed to stay out of the skip-index analyzer through 26.8**, not just the
  original 26.6.3 build — `EXPLAIN indexes=1` showed a full granule scan on all three versions,
  while `hasAnyTokens` on the identical predicate correctly pruned (and hit a trivial index-only
  count on 26.8). Confirmed the real production consumer: LogQL's chained `|=`/`or` line-filter
  alternates (`internal/logql/lower.go`'s `lowerLineFilterChain`) lower to exactly the `OpOr`
  chain of `position()` predicates a working collapse would target — and it never fires.
- **`use_text_index_postings_cache=1` measured no win**, even in its own best case (an identical
  predicate repeated every iteration): 12.7 vs 12.4 QPS (2-stage chain), 27.1 vs 26.3 QPS (3-stage
  chain) — consistently at or below the off baseline.

Both closed negative.

### Labels corrected

`#2827` and `#2838` carried a bare `bug` label; corrected to `ch-capability-audit`
(`gh issue edit --remove-label bug --add-label ch-capability-audit`), matching the convention every
other closed issue under the #2778 and #2772 audit epics uses (#2779, #2780, #2781, #2766, etc.).

## What's in this PR

Documentation only — `docs/operations.md`, `docs/clickhouse-optimizations.md`, and
`internal/schema/ddl/ddl.go`'s codec package doc comment, recording each measured verdict and
correcting the two wrong #2822 premises in place, per M5's exit criteria. No `chopt` registry
change, since every candidate measured negative.

## Real-session transcript

The full command-by-command transcript (container setup, table DDL, seeding, every
`EXPLAIN`/`clickhouse-benchmark` run) is long; the essential numbers are summarized above and in
the doc sections this PR edits. Full transcript available on request — ask and I'll paste it into
a PR comment.

## Test plan

- [x] `go build ./...` — comment-only changes, verified compiling.
- [x] `node .github/scripts/markdownlint-run.mjs` — 0 issues on the edited docs.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — no SQL touched (pre-push hook ran it clean).
- [x] Labels corrected on #2827 and #2838.
- [x] Issues #2822, #2827, #2837, #2838 closed with the measured evidence recorded in each.

Closes #2822, closes #2827, closes #2837, closes #2838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sse3zjfiAaP27w82mWRBtU
