### PR TITLE
feat(chsql): thread attribute-access strategy for JSON-typed logs columns

### DIFF
--- a/cmd/cerberus/admit_tail_budget_test.go
+++ b/cmd/cerberus/admit_tail_budget_test.go
@@ -145,7 +145,7 @@ func TestNewLokiHandler_WiresBothBudgets(t *testing.T) {
 	})
 	limiters := newAdmitLimiters(cfg, quietLogger())
 
-	h := newLokiHandler(lazyClient(t), cfg, chopt.EnabledSet{}, limiters, quietLogger(), engine.ResourceBoundOverrides{})
+	h := newLokiHandler(lazyClient(t), cfg, chopt.EnabledSet{}, limiters, quietLogger(), engine.ResourceBoundOverrides{}, nil)
 
 	if h.Limiter != limiters.loki {
 		t.Errorf("Handler.Limiter = %p, want the loki request budget %p", h.Limiter, limiters.loki)
@@ -189,7 +189,7 @@ func TestMountAPIHeads_TailAndQueryBudgetsAreWiredEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	mux := http.NewServeMux()
-	if _, err := mountAPIHeads(ctx, mux, lazyClient(t), cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}); err != nil {
+	if _, err := mountAPIHeads(ctx, mux, lazyClient(t), cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil); err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}
 	srv := httptest.NewServer(mux)

--- a/cmd/cerberus/chopt_reprobe_test.go
+++ b/cmd/cerberus/chopt_reprobe_test.go
@@ -182,7 +182,7 @@ func mountedConsumers(t *testing.T, enabledHeads string) chOptConsumers {
 	t.Cleanup(cancel)
 
 	heads, err := mountAPIHeads(ctx, http.NewServeMux(), lazyClient(t), cfg, chopt.EnabledSet{},
-		limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{})
+		limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil)
 	if err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}

--- a/cmd/cerberus/enabled_heads_test.go
+++ b/cmd/cerberus/enabled_heads_test.go
@@ -62,7 +62,7 @@ func buildHeadsTestServer(t *testing.T, enabledHeads string) *httptest.Server {
 	// past the test.
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	if _, err := mountAPIHeads(ctx, traceMux, client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}); err != nil {
+	if _, err := mountAPIHeads(ctx, traceMux, client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil); err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}
 

--- a/cmd/cerberus/loki_max_query_samples_test.go
+++ b/cmd/cerberus/loki_max_query_samples_test.go
@@ -51,7 +51,7 @@ func TestNewLokiHandler_WiresMaxQuerySamples(t *testing.T) {
 	cfg := config.Config{Logs: schema.DefaultOTelLogs()}
 	limiters := newAdmitLimiters(cfg, quietLogger())
 
-	h := newLokiHandler(client, cfg, chopt.EnabledSet{}, limiters, quietLogger(), engine.ResourceBoundOverrides{})
+	h := newLokiHandler(client, cfg, chopt.EnabledSet{}, limiters, quietLogger(), engine.ResourceBoundOverrides{}, nil)
 
 	if h.Engine == nil {
 		t.Fatal("Handler.Engine is nil")
@@ -86,7 +86,7 @@ func TestMountAPIHeads_EveryBuiltEngineCarriesMaxQuerySamples(t *testing.T) {
 	logger := quietLogger()
 	limiters := newAdmitLimiters(cfg, logger)
 
-	heads, err := mountAPIHeads(t.Context(), http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{})
+	heads, err := mountAPIHeads(t.Context(), http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil)
 	if err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -33,6 +33,7 @@ import (
 	tempogrpc "github.com/tsouza/cerberus/internal/api/tempo/grpc"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chopt"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/optcorpus"
@@ -183,6 +184,7 @@ func mountAPIHeads(
 	logger *slog.Logger,
 	resourceBounds engine.ResourceBoundOverrides,
 	promResourceBounds promql.ResourceBounds,
+	logsAttrStrategies chsql.AttrStrategies,
 ) (apiHeads, error) {
 	// engines accumulates the engines actually built so the corpus reconciler
 	// observes only live heads (a disabled head has no engine to observe), and
@@ -221,7 +223,7 @@ func mountAPIHeads(
 
 	if cfg.HeadEnabled(config.HeadLoki) {
 		lokiClient := client.ForHead(chclient.HeadLoki)
-		lokiHandler := newLokiHandler(lokiClient, cfg, optSet, limiters, logger, resourceBounds)
+		lokiHandler := newLokiHandler(lokiClient, cfg, optSet, limiters, logger, resourceBounds, logsAttrStrategies)
 		lokiHandler.Mount(traceMux)
 		engines = append(engines, lokiHandler.Engine)
 	}
@@ -540,7 +542,7 @@ func run() error {
 	// returned schemaPresent func reports NOT READY on /readyz and a
 	// background re-probe flips it ready once an external writer creates the
 	// schema, with no restart. CERBERUS_REQUIREMENTS_CHECK=false skips it.
-	schemaPresent, err := runRequirementsCheck(ctx, logger, client, cfg)
+	schemaPresent, logsAttrStrategies, err := runRequirementsCheck(ctx, logger, client, cfg)
 	if err != nil {
 		return err
 	}
@@ -591,7 +593,7 @@ func run() error {
 		return err
 	}
 
-	heads, err := mountAPIHeads(ctx, traceMux, client, cfg, optSet, limiters, logger, resourceBounds, promResourceBounds)
+	heads, err := mountAPIHeads(ctx, traceMux, client, cfg, optSet, limiters, logger, resourceBounds, promResourceBounds, logsAttrStrategies)
 	if err != nil {
 		return err
 	}
@@ -1388,7 +1390,7 @@ func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 // silently at the callsite, and transposing THESE two mounts /tail on the
 // request budget and every ordinary route on the tail budget — a subtler
 // #1482. Selecting the fields by name here makes that untypeable.
-func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, limiters admitLimiters, logger *slog.Logger, resourceBounds engine.ResourceBoundOverrides) *loki.Handler {
+func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.EnabledSet, limiters admitLimiters, logger *slog.Logger, resourceBounds engine.ResourceBoundOverrides, logsAttrStrategies chsql.AttrStrategies) *loki.Handler {
 	h := loki.New(client, cfg.Logs, logger.With("api", "loki"))
 	h.Limiter = limiters.loki
 	h.TailLimiter = limiters.lokiTail
@@ -1404,6 +1406,14 @@ func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 	// request.
 	h.TextIndexLineFilter = optSet.Has(chopt.FeatureTextIndexLineFilter)
 	h.Lang.TextIndexLineFilter = h.TextIndexLineFilter
+	// AttrStrategies (cerberus issue #2777) is the preflight boot probe's
+	// resolved verdict on the logs attribute-map columns' physical shape —
+	// see runRequirementsCheck's doc for the known cold-start-race
+	// limitation. nil (the overwhelmingly common case: no JSON-typed
+	// column detected, or the requirements check disabled) renders
+	// byte-identical to before this field existed.
+	h.AttrStrategies = logsAttrStrategies
+	h.Lang.AttrStrategies = h.AttrStrategies
 	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	h.TailWriteTimeout = cfg.LokiTailWriteTimeout
 	// LabelCatalogEnabled (cerberus issue #2770) is the resolved chopt
@@ -2370,15 +2380,30 @@ func preflightRequirementsFromConfig(cfg config.Config) preflight.Requirements {
 	}
 }
 
+// runRequirementsCheck also returns the resolved logs AttrStrategies
+// (cerberus issue #2777) so the caller can wire it onto the Loki head's
+// Handler / *logql.Lang — see newLokiHandler. Known limitation (documented
+// rather than silently accepted): on the TRANSIENT not-ready path (the
+// logs table doesn't exist yet at boot), this is necessarily nil — the
+// shape can't be introspected before the table exists — and it stays nil
+// for the rest of THIS process's life even after the background re-probe
+// (reprobeSchema) flips /readyz once the schema appears; a JSON-typed
+// logs schema created during that race window is picked up correctly only
+// on the NEXT boot. This mirrors decideRequirementsOutcome's own
+// boot-resolved-once posture for every other preflight finding — nothing
+// here re-derives shape facts after the readiness re-probe passes, and
+// doing so would require making the Handler's resolved strategy mutable
+// under concurrent requests, which cerberus issue #2777 explicitly avoids
+// (chopt-style pure, boot-resolved strategy, zero per-query branching).
 func runRequirementsCheck(
 	ctx context.Context,
 	logger *slog.Logger,
 	client *chclient.Client,
 	cfg config.Config,
-) (health.SchemaPresentFunc, error) {
+) (health.SchemaPresentFunc, chsql.AttrStrategies, error) {
 	if !cfg.RequirementsCheck {
 		logger.Info("requirements check disabled (CERBERUS_REQUIREMENTS_CHECK=false)")
-		return nil, nil
+		return nil, nil, nil
 	}
 	req := preflightRequirementsFromConfig(cfg)
 	res := preflight.RunIfEnabled(ctx, cfg.RequirementsCheck, client, req)
@@ -2391,7 +2416,7 @@ func runRequirementsCheck(
 
 	outcome := decideRequirementsOutcome(res, cfg.Schema, cfg.ClickHouse.Database)
 	if outcome.fatalErr != nil {
-		return nil, outcome.fatalErr
+		return nil, nil, outcome.fatalErr
 	}
 	if outcome.notReadyReason != "" {
 		// Transient: boot but stay NOT READY; the background re-probe (reusing
@@ -2400,7 +2425,7 @@ func runRequirementsCheck(
 		logger.Warn(outcome.logMsg, "reason", outcome.notReadyReason)
 		present := newSchemaPresentSignal(outcome.notReadyReason)
 		go reprobeSchema(ctx, logger, client, req, present, schemaRetryInterval)
-		return present.Func(), nil
+		return present.Func(), nil, nil
 	}
 
 	logger.Info(
@@ -2408,7 +2433,7 @@ func runRequirementsCheck(
 		"database", cfg.ClickHouse.Database,
 		"native_rate", cfg.ExperimentalTSGridRange,
 	)
-	return nil, nil
+	return nil, res.LogsAttrStrategies, nil
 }
 
 // requirementsOutcome is the boot decision decideRequirementsOutcome derives

--- a/cmd/cerberus/solver_no_background_loop_test.go
+++ b/cmd/cerberus/solver_no_background_loop_test.go
@@ -77,7 +77,7 @@ func TestMountAPIHeads_PromStartsNoBackgroundLoop(t *testing.T) {
 		goleak.IgnoreCurrent(),
 	}
 
-	if _, err := mountAPIHeads(ctx, http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}); err != nil {
+	if _, err := mountAPIHeads(ctx, http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil); err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2811,16 +2811,28 @@ precise boot-time finding:
   signal. The check honours every `CERBERUS_SCHEMA_*` table rename — it
   validates the *active* shape.
   - **Exception: JSON-typed attribute maps on logs/traces.** Cerberus issue
-    [#2777](https://github.com/tsouza/cerberus/issues/2777) phase 1: when a
-    **logs or traces** table's attribute-map column is typed ClickHouse's
-    `JSON` instead (the upstream OTel exporter's `json:true` schema variant),
+    [#2777](https://github.com/tsouza/cerberus/issues/2777): when a **logs or
+    traces** table's attribute-map column is typed ClickHouse's `JSON`
+    instead (the upstream OTel exporter's `json:true` schema variant),
     startup **boots** rather than failing, with a **warning** logged naming
-    the table/column — query lowering against a JSON-typed attribute map is
-    not implemented yet (only detection is), so queries touching that
-    column's keys still fail, just at query time instead of at boot. Metrics
-    attribute-map columns are **not** covered by this exception and stay
-    `Map(String, String)`-only — they carry the metric's series identity, out
-    of scope per the issue itself.
+    the table/column.
+    - **Logs**: per-key attribute lookups now work against a JSON-typed
+      column — stream-selector label matchers (`{app="foo"}`),
+      `detected_level`, and any other bare `MapAccess`/`mapContains` read.
+      The warning names what remains unsupported: LogQL operations that need
+      the *whole* attribute map at once (`| line_format`, `| label_format`,
+      `| unpack`, wildcard `keep`/`drop`), the `/labels` / `/series` /
+      `/detected_fields` metadata endpoints (their queries bypass the
+      per-key lowering entirely), and a table whose ingestion ever used
+      `json_type_escape_dots_in_keys=1` or mixes dotted-key encodings —
+      tracked as [#3063](https://github.com/tsouza/cerberus/issues/3063).
+    - **Traces**: query lowering against a JSON-typed attribute map is not
+      implemented yet (only detection is), so queries touching that column's
+      keys still fail, just at query time instead of at boot — tracked as
+      [#3062](https://github.com/tsouza/cerberus/issues/3062).
+    - Metrics attribute-map columns are **not** covered by this exception
+      and stay `Map(String, String)`-only — they carry the metric's series
+      identity, out of scope per the issue itself.
 - **Absent (not-yet-provisioned) schema.** When the configured tables are
   **entirely absent** (`system.columns` reports zero rows for them), cerberus
   does **not** crash-loop — it **boots and waits**. This is the cerberus +

--- a/internal/api/loki/attr_strategy_test.go
+++ b/internal/api/loki/attr_strategy_test.go
@@ -1,0 +1,68 @@
+package loki_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestQuery_JSONAttrStrategyRendersDynamicSubcolumnPath is the end-to-end
+// integration proof for cerberus issue #2777's threading: a Handler whose
+// AttrStrategies marks the logs ResourceAttributes column as
+// AttrStrategyJSON (mirroring cmd/cerberus's runRequirementsCheck ->
+// newLokiHandler wiring) must emit chsql's JSON dynamic-subcolumn read for
+// a `{job="api"}` stream-selector query, not the Map bracket-subscript
+// shape TestQuery_Streams (the byte-identical-Map-path sibling in this
+// same package) pins for the default (nil AttrStrategies) Handler.
+//
+// This closes the loop the chsql-level tests (attr_strategy_test.go,
+// attr_strategy_json_chdb_test.go in internal/chsql) don't reach on their
+// own: those prove the RENDERING primitive is correct in isolation; this
+// proves a real HTTP request, through Handler -> logql.Lang ->
+// engine.Engine -> chsql.Emit, actually resolves and applies the
+// AttrStrategies a caller wires onto the Handler.
+func TestQuery_JSONAttrStrategyRendersDynamicSubcolumnPath(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelLogs()
+	q := &stubQuerier{}
+	h := loki.New(q, s, nil)
+	// Mirrors cmd/cerberus's newLokiHandler: both the Handler's own field
+	// (for a future per-request langForRequest copy) AND the long-lived
+	// h.Lang (the handler's own field is not read directly by /query — see
+	// Handler's own doc — but wiring it too matches production and would
+	// catch a future refactor that starts reading it).
+	h.AttrStrategies = chsql.AttrStrategies{s.ResourceAttributesColumn: chsql.AttrStrategyJSON}
+	h.Lang.AttrStrategies = h.AttrStrategies
+
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + `/loki/api/v1/query?query=%7Bjob%3D%22api%22%7D`)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	sql := q.LastSQL()
+	if sql == "" {
+		t.Fatal("stubQuerier saw no SQL — request never reached the engine")
+	}
+	if !strings.Contains(sql, s.ResourceAttributesColumn+"`.`job`.:String") {
+		t.Errorf("SQL does not carry the JSON dynamic-subcolumn read for %q:\n%s", s.ResourceAttributesColumn, sql)
+	}
+	if strings.Contains(sql, "`"+s.ResourceAttributesColumn+"`[") {
+		t.Errorf("SQL still carries a Map bracket-subscript against %q, want the JSON path instead:\n%s",
+			s.ResourceAttributesColumn, sql)
+	}
+}

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/api/reqctx"
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/logql"
 	"github.com/tsouza/cerberus/internal/optimizer"
@@ -134,6 +135,17 @@ type Handler struct {
 	// default — every bare Handler{} test fixture) keeps the LogQL emitter
 	// byte-identical to today.
 	TextIndexLineFilter bool
+
+	// AttrStrategies resolves how the logs attribute-map columns are
+	// physically stored (cerberus issue #2777), wired from
+	// preflight.Result.LogsAttrStrategies in cmd/cerberus — mirroring
+	// TextIndexLineFilter above: langForRequest / langForRangeRequest copy
+	// it onto every per-request *logql.Lang, and New's own long-lived
+	// h.Lang picks it up the same way. nil (the default — every bare
+	// Handler{} test fixture, and any deployment whose logs attribute-map
+	// columns are all Map(String,String)) keeps the LogQL emitter
+	// byte-identical to before this field existed.
+	AttrStrategies chsql.AttrStrategies
 
 	// LabelCatalogEnabled reports whether internal/schema/ddl provisioned
 	// the loki_label_catalog refreshable materialized view (cerberus issue
@@ -534,6 +546,7 @@ func (h *Handler) langForRequest(start, end time.Time, limit int, dir logDirecti
 		TextIndexLineFilter: h.TextIndexLineFilter,
 		LogLineLimit:        int64(limit),
 		LogLineBackward:     dir == directionBackward,
+		AttrStrategies:      h.AttrStrategies,
 	}
 }
 
@@ -557,6 +570,7 @@ func (h *Handler) langForRangeRequest(start, end time.Time, step time.Duration, 
 		TextIndexLineFilter: h.TextIndexLineFilter,
 		LogLineLimit:        int64(limit),
 		LogLineBackward:     dir == directionBackward,
+		AttrStrategies:      h.AttrStrategies,
 	}
 }
 

--- a/internal/chplan/attr_strategy.go
+++ b/internal/chplan/attr_strategy.go
@@ -1,0 +1,90 @@
+package chplan
+
+// AttrStrategy selects how one attribute-map column is physically stored,
+// and therefore how a per-key expression against it (MapAccess,
+// FnMapContainsKey) must be rendered.
+//
+// cerberus issue #2777: the OTel ClickHouse Exporter's `json:true` schema
+// variant types the logs/traces attribute-map columns (Attributes /
+// ResourceAttributes / ScopeAttributes) as ClickHouse's native JSON rather
+// than Map(String,String). internal/preflight's boot probe already detects
+// this shape (isJSONAttrType) and boots with a WARNING instead of a FATAL
+// (see preflight.go's Gate 2); this type is the other half — the resolved
+// per-column DECISION that lets chsql render the right SQL shape once the
+// probe has spoken, rather than re-deriving it per query.
+//
+// Declared here rather than in internal/chsql because internal/logql's
+// Lang.EmitAttrStrategies() must return this type to satisfy the shared
+// Lang contract engine.attrStrategier reads, and logql is architecturally
+// forbidden from depending on chsql (.go-arch-lint.yml) — chplan is the
+// one package both logql and chsql already depend on. chsql re-exports
+// AttrStrategy / AttrStrategies / AttrStrategyMap / AttrStrategyJSON as
+// type/const aliases of the ones declared here, so every existing
+// chsql.AttrStrategy* reference keeps compiling unchanged.
+type AttrStrategy int
+
+const (
+	// AttrStrategyMap is the zero value and the default: the column is a
+	// genuine ClickHouse Map(String,String), and MapAccess / mapContains
+	// render exactly as they always have — a bracket subscript / a plain
+	// mapContains(...) call. Every chsql Builder and QueryBuilder defaults
+	// to this because AttrStrategies is nil unless a caller explicitly
+	// resolves and passes one (see AttrStrategies.Lookup) — so every one
+	// of chsql's ~50+ existing NewQuery() call sites, and every plan that
+	// never touches a JSON-typed column, keeps emitting byte-identical SQL.
+	// The refactor-guard test in chsql's attr_strategy_test.go pins this.
+	AttrStrategyMap AttrStrategy = iota
+
+	// AttrStrategyJSON means the column is ClickHouse's native JSON type.
+	// chsql's exprMapAccess and its FnMapContainsKey render hook branch on
+	// it — see their doc comments for the exact SQL shape and the
+	// missing-vs-empty semantics decision. Only applies when the map/column
+	// operand is a bare *ColumnRef (never a composed intermediate Map
+	// expression built by mapUpdate/mapConcat/map(), which really is a Map
+	// at the SQL level regardless of the strategy of the column it was
+	// seeded from) — MapAccess additionally requires a literal
+	// (*LitString) key, since ClickHouse's JSON dynamic-subcolumn path
+	// syntax is a compile-time path expression, not a bound parameter.
+	//
+	// Scope (cerberus issue #2777, this slice): wired for LOGS only.
+	// Traces detection already ships (preflight's jsonAttrMapCompat), but
+	// query-time rendering for traces is tracked separately as cerberus
+	// issue #3062 — internal/engine never resolves a non-nil
+	// AttrStrategies for a TraceQL request in this version, so a
+	// JSON-typed traces attribute column still fails at query time
+	// exactly as before (no behaviour change, no untested accidental
+	// support). Metrics never sets this: attribute maps there carry
+	// series identity and preflight FATALs on anything but Map.
+	AttrStrategyJSON
+)
+
+// AttrStrategies resolves the AttrStrategy for one column, keyed by the
+// column's bare name (schema.Logs.AttributesColumn etc — never
+// table-qualified, and never disambiguated across signals: see the doc
+// below on why that is safe).
+//
+// Why bare-name keying doesn't collide across signals: the OTel-CH default
+// schema reuses "ResourceAttributes" / "ScopeAttributes" as the column name
+// across metrics, logs AND traces, so a single global bare-name map fed
+// from every signal's boot-probe findings would misapply one signal's
+// strategy to another's identically-named column. AttrStrategies sidesteps
+// this by being scoped PER SIGNAL at the call site instead: preflight
+// resolves one map per signal (Result.LogsAttrStrategies /
+// TracesAttrStrategies), and internal/engine injects only the map for the
+// signal actually being queried (chsql.WithAttrStrategies(ctx, ...) called
+// with LogsAttrStrategies for a LogQL request, nil for PromQL/TraceQL in
+// this version) — so a chsql.Builder rendering one query only ever sees
+// that one signal's resolved strategies, never a merged cross-signal map.
+type AttrStrategies map[string]AttrStrategy
+
+// Lookup returns the AttrStrategy configured for column, or
+// AttrStrategyMap when s is nil or has no entry for it — the safe zero
+// value that keeps every construction path that never heard of this
+// mechanism (a bare NewBuilder()/NewQuery(), the ~50+ pre-existing chsql
+// call sites) rendering exactly the SQL it always has.
+func (s AttrStrategies) Lookup(column string) AttrStrategy {
+	if s == nil {
+		return AttrStrategyMap
+	}
+	return s[column]
+}

--- a/internal/chsql/attr_strategy.go
+++ b/internal/chsql/attr_strategy.go
@@ -1,0 +1,109 @@
+package chsql
+
+import "context"
+
+// AttrStrategy selects how one attribute-map column is physically stored,
+// and therefore how a per-key expression against it (chplan.MapAccess,
+// chplan.FnMapContainsKey) must be rendered.
+//
+// cerberus issue #2777: the OTel ClickHouse Exporter's `json:true` schema
+// variant types the logs/traces attribute-map columns (Attributes /
+// ResourceAttributes / ScopeAttributes) as ClickHouse's native JSON rather
+// than Map(String,String). internal/preflight's boot probe already detects
+// this shape (isJSONAttrType) and boots with a WARNING instead of a FATAL
+// (see preflight.go's Gate 2); this type is the other half — the resolved
+// per-column DECISION that lets chsql render the right SQL shape once the
+// probe has spoken, rather than re-deriving it per query.
+type AttrStrategy int
+
+const (
+	// AttrStrategyMap is the zero value and the default: the column is a
+	// genuine ClickHouse Map(String,String), and MapAccess / mapContains
+	// render exactly as they always have — a bracket subscript / a plain
+	// mapContains(...) call. Every Builder and QueryBuilder defaults to
+	// this because AttrStrategies is nil unless a caller explicitly
+	// resolves and passes one (see AttrStrategies.Lookup) — so every one
+	// of chsql's ~50+ existing NewQuery() call sites, and every plan that
+	// never touches a JSON-typed column, keeps emitting byte-identical SQL.
+	// The refactor-guard test in attr_strategy_test.go pins this.
+	AttrStrategyMap AttrStrategy = iota
+
+	// AttrStrategyJSON means the column is ClickHouse's native JSON type.
+	// exprMapAccess and the FnMapContainsKey render hook branch on it —
+	// see their doc comments for the exact SQL shape and the
+	// missing-vs-empty semantics decision. Only applies when the map/column
+	// operand is a bare *chplan.ColumnRef (never a composed intermediate
+	// Map expression built by mapUpdate/mapConcat/map(), which really is
+	// a Map at the SQL level regardless of the strategy of the column it
+	// was seeded from) — MapAccess additionally requires a literal
+	// (*chplan.LitString) key, since ClickHouse's JSON dynamic-subcolumn
+	// path syntax is a compile-time path expression, not a bound
+	// parameter.
+	//
+	// Scope (cerberus issue #2777, this slice): wired for LOGS only.
+	// Traces detection already ships (preflight's jsonAttrMapCompat), but
+	// query-time rendering for traces is tracked separately as cerberus
+	// issue #3062 — internal/engine never resolves a non-nil
+	// AttrStrategies for a TraceQL request in this version, so a
+	// JSON-typed traces attribute column still fails at query time
+	// exactly as before (no behaviour change, no untested accidental
+	// support). Metrics never sets this: attribute maps there carry
+	// series identity and preflight FATALs on anything but Map.
+	AttrStrategyJSON
+)
+
+// AttrStrategies resolves the AttrStrategy for one column, keyed by the
+// column's bare name (schema.Logs.AttributesColumn etc — never
+// table-qualified, and never disambiguated across signals: see the doc
+// below on why that is safe).
+//
+// Why bare-name keying doesn't collide across signals: the OTel-CH default
+// schema reuses "ResourceAttributes" / "ScopeAttributes" as the column name
+// across metrics, logs AND traces, so a single global bare-name map fed
+// from every signal's boot-probe findings would misapply one signal's
+// strategy to another's identically-named column. AttrStrategies sidesteps
+// this by being scoped PER SIGNAL at the call site instead: preflight
+// resolves one map per signal (Result.LogsAttrStrategies /
+// TracesAttrStrategies), and internal/engine injects only the map for the
+// signal actually being queried (WithAttrStrategies(ctx, ...) called with
+// LogsAttrStrategies for a LogQL request, nil for PromQL/TraceQL in this
+// version) — so a chsql.Builder rendering one query only ever sees that one
+// signal's resolved strategies, never a merged cross-signal map.
+type AttrStrategies map[string]AttrStrategy
+
+// Lookup returns the AttrStrategy configured for column, or
+// AttrStrategyMap when s is nil or has no entry for it — the safe zero
+// value that keeps every construction path that never heard of this
+// mechanism (a bare NewBuilder()/NewQuery(), the ~50+ pre-existing chsql
+// call sites) rendering exactly the SQL it always has.
+func (s AttrStrategies) Lookup(column string) AttrStrategy {
+	if s == nil {
+		return AttrStrategyMap
+	}
+	return s[column]
+}
+
+// attrStrategiesCtxKey is the context key for WithAttrStrategies /
+// attrStrategiesFromCtx. Mirrors the unexported-key pattern
+// WithSpansTable/spansTableFromCtx (scan_resource_bound.go) and
+// WithDeltaPrefixLookback/deltaPrefixLookbackFromCtx (range_window.go)
+// already use for per-request emit-time configuration.
+type attrStrategiesCtxKey struct{}
+
+// WithAttrStrategies returns a context carrying the resolved
+// AttrStrategies chsql.Emit renders the plan's attribute-map accesses
+// against. internal/engine calls this once per request, scoped to the
+// signal actually being queried (see AttrStrategies's doc) — a caller
+// that never calls it (every non-engine chsql.Emit call, every direct
+// QueryBuilder use) gets the nil default, i.e. AttrStrategyMap
+// everywhere.
+func WithAttrStrategies(ctx context.Context, s AttrStrategies) context.Context {
+	return context.WithValue(ctx, attrStrategiesCtxKey{}, s)
+}
+
+// attrStrategiesFromCtx reads the AttrStrategies WithAttrStrategies set,
+// or nil (AttrStrategyMap everywhere) when it was never called.
+func attrStrategiesFromCtx(ctx context.Context) AttrStrategies {
+	s, _ := ctx.Value(attrStrategiesCtxKey{}).(AttrStrategies)
+	return s
+}

--- a/internal/chsql/attr_strategy.go
+++ b/internal/chsql/attr_strategy.go
@@ -1,87 +1,30 @@
 package chsql
 
-import "context"
+import (
+	"context"
 
-// AttrStrategy selects how one attribute-map column is physically stored,
-// and therefore how a per-key expression against it (chplan.MapAccess,
-// chplan.FnMapContainsKey) must be rendered.
-//
-// cerberus issue #2777: the OTel ClickHouse Exporter's `json:true` schema
-// variant types the logs/traces attribute-map columns (Attributes /
-// ResourceAttributes / ScopeAttributes) as ClickHouse's native JSON rather
-// than Map(String,String). internal/preflight's boot probe already detects
-// this shape (isJSONAttrType) and boots with a WARNING instead of a FATAL
-// (see preflight.go's Gate 2); this type is the other half — the resolved
-// per-column DECISION that lets chsql render the right SQL shape once the
-// probe has spoken, rather than re-deriving it per query.
-type AttrStrategy int
-
-const (
-	// AttrStrategyMap is the zero value and the default: the column is a
-	// genuine ClickHouse Map(String,String), and MapAccess / mapContains
-	// render exactly as they always have — a bracket subscript / a plain
-	// mapContains(...) call. Every Builder and QueryBuilder defaults to
-	// this because AttrStrategies is nil unless a caller explicitly
-	// resolves and passes one (see AttrStrategies.Lookup) — so every one
-	// of chsql's ~50+ existing NewQuery() call sites, and every plan that
-	// never touches a JSON-typed column, keeps emitting byte-identical SQL.
-	// The refactor-guard test in attr_strategy_test.go pins this.
-	AttrStrategyMap AttrStrategy = iota
-
-	// AttrStrategyJSON means the column is ClickHouse's native JSON type.
-	// exprMapAccess and the FnMapContainsKey render hook branch on it —
-	// see their doc comments for the exact SQL shape and the
-	// missing-vs-empty semantics decision. Only applies when the map/column
-	// operand is a bare *chplan.ColumnRef (never a composed intermediate
-	// Map expression built by mapUpdate/mapConcat/map(), which really is
-	// a Map at the SQL level regardless of the strategy of the column it
-	// was seeded from) — MapAccess additionally requires a literal
-	// (*chplan.LitString) key, since ClickHouse's JSON dynamic-subcolumn
-	// path syntax is a compile-time path expression, not a bound
-	// parameter.
-	//
-	// Scope (cerberus issue #2777, this slice): wired for LOGS only.
-	// Traces detection already ships (preflight's jsonAttrMapCompat), but
-	// query-time rendering for traces is tracked separately as cerberus
-	// issue #3062 — internal/engine never resolves a non-nil
-	// AttrStrategies for a TraceQL request in this version, so a
-	// JSON-typed traces attribute column still fails at query time
-	// exactly as before (no behaviour change, no untested accidental
-	// support). Metrics never sets this: attribute maps there carry
-	// series identity and preflight FATALs on anything but Map.
-	AttrStrategyJSON
+	"github.com/tsouza/cerberus/internal/chplan"
 )
 
-// AttrStrategies resolves the AttrStrategy for one column, keyed by the
-// column's bare name (schema.Logs.AttributesColumn etc — never
-// table-qualified, and never disambiguated across signals: see the doc
-// below on why that is safe).
-//
-// Why bare-name keying doesn't collide across signals: the OTel-CH default
-// schema reuses "ResourceAttributes" / "ScopeAttributes" as the column name
-// across metrics, logs AND traces, so a single global bare-name map fed
-// from every signal's boot-probe findings would misapply one signal's
-// strategy to another's identically-named column. AttrStrategies sidesteps
-// this by being scoped PER SIGNAL at the call site instead: preflight
-// resolves one map per signal (Result.LogsAttrStrategies /
-// TracesAttrStrategies), and internal/engine injects only the map for the
-// signal actually being queried (WithAttrStrategies(ctx, ...) called with
-// LogsAttrStrategies for a LogQL request, nil for PromQL/TraceQL in this
-// version) — so a chsql.Builder rendering one query only ever sees that one
-// signal's resolved strategies, never a merged cross-signal map.
-type AttrStrategies map[string]AttrStrategy
+// AttrStrategy, AttrStrategies, AttrStrategyMap and AttrStrategyJSON are
+// aliases of the chplan types of the same name — declared there, not here,
+// because internal/logql's Lang.EmitAttrStrategies() must return this type
+// to satisfy the shared Lang contract engine.attrStrategier reads, and
+// logql is architecturally forbidden from depending on chsql
+// (.go-arch-lint.yml); chplan is the one package both logql and chsql
+// already depend on. See chplan.AttrStrategy's own doc for the full
+// design (the missing-vs-empty semantics decision, the per-signal scoping
+// rationale, cerberus issue #2777). Aliasing here means every existing
+// chsql.AttrStrategy* reference keeps compiling unchanged.
+type (
+	AttrStrategy   = chplan.AttrStrategy
+	AttrStrategies = chplan.AttrStrategies
+)
 
-// Lookup returns the AttrStrategy configured for column, or
-// AttrStrategyMap when s is nil or has no entry for it — the safe zero
-// value that keeps every construction path that never heard of this
-// mechanism (a bare NewBuilder()/NewQuery(), the ~50+ pre-existing chsql
-// call sites) rendering exactly the SQL it always has.
-func (s AttrStrategies) Lookup(column string) AttrStrategy {
-	if s == nil {
-		return AttrStrategyMap
-	}
-	return s[column]
-}
+const (
+	AttrStrategyMap  = chplan.AttrStrategyMap
+	AttrStrategyJSON = chplan.AttrStrategyJSON
+)
 
 // attrStrategiesCtxKey is the context key for WithAttrStrategies /
 // attrStrategiesFromCtx. Mirrors the unexported-key pattern

--- a/internal/chsql/attr_strategy_json_chdb_test.go
+++ b/internal/chsql/attr_strategy_json_chdb_test.go
@@ -1,0 +1,293 @@
+//go:build chdb
+
+// chDB-backed proof of cerberus issue #2777's missing-vs-empty semantics
+// decision: a raw ClickHouse JSON dynamic-subcolumn path read and a Map
+// subscript disagree on what a MISSING key returns (NULL vs the empty
+// string), and chsql's exprMapAccess JSON branch (builder.go) deliberately
+// normalises that difference away with a coalesce-to-empty-string wrap so
+// every existing chplan-level lowering — written against the Map contract
+// — keeps working unmodified against a JSON-typed column. This file pins
+// BOTH halves:
+//
+//  1. the raw discrepancy exists (justifying the coalesce design choice in
+//     the first place — a substrate where Map and JSON already agreed
+//     would make the wrap dead code), and
+//  2. chsql's ACTUAL emitted SQL (via the public chsql.NewQuery /
+//     QueryBuilder.WithAttrStrategies surface, not a hand-written
+//     comparison string) reproduces the Map contract exactly: the same
+//     missing-key value, and the same present-vs-absent distinction via
+//     FnMapContainsKey/mapContains vs has(JSONAllPaths(...)).
+//
+// This is SEPARATE from, and not a substitute for,
+// TestAttrStrategy_MapPathByteIdentical (attr_strategy_test.go) — that
+// test is the refactor guard proving the pre-#2777 Map path emits
+// byte-identical SQL; this one is evidence the NEW JSON path actually
+// works against real ClickHouse (chDB, version pinned by versions.yaml's
+// chdb_substrate).
+package chsql_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+// attrStrategyJSONSeedDDL creates one Map-typed and one JSON-typed
+// attribute table with logically equivalent content, so every query below
+// runs against both and compares.
+//
+// Row 1: both keys present, http.status_code="200".
+// Row 2: only service.name present — http.status_code absent.
+// Row 3: service.name present but set to the EMPTY STRING — the
+// present-but-empty case that must read back as the empty string (not
+// NULL) on the JSON side, exactly as a Map's stored empty value does,
+// distinguishing it from row 2's genuinely absent key.
+const attrStrategyJSONSeedDDL = `
+CREATE OR REPLACE TABLE attrs_map (
+    id UInt32,
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree ORDER BY id;
+
+CREATE OR REPLACE TABLE attrs_json (
+    id UInt32,
+    ResourceAttributes JSON
+) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO attrs_map VALUES
+    (1, map('service.name', 'foo', 'http.status_code', '200')),
+    (2, map('service.name', 'bar')),
+    (3, map('service.name', ''));
+
+INSERT INTO attrs_json VALUES
+    (1, '{"service.name":"foo","http.status_code":"200"}'),
+    (2, '{"service.name":"bar"}'),
+    (3, '{"service.name":""}');
+`
+
+// renderAttrSelect renders "SELECT <expr> FROM <table> ORDER BY id" via
+// the public chsql surface, with strategies applied via
+// WithAttrStrategies (nil for the Map-typed table, which never calls it —
+// mirroring how a production caller that never resolved a JSON strategy
+// never calls it either).
+func renderAttrSelect(t *testing.T, table string, strategies chsql.AttrStrategies, expr chplan.Expr) (string, []any) {
+	t.Helper()
+	var renderErr error
+	qb := chsql.NewQuery().
+		Select(func(b *chsql.Builder) {
+			renderErr = b.Expr(expr)
+		}).
+		From(chsql.Col(table)).
+		OrderBy(chsql.Col("id"), false)
+	if strategies != nil {
+		qb = qb.WithAttrStrategies(strategies)
+	}
+	sql, args := qb.Build()
+	if renderErr != nil {
+		t.Fatalf("render select expr: %v", renderErr)
+	}
+	return sql, args
+}
+
+// queryStringColumn runs sql/args and returns one Nullable(String) column,
+// row order preserved (the query already carries ORDER BY id).
+func queryStringColumn(t *testing.T, db *sql.DB, query string, args []any) []sql.NullString {
+	t.Helper()
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		t.Fatalf("query: %v\nSQL: %s", err, query)
+	}
+	defer rows.Close()
+	var out []sql.NullString
+	for rows.Next() {
+		var v sql.NullString
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration: %v", err)
+	}
+	return out
+}
+
+// queryBoolColumn runs sql/args and returns one UInt8-as-bool column.
+func queryBoolColumn(t *testing.T, db *sql.DB, query string, args []any) []bool {
+	t.Helper()
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		t.Fatalf("query: %v\nSQL: %s", err, query)
+	}
+	defer rows.Close()
+	var out []bool
+	for rows.Next() {
+		var v uint8
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, v != 0)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration: %v", err)
+	}
+	return out
+}
+
+func ns(v string) sql.NullString { return sql.NullString{String: v, Valid: true} }
+
+var nsNull = sql.NullString{}
+
+// TestAttrStrategyJSON_RawPathDiffersFromMap is half 1 of the pinning: a
+// raw ClickHouse JSON dynamic-subcolumn read and a Map subscript
+// genuinely disagree on a missing key (NULL vs the empty string) — the
+// discrepancy chsql's coalesce wrap exists to paper over. This query is
+// deliberately NOT run through chsql (no coalesce) so it shows what the
+// JSON type does on its own.
+func TestAttrStrategyJSON_RawPathDiffersFromMap(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(attrStrategyJSONSeedDDL); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	mapGot := queryStringColumn(t, db,
+		"SELECT ResourceAttributes['http.status_code'] FROM attrs_map ORDER BY id", nil)
+	jsonRawGot := queryStringColumn(t, db,
+		"SELECT ResourceAttributes.`http.status_code`.:String FROM attrs_json ORDER BY id", nil)
+
+	wantMap := []sql.NullString{ns("200"), ns(""), ns("")}
+	if !equalNullStrings(mapGot, wantMap) {
+		t.Fatalf("Map subscript = %v, want %v", mapGot, wantMap)
+	}
+	wantJSONRaw := []sql.NullString{ns("200"), nsNull, nsNull}
+	if !equalNullStrings(jsonRawGot, wantJSONRaw) {
+		t.Fatalf("raw JSON path read = %v, want %v (row 2/3 must be NULL, not the empty string, "+
+			"proving the raw JSON path genuinely differs from Map's default-value semantics)",
+			jsonRawGot, wantJSONRaw)
+	}
+}
+
+// TestAttrStrategyJSON_MapAccessMatchesMapSemantics is half 2: chsql's
+// ACTUAL rendered SQL (via chplan.MapAccess + AttrStrategyJSON, the exact
+// path a LogQL label matcher against a JSON-typed ResourceAttributes
+// column takes) reproduces the Map subscript's missing-key value exactly
+// — the empty string, never NULL — for both a genuinely-absent key (row
+// 2) and a present-but-empty one (row 3, which must read back as the
+// empty string, not merely "non-NULL").
+func TestAttrStrategyJSON_MapAccessMatchesMapSemantics(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(attrStrategyJSONSeedDDL); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	mapAccess := func(col string) *chplan.MapAccess {
+		return &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: "ResourceAttributes"},
+			Key: &chplan.LitString{V: col},
+		}
+	}
+
+	for _, key := range []string{"service.name", "http.status_code"} {
+		key := key
+		t.Run(key, func(t *testing.T) {
+			mapSQL, mapArgs := renderAttrSelect(t, "attrs_map", nil, mapAccess(key))
+			jsonSQL, jsonArgs := renderAttrSelect(t, "attrs_json",
+				chsql.AttrStrategies{"ResourceAttributes": chsql.AttrStrategyJSON}, mapAccess(key))
+
+			mapGot := queryStringColumn(t, db, mapSQL, mapArgs)
+			jsonGot := queryStringColumn(t, db, jsonSQL, jsonArgs)
+
+			if !equalNullStrings(mapGot, jsonGot) {
+				t.Errorf("key %q: Map rendering = %v, JSON rendering = %v — chsql's JSON MapAccess "+
+					"branch must reproduce the Map subscript's missing-key contract exactly",
+					key, mapGot, jsonGot)
+			}
+		})
+	}
+}
+
+// TestAttrStrategyJSON_MapContainsKeyMatchesMapSemantics pins
+// FnMapContainsKey's JSON branch (has(JSONAllPaths(...), ...)) against
+// mapContains's real existence semantics: both must distinguish
+// present-with-empty-value (row 3) from genuinely-absent (row 2), which
+// exprMapAccess's coalesce-to-empty-string wrap deliberately gives up —
+// this is the check that recovers it.
+func TestAttrStrategyJSON_MapContainsKeyMatchesMapSemantics(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(attrStrategyJSONSeedDDL); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	mapContains := func(col string) *chplan.FuncCall {
+		return &chplan.FuncCall{
+			Fn: chplan.FnMapContainsKey,
+			Args: []chplan.Expr{
+				&chplan.ColumnRef{Name: "ResourceAttributes"},
+				&chplan.LitString{V: col},
+			},
+		}
+	}
+
+	for _, key := range []string{"service.name", "http.status_code"} {
+		key := key
+		t.Run(key, func(t *testing.T) {
+			mapSQL, mapArgs := renderAttrSelect(t, "attrs_map", nil, mapContains(key))
+			jsonSQL, jsonArgs := renderAttrSelect(t, "attrs_json",
+				chsql.AttrStrategies{"ResourceAttributes": chsql.AttrStrategyJSON}, mapContains(key))
+
+			mapGot := queryBoolColumn(t, db, mapSQL, mapArgs)
+			jsonGot := queryBoolColumn(t, db, jsonSQL, jsonArgs)
+
+			if len(mapGot) != len(jsonGot) {
+				t.Fatalf("key %q: row count mismatch: Map %d, JSON %d", key, len(mapGot), len(jsonGot))
+			}
+			for i := range mapGot {
+				if mapGot[i] != jsonGot[i] {
+					t.Errorf("key %q row %d: mapContains=%v has(JSONAllPaths(...))=%v, want equal",
+						key, i+1, mapGot[i], jsonGot[i])
+				}
+			}
+		})
+	}
+
+	// Explicit sanity check on the shape that matters most: row 3
+	// (present, empty value) must report TRUE (present) on both sides,
+	// distinguishing it from row 2 (absent, FALSE) — this is exactly the
+	// distinction exprMapAccess's coalesce wrap cannot make on its own.
+	mapSQL, mapArgs := renderAttrSelect(t, "attrs_map", nil, mapContains("service.name"))
+	jsonSQL, jsonArgs := renderAttrSelect(t, "attrs_json",
+		chsql.AttrStrategies{"ResourceAttributes": chsql.AttrStrategyJSON}, mapContains("service.name"))
+	wantPresence := []bool{true, true, true} // service.name is present (possibly empty) on every row
+	if got := queryBoolColumn(t, db, mapSQL, mapArgs); !equalBools(got, wantPresence) {
+		t.Fatalf("Map mapContains(service.name) = %v, want %v", got, wantPresence)
+	}
+	if got := queryBoolColumn(t, db, jsonSQL, jsonArgs); !equalBools(got, wantPresence) {
+		t.Fatalf("JSON has(JSONAllPaths(...), service.name) = %v, want %v", got, wantPresence)
+	}
+}
+
+func equalNullStrings(a, b []sql.NullString) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalBools(a, b []bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/chsql/attr_strategy_test.go
+++ b/internal/chsql/attr_strategy_test.go
@@ -1,0 +1,247 @@
+package chsql_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// renderExpr renders x against a Builder carrying strategies (nil is the
+// pre-#2777 default: AttrStrategyMap everywhere) and returns the rendered
+// SQL and bound args.
+func renderExpr(t *testing.T, strategies chsql.AttrStrategies, x chplan.Expr) (string, []any) {
+	t.Helper()
+	b := chsql.NewBuilderWithAttrStrategies(strategies)
+	if err := b.Expr(x); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	sql, args, err := b.Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return sql, args
+}
+
+// TestAttrStrategy_MapPathByteIdentical is the refactor guard cerberus
+// issue #2777 requires: proof that threading AttrStrategies through
+// chsql.Builder / chsql.QueryBuilder's construction did not change ONE
+// BYTE of the SQL emitted for the Map path — the only path every one of
+// chsql's pre-existing call sites exercises. This is DELIBERATELY separate
+// from, and is NOT evidence for, the JSON-path tests below: it only proves
+// the pre-#2777 behaviour survived the strategy-threading refactor
+// unchanged.
+//
+// Four constructions of the identical chplan trees are compared against
+// the exact literal pre-#2777 SQL shape:
+//   - chsql.NewBuilder() (no strategies field even settable before this
+//     change existed) — the zero-value / "never heard of AttrStrategies"
+//     caller every one of chsql's ~50+ existing NewQuery() sites is,
+//   - NewBuilderWithAttrStrategies(nil),
+//   - NewBuilderWithAttrStrategies with an explicit AttrStrategyMap entry
+//     for the column, and
+//   - NewBuilderWithAttrStrategies with a non-nil map that has NO entry at
+//     all for the column (the real production shape: a per-signal
+//     strategies map that only ever carries entries for columns preflight
+//     actually detected as JSON — every other column resolves via the
+//     map-miss zero value).
+//
+// All four must render `<col>[?]` for MapAccess and
+// `mapContains(<col>, ?)` for FnMapContainsKey — the exact shape
+// TestAttrStrategy_MapPathByteIdentical's git history shows chsql emitted
+// before cerberus issue #2777 touched this file.
+func TestAttrStrategy_MapPathByteIdentical(t *testing.T) {
+	t.Parallel()
+
+	mapAccess := &chplan.MapAccess{
+		Map: &chplan.ColumnRef{Name: "ResourceAttributes"},
+		Key: &chplan.LitString{V: "service.name"},
+	}
+	mapContains := &chplan.FuncCall{
+		Fn:   chplan.FnMapContainsKey,
+		Args: []chplan.Expr{&chplan.ColumnRef{Name: "ResourceAttributes"}, &chplan.LitString{V: "service.name"}},
+	}
+
+	const wantMapAccessSQL = "`ResourceAttributes`[?]"
+	const wantMapContainsSQL = "mapContains(`ResourceAttributes`, ?)"
+
+	variants := []struct {
+		name       string
+		strategies chsql.AttrStrategies
+	}{
+		{"legacy NewBuilder (no strategies field settable)", nil},
+		{"NewBuilderWithAttrStrategies(nil)", nil},
+		{"explicit AttrStrategyMap for the column", chsql.AttrStrategies{"ResourceAttributes": chsql.AttrStrategyMap}},
+		{"non-nil map with no entry for the column", chsql.AttrStrategies{"SomeOtherColumn": chsql.AttrStrategyJSON}},
+	}
+
+	for _, v := range variants {
+		t.Run("MapAccess/"+v.name, func(t *testing.T) {
+			t.Parallel()
+			sql, args := renderExpr(t, v.strategies, mapAccess)
+			if sql != wantMapAccessSQL {
+				t.Errorf("MapAccess SQL = %q, want %q", sql, wantMapAccessSQL)
+			}
+			if len(args) != 1 || args[0] != "service.name" {
+				t.Errorf("MapAccess args = %v, want [service.name]", args)
+			}
+		})
+		t.Run("FnMapContainsKey/"+v.name, func(t *testing.T) {
+			t.Parallel()
+			sql, args := renderExpr(t, v.strategies, mapContains)
+			if sql != wantMapContainsSQL {
+				t.Errorf("FnMapContainsKey SQL = %q, want %q", sql, wantMapContainsSQL)
+			}
+			if len(args) != 1 || args[0] != "service.name" {
+				t.Errorf("FnMapContainsKey args = %v, want [service.name]", args)
+			}
+		})
+	}
+
+	// chsql.NewBuilder() itself (not NewBuilderWithAttrStrategies) is the
+	// literal call every pre-existing production site makes — confirm it
+	// independently, not just via the nil-strategies variant above.
+	t.Run("MapAccess/chsql.NewBuilder()", func(t *testing.T) {
+		t.Parallel()
+		b := chsql.NewBuilder()
+		if err := b.Expr(mapAccess); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		sql, _, err := b.Build()
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		if sql != wantMapAccessSQL {
+			t.Errorf("MapAccess SQL = %q, want %q", sql, wantMapAccessSQL)
+		}
+	})
+}
+
+// TestAttrStrategy_JSONMapAccess pins the JSON-strategy rendering of
+// chplan.MapAccess (exprMapAccess's JSON branch), including its
+// restriction to a bare ColumnRef with a literal key.
+func TestAttrStrategy_JSONMapAccess(t *testing.T) {
+	t.Parallel()
+
+	strategies := chsql.AttrStrategies{"ResourceAttributes": chsql.AttrStrategyJSON}
+
+	t.Run("literal key renders the dynamic subcolumn path", func(t *testing.T) {
+		t.Parallel()
+		mapAccess := &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: "ResourceAttributes"},
+			Key: &chplan.LitString{V: "http.status_code"},
+		}
+		sql, args := renderExpr(t, strategies, mapAccess)
+		const want = "coalesce(`ResourceAttributes`.`http.status_code`.:String, '')"
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+		if len(args) != 0 {
+			t.Errorf("args = %v, want none — the JSON path key is a compile-time literal, never bound", args)
+		}
+	})
+
+	t.Run("non-literal key falls back to the Map subscript shape", func(t *testing.T) {
+		t.Parallel()
+		// ClickHouse's JSON dynamic-subcolumn path syntax is a
+		// compile-time path expression, not a function argument — a
+		// non-literal key cannot use it, so this MUST fall back to the
+		// bracket-subscript shape (which will fail at CH query time
+		// against a genuine JSON column — no worse than before this
+		// issue's work, and no plan in this codebase currently builds
+		// this shape against a bare attribute-map column).
+		dynamicKey := &chplan.FuncCall{Fn: chplan.FnLower, Args: []chplan.Expr{&chplan.LitString{V: "X"}}}
+		mapAccess := &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: "ResourceAttributes"},
+			Key: dynamicKey,
+		}
+		sql, _ := renderExpr(t, strategies, mapAccess)
+		const want = "`ResourceAttributes`[lower(?)]"
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+	})
+
+	t.Run("composed map operand falls back to the Map subscript shape", func(t *testing.T) {
+		t.Parallel()
+		// mapUpdate/mapConcat/map(...) — anything that ISN'T a bare
+		// ColumnRef — really is a ClickHouse Map at the SQL level
+		// regardless of the strategy of the column it was seeded from,
+		// so it must never take the JSON branch even when the strategies
+		// map happens to carry an entry matching no real column here.
+		composedMap := &chplan.FuncCall{Fn: chplan.FnMap, Args: []chplan.Expr{&chplan.LitString{V: "k"}, &chplan.LitString{V: "v"}}}
+		mapAccess := &chplan.MapAccess{
+			Map: composedMap,
+			Key: &chplan.LitString{V: "k"},
+		}
+		sql, _ := renderExpr(t, strategies, mapAccess)
+		const want = "map(?, ?)[?]"
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+	})
+
+	t.Run("qualified column renders the qualified path", func(t *testing.T) {
+		t.Parallel()
+		mapAccess := &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: "ResourceAttributes", Qualifier: "L"},
+			Key: &chplan.LitString{V: "service.name"},
+		}
+		sql, _ := renderExpr(t, strategies, mapAccess)
+		const want = "coalesce(`L`.`ResourceAttributes`.`service.name`.:String, '')"
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+	})
+
+	t.Run("key with an embedded backtick is safely escaped", func(t *testing.T) {
+		t.Parallel()
+		mapAccess := &chplan.MapAccess{
+			Map: &chplan.ColumnRef{Name: "ResourceAttributes"},
+			Key: &chplan.LitString{V: "weird`key"},
+		}
+		sql, _ := renderExpr(t, strategies, mapAccess)
+		const want = "coalesce(`ResourceAttributes`.`weird``key`.:String, '')"
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+	})
+}
+
+// TestAttrStrategy_JSONMapContainsKey pins the JSON-strategy rendering of
+// chplan.FnMapContainsKey (exprMapContainsKey's JSON branch).
+func TestAttrStrategy_JSONMapContainsKey(t *testing.T) {
+	t.Parallel()
+
+	strategies := chsql.AttrStrategies{"ResourceAttributes": chsql.AttrStrategyJSON}
+
+	t.Run("JSON-strategy column renders has(JSONAllPaths(...))", func(t *testing.T) {
+		t.Parallel()
+		call := &chplan.FuncCall{
+			Fn:   chplan.FnMapContainsKey,
+			Args: []chplan.Expr{&chplan.ColumnRef{Name: "ResourceAttributes"}, &chplan.LitString{V: "http.status_code"}},
+		}
+		sql, args := renderExpr(t, strategies, call)
+		const want = "has(JSONAllPaths(`ResourceAttributes`), ?)"
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+		if len(args) != 1 || args[0] != "http.status_code" {
+			t.Errorf("args = %v, want [http.status_code] — unlike MapAccess, the key need not be a literal", args)
+		}
+	})
+
+	t.Run("non-ColumnRef first argument falls back to mapContains", func(t *testing.T) {
+		t.Parallel()
+		composedMap := &chplan.FuncCall{Fn: chplan.FnMap, Args: []chplan.Expr{&chplan.LitString{V: "k"}, &chplan.LitString{V: "v"}}}
+		call := &chplan.FuncCall{
+			Fn:   chplan.FnMapContainsKey,
+			Args: []chplan.Expr{composedMap, &chplan.LitString{V: "k"}},
+		}
+		sql, _ := renderExpr(t, strategies, call)
+		const want = "mapContains(map(?, ?), ?)"
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+	})
+}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -29,6 +29,16 @@ type Builder struct {
 	sb   strings.Builder
 	args []any
 
+	// attrStrategies resolves how an attribute-map column that appears as
+	// a bare chplan.ColumnRef renders a per-key access (exprMapAccess,
+	// the FnMapContainsKey render hook) — see AttrStrategies's doc
+	// (attr_strategy.go). nil (the zero value, set by every existing
+	// NewBuilder() call) means AttrStrategyMap for every column, so this
+	// field is purely additive: nothing that predates cerberus issue
+	// #2777 sets it, and every one of those call sites keeps emitting
+	// byte-identical SQL.
+	attrStrategies AttrStrategies
+
 	// err is the first error Expr encountered while rendering into this
 	// Builder, first-error-wins. It exists because Frag has no error
 	// return (`func(b *Builder)`), so an expression embedded via a
@@ -47,6 +57,13 @@ type Builder struct {
 
 // NewBuilder returns an empty Builder. Equivalent to &Builder{}.
 func NewBuilder() *Builder { return &Builder{} }
+
+// NewBuilderWithAttrStrategies returns an empty Builder that renders
+// attribute-map accesses against s (see AttrStrategies). QueryBuilder's
+// internal render path (subquerySQL) is the only caller — external code
+// opts in via QueryBuilder.WithAttrStrategies, not this constructor
+// directly.
+func NewBuilderWithAttrStrategies(s AttrStrategies) *Builder { return &Builder{attrStrategies: s} }
 
 // String returns the accumulated SQL.
 func (b *Builder) String() string { return b.sb.String() }
@@ -868,7 +885,18 @@ func (b *Builder) emitGoModulo(left, right chplan.Expr) error {
 
 // exprFunc renders a FuncCall by resolving its sealed Fn through
 // fnResolutions (internal/chsql/fnresolution.go).
+//
+// chplan.FnMapContainsKey is special-cased ahead of that lookup (see
+// exprMapContainsKey) rather than via fnResolution's Render hook: a Render
+// function stored in the fnResolutions map that itself calls b.Expr
+// transitively reaches resolveFn again (through the generic exprFunc /
+// resolveAggFuncName paths), which reads that very map — Go's
+// initialization-dependency analysis treats that as a package-init cycle
+// even though it is runtime-safe, so the branch has to live here instead.
 func (b *Builder) exprFunc(f *chplan.FuncCall) error {
+	if f.Fn == chplan.FnMapContainsKey {
+		return b.exprMapContainsKey(f.Args)
+	}
 	name, render, err := resolveFn(f.Fn)
 	if err != nil {
 		return err
@@ -942,7 +970,74 @@ func (b *Builder) exprWindow(w *chplan.WindowExpr) error {
 	return firstErr
 }
 
+// exprMapAccess renders a chplan.MapAccess. The default (AttrStrategyMap,
+// or a Map operand that isn't a bare column — a composed intermediate map
+// like mapUpdate/mapConcat's result really IS a ClickHouse Map regardless
+// of the strategy of the column it was seeded from) shape is unchanged:
+// `<Map>[<Key>]`.
+//
+// cerberus issue #2777: when m.Map is a bare *chplan.ColumnRef whose
+// AttrStrategy (b.attrStrategies) is AttrStrategyJSON, AND m.Key is a
+// compile-time literal (*chplan.LitString) — ClickHouse's JSON
+// dynamic-subcolumn path syntax is a syntax-level path expression, not a
+// function argument, so a non-literal key cannot use it and falls back to
+// the Map shape (which will fail at query time against a real JSON column,
+// exactly as it did before this issue's work; no plan in this codebase
+// currently builds a non-literal MapAccess against a bare attribute-map
+// column, see attribute_lookup.go) — the rendering instead reads the
+// dynamic subcolumn:
+//
+//	coalesce(<col>.<key, backtick-quoted>.:String, the empty string)
+//
+// Two decisions this bakes in, both empirically verified against real
+// ClickHouse (26.5, JSON GA since 25.3) rather than assumed:
+//
+//  1. Dotted OTel keys (http.status_code) nest by ClickHouse's JSON
+//     default — inserting {"http.status_code":"200"} creates a two-level
+//     path, and a single backtick-quoted identifier carrying the literal
+//     dotted string as ONE token reads it back correctly: ClickHouse's
+//     JSON path grammar splits on the dot for nesting regardless of
+//     backtick quoting, so b.Ident(key) — the same backtick-doubling
+//     identifier writer QualIdent uses, safe against a key containing
+//     backticks/spaces/anything else — is both the safe AND the correct
+//     choice; no manual segment-splitting is needed. This targets
+//     ClickHouse's DEFAULT dot-nesting behaviour only; a table whose
+//     ingestion path also or ever set json_type_escape_dots_in_keys=1
+//     (percent-encoded flat keys, CH 25.8+) is an explicit, documented
+//     non-goal of this slice — tracked as cerberus issue #3063's
+//     mixed-history hazard.
+//  2. Missing-vs-empty semantics deliberately DIFFER between a raw JSON
+//     path read and a Map subscript, and the coalesce wrap exists to
+//     NORMALISE that difference away at this one rendering boundary: a
+//     JSON path read on a missing key returns SQL NULL (verified: a
+//     present-but-empty-string value reads back as the empty string, a
+//     genuinely absent path reads back NULL — JSON's Dynamic-subcolumn
+//     read distinguishes the two), whereas a ClickHouse Map subscript on
+//     a missing key returns the value type's default — the empty string,
+//     never NULL. Every existing chplan-level lowering
+//     (OTelDottedFallbackChain's terminal bare-MapAccess arm, PromQL/LogQL
+//     label resolution, ...) was written against the Map contract and
+//     relies on bare MapAccess silently defaulting to the empty string for
+//     an absent key, using a SEPARATE mapContains/FnMapContainsKey check
+//     wherever it needs to distinguish present-empty from absent.
+//     Coalescing to the empty string here reproduces that exact contract
+//     for a JSON-typed column so every one of those call sites keeps
+//     working unmodified against either physical storage; genuine
+//     presence/absence still goes through FnMapContainsKey, whose JSON
+//     rendering (below) preserves the real distinction via
+//     has(JSONAllPaths(...), ...). Pinned by a chDB differential test
+//     (attr_strategy_json_chdb_test.go).
 func (b *Builder) exprMapAccess(m *chplan.MapAccess) error {
+	if col, key, ok := jsonAttrKeyAccess(b, m); ok {
+		b.sb.WriteString("coalesce(")
+		if err := b.Expr(col); err != nil {
+			return err
+		}
+		b.sb.WriteByte('.')
+		b.Ident(key)
+		b.sb.WriteString(".:String, '')")
+		return nil
+	}
 	if err := b.Expr(m.Map); err != nil {
 		return err
 	}
@@ -951,6 +1046,88 @@ func (b *Builder) exprMapAccess(m *chplan.MapAccess) error {
 		return err
 	}
 	b.sb.WriteByte(']')
+	return nil
+}
+
+// jsonAttrColumn reports whether e is a bare *chplan.ColumnRef whose
+// AttrStrategy (per b.attrStrategies) is AttrStrategyJSON — the shared
+// precondition exprMapAccess and exprMapContainsKey both branch on.
+func jsonAttrColumn(b *Builder, e chplan.Expr) (*chplan.ColumnRef, bool) {
+	col, ok := e.(*chplan.ColumnRef)
+	if !ok {
+		return nil, false
+	}
+	if b.attrStrategies.Lookup(col.Name) != AttrStrategyJSON {
+		return nil, false
+	}
+	return col, true
+}
+
+// jsonAttrKeyAccess reports whether m is a JSON-strategy attribute-map
+// access with a compile-time-known key: m.Map is a bare JSON-strategy
+// ColumnRef (jsonAttrColumn) and m.Key is a *chplan.LitString. Both
+// conditions are required — see exprMapAccess's doc for why a non-literal
+// key can't use the JSON dynamic-subcolumn path syntax.
+func jsonAttrKeyAccess(b *Builder, m *chplan.MapAccess) (*chplan.ColumnRef, string, bool) {
+	col, ok := jsonAttrColumn(b, m.Map)
+	if !ok {
+		return nil, "", false
+	}
+	key, ok := m.Key.(*chplan.LitString)
+	if !ok {
+		return nil, "", false
+	}
+	return col, key.V, true
+}
+
+// exprMapContainsKey renders chplan.FnMapContainsKey. exprFunc dispatches
+// here ahead of the generic fnResolutions lookup (see exprFunc's doc for
+// why this can't be a fnRender hook stored in that table). The default
+// shape — args[0] not a JSON-strategy bare column, or an unexpected arity
+// — is unchanged: `mapContains(<args>)`, byte-identical to the plain-Name
+// resolution this replaces.
+//
+// cerberus issue #2777: when args[0] is a bare JSON-strategy ColumnRef,
+// existence renders as
+//
+//	has(JSONAllPaths(<col>), <key>)
+//
+// — ClickHouse's JSON type reports the FULL dotted OTel key as one leaf
+// path string in JSONAllPaths (verified: {"http.status_code":"200"}
+// reports the path "http.status_code", not the two intermediate/nested
+// segments), so args[1] renders exactly as it would for mapContains — no
+// per-segment decomposition needed, and (unlike exprMapAccess's JSON
+// branch) args[1] need not be a literal, since has(...) takes a plain
+// runtime argument rather than a path-syntax token. This is the real
+// present-vs-absent existence check exprMapAccess's coalesce-to-empty-string wrap
+// deliberately gives up in exchange for reproducing the Map contract —
+// see that function's doc. Pinned by a chDB differential test
+// (attr_strategy_json_chdb_test.go).
+func (b *Builder) exprMapContainsKey(args []chplan.Expr) error {
+	if len(args) == 2 {
+		if col, ok := jsonAttrColumn(b, args[0]); ok {
+			b.sb.WriteString("has(JSONAllPaths(")
+			if err := b.Expr(col); err != nil {
+				return err
+			}
+			b.sb.WriteString("), ")
+			if err := b.Expr(args[1]); err != nil {
+				return err
+			}
+			b.sb.WriteByte(')')
+			return nil
+		}
+	}
+	b.sb.WriteString("mapContains(")
+	for i, a := range args {
+		if i > 0 {
+			b.sb.WriteString(", ")
+		}
+		if err := b.Expr(a); err != nil {
+			return err
+		}
+	}
+	b.sb.WriteByte(')')
 	return nil
 }
 
@@ -2739,6 +2916,25 @@ type QueryBuilder struct {
 	limit      int64
 	hasLimit   bool
 	limitBy    []Frag
+
+	// attrStrategies is threaded into the Builder subquerySQL renders
+	// against (see AttrStrategies). Set via WithAttrStrategies; the zero
+	// value (nil) renders every attribute-map column as Map, exactly as
+	// before cerberus issue #2777. chsql.emitSelect is the one production
+	// setter — it copies the emitter's resolved strategies onto every
+	// QueryBuilder it renders, so a plan assembled across many nested
+	// QueryBuilders (one per chplan node) sees the same resolved
+	// strategies throughout without each node's lowering/emit code having
+	// to know about it.
+	attrStrategies AttrStrategies
+}
+
+// WithAttrStrategies sets the AttrStrategies this QueryBuilder's Build /
+// Frag renders attribute-map accesses against. See AttrStrategies's doc
+// for why this is scoped per signal rather than a single global map.
+func (s *QueryBuilder) WithAttrStrategies(strategies AttrStrategies) *QueryBuilder {
+	s.attrStrategies = strategies
+	return s
 }
 
 type orderKey struct {
@@ -2989,7 +3185,7 @@ func (s *QueryBuilder) Build() (string, []any) {
 // work around. Unexported: Build stays the public two-value surface
 // every non-chsql caller already depends on.
 func (s *QueryBuilder) subquerySQL() (string, []any, error) {
-	b := NewBuilder()
+	b := NewBuilderWithAttrStrategies(s.attrStrategies)
 	s.writeInto(b)
 	return b.Build()
 }

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -160,6 +160,7 @@ func Emit(ctx context.Context, n chplan.Node) (string, []any, error) {
 
 		emittedSQLMaxBytes: maxEmittedSQLBytesFromCtx(ctx),
 		rootPlan:           n,
+		attrStrategies:     attrStrategiesFromCtx(ctx),
 	}
 	// Collapse a structure-tab plan's repeated top-N trace-id gates onto one
 	// single-evaluation scalar binding hoisted to the outermost statement
@@ -353,6 +354,21 @@ type emitter struct {
 	// ceiling first (see requireEmittedSQLBounded). Nothing reads it on the
 	// success path, and an emitter built outside Emit leaves it nil.
 	rootPlan chplan.Node
+
+	// attrStrategies resolves how an attribute-map column that appears as
+	// a bare chplan.ColumnRef renders a per-key access (cerberus issue
+	// #2777) — see AttrStrategies's doc (attr_strategy.go). Seeded once
+	// per Emit call from attrStrategiesFromCtx(ctx) (internal/engine
+	// threads it via chsql.WithAttrStrategies — see emitForHead /
+	// routeBExecCtx). Every per-node QueryBuilder this emitter assembles
+	// via emitSelect copies it on before rendering (QueryBuilder.
+	// WithAttrStrategies), so a plan composed of many nested Scan/Filter/
+	// Aggregate node emits — each of which builds its OWN fresh
+	// chsql.Builder via QueryBuilder.subquerySQL — all see the SAME
+	// resolved strategies. nil (an emitter built outside Emit, or a
+	// request whose ctx never carried one) renders every attribute-map
+	// column as Map, byte-identical to before this field existed.
+	attrStrategies AttrStrategies
 
 	// cteSeq is a monotonic counter handed out to every emitter that
 	// registers a named CTE, so each one gets a unique name: the

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -63,11 +63,24 @@ func (e *emitter) subqueryFrag(n chplan.Node) (Frag, error) {
 // SQL + args into the emitter's output. Centralises the splice
 // boilerplate so the per-node emitters stay focused on slot assembly.
 //
+// sb.attrStrategies is stamped from e.attrStrategies (cerberus issue
+// #2777) before rendering, unconditionally: every per-node emitter builds
+// its OWN fresh QueryBuilder and this is the one chokepoint every one of
+// them funnels through to render it, so this single line is what makes
+// the emitter's resolved AttrStrategies (seeded once from ctx by Emit)
+// reach every Scan/Filter/Aggregate/... node's chsql.MapAccess /
+// FnMapContainsKey rendering without each per-node emitter function
+// having to know this mechanism exists. e.attrStrategies is nil unless
+// Emit's ctx carried one, so a caller/plan that never heard of this
+// feature overwrites sb.attrStrategies with the same nil it already had —
+// a genuine no-op.
+//
 // Returns sb's sticky first-error (see Builder.err, #1449) instead of
 // silently dropping it — callers propagate it via `return e.emitSelect(sb)`
 // rather than the old pre-flight-render-then-discard-and-render-again
 // pattern.
 func (e *emitter) emitSelect(sb *QueryBuilder) error {
+	sb.attrStrategies = e.attrStrategies
 	sql, args, err := sb.subquerySQL()
 	if err != nil {
 		return err

--- a/internal/chsql/fnresolution.go
+++ b/internal/chsql/fnresolution.go
@@ -70,9 +70,23 @@ var fnResolutions = map[chplan.Fn]fnResolution{
 	chplan.FnTupleElement:      {Name: "tupleElement"},
 
 	// Map functions.
-	chplan.FnMap:            {Name: "map"},
-	chplan.FnMapApply:       {Name: "mapApply"},
-	chplan.FnMapMerge:       {Name: "mapConcat"},
+	chplan.FnMap:      {Name: "map"},
+	chplan.FnMapApply: {Name: "mapApply"},
+	chplan.FnMapMerge: {Name: "mapConcat"},
+	// FnMapContainsKey's Name entry below is only the fallback path a
+	// non-JSON-strategy call takes: exprFunc special-cases this Fn ahead
+	// of the resolveFn lookup (see exprMapContainsKey in builder.go) so
+	// cerberus issue #2777's `has(JSONAllPaths(<col>), <key>)` JSON
+	// rendering can call b.Expr on its args without creating a
+	// package-init cycle through fnResolutions (a fnRender hook stored in
+	// this map that itself calls b.Expr transitively reaches resolveFn,
+	// which reads this very map — Go's initialization-dependency analysis
+	// flags that as illegal even though it's runtime-safe). The Name
+	// entry stays so resolveFn's completeness scan
+	// (fnresolution_completeness_test.go) keeps validating this Fn is
+	// declared exactly once, and so exprMapContainsKey's own fallback
+	// renders the byte-identical `mapContains(...)` a plain Name
+	// resolution always has.
 	chplan.FnMapContainsKey: {Name: "mapContains"},
 	chplan.FnMapFilter:      {Name: "mapFilter"},
 	chplan.FnMapFromArrays:  {Name: "mapFromArrays"},

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -106,6 +106,32 @@ func (ChsqlEmitter) Emit(ctx context.Context, plan chplan.Node) (string, []any, 
 // chsql.Emit's RequireSpansScansBounded chokepoint runs over the whole plan.
 type spansTabler interface{ SpansTable() string }
 
+// attrStrategier is implemented by a Lang whose plans should render
+// attribute-map accesses against a resolved chsql.AttrStrategies (cerberus
+// issue #2777) rather than assuming every attribute column is a
+// ClickHouse Map. Only *logql.Lang implements it today — the
+// LogsAttrStrategies preflight resolves is threaded onto it by
+// internal/api/loki's Handler at construction; PromQL / TraceQL don't
+// implement this interface, so their plans render exactly as before this
+// issue's work (chsql.Emit's ctx never carries a non-nil AttrStrategies
+// for them, which chsql.AttrStrategies.Lookup already treats as "every
+// column is Map").
+type attrStrategier interface{ EmitAttrStrategies() chsql.AttrStrategies }
+
+// attrStrategiesForLang duck-types lang against attrStrategier and returns
+// its resolved AttrStrategies, or nil for a Lang that doesn't implement it
+// (PromQL / TraceQL today). Shared by emitForHead (route A) and every
+// route-B dispatch path (routeBExecCtx's callers) so both routes resolve
+// the identical value for the same Lang — route B's plan is a re-anchored
+// copy of route A's, and the physical column shape a chsql.MapAccess
+// renders against does not change depending on which route dispatches it.
+func attrStrategiesForLang(lang Lang) chsql.AttrStrategies {
+	if as, ok := lang.(attrStrategier); ok {
+		return as.EmitAttrStrategies()
+	}
+	return nil
+}
+
 // rangeSeriesOrderer is implemented by a Lang whose route-A SQL wants its
 // rows sorted before a streaming, per-series pivot downstream reads them
 // (the Prom head's matrixFromCursor — see prom.lang.RangeSeriesOrder's doc
@@ -162,6 +188,7 @@ func emitForHead(
 	if st, ok := lang.(spansTabler); ok {
 		ctx = chsql.WithSpansTable(ctx, st.SpansTable())
 	}
+	ctx = chsql.WithAttrStrategies(ctx, attrStrategiesForLang(lang))
 	if ro, ok := lang.(rangeSeriesOrderer); ok {
 		plan = ro.RangeSeriesOrder(plan)
 	}
@@ -1766,8 +1793,18 @@ func routeBExecCtx(
 	bounds ResourceBoundOverrides,
 	rangeBucketGridNativeMaxRows, rangeBucketGridNativeMaxDensityUnits int64,
 	actualsTracker *actuals.Tracker,
+	attrStrategies chsql.AttrStrategies,
 ) context.Context {
 	ctx = chclient.WithResponseShape(chclient.WithProgressFor(ctx, langName), responseShape)
+	// cerberus issue #2777: route B's shards emit through
+	// engine.ChsqlEmitter, which never sees a Lang (see ChsqlEmitter's
+	// doc) — so, exactly like DeltaPrefixLookback below, the resolved
+	// AttrStrategies has to ride the ctx every route-B dispatch builds
+	// here rather than being read from a Lang at emit time. Every one of
+	// this function's 4 callers resolves it via attrStrategiesForLang(lang)
+	// BEFORE calling in, so a shard's rendering matches what route A would
+	// have rendered for the identical (re-anchored) plan.
+	ctx = chsql.WithAttrStrategies(ctx, attrStrategies)
 	// Issue #2789: tag this route-B dispatch for actuals capture — see
 	// applyActualsCapture's own doc. Threaded here (rather than assumed
 	// already on ctx) because route B is the SAME funnel every
@@ -1861,6 +1898,7 @@ func (e *Engine) executeRouted(
 		routeBExecCtx(
 			ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled,
 			e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals,
+			attrStrategiesForLang(lang),
 		), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	if err != nil {
@@ -2073,7 +2111,8 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 	// back to the ordinary route-A dispatch below exactly as if this had
 	// never run (Major-2's symmetric fallback).
 	budget := chclient.SampleBudgetFromContext(ctx)
-	if cur, info, usedDecision, key, ok := e.tryRouteMemoHit(ctx, lang.Name(), meta.ResponseShape, plan, decision, budget); ok {
+	attrStrategies := attrStrategiesForLang(lang)
+	if cur, info, usedDecision, key, ok := e.tryRouteMemoHit(ctx, lang.Name(), meta.ResponseShape, plan, decision, budget, attrStrategies); ok {
 		result := e.buildRoutedCursorResult(meta, plan, lang.Name(), usedDecision, cur, info, "memo-hit")
 		// See routeMemoHitObserveDrainOutcome's own doc: issue #3035's
 		// sampling-bias fix, unlike Retry below (which only ever fires on a
@@ -2115,7 +2154,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 		// failure (including "retry does not apply here") the original
 		// route-A error is what surfaces, unchanged.
 		if cur, info, usedDecision, observeFn, retried := e.retryOnRouteAResourceFailure(
-			ctx, lang.Name(), meta.ResponseShape, plan, decision, budget, err, time.Since(dispatchStart),
+			ctx, lang.Name(), meta.ResponseShape, plan, decision, budget, err, time.Since(dispatchStart), attrStrategies,
 		); retried {
 			retryResult := e.buildRoutedCursorResult(meta, plan, lang.Name(), usedDecision, cur, info, "retry")
 			retryResult.ObserveDrainOutcome = observeFn
@@ -2144,7 +2183,7 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 			// drain — the full wall time this route-A attempt cost before the
 			// caller saw drainErr, which is what the cancellation floor reads.
 			cur, info, usedDecision, observeFn, retried := e.retryOnRouteAResourceFailure(
-				retryCtx, lang.Name(), meta.ResponseShape, plan, decision, budget, drainErr, time.Since(dispatchStart),
+				retryCtx, lang.Name(), meta.ResponseShape, plan, decision, budget, drainErr, time.Since(dispatchStart), attrStrategies,
 			)
 			if !retried {
 				return CursorResult{}, false
@@ -2375,6 +2414,7 @@ func (e *Engine) executeRoutedCursor(
 		routeBExecCtx(
 			ctx, lang.Name(), meta.ResponseShape, decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled,
 			e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals,
+			attrStrategiesForLang(lang),
 		), lang.Name(), decision, chclient.SampleBudgetFromContext(ctx),
 	)
 	execT.Done(ctx)

--- a/internal/engine/route_b_response_shape_wiring_test.go
+++ b/internal/engine/route_b_response_shape_wiring_test.go
@@ -121,7 +121,7 @@ func routeBDispatches() []routeBDispatch {
 				memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 
 				cur, _, usedDecision, _, ok := eng.tryRouteMemoHit(
-					context.Background(), solver.LangPromQL, meta.ResponseShape, plan, seed, nil,
+					context.Background(), solver.LangPromQL, meta.ResponseShape, plan, seed, nil, nil,
 				)
 				if !ok {
 					t.Fatal("tryRouteMemoHit did not dispatch on a live PreferB verdict")
@@ -149,14 +149,14 @@ func routeBDispatches() []routeBDispatch {
 				// TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration).
 				if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(
 					context.Background(), solver.LangPromQL, meta.ResponseShape, plan, seed, nil,
-					chclient.ErrMemoryLimitExceeded, 0,
+					chclient.ErrMemoryLimitExceeded, 0, nil,
 				); retried {
 					t.Fatal("probed on the FIRST route-A resource failure — fixture no longer matches the memo's corroboration rule")
 				}
 
 				cur, _, usedDecision, observeFn, retried := eng.retryOnRouteAResourceFailure(
 					context.Background(), solver.LangPromQL, meta.ResponseShape, plan, seed, nil,
-					chclient.ErrMemoryLimitExceeded, 0,
+					chclient.ErrMemoryLimitExceeded, 0, nil,
 				)
 				if !retried {
 					t.Fatal("retryOnRouteAResourceFailure did not probe route B after a resource failure")

--- a/internal/engine/route_b_tsgrid_setting_test.go
+++ b/internal/engine/route_b_tsgrid_setting_test.go
@@ -117,7 +117,7 @@ func TestRouteBExecCtx_StampsTSGridSettingForNativeShards(t *testing.T) {
 			t.Parallel()
 
 			ctx := routeBExecCtx(context.Background(), "promql",
-				chclient.ResponseShapeMatrix, tsGridRouteBDecision(tc.wrap), 0, false, ResourceBoundOverrides{}, 0, 0, nil)
+				chclient.ResponseShapeMatrix, tsGridRouteBDecision(tc.wrap), 0, false, ResourceBoundOverrides{}, 0, 0, nil, nil)
 
 			settings := chclient.QuerySettingsFromContext(ctx)
 			_, got := settings[chclient.SettingExperimentalTSGridAggregate]
@@ -144,7 +144,7 @@ func TestRouteBExecCtx_StampsTSGridSettingForNativeShards(t *testing.T) {
 func TestRouteBExecCtx_NilDecisionStampsNothing(t *testing.T) {
 	t.Parallel()
 
-	ctx := routeBExecCtx(context.Background(), "promql", chclient.ResponseShapeMatrix, nil, 0, false, ResourceBoundOverrides{}, 0, 0, nil)
+	ctx := routeBExecCtx(context.Background(), "promql", chclient.ResponseShapeMatrix, nil, 0, false, ResourceBoundOverrides{}, 0, 0, nil, nil)
 	if settings := chclient.QuerySettingsFromContext(ctx); len(settings) != 0 {
 		t.Fatalf("nil decision stamped settings %v", settings)
 	}

--- a/internal/engine/route_memo_wiring.go
+++ b/internal/engine/route_memo_wiring.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/routememo"
 	"github.com/tsouza/cerberus/internal/solver"
 	"github.com/tsouza/cerberus/internal/telemetry"
@@ -192,6 +193,7 @@ func (e *Engine) tryRouteMemoHit(
 	plan chplan.Node,
 	seedDecision *solver.Decision,
 	budget *chclient.SampleBudget,
+	attrStrategies chsql.AttrStrategies,
 ) (cursor chclient.Cursor, info *solver.ExecInfo, usedDecision *solver.Decision, key routememo.Key, dispatched bool) {
 	if !e.routeMemoActive() || seedDecision == nil {
 		return nil, nil, nil, routememo.Key{}, false
@@ -228,7 +230,7 @@ func (e *Engine) tryRouteMemoHit(
 	defer dispatchDone()
 
 	cur, execInfo, err := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals), langName, d.decision, budget,
+		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals, attrStrategies), langName, d.decision, budget,
 	)
 	if err != nil {
 		// A pre-flight failure (breaker/emit/gate/now64) classifies
@@ -281,6 +283,7 @@ func (e *Engine) retryOnRouteAResourceFailure(
 	budget *chclient.SampleBudget,
 	err error,
 	elapsed time.Duration,
+	attrStrategies chsql.AttrStrategies,
 ) (cursor chclient.Cursor, info *solver.ExecInfo, usedDecision *solver.Decision, observeFn func(drainErr error), retried bool) {
 	if !e.routeMemoActive() || seedDecision == nil {
 		return nil, nil, nil, nil, false
@@ -392,7 +395,7 @@ func (e *Engine) retryOnRouteAResourceFailure(
 	dispatchDone := telemetry.ObserveRoutedDispatchInflight(ctx)
 
 	cur, execInfo, dispatchErr := e.Solver.Executor.Execute(
-		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals), langName, d.decision, budget,
+		routeBExecCtx(ctx, langName, responseShape, d.decision, e.DeltaPrefixLookback, e.DeltaPrefixReadEnabled, e.resourceBoundOverrides(), e.RangeBucketGridNativeMaxRows, e.RangeBucketGridNativeMaxDensityUnits, e.Actuals, attrStrategies), langName, d.decision, budget,
 	)
 	if dispatchErr != nil {
 		// A pre-flight failure classifies NoEvidence by construction —

--- a/internal/engine/route_memo_wiring_test.go
+++ b/internal/engine/route_memo_wiring_test.go
@@ -333,7 +333,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 		eng, _ := newMemoWiringEngine(t, cq)
 		seed := memoWiringNotRoutedDecision(t)
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNotEligible]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, memoWiringIneligiblePlan(), seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, memoWiringIneligiblePlan(), seed, nil, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched despite a structurally ineligible plan")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNotEligible]
@@ -368,7 +368,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 			GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
 		}
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNotFresh]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, notFreshPlan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, notFreshPlan, seed, nil, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched on a request whose End has not aged past the live-edge margin")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNotFresh]
@@ -386,7 +386,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 		seed := memoWiringNotRoutedDecision(t)
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNoPreferB]
 		// Fresh memo: Lookup(k) reports Unknown, not PreferB.
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched with no recorded verdict")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNoPreferB]
@@ -405,7 +405,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 		memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 		memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) }) // past re-validation midpoint
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineStale]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched on a STALE PreferB verdict")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineStale]
@@ -421,7 +421,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 		d := eng.deriveRouteMemoDispatch(plan, seed, memoWiringGridEnd.Add(2*memoWiringGridStep))
 		memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineBreakerOpen]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched with the breaker OPEN")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineBreakerOpen]
@@ -444,7 +444,7 @@ func TestTryRouteMemoHit_RecordsDeclineReasons(t *testing.T) {
 			}
 		}
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNoDispatchToken]
-		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
+		if _, _, _, _, ok := eng.tryRouteMemoHit(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, nil); ok {
 			t.Fatal("tryRouteMemoHit dispatched despite an exhausted admission semaphore")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineNoDispatchToken]
@@ -471,7 +471,7 @@ func TestRetryOnRouteAResourceFailure_RecordsProbeDeclineReasons(t *testing.T) {
 		// First resource failure on a fresh Unknown key: corroboration=1,
 		// below minCorroboratingFailures — ObserveRouteAFailureAndMaybeBeginProbe
 		// itself refuses, for a reason OTHER than cluster-wide pressure.
-		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0); retried {
+		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil); retried {
 			t.Fatal("retried on the first route-A resource failure")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineProbeNotAdmitted]
@@ -502,7 +502,7 @@ func TestRetryOnRouteAResourceFailure_RecordsProbeDeclineReasons(t *testing.T) {
 			t.Fatalf("fixture failed to establish UnderPressure()==true")
 		}
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineUnderPressure]
-		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0); retried {
+		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil); retried {
 			t.Fatal("retried while the memo is under cluster-wide pressure")
 		}
 		after := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineUnderPressure]
@@ -533,7 +533,7 @@ func TestRetryOnRouteAResourceFailure_RoutedDispatchInflight(t *testing.T) {
 	}
 
 	// corroboration=1: below threshold, no dispatch, no inflight movement.
-	if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0); retried {
+	if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil); retried {
 		t.Fatal("retried on the first route-A resource failure")
 	}
 	if got := routedDispatchInflightValue(t, reader); got != 0 {
@@ -541,7 +541,7 @@ func TestRetryOnRouteAResourceFailure_RoutedDispatchInflight(t *testing.T) {
 	}
 
 	// corroboration=2: probe admitted, dispatch begins.
-	_, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	_, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if !retried {
 		t.Fatal("did not retry on the 2nd consecutive route-A resource failure")
 	}
@@ -570,7 +570,7 @@ func TestRouteABSuccessTotal(t *testing.T) {
 		eng, _ := newMemoWiringEngine(t, cq)
 		seed := memoWiringNotRoutedDecision(t)
 		before := routeABSuccessByRoute(t, reader)[telemetry.RouteChoiceA]
-		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, nil, 0); retried {
+		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, nil, 0, nil); retried {
 			t.Fatal("a Success classification must never itself trigger a retry dispatch")
 		}
 		after := routeABSuccessByRoute(t, reader)[telemetry.RouteChoiceA]
@@ -584,10 +584,10 @@ func TestRouteABSuccessTotal(t *testing.T) {
 		eng, _ := newMemoWiringEngine(t, cq)
 		seed := memoWiringNotRoutedDecision(t)
 		ctx := t.Context()
-		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0); retried {
+		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil); retried {
 			t.Fatal("retried on the first route-A resource failure")
 		}
-		_, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+		_, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 		if !retried {
 			t.Fatal("did not retry on the 2nd consecutive route-A resource failure")
 		}
@@ -663,7 +663,7 @@ func TestTryRouteMemoHit_DispatchesOnLivePreferBVerdict(t *testing.T) {
 	}
 	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 
-	cur, info, usedDecision, gotKey, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
+	cur, info, usedDecision, gotKey, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, nil)
 	if !ok {
 		t.Fatal("tryRouteMemoHit did not dispatch on a live PreferB verdict")
 	}
@@ -693,7 +693,7 @@ func TestTryRouteMemoHit_UnknownKeyNeverDispatches(t *testing.T) {
 	plan := memoWiringEligiblePlan()
 	seed := memoWiringNotRoutedDecision(t)
 
-	_, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
+	_, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, nil)
 	if ok {
 		t.Fatal("tryRouteMemoHit dispatched for an Unknown key — must never memo-hit without a recorded verdict")
 	}
@@ -723,7 +723,7 @@ func TestTryRouteMemoHit_StaleVerdictFallsBackToCaller(t *testing.T) {
 	// crossing the TTL itself.
 	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
 
-	_, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
+	_, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, nil)
 	if ok {
 		t.Fatal("tryRouteMemoHit dispatched on a STALE PreferB verdict — must fall through to route A instead")
 	}
@@ -768,7 +768,7 @@ func TestTryRouteMemoHit_PreFlightFailureFallsBackToRouteA(t *testing.T) {
 	d := eng.deriveRouteMemoDispatch(plan, seed, fixedNow)
 	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 
-	cur, info, usedDecision, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
+	cur, info, usedDecision, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, nil)
 	if ok {
 		t.Fatal("tryRouteMemoHit reported dispatched=true despite a pre-flight emit failure")
 	}
@@ -808,7 +808,7 @@ func TestTryRouteMemoHit_MidDrainResourceFailure_ObserveViaClassify(t *testing.T
 	d := eng.deriveRouteMemoDispatch(plan, seed, fixedNow)
 	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 
-	cur, _, _, gotKey, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil)
+	cur, _, _, gotKey, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, nil)
 	if !ok {
 		t.Fatal("tryRouteMemoHit must dispatch (Execute's synchronous return has no visibility into a per-shard open error)")
 	}
@@ -860,7 +860,7 @@ func TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration(t *testing.T) {
 
 	// First resource failure: corroboration=1, below the threshold — must
 	// NOT retry.
-	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if retried {
 		t.Fatal("retried on the FIRST route-A resource failure — corroboration requires more than one")
 	}
@@ -871,7 +871,7 @@ func TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration(t *testing.T) {
 	// Second consecutive resource failure, same key, no intervening
 	// success: corroboration=2 (the default minCorroboratingFailures) —
 	// NOW a probe is admitted and route B dispatches.
-	cur, info, usedDecision, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	cur, info, usedDecision, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if !retried {
 		t.Fatal("did not retry on the 2nd consecutive route-A resource failure")
 	}
@@ -918,8 +918,8 @@ func TestRetryOnRouteAResourceFailure_ObserveFnRecordsMagnitudeOnCleanProbe(t *t
 
 	// Two consecutive route-A resource failures earn the first probe (see
 	// TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration).
-	eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
-	cur, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
+	cur, _, _, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if !retried {
 		t.Fatal("did not retry on the 2nd consecutive route-A resource failure")
 	}
@@ -1010,7 +1010,7 @@ func TestRetryOnRouteAResourceFailure_TrivialMagnitudeDeclinesRevalidation(t *te
 	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
 
 	before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineTrivialMagnitude]
-	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if retried {
 		t.Fatal("retried a stale-PreferB re-validation despite a well-corroborated trivially small tracked magnitude")
 	}
@@ -1048,7 +1048,7 @@ func TestRetryOnRouteAResourceFailure_LargeMagnitudeStillRevalidates(t *testing.
 	}
 	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
 
-	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if !retried {
 		t.Fatal("declined a stale-PreferB re-validation despite a LARGE tracked magnitude — the trivial-magnitude gate must not over-trigger")
 	}
@@ -1076,7 +1076,7 @@ func TestRetryOnRouteAResourceFailure_UnderCorroboratedMagnitudeStillRevalidates
 	memo.RecordActualMagnitude(d.key, 1)
 	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
 
-	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if !retried {
 		t.Fatal("declined a stale-PreferB re-validation on a single, under-corroborated trivial-magnitude reading")
 	}
@@ -1096,7 +1096,7 @@ func TestRetryOnRouteAResourceFailure_NonResourceErrorNeverRetried(t *testing.T)
 
 	timeoutErr := &solver.SolverTimeoutError{Timeout: "60s"}
 	for i := 0; i < 5; i++ {
-		_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, timeoutErr, 0)
+		_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, timeoutErr, 0, nil)
 		if retried {
 			t.Fatalf("iteration %d: retried on a NoEvidence-class error (solver timeout)", i)
 		}
@@ -1119,7 +1119,7 @@ func TestRetryOnRouteAResourceFailure_ClientGoneNeverRetried(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0)
+	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if retried {
 		t.Fatal("retried on a cancelled context — no client is there to receive the retry's answer")
 	}
@@ -1149,7 +1149,7 @@ func TestRetryOnRouteAResourceFailure_CostlyCancellationRecordedNeverRetried(t *
 	cancel()
 
 	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(
-		ctx, "promql", memoWiringResponseShape, plan, seed, nil, context.Canceled, costlyCancellationFloor,
+		ctx, "promql", memoWiringResponseShape, plan, seed, nil, context.Canceled, costlyCancellationFloor, nil,
 	)
 	if retried {
 		t.Fatal("retried a dead context — a retry dispatch would run for nobody")
@@ -1177,7 +1177,7 @@ func TestRetryOnRouteAResourceFailure_EarlyCancellationNotRecorded(t *testing.T)
 	cancel()
 
 	_, _, _, _, retried := eng.retryOnRouteAResourceFailure(
-		ctx, "promql", memoWiringResponseShape, plan, seed, nil, context.Canceled, 200*time.Millisecond,
+		ctx, "promql", memoWiringResponseShape, plan, seed, nil, context.Canceled, 200*time.Millisecond, nil,
 	)
 	if retried {
 		t.Fatal("retried a dead context")
@@ -1200,10 +1200,10 @@ func TestRouteMemoWiring_InactiveWhenRouteMemoNil(t *testing.T) {
 	plan := memoWiringEligiblePlan()
 	seed := memoWiringNotRoutedDecision(t)
 
-	if _, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil); ok {
+	if _, _, _, _, ok := eng.tryRouteMemoHit(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, nil); ok {
 		t.Fatal("tryRouteMemoHit dispatched with RouteMemo nil")
 	}
-	if _, _, _, _, ok := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0); ok {
+	if _, _, _, _, ok := eng.retryOnRouteAResourceFailure(context.Background(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil); ok {
 		t.Fatal("retryOnRouteAResourceFailure dispatched with RouteMemo nil")
 	}
 	if cq.opens.Load() != 0 {

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/telemetry"
@@ -72,7 +73,28 @@ type Lang struct {
 	// see its doc comment.
 	LogLineLimit    int64
 	LogLineBackward bool
+
+	// AttrStrategies resolves how the logs attribute-map columns
+	// (Schema.AttributesColumn / ResourceAttributesColumn /
+	// ScopeAttributesColumn) are physically stored, per
+	// internal/preflight's boot probe (cerberus issue #2777,
+	// Result.LogsAttrStrategies) — nil (the zero value) means every
+	// column is a genuine ClickHouse Map, rendering byte-identical to
+	// before this field existed. internal/api/loki's Handler resolves
+	// this once at construction (from the preflight Result cmd/cerberus
+	// already runs) and copies it onto every per-request *Lang it builds,
+	// exactly like Schema. EmitAttrStrategies (below) is the duck-typed
+	// hook engine.emitForHead reads to thread it onto the emit-time
+	// context — the same pattern spansTabler / rangeSeriesOrderer already
+	// use for Tempo / Prometheus-specific emit behaviour.
+	AttrStrategies chsql.AttrStrategies
 }
+
+// EmitAttrStrategies returns the AttrStrategies this Lang's queries should
+// render attribute-map accesses against — see the AttrStrategies field's
+// doc. engine.emitForHead duck-types on this to thread it onto the emit
+// context via chsql.WithAttrStrategies.
+func (l *Lang) EmitAttrStrategies() chsql.AttrStrategies { return l.AttrStrategies }
 
 // errorTypes mirrors the Loki errorType vocabulary the handler emits.
 // Duplicated here (not re-imported from internal/api/loki) so the LogQL

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/cerbtrace"
 	"github.com/tsouza/cerberus/internal/chplan"
-	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/telemetry"
@@ -87,14 +86,17 @@ type Lang struct {
 	// hook engine.emitForHead reads to thread it onto the emit-time
 	// context — the same pattern spansTabler / rangeSeriesOrderer already
 	// use for Tempo / Prometheus-specific emit behaviour.
-	AttrStrategies chsql.AttrStrategies
+	AttrStrategies chplan.AttrStrategies
 }
 
 // EmitAttrStrategies returns the AttrStrategies this Lang's queries should
 // render attribute-map accesses against — see the AttrStrategies field's
 // doc. engine.emitForHead duck-types on this to thread it onto the emit
-// context via chsql.WithAttrStrategies.
-func (l *Lang) EmitAttrStrategies() chsql.AttrStrategies { return l.AttrStrategies }
+// context via chsql.WithAttrStrategies. Returns chplan.AttrStrategies
+// (a chsql.AttrStrategies alias) rather than importing chsql directly:
+// logql is architecturally forbidden from depending on chsql
+// (.go-arch-lint.yml) — see chplan.AttrStrategy's own doc.
+func (l *Lang) EmitAttrStrategies() chplan.AttrStrategies { return l.AttrStrategies }
 
 // errorTypes mirrors the Loki errorType vocabulary the handler emits.
 // Duplicated here (not re-imported from internal/api/loki) so the LogQL

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -15,13 +15,17 @@
 //     system.columns and validated to carry the essential columns the
 //     emitters require, with the attribute-map columns typed
 //     Map(String, String) — except logs' and traces' attribute maps, which
-//     may alternatively be typed JSON (cerberus issue #2777 phase 1's
-//     boot-probe compat: the upstream OTel exporter's `json:true` schema
-//     variant). A JSON-typed attribute map there boots with a WARNING rather
-//     than a FATAL, since query lowering against it is a follow-up (the
-//     emitters still assume Map). Metrics attribute maps carry series
-//     identity and stay Map-only per the issue's own scoping — see
-//     tableReq.jsonAttrMapCompat.
+//     may alternatively be typed JSON (cerberus issue #2777: the upstream
+//     OTel exporter's `json:true` schema variant). A JSON-typed attribute
+//     map there boots with a WARNING rather than a FATAL and, for LOGS,
+//     also RESOLVES a chsql.AttrStrategies the query emitters actually
+//     render against for per-key lookups (Result.LogsAttrStrategies —
+//     internal/engine threads it onto the emit context; see
+//     tableReq.jsonQuerySupported). Traces detection ships too
+//     (Result.TracesAttrStrategies is resolved) but is not yet threaded
+//     into any TraceQL request (cerberus issue #3062). Metrics attribute
+//     maps carry series identity and stay Map-only per the issue's own
+//     scoping — see tableReq.jsonAttrMapCompat.
 //   - Gate 3 (storage tiering): when a storage policy or a tiering volume is
 //     configured, the policy's volumes are read from system.storage_policies
 //     and the configuration is checked for being ACCEPTED BUT INERT — a

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -316,6 +316,62 @@ type Result struct {
 	UnreachableErr    error
 	DatabaseAbsent    bool
 	DatabaseAbsentErr error
+
+	// LogsAttrStrategies resolves, per logs attribute-map column name, the
+	// chsql.AttrStrategy the boot probe detected (cerberus issue #2777):
+	// AttrStrategyJSON for a column system.columns reports as ClickHouse's
+	// JSON type, absent (chsql's nil-safe default) for every column
+	// reporting the expected Map(String,String). nil when the logs table
+	// carries no JSON-typed attribute columns at all — the common case,
+	// and the only case before this issue's work existed.
+	//
+	// cmd/cerberus is the only intended consumer: it threads this into
+	// internal/engine's construction so a LogQL request's ctx carries it
+	// via chsql.WithAttrStrategies, scoped to LogQL only (see
+	// chsql.AttrStrategies's doc for why a bare-column-name map must never
+	// be shared across signals). A nil value here is indistinguishable
+	// from "preflight never ran" and from "every logs attribute column is
+	// Map" — both resolve to the same all-Map behaviour, which is correct
+	// for both.
+	LogsAttrStrategies AttrStrategies
+
+	// TracesAttrStrategies is LogsAttrStrategies's traces counterpart —
+	// resolved by the SAME boot-probe detection (tableReq.jsonAttrMapCompat
+	// covers both logs and traces) but deliberately NOT wired into
+	// internal/engine's TraceQL request context in this version: chsql's
+	// JSON rendering branch (exprMapAccess / FnMapContainsKey) has only
+	// been verified for logs' per-key lookup shapes, and traces carries
+	// its own unverified risk (TraceQL's comparison typing, the
+	// structural-join / nested-set emitters) — see cerberus issue #3062
+	// (traces JSON-attribute query support), a sub-issue of #2777. The
+	// field exists so that follow-up only
+	// has to wire cmd/cerberus + internal/engine, not touch preflight's
+	// detection again — it is always populated (or nil) exactly as
+	// LogsAttrStrategies is, from the same checkSchema pass.
+	TracesAttrStrategies AttrStrategies
+}
+
+// AttrStrategies is preflight's own alias for chsql.AttrStrategies —
+// declared here (rather than importing chsql.AttrStrategies inline at
+// every use) purely so Result's field docs above read as preflight
+// vocabulary; the underlying type is identical and assignment-compatible.
+type AttrStrategies = chsql.AttrStrategies
+
+// attrStrategiesFor turns the JSON-typed attribute-column names one
+// table's boot probe found into an AttrStrategies map, or nil when cols is
+// empty — nil is AttrStrategies's own "every column is Map" default (see
+// chsql.AttrStrategies.Lookup), so a table with no JSON columns detected
+// resolves to exactly the same nil Result field a preflight run before
+// cerberus issue #2777 would have left zero-valued.
+func attrStrategiesFor(cols []string) AttrStrategies {
+	if len(cols) == 0 {
+		return nil
+	}
+	out := make(AttrStrategies, len(cols))
+	for _, c := range cols {
+		out[c] = chsql.AttrStrategyJSON
+	}
+	return out
 }
 
 // SchemaProvisioned reports whether the schema is fully present (whatever
@@ -406,7 +462,7 @@ func Run(ctx context.Context, q Querier, req Requirements) Result {
 		return Result{DatabaseAbsent: true, DatabaseAbsentErr: dbAbsent}
 	}
 
-	schemaProblems, absent, schemaWarnings, unreachable := checkSchema(ctx, q, req)
+	schemaProblems, absent, schemaWarnings, jsonColsByTable, unreachable := checkSchema(ctx, q, req)
 	if unreachable != nil {
 		return Result{Unreachable: true, UnreachableErr: unreachable}
 	}
@@ -423,7 +479,12 @@ func Run(ctx context.Context, q Querier, req Requirements) Result {
 
 	problems := append(versionProblems, schemaProblems...)
 
-	res := Result{Warnings: warnings, AbsentTables: absent}
+	res := Result{
+		Warnings:             warnings,
+		AbsentTables:         absent,
+		LogsAttrStrategies:   attrStrategiesFor(jsonColsByTable[req.Logs.LogsTable]),
+		TracesAttrStrategies: attrStrategiesFor(jsonColsByTable[req.Traces.SpansTable]),
+	}
 	if len(problems) == 0 {
 		return res
 	}
@@ -699,6 +760,22 @@ type tableReq struct {
 	// genuine FATAL misconfiguration; requiredTables leaves this false for
 	// every metrics tableReq.
 	jsonAttrMapCompat bool
+	// jsonQuerySupported narrows jsonAttrMapCompat's warning text and
+	// controls whether this table's JSON-typed attribute columns are
+	// surfaced through Result.LogsAttrStrategies / TracesAttrStrategies for
+	// internal/engine to actually render queries against (cerberus issue
+	// #2777, the chsql.Builder attribute-access-strategy threading slice).
+	// True only for logs: chsql's exprMapAccess / FnMapContainsKey render
+	// hooks now have a JSON branch, wired for logs' per-key lookups (label
+	// matchers, detected_level, the OTelDottedFallbackChain candidate
+	// chain). False for traces — detection ships here, but chsql's JSON
+	// branch is not wired into any TraceQL-facing AttrStrategies in this
+	// version, so a JSON-typed traces attribute column still fails at
+	// query time exactly as before (deliberately: TraceQL's comparison
+	// typing and the structural-join emitters are unverified against the
+	// JSON path — see cerberus issue #3062, a sub-issue of #2777).
+	// requiredTables is the only place that sets this.
+	jsonQuerySupported bool
 	// materializedColumns is the subset of columns that must be typed a
 	// SPECIFIC ClickHouse type rather than checked for mere existence —
 	// the materialized span/resource attribute columns an operator opted
@@ -774,8 +851,9 @@ func requiredTables(req Requirements) []tableReq {
 				l.TimestampColumn, l.BodyColumn, l.ServiceNameColumn,
 				l.AttributesColumn, l.ResourceAttributesColumn,
 			),
-			attrMap:           nonEmpty(l.AttributesColumn, l.ResourceAttributesColumn, l.ScopeAttributesColumn),
-			jsonAttrMapCompat: true,
+			attrMap:            nonEmpty(l.AttributesColumn, l.ResourceAttributesColumn, l.ScopeAttributesColumn),
+			jsonAttrMapCompat:  true,
+			jsonQuerySupported: true,
 		})
 	}
 
@@ -862,36 +940,43 @@ func nonEmpty(vals ...string) []string {
 // tableReq.jsonAttrMapCompat). Distinct tables that resolve to the same
 // physical name (Gauge==Sum on a collapsed schema) are introspected once.
 //
-// It returns three slices: the FATAL wrong-shape problems (missing columns /
+// It returns four values: the FATAL wrong-shape problems (missing columns /
 // wrong attribute-map types / introspection errors) for the aggregated boot
 // failure, the ABSENT-table names — tables system.columns reports zero rows
-// for, i.e. not yet provisioned — and the boot-probe WARNINGS (a
-// jsonAttrMapCompat table whose attribute map is JSON-typed). An
+// for, i.e. not yet provisioned — the boot-probe WARNINGS (a
+// jsonAttrMapCompat table whose attribute map is JSON-typed), and
+// jsonColsByTable, the JSON-typed attribute columns found per jsonQuerySupported
+// table name (logs today; see tableReq.jsonQuerySupported) — Run resolves
+// this into Result.LogsAttrStrategies / TracesAttrStrategies. An
 // entirely-absent table is transient (the schema race), so it lands in the
-// second slice and is NOT a wrong-shape problem; a table that exists but has
+// second value and is NOT a wrong-shape problem; a table that exists but has
 // the wrong columns is.
-func checkSchema(ctx context.Context, q Querier, req Requirements) (problems, absent, warnings []string, unreachable error) {
+func checkSchema(ctx context.Context, q Querier, req Requirements) (problems, absent, warnings []string, jsonColsByTable map[string][]string, unreachable error) {
 	seen := map[string]bool{}
+	jsonColsByTable = map[string][]string{}
 	for _, t := range requiredTables(req) {
 		if t.name == "" || seen[t.name] {
 			continue
 		}
 		seen[t.name] = true
-		probs, warns, isAbsent, unreach := checkTable(ctx, q, req.Database, t)
+		probs, warns, jsonCols, isAbsent, unreach := checkTable(ctx, q, req.Database, t)
 		if unreach != nil {
 			// A transport failure mid-introspection means the server dropped
 			// (or never came up): abandon the shape gate and report unreachable
 			// so the caller waits rather than recording a half-introspected
 			// schema as wrong-shape.
-			return nil, nil, nil, unreach
+			return nil, nil, nil, nil, unreach
 		}
 		problems = append(problems, probs...)
 		warnings = append(warnings, warns...)
 		if isAbsent {
 			absent = append(absent, t.name)
 		}
+		if len(jsonCols) > 0 {
+			jsonColsByTable[t.name] = append(jsonColsByTable[t.name], jsonCols...)
+		}
 	}
-	return problems, absent, warnings, nil
+	return problems, absent, warnings, jsonColsByTable, nil
 }
 
 // checkTable introspects one table via system.columns and validates its
@@ -912,7 +997,7 @@ func checkSchema(ctx context.Context, q Querier, req Requirements) (problems, ab
 //     JSON-typed attribute map on a jsonAttrMapCompat table (logs/traces),
 //     which is a WARNING instead of a problem (cerberus issue #2777 phase 1
 //     boot-probe compat; see tableReq.jsonAttrMapCompat and isJSONAttrType).
-func checkTable(ctx context.Context, q Querier, database string, t tableReq) (problems, warnings []string, absent bool, unreachable error) {
+func checkTable(ctx context.Context, q Querier, database string, t tableReq) (problems, warnings, jsonCols []string, absent bool, unreachable error) {
 	sql, args := chsql.NewQuery().
 		Select(chsql.Col("name"), chsql.Col("type")).
 		From(chsql.Qual("system", "columns")).
@@ -924,15 +1009,15 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) (pr
 	rows, err := q.QueryNameTypePairs(ctx, sql, args...)
 	if err != nil {
 		if isUnreachable(err) {
-			return nil, nil, false, err
+			return nil, nil, nil, false, err
 		}
-		return []string{fmt.Sprintf("could not introspect table %s: %v", t.name, err)}, nil, false, nil
+		return []string{fmt.Sprintf("could not introspect table %s: %v", t.name, err)}, nil, nil, false, nil
 	}
 	if len(rows) == 0 {
 		// Entirely absent: the schema has not been provisioned yet. This is
 		// the transient startup race, not a misconfiguration — surface it as
 		// absent so the caller waits (NOT READY) rather than exiting.
-		return nil, nil, true, nil
+		return nil, nil, nil, true, nil
 	}
 
 	types := make(map[string]string, len(rows))
@@ -958,17 +1043,38 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) (pr
 			continue
 		}
 		if t.jsonAttrMapCompat && isJSONAttrType(got) {
-			// Boot-probe compat (cerberus issue #2777 phase 1): a JSON-typed
-			// attribute map on logs/traces boots instead of FATALing, but the
-			// query emitters still assume Map, so this is surfaced as a
-			// WARNING rather than silently accepted — an operator on this
-			// schema needs to know query support isn't there yet.
-			warnings = append(warnings, fmt.Sprintf(
-				"table %s column %s: JSON-typed attribute schema detected (cerberus issue #2777 phase 1 "+
-					"boot-probe compat) — boot allowed, but attribute-path query lowering is not implemented "+
-					"yet; queries touching this column's attribute keys will fail until follow-up work lands",
-				t.name, col,
-			))
+			// Boot-probe compat (cerberus issue #2777): a JSON-typed
+			// attribute map on logs/traces boots instead of FATALing. The
+			// warning's own text is the DELIBERATE per-table posture
+			// decision (never inherited by default): jsonQuerySupported
+			// tables (logs) now have a real, tested chsql JSON rendering
+			// path for per-key attribute lookups, so the warning narrows to
+			// naming the KNOWN remaining gaps rather than claiming nothing
+			// works; a table without it (traces) keeps the original
+			// "nothing works yet" text, because chsql's JSON branch is not
+			// wired into any AttrStrategies TraceQL requests carry.
+			if t.jsonQuerySupported {
+				jsonCols = append(jsonCols, col)
+				warnings = append(warnings, fmt.Sprintf(
+					"table %s column %s: JSON-typed attribute schema detected (cerberus issue #2777) — "+
+						"per-key attribute lookups (label matchers, detected_level, and other bare "+
+						"MapAccess/mapContains reads against this column) are supported. NOT yet "+
+						"supported (tracked as cerberus issue #3063): operations that need the FULL "+
+						"attribute map at once (LogQL line_format / label_format / unpack / keep|drop "+
+						"with no argument list), the /labels /series /detected_fields metadata "+
+						"endpoints, and any table whose ingestion ever used "+
+						"json_type_escape_dots_in_keys=1 or mixed dotted-key encodings — those still "+
+						"fail at query time",
+					t.name, col,
+				))
+			} else {
+				warnings = append(warnings, fmt.Sprintf(
+					"table %s column %s: JSON-typed attribute schema detected (cerberus issue #2777) — "+
+						"boot allowed, but attribute-path query lowering is not implemented for this table "+
+						"yet; queries touching this column's attribute keys will fail until follow-up work lands",
+					t.name, col,
+				))
+			}
 			continue
 		}
 		problems = append(problems, fmt.Sprintf(
@@ -997,7 +1103,7 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) (pr
 			))
 		}
 	}
-	return problems, warnings, false, nil
+	return problems, warnings, jsonCols, false, nil
 }
 
 // normalizeType canonicalises a ClickHouse type string for comparison:

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
@@ -448,12 +449,16 @@ func TestRunWrongAttributeTypeFails(t *testing.T) {
 	}
 }
 
-// TestRunLogsJSONAttrMapPassesWithWarning pins cerberus issue #2777 phase
-// 1's boot-probe compat: a logs table whose attribute-map columns are typed
-// JSON (the upstream OTel exporter's `json:true` schema variant) boots
-// instead of FATALing, with a WARNING naming the table/column and pointing
-// at the issue — the query emitters don't lower against JSON yet, so an
-// operator on this schema needs to know that up front.
+// TestRunLogsJSONAttrMapPassesWithWarning pins cerberus issue #2777's
+// boot-probe compat AND its deliberate boot-warning-posture decision: a
+// logs table whose attribute-map columns are typed JSON (the upstream OTel
+// exporter's `json:true` schema variant) boots instead of FATALing, with a
+// WARNING that — now that chsql actually has a JSON rendering path for
+// logs' per-key lookups — says what IS supported (not "nothing works
+// yet") and still names what remains unsupported (full-map operations,
+// escape-dots-in-keys schemas). Result.LogsAttrStrategies must resolve the
+// column to AttrStrategyJSON so internal/engine can thread it into a LogQL
+// request's ctx.
 func TestRunLogsJSONAttrMapPassesWithWarning(t *testing.T) {
 	t.Parallel()
 	cols := healthyColumns()
@@ -472,16 +477,30 @@ func TestRunLogsJSONAttrMapPassesWithWarning(t *testing.T) {
 		t.Fatalf("want exactly 1 warning, got %d: %v", len(res.Warnings), res.Warnings)
 	}
 	w := res.Warnings[0]
-	for _, want := range []string{l.LogsTable, l.AttributesColumn, "JSON-typed attribute schema", "#2777"} {
+	for _, want := range []string{l.LogsTable, l.AttributesColumn, "JSON-typed attribute schema", "#2777", "are supported"} {
 		if !strings.Contains(w, want) {
 			t.Errorf("warning missing %q: %s", want, w)
 		}
 	}
+	if strings.Contains(w, "not implemented") {
+		t.Errorf("logs warning must not claim query lowering is unimplemented — it is, for per-key lookups: %s", w)
+	}
+	if got := res.LogsAttrStrategies.Lookup(l.AttributesColumn); got != chsql.AttrStrategyJSON {
+		t.Errorf("LogsAttrStrategies.Lookup(%q) = %v, want AttrStrategyJSON", l.AttributesColumn, got)
+	}
+	if res.TracesAttrStrategies != nil {
+		t.Errorf("TracesAttrStrategies = %v, want nil (no traces column was made JSON in this test)", res.TracesAttrStrategies)
+	}
 }
 
 // TestRunTracesJSONAttrMapPassesWithWarning is the traces counterpart of
-// TestRunLogsJSONAttrMapPassesWithWarning — the other signal the issue's
-// Phase 1 boot-probe compat covers.
+// TestRunLogsJSONAttrMapPassesWithWarning — the other signal the boot-probe
+// compat covers. Unlike logs, chsql's JSON rendering branch is NOT wired
+// into any TraceQL-facing AttrStrategies in this version (see
+// tableReq.jsonQuerySupported's doc), so the warning keeps its original
+// "nothing works at query time yet" text, and Result.TracesAttrStrategies
+// stays nil even though the column WAS detected as JSON — a deliberate
+// choice, not an oversight: see cerberus issue #3062, a sub-issue of #2777.
 func TestRunTracesJSONAttrMapPassesWithWarning(t *testing.T) {
 	t.Parallel()
 	cols := healthyColumns()
@@ -500,10 +519,17 @@ func TestRunTracesJSONAttrMapPassesWithWarning(t *testing.T) {
 		t.Fatalf("want exactly 1 warning, got %d: %v", len(res.Warnings), res.Warnings)
 	}
 	w := res.Warnings[0]
-	for _, want := range []string{tr.SpansTable, tr.ResourceAttributesColumn, "JSON-typed attribute schema", "#2777"} {
+	for _, want := range []string{tr.SpansTable, tr.ResourceAttributesColumn, "JSON-typed attribute schema", "#2777", "not implemented"} {
 		if !strings.Contains(w, want) {
 			t.Errorf("warning missing %q: %s", want, w)
 		}
+	}
+	if res.TracesAttrStrategies != nil {
+		t.Errorf("TracesAttrStrategies = %v, want nil — chsql's JSON branch is not wired for traces in this version",
+			res.TracesAttrStrategies)
+	}
+	if res.LogsAttrStrategies != nil {
+		t.Errorf("LogsAttrStrategies = %v, want nil (no logs column was made JSON in this test)", res.LogsAttrStrategies)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the JSON-typed-attributes capability gap for **logs** (cerberus issue #2777, M5's largest backlog item): a cerberus configured against the OTel exporter's `json:true` logs schema now answers attribute-key queries correctly (label matchers, `detected_level`, and any other bare per-key `MapAccess`/`mapContains` read) instead of failing at query time with `ILLEGAL_TYPE_OF_ARGUMENT`.

**Framing correction already on record** (M5 milestone, restated here for the PR record): this is a P2 capability-breadth gap, not a P1 degradation — the pre-#2879 state was a total boot refusal serving nothing; today's state (post-#2879, pre-this-PR) boots and serves every query that doesn't touch a JSON-typed attribute key. This PR is the next capability slice, not a fire-drill fix.

## Design

**Attribute-access strategy threading** (`internal/chsql`):
- New `chsql.AttrStrategy` (`AttrStrategyMap` / `AttrStrategyJSON`) and `chsql.AttrStrategies` (a `map[string]AttrStrategy` keyed by bare column name).
- `Builder` gains a nil-safe `attrStrategies` field; `QueryBuilder.WithAttrStrategies(...)` sets it, and every render path (`subquerySQL`, and `emitSelect`'s single chokepoint every per-node emitter funnels through) copies the emitter's resolved value onto each fresh `Builder`/`QueryBuilder` it constructs. `nil` (every pre-existing call site, ~50+ of them) resolves to `AttrStrategyMap` for every column — **zero per-query branching**, decided once per request from a boot-resolved map, matching the `chopt`-style pure-strategy pattern the codebase already uses elsewhere.
- `exprMapAccess`'s JSON branch triggers only when the Map operand is a bare `*chplan.ColumnRef` (never a composed `mapUpdate`/`mapConcat`/`map()` result, which really is a Map at the SQL level) **and** the key is a compile-time `*chplan.LitString` (ClickHouse's JSON dynamic-subcolumn path syntax is a syntax-level path expression, not a bound parameter). Renders `coalesce(<col>.<key, backtick-quoted>.:String, '')`.
- `exprMapContainsKey`'s JSON branch (special-cased ahead of the generic `fnResolutions` table — a `fnRender` hook stored in that map that calls `b.Expr` creates a Go package-initialization cycle back through `resolveFn`) renders `has(JSONAllPaths(<col>), <key>)`.

**Missing-vs-empty semantics — pinned by real chDB tests, not assumed:**
- A raw JSON path read (`col.\`key\`.:String`) returns **NULL** for a missing key; a Map subscript returns the value type's default, the **empty string**. `TestAttrStrategyJSON_RawPathDiffersFromMap` (chDB-tagged) proves this discrepancy is real on ClickHouse 26.5.
- `exprMapAccess`'s `coalesce(..., '')` wrap deliberately normalises this away so every existing chplan-level lowering — written against the Map contract (e.g. `qlcommon.OTelDottedFallbackChain`'s terminal bare-`MapAccess` arm) — keeps working unmodified against a JSON-typed column. `TestAttrStrategyJSON_MapAccessMatchesMapSemantics` proves chsql's actual rendered SQL reproduces the Map contract exactly, for both a genuinely-absent key and a present-but-empty one.
- Real presence/absence (present-empty vs. absent) is recovered via `FnMapContainsKey`'s `has(JSONAllPaths(...))`, which `TestAttrStrategyJSON_MapContainsKeyMatchesMapSemantics` proves agrees with `mapContains` row-for-row, including the present-empty case.
- Dotted OTel keys (`http.status_code`) nest by ClickHouse's JSON **default** behaviour; a single backtick-quoted identifier carrying the literal dotted string as one token reads back correctly because ClickHouse's JSON path grammar splits on the dot for nesting regardless of quoting (empirically verified — see `exprMapAccess`'s doc comment). This targets the CH default only; `json_type_escape_dots_in_keys=1` / mixed-history schemas are an explicit, tracked non-goal (#3063).

**Refactor guard, kept separate from the JSON-path evidence per the exit criterion:** `TestAttrStrategy_MapPathByteIdentical` renders the same `chplan.MapAccess` / `FnMapContainsKey` trees through `chsql.NewBuilder()`, `NewBuilderWithAttrStrategies(nil)`, an explicit `AttrStrategyMap` entry, and a non-nil map with no entry for the column — all four assert the exact literal pre-#2777 SQL shape. This is NOT evidence the JSON path works; it only proves the threading refactor didn't touch the Map path.

**End-to-end wiring:**
- `internal/preflight` now *resolves* (not just warns about) the JSON-typed columns its existing boot probe (#2879) detects, into `Result.LogsAttrStrategies` / `Result.TracesAttrStrategies`.
- `internal/engine` threads the resolved value onto the emit-time `ctx` via a duck-typed `attrStrategier` interface (mirrors the existing `spansTabler` pattern) for **both** dispatch routes — route A's `emitForHead` and every route-B path (`routeBExecCtx`, `tryRouteMemoHit`, `retryOnRouteAResourceFailure`) — so a solver-routed shard renders identically to the unrouted plan.
- `logql.Lang` implements `attrStrategier`; `internal/api/loki`'s `Handler` copies the preflight-resolved value onto every per-request `*logql.Lang`; `cmd/cerberus`'s `runRequirementsCheck` → `newLokiHandler` wires it end to end.
- `TestQuery_JSONAttrStrategyRendersDynamicSubcolumnPath` (`internal/api/loki`) drives a **real HTTP request** through the whole chain and asserts the emitted SQL against a stub Querier. This test caught a real bug during development: the `chsql.Emit` entry point itself never read the ctx-level strategy (only the lower-level `chsql.NewQuery` surface did) — the rendering-primitive-level unit tests didn't reach far enough to catch it. Fixed by seeding `emitter.attrStrategies` from ctx in `Emit()` and stamping it onto every `QueryBuilder` at the `emitSelect` chokepoint.

## Boot-warning posture decision (deliberate, not inherited by default)

Now that logs' per-key lookups actually work, `internal/preflight`'s warning for a JSON-typed **logs** attribute column narrows from "boot allowed, nothing works yet" to naming what **is** supported (label matchers, `detected_level`, other bare `MapAccess`/`mapContains` reads) and what remains unsupported (full-map LogQL operations, the `/labels` `/series` `/detected_fields` metadata endpoints, `escape_dots_in_keys`/mixed-history schemas — tracked as #3063).

**Traces keeps its original "nothing works at query time yet" text**, and `TracesAttrStrategies` is resolved but never threaded into TraceQL's request context in this version. The JSON rendering mechanism itself is column-generic, but TraceQL carries its own unverified risk (comparison typing, structural-join/nested-set emitters that may not route through the `emitSelect` chokepoint this PR's threading relies on) — tracked as #3062.

## Scope and follow-ups

This is the largest single item in M5's backlog; splitting was expected and is documented rather than silently ballooning:

- **This PR**: chsql strategy-threading infrastructure + JSON-path rendering + end-to-end wiring, for **logs' per-key attribute lookups only**.
- **#3062** (sub-issue of #2777): TraceQL JSON-typed attribute column query support — audit which `chsql` sites bypass the `emitSelect` chokepoint, wire `TracesAttrStrategies` through `internal/engine`/`internal/api/tempo`, TraceQL-specific chDB differentials (comparison typing, structural joins).
- **#3063** (sub-issue of #2777): LogQL full-map operations (`line_format`/`label_format`/`unpack`/wildcard `keep`/`drop`), JSON-aware metadata/discovery endpoints (`/labels`, `/series`, `/detected_fields`, ...), and the `escape_dots_in_keys` / mixed-history hazard.
- Metrics stays Map-only, unchanged — explicit scoping from the original issue (series identity), not revisited here.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — no raw SQL token writes outside the approved layer.
- [x] `go test -race ./internal/chsql/... ./internal/preflight/... ./internal/logql/... ./internal/api/loki/... ./internal/engine/... ./cmd/cerberus/...` — all pass, including the full pre-existing suite unchanged (Map-path byte-identity).
- [x] `go test -tags chdb ./internal/chsql/... ./internal/preflight/... ./internal/logql/... ./internal/api/loki/...` — all pass, including the three new real chDB differential tests pinning missing-vs-empty semantics.
- [x] `go test -race ./internal/promql/... ./internal/traceql/... ./internal/api/prom/... ./internal/api/tempo/...` — blast-radius packages for the shared `internal/engine` changes (route A/B threading), unaffected.
- [x] `TestQuery_JSONAttrStrategyRendersDynamicSubcolumnPath` — end-to-end integration test through the real HTTP handler.
- [x] Sub-issues #3062, #3063 filed and linked as real GitHub sub-issues under #2777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
