### PR TITLE
feat(traceql): thread JSON-typed attribute strategy through traces queries

### DIFF
--- a/cmd/cerberus/admit_tail_budget_test.go
+++ b/cmd/cerberus/admit_tail_budget_test.go
@@ -189,7 +189,7 @@ func TestMountAPIHeads_TailAndQueryBudgetsAreWiredEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	mux := http.NewServeMux()
-	if _, err := mountAPIHeads(ctx, mux, lazyClient(t), cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil); err != nil {
+	if _, err := mountAPIHeads(ctx, mux, lazyClient(t), cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, preflightAttrStrategies{}); err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}
 	srv := httptest.NewServer(mux)

--- a/cmd/cerberus/chopt_reprobe_test.go
+++ b/cmd/cerberus/chopt_reprobe_test.go
@@ -182,7 +182,7 @@ func mountedConsumers(t *testing.T, enabledHeads string) chOptConsumers {
 	t.Cleanup(cancel)
 
 	heads, err := mountAPIHeads(ctx, http.NewServeMux(), lazyClient(t), cfg, chopt.EnabledSet{},
-		limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil)
+		limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, preflightAttrStrategies{})
 	if err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}

--- a/cmd/cerberus/enabled_heads_test.go
+++ b/cmd/cerberus/enabled_heads_test.go
@@ -62,7 +62,7 @@ func buildHeadsTestServer(t *testing.T, enabledHeads string) *httptest.Server {
 	// past the test.
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	if _, err := mountAPIHeads(ctx, traceMux, client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil); err != nil {
+	if _, err := mountAPIHeads(ctx, traceMux, client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, preflightAttrStrategies{}); err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}
 

--- a/cmd/cerberus/loki_max_query_samples_test.go
+++ b/cmd/cerberus/loki_max_query_samples_test.go
@@ -86,7 +86,7 @@ func TestMountAPIHeads_EveryBuiltEngineCarriesMaxQuerySamples(t *testing.T) {
 	logger := quietLogger()
 	limiters := newAdmitLimiters(cfg, logger)
 
-	heads, err := mountAPIHeads(t.Context(), http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil)
+	heads, err := mountAPIHeads(t.Context(), http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, preflightAttrStrategies{})
 	if err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -184,7 +184,7 @@ func mountAPIHeads(
 	logger *slog.Logger,
 	resourceBounds engine.ResourceBoundOverrides,
 	promResourceBounds promql.ResourceBounds,
-	logsAttrStrategies chsql.AttrStrategies,
+	attrStrategies preflightAttrStrategies,
 ) (apiHeads, error) {
 	// engines accumulates the engines actually built so the corpus reconciler
 	// observes only live heads (a disabled head has no engine to observe), and
@@ -223,7 +223,7 @@ func mountAPIHeads(
 
 	if cfg.HeadEnabled(config.HeadLoki) {
 		lokiClient := client.ForHead(chclient.HeadLoki)
-		lokiHandler := newLokiHandler(lokiClient, cfg, optSet, limiters, logger, resourceBounds, logsAttrStrategies)
+		lokiHandler := newLokiHandler(lokiClient, cfg, optSet, limiters, logger, resourceBounds, attrStrategies.Logs)
 		lokiHandler.Mount(traceMux)
 		engines = append(engines, lokiHandler.Engine)
 	}
@@ -248,6 +248,14 @@ func mountAPIHeads(
 		// on a deployment where the DDL side actually created it. Mirrors
 		// newLokiHandler's own LabelCatalogEnabled wiring.
 		tempoHandler.TagCatalogEnabled = cfg.SchemaTempoTagCatalogMV
+		// AttrStrategies (cerberus issue #2777 / #3062) is the preflight
+		// boot probe's resolved verdict on the traces attribute-map
+		// columns' physical shape — see runRequirementsCheck's doc for
+		// the known cold-start-race limitation shared with the logs
+		// wiring above. nil (the overwhelmingly common case: no
+		// JSON-typed column detected, or the requirements check
+		// disabled) renders byte-identical to before this field existed.
+		tempoHandler.SetAttrStrategies(attrStrategies.Traces)
 		tempoHandler.Engine.Settings = settingsRules(cfg, optSet)
 		// The per-query sample budget the ENGINE-level bounds read. The cursor
 		// enforces the same ceiling on rows it drains from ClickHouse, but the
@@ -542,7 +550,7 @@ func run() error {
 	// returned schemaPresent func reports NOT READY on /readyz and a
 	// background re-probe flips it ready once an external writer creates the
 	// schema, with no restart. CERBERUS_REQUIREMENTS_CHECK=false skips it.
-	schemaPresent, logsAttrStrategies, err := runRequirementsCheck(ctx, logger, client, cfg)
+	schemaPresent, attrStrategies, err := runRequirementsCheck(ctx, logger, client, cfg)
 	if err != nil {
 		return err
 	}
@@ -593,7 +601,7 @@ func run() error {
 		return err
 	}
 
-	heads, err := mountAPIHeads(ctx, traceMux, client, cfg, optSet, limiters, logger, resourceBounds, promResourceBounds, logsAttrStrategies)
+	heads, err := mountAPIHeads(ctx, traceMux, client, cfg, optSet, limiters, logger, resourceBounds, promResourceBounds, attrStrategies)
 	if err != nil {
 		return err
 	}
@@ -2380,30 +2388,44 @@ func preflightRequirementsFromConfig(cfg config.Config) preflight.Requirements {
 	}
 }
 
-// runRequirementsCheck also returns the resolved logs AttrStrategies
-// (cerberus issue #2777) so the caller can wire it onto the Loki head's
-// Handler / *logql.Lang — see newLokiHandler. Known limitation (documented
-// rather than silently accepted): on the TRANSIENT not-ready path (the
-// logs table doesn't exist yet at boot), this is necessarily nil — the
-// shape can't be introspected before the table exists — and it stays nil
-// for the rest of THIS process's life even after the background re-probe
-// (reprobeSchema) flips /readyz once the schema appears; a JSON-typed
-// logs schema created during that race window is picked up correctly only
-// on the NEXT boot. This mirrors decideRequirementsOutcome's own
-// boot-resolved-once posture for every other preflight finding — nothing
-// here re-derives shape facts after the readiness re-probe passes, and
-// doing so would require making the Handler's resolved strategy mutable
-// under concurrent requests, which cerberus issue #2777 explicitly avoids
-// (chopt-style pure, boot-resolved strategy, zero per-query branching).
+// preflightAttrStrategies carries runRequirementsCheck's per-signal
+// AttrStrategies findings back to the caller. Named — rather than two
+// positional chsql.AttrStrategies return values — for the identical
+// anti-transposition reason admitLimiters exists (see its own doc): two
+// same-typed values transpose silently at a callsite, and swapping these
+// would silently apply the traces schema's strategy to the logs head (and
+// vice versa) with no compiler diagnostic.
+type preflightAttrStrategies struct {
+	Logs   chsql.AttrStrategies
+	Traces chsql.AttrStrategies
+}
+
+// runRequirementsCheck also returns the resolved per-signal AttrStrategies
+// (cerberus issue #2777, extended to traces by #3062) so the caller can
+// wire them onto the Loki / Tempo heads' Handlers — see newLokiHandler and
+// mountAPIHeads' tempoHandler.SetAttrStrategies call. Known limitation
+// (documented rather than silently accepted): on the TRANSIENT not-ready
+// path (a table doesn't exist yet at boot), both fields are necessarily
+// the zero value — the shape can't be introspected before the table
+// exists — and they stay zero for the rest of THIS process's life even
+// after the background re-probe (reprobeSchema) flips /readyz once the
+// schema appears; a JSON-typed schema created during that race window is
+// picked up correctly only on the NEXT boot. This mirrors
+// decideRequirementsOutcome's own boot-resolved-once posture for every
+// other preflight finding — nothing here re-derives shape facts after the
+// readiness re-probe passes, and doing so would require making the
+// Handler's resolved strategy mutable under concurrent requests, which
+// cerberus issue #2777 explicitly avoids (chopt-style pure, boot-resolved
+// strategy, zero per-query branching).
 func runRequirementsCheck(
 	ctx context.Context,
 	logger *slog.Logger,
 	client *chclient.Client,
 	cfg config.Config,
-) (health.SchemaPresentFunc, chsql.AttrStrategies, error) {
+) (health.SchemaPresentFunc, preflightAttrStrategies, error) {
 	if !cfg.RequirementsCheck {
 		logger.Info("requirements check disabled (CERBERUS_REQUIREMENTS_CHECK=false)")
-		return nil, nil, nil
+		return nil, preflightAttrStrategies{}, nil
 	}
 	req := preflightRequirementsFromConfig(cfg)
 	res := preflight.RunIfEnabled(ctx, cfg.RequirementsCheck, client, req)
@@ -2416,7 +2438,7 @@ func runRequirementsCheck(
 
 	outcome := decideRequirementsOutcome(res, cfg.Schema, cfg.ClickHouse.Database)
 	if outcome.fatalErr != nil {
-		return nil, nil, outcome.fatalErr
+		return nil, preflightAttrStrategies{}, outcome.fatalErr
 	}
 	if outcome.notReadyReason != "" {
 		// Transient: boot but stay NOT READY; the background re-probe (reusing
@@ -2425,7 +2447,7 @@ func runRequirementsCheck(
 		logger.Warn(outcome.logMsg, "reason", outcome.notReadyReason)
 		present := newSchemaPresentSignal(outcome.notReadyReason)
 		go reprobeSchema(ctx, logger, client, req, present, schemaRetryInterval)
-		return present.Func(), nil, nil
+		return present.Func(), preflightAttrStrategies{}, nil
 	}
 
 	logger.Info(
@@ -2433,7 +2455,7 @@ func runRequirementsCheck(
 		"database", cfg.ClickHouse.Database,
 		"native_rate", cfg.ExperimentalTSGridRange,
 	)
-	return nil, res.LogsAttrStrategies, nil
+	return nil, preflightAttrStrategies{Logs: res.LogsAttrStrategies, Traces: res.TracesAttrStrategies}, nil
 }
 
 // requirementsOutcome is the boot decision decideRequirementsOutcome derives

--- a/cmd/cerberus/solver_no_background_loop_test.go
+++ b/cmd/cerberus/solver_no_background_loop_test.go
@@ -77,7 +77,7 @@ func TestMountAPIHeads_PromStartsNoBackgroundLoop(t *testing.T) {
 		goleak.IgnoreCurrent(),
 	}
 
-	if _, err := mountAPIHeads(ctx, http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, nil); err != nil {
+	if _, err := mountAPIHeads(ctx, http.NewServeMux(), client, cfg, chopt.EnabledSet{}, limiters, logger, engine.ResourceBoundOverrides{}, promql.ResourceBounds{}, preflightAttrStrategies{}); err != nil {
 		t.Fatalf("mountAPIHeads: %v", err)
 	}
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2879,10 +2879,26 @@ precise boot-time finding:
       per-key lowering entirely), and a table whose ingestion ever used
       `json_type_escape_dots_in_keys=1` or mixes dotted-key encodings —
       tracked as [#3063](https://github.com/tsouza/cerberus/issues/3063).
-    - **Traces**: query lowering against a JSON-typed attribute map is not
-      implemented yet (only detection is), so queries touching that column's
-      keys still fail, just at query time instead of at boot — tracked as
-      [#3062](https://github.com/tsouza/cerberus/issues/3062).
+    - **Traces**: per-key attribute lookups and comparisons now work against
+      a JSON-typed column too — span/resource/scope attribute matchers
+      (`{ span.foo = "bar" }`), numeric/duration comparisons
+      (`{ span.http.status_code > 100 }`), and existence checks
+      (`{ span.foo != nil }`). The warning names what remains unsupported:
+      the `compare()` spanset-metrics operator's well-known/generic
+      attribute fan-out, the `/api/search/tags` /
+      `/api/search/tag/{name}/values` discovery endpoints (their queries
+      bypass the per-key lowering entirely, like logs' metadata endpoints
+      above), and a table whose ingestion ever used
+      `json_type_escape_dots_in_keys=1` or mixes dotted-key encodings —
+      tracked as [#3065](https://github.com/tsouza/cerberus/issues/3065).
+      One further caveat specific to `ResourceAttributes`: `/api/search`'s
+      own baseline response shaping merges `ResourceAttributes` with
+      synthetic trace/span/parent-span-id keys on every response, which is
+      itself a full-map operation a JSON-typed `ResourceAttributes` column
+      cannot satisfy yet — so `/api/search` fails on every query
+      regardless of filter shape until #3065 lands the full-map JSON
+      bridge, if `ResourceAttributes` (not `SpanAttributes` /
+      `ScopeAttributes`) is the JSON-typed column.
     - Metrics attribute-map columns are **not** covered by this exception
       and stay `Map(String, String)`-only — they carry the metric's series
       identity, out of scope per the issue itself.

--- a/internal/api/tempo/attr_strategy_json_chdb_test.go
+++ b/internal/api/tempo/attr_strategy_json_chdb_test.go
@@ -1,0 +1,324 @@
+//go:build chdb
+
+// chDB-backed proof of cerberus issue #3062's two open questions, which
+// #2777's own PR body flagged as TraceQL-specific risk beyond what the
+// LogQL differentials (internal/chsql/attr_strategy_json_chdb_test.go)
+// covered:
+//
+//  1. Comparison typing — does a JSON dynamic-subcolumn read compose
+//     correctly with TraceQL's numeric coercion (coerceFieldAccess's
+//     toFloat64OrNull wrap), matching Map's "NULL for absent/non-numeric,
+//     never a query-aborting cast error" contract? Answered empirically
+//     below: yes, because chsql.exprFieldAccess's JSON branch normalises
+//     missing-vs-empty exactly like exprMapAccess's does (see its own
+//     doc), so the string toFloat64OrNull receives is byte-identical
+//     between the two physical storages for every case exercised here.
+//  2. Structural-join / nested-set emitters — do they route a JSON-typed
+//     attribute predicate through the SAME attrStrategies the plain scan
+//     path uses, or does the closure/union machinery's own QueryBuilder
+//     composition (rightArm/leftArm built via NewQuery(), never calling
+//     WithAttrStrategies themselves) silently fall back to the Map
+//     shape? Answered empirically below: the strategy survives, because
+//     QueryBuilder.Frag() shares the enclosing Builder rather than
+//     spinning up its own (see builder.go's subquerySQL/Frag), so
+//     whichever QueryBuilder the emitter's own emitSelect chokepoint
+//     stamped is the one every nested arm renders against.
+//
+// Both variants run through tempo.Handler's full /api/search pipeline
+// (parse -> lower -> wrap -> optimize -> emit -> ClickHouse -> response
+// shaping), with Handler.SetAttrStrategies wired exactly as
+// cmd/cerberus's mountAPIHeads wires it from a real preflight run — this
+// file only replaces preflight's boot probe with a direct
+// SetAttrStrategies call so the DDL's column type can be asserted
+// against directly rather than re-deriving it from system.columns.
+//
+// ResourceAttributes stays Map(String,String) in EVERY table this file
+// seeds, even the "JSON" variant — only SpanAttributes flips. This is
+// deliberate, not an oversight: canonicalSampleProjections /
+// sampleProjectionsWithSelected (handler.go) unconditionally build the
+// /api/search response's Attributes column via
+// mapConcat(ResourceAttributes, map('__cerberus_traceID', ..., ...)) —
+// a genuine FULL-MAP read over ResourceAttributes needed on EVERY
+// response (the synthetic trace/parent-span-id keys toTraceSummaries
+// groups by), not something a query can opt out of. That is a full-map
+// operation in exactly the sense cerberus issue #3065 scopes as a
+// follow-up (JSONAllPaths-based reconstruction — a plain
+// CAST(json_col, 'Map(String,String)') was tried and rejected empirically:
+// ClickHouse 26.5 raises TYPE_MISMATCH, "Unsupported types to CAST AS
+// Map"), so a JSON-typed ResourceAttributes column breaks EVERY
+// /api/search response today regardless of the query's own filter
+// shape — filed as #3065's item 0, ahead of compare()/tag-discovery,
+// specifically because it blocks the baseline endpoint rather than an
+// advanced operator. This file's own tests exercise the per-key
+// FieldAccess/FnMapContainsKey mechanism the wiring in this PR actually
+// fixes (SpanAttributes), which does not depend on that follow-up.
+//
+// The Map and JSON variants use DISTINCT table names (via a custom
+// schema.Traces.SpansTable, not the package's shared "otel_traces"
+// tracesDDL/tracesSeed constants other files here use) rather than two
+// same-named tables in sequence: chclienttest.NewChDB's session is
+// process-global (chdb-go caches one engine per process — see its own
+// doc, and internal/chsqltest's identical note) and Client.Seed silently
+// PROMOTES "CREATE TABLE" to "CREATE OR REPLACE TABLE" (testsql's
+// PromoteCreateTable), so two same-named "otel_traces" tables built by
+// two separate newAttrStrategyChDBServer calls would silently replace
+// one another — the second CREATE would retype the FIRST server's table
+// out from under it. Distinct table names let both servers coexist
+// through the whole test, exactly like the LogQL differential's
+// attrs_map/attrs_json tables in an isolated database.
+package tempo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// jsonAttrTracesDDL renders an otel_traces-shaped table named table with
+// spanAttrType / resourceAttrType as its SpanAttributes / ResourceAttributes
+// column types independently — either "Map(String, String)" or "JSON" —
+// so the Map and JSON variants stay byte-identical apart from that type
+// and their table name. Independent rather than one shared type because
+// this file's tests deliberately keep ResourceAttributes Map-typed even
+// in the "JSON" variant — see the package doc for why.
+func jsonAttrTracesDDL(table, spanAttrType, resourceAttrType string) string {
+	return fmt.Sprintf(`CREATE TABLE %s (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    SpanKind LowCardinality(String),
+    Duration Int64,
+    Timestamp DateTime64(9),
+    StatusCode LowCardinality(String),
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String,
+    SpanAttributes %s,
+    ResourceAttributes %s
+) ENGINE = MergeTree() ORDER BY (Timestamp);`, table, spanAttrType, resourceAttrType)
+}
+
+// jsonAttrComparisonSeedMap / jsonAttrComparisonSeedJSON seed four
+// independent single-span traces into table, exercising every
+// missing-vs-present shape a numeric comparison must handle:
+//
+//	s1 http.status_code="200"  (numeric string    -> matches > 100)
+//	s2 (key absent entirely)   (missing            -> NULL, no match)
+//	s3 http.status_code="abc"  (non-numeric string -> NULL, no match)
+//	s4 http.status_code=""     (present, empty     -> NULL, no match;
+//	                             but IS present for `!= nil`)
+func jsonAttrComparisonSeedMap(table string) string {
+	return fmt.Sprintf(`INSERT INTO %s VALUES
+    ('c0000000000000000000000000000001', '3000000000000001', '', 's1', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000001', 9), 'Unset', '', '', '', map('http.status_code', '200'), map()),
+    ('c0000000000000000000000000000002', '3000000000000002', '', 's2', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000002', 9), 'Unset', '', '', '', map(), map()),
+    ('c0000000000000000000000000000003', '3000000000000003', '', 's3', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000003', 9), 'Unset', '', '', '', map('http.status_code', 'abc'), map()),
+    ('c0000000000000000000000000000004', '3000000000000004', '', 's4', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000004', 9), 'Unset', '', '', '', map('http.status_code', ''), map());`, table)
+}
+
+// jsonAttrComparisonSeedJSON seeds the JSON-variant table. ResourceAttributes
+// stays map() (Map(String,String)) even here — see the package doc for
+// why only SpanAttributes flips to a JSON literal.
+func jsonAttrComparisonSeedJSON(table string) string {
+	return fmt.Sprintf(`INSERT INTO %s VALUES
+    ('c0000000000000000000000000000001', '3000000000000001', '', 's1', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000001', 9), 'Unset', '', '', '', '{"http.status_code":"200"}', map()),
+    ('c0000000000000000000000000000002', '3000000000000002', '', 's2', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000002', 9), 'Unset', '', '', '', '{}', map()),
+    ('c0000000000000000000000000000003', '3000000000000003', '', 's3', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000003', 9), 'Unset', '', '', '', '{"http.status_code":"abc"}', map()),
+    ('c0000000000000000000000000000004', '3000000000000004', '', 's4', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000004', 9), 'Unset', '', '', '', '{"http.status_code":""}', map());`, table)
+}
+
+// jsonAttrSearchWindowQS is the fixed /api/search start/end reused across
+// this file's tests (matches search_select_plain_filter_chdb_test.go's
+// own window, wide enough to cover 2026-05-01).
+const jsonAttrSearchWindowQS = "start=1777593600&end=1777680000&limit=20&spss=20"
+
+// newAttrStrategyChDBServer builds a tempo.Handler over a table named
+// table (created by ddl, populated by seed) with attrStrategies wired via
+// SetAttrStrategies exactly as cmd/cerberus wires preflight's resolved
+// Result.TracesAttrStrategies — see tempo.Handler.SetAttrStrategies's doc
+// for why a setter is needed rather than a plain field assignment. The
+// schema's SpansTable is overridden to table so Map and JSON variants can
+// coexist in the shared chDB session under distinct table names (see this
+// file's own package doc).
+func newAttrStrategyChDBServer(t *testing.T, c *chclienttest.Client, table, ddl, seed string, attrStrategies chsql.AttrStrategies) *httptest.Server {
+	t.Helper()
+	c.Seed(t, ddl)
+	c.Seed(t, seed)
+	s := schema.DefaultOTelTraces()
+	s.SpansTable = table
+	h := tempo.New(c, s, "v-test", nil)
+	h.SetAttrStrategies(attrStrategies)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// searchSpanIDs issues /api/search for query and returns the sorted set
+// of matched span IDs across every returned trace/spanset — the
+// comparison unit both tests below use, since it is agnostic to
+// spanset/trace grouping shape and only cares about WHICH spans matched.
+func searchSpanIDs(t *testing.T, srv *httptest.Server, query string) []string {
+	t.Helper()
+	resp, err := http.Get(srv.URL + "/api/search?q=" + url.QueryEscape(query) + "&" + jsonAttrSearchWindowQS)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s\nquery: %s", resp.StatusCode, body, query)
+	}
+	var sr tempo.SearchResponse
+	if err := json.Unmarshal([]byte(body), &sr); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	var ids []string
+	for _, tr := range sr.Traces {
+		for _, ss := range tr.SpanSets {
+			for _, sp := range ss.Spans {
+				ids = append(ids, sp.SpanID)
+			}
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// TestTraceQL_JSONAttrStrategy_ComparisonTyping_ChDB is half 1: it runs
+// an equality match, a numeric comparison (the open "comparison typing"
+// question), and an existence check against BOTH a Map-typed and a
+// JSON-typed otel_traces-shaped table, for every missing/non-numeric/empty
+// shape jsonAttrComparisonSeedMap/JSON seeds — proving chsql's
+// exprFieldAccess JSON branch reproduces Map's contract for the exact
+// query shapes TraceQL builds (FieldAccess reads, toFloat64OrNull
+// coercion, FnMapContainsKey existence), not merely that the two happen
+// to agree by accident on one shape.
+func TestTraceQL_JSONAttrStrategy_ComparisonTyping_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	const mapTable, jsonTable = "attr_strategy_cmp_map", "attr_strategy_cmp_json"
+	strategies := chsql.AttrStrategies{"SpanAttributes": chsql.AttrStrategyJSON}
+	mapSrv := newAttrStrategyChDBServer(t, c, mapTable,
+		jsonAttrTracesDDL(mapTable, "Map(String, String)", "Map(String, String)"), jsonAttrComparisonSeedMap(mapTable), nil)
+	jsonSrv := newAttrStrategyChDBServer(t, c, jsonTable,
+		jsonAttrTracesDDL(jsonTable, "JSON", "Map(String, String)"), jsonAttrComparisonSeedJSON(jsonTable), strategies)
+
+	cases := []struct {
+		name  string
+		query string
+		want  []string // sorted span IDs
+	}{
+		{
+			name:  "equality",
+			query: `{ span.http.status_code = "200" }`,
+			want:  []string{"3000000000000001"},
+		},
+		{
+			name:  "numeric_comparison",
+			query: `{ span.http.status_code > 100 }`,
+			want:  []string{"3000000000000001"},
+		},
+		{
+			name:  "existence",
+			query: `{ span.http.status_code != nil }`,
+			want:  []string{"3000000000000001", "3000000000000003", "3000000000000004"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mapGot := searchSpanIDs(t, mapSrv, c.query)
+			jsonGot := searchSpanIDs(t, jsonSrv, c.query)
+			if !equalStrSlices(mapGot, c.want) {
+				t.Fatalf("Map query %q = %v, want %v (test's own expectation, not just Map==JSON)", c.query, mapGot, c.want)
+			}
+			if !equalStrSlices(jsonGot, c.want) {
+				t.Errorf("JSON query %q = %v, want %v — chsql's exprFieldAccess JSON branch must reproduce "+
+					"the Map subscript's comparison-typing contract exactly", c.query, jsonGot, c.want)
+			}
+		})
+	}
+}
+
+// jsonAttrStructuralSeedMap / jsonAttrStructuralSeedJSON seed a two-span
+// trace into table — root (resource.service.name="frontend") with one
+// child (span.http.status_code="500") — plus an unrelated single-span
+// trace that must never match the structural relation.
+func jsonAttrStructuralSeedMap(table string) string {
+	return fmt.Sprintf(`INSERT INTO %s VALUES
+    ('d0000000000000000000000000000001', '4000000000000001', '', 'GET /home', 'Server', 1000, toDateTime64('2026-05-01 11:00:00.000000001', 9), 'Unset', '', '', '', map(), map('service.name', 'frontend')),
+    ('d0000000000000000000000000000001', '4000000000000002', '4000000000000001', 'checkout', 'Server', 700, toDateTime64('2026-05-01 11:00:00.000000002', 9), 'Error', '', '', '', map('http.status_code', '500'), map()),
+    ('d0000000000000000000000000000002', '4000000000000003', '', 'solo', 'Server', 300, toDateTime64('2026-05-01 11:00:00.000000003', 9), 'Unset', '', '', '', map('http.status_code', '500'), map('service.name', 'other'));`, table)
+}
+
+// jsonAttrStructuralSeedJSON seeds the JSON-variant table. ResourceAttributes
+// stays map() (Map(String,String)) even here — see the package doc — so
+// this seed differs from jsonAttrStructuralSeedMap only in SpanAttributes'
+// literal shape.
+func jsonAttrStructuralSeedJSON(table string) string {
+	return fmt.Sprintf(`INSERT INTO %s VALUES
+    ('d0000000000000000000000000000001', '4000000000000001', '', 'GET /home', 'Server', 1000, toDateTime64('2026-05-01 11:00:00.000000001', 9), 'Unset', '', '', '', '{}', map('service.name', 'frontend')),
+    ('d0000000000000000000000000000001', '4000000000000002', '4000000000000001', 'checkout', 'Server', 700, toDateTime64('2026-05-01 11:00:00.000000002', 9), 'Error', '', '', '', '{"http.status_code":"500"}', map()),
+    ('d0000000000000000000000000000002', '4000000000000003', '', 'solo', 'Server', 300, toDateTime64('2026-05-01 11:00:00.000000003', 9), 'Unset', '', '', '', '{"http.status_code":"500"}', map('service.name', 'other'));`, table)
+}
+
+// TestTraceQL_JSONAttrStrategy_StructuralJoin_ChDB is half 2: a `>>`
+// structural-child query filters the LEFT (ancestor) operand on a
+// (Map-typed, in both variants — see the package doc) RESOURCE attribute
+// and the RIGHT (descendant) operand on a JSON-typed SPAN attribute —
+// settling empirically whether structural_join.go's rightArm/leftArm
+// QueryBuilders (built via NewQuery(), never calling WithAttrStrategies
+// themselves — see this file's own package doc) inherit the strategy the
+// outer emitSelect chokepoint stamped, or silently fall back to the Map
+// shape and either fail with ILLEGAL_TYPE_OF_ARGUMENT or (worse) silently
+// match nothing. Mixing one Map-typed and one JSON-typed carrier column
+// inside a single structural plan additionally proves attrStrategies
+// applies PER COLUMN within one composite plan, not merely per-request.
+// The unrelated second trace shares the descendant's attribute value but
+// not the ancestor relationship, so an over-wide match (the strategy
+// leaking scope, or the relation collapsing to an unscoped predicate)
+// would be caught by an unexpected extra span ID.
+func TestTraceQL_JSONAttrStrategy_StructuralJoin_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	const mapTable, jsonTable = "attr_strategy_struct_map", "attr_strategy_struct_json"
+	strategies := chsql.AttrStrategies{"SpanAttributes": chsql.AttrStrategyJSON}
+	mapSrv := newAttrStrategyChDBServer(t, c, mapTable,
+		jsonAttrTracesDDL(mapTable, "Map(String, String)", "Map(String, String)"), jsonAttrStructuralSeedMap(mapTable), nil)
+	jsonSrv := newAttrStrategyChDBServer(t, c, jsonTable,
+		jsonAttrTracesDDL(jsonTable, "JSON", "Map(String, String)"), jsonAttrStructuralSeedJSON(jsonTable), strategies)
+
+	const query = `{ resource.service.name = "frontend" } >> { span.http.status_code = "500" }`
+	want := []string{"4000000000000002"} // only the checkout child under the frontend root
+
+	mapGot := searchSpanIDs(t, mapSrv, query)
+	if !equalStrSlices(mapGot, want) {
+		t.Fatalf("Map structural query = %v, want %v (test's own expectation, not just Map==JSON)", mapGot, want)
+	}
+	jsonGot := searchSpanIDs(t, jsonSrv, query)
+	if !equalStrSlices(jsonGot, want) {
+		t.Errorf("JSON structural query = %v, want %v — the structural-join emitter's rightArm/leftArm "+
+			"QueryBuilders must inherit the outer emitSelect chokepoint's AttrStrategies, not fall back to Map",
+			jsonGot, want)
+	}
+}
+
+func equalStrSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/tempo/handler.go
+++ b/internal/api/tempo/handler.go
@@ -185,6 +185,35 @@ type Handler struct {
 	// byte-identical to before this feature existed. Mirrors
 	// internal/api/loki.Handler.LabelCatalogEnabled.
 	TagCatalogEnabled bool
+
+	// AttrStrategies resolves how the traces attribute-map columns are
+	// physically stored — internal/preflight's boot probe's resolved
+	// verdict (cerberus issue #2777 / #3062), wired from cmd/cerberus's
+	// preflight.Result.TracesAttrStrategies via SetAttrStrategies. nil
+	// (the default — no JSON-typed column detected, or the requirements
+	// check disabled) renders byte-identical to before this field
+	// existed. Kept here (in addition to lang.AttrStrategies, which is
+	// what the engine's attrStrategier duck-type actually reads at emit
+	// time) purely so a caller can read back what was configured,
+	// mirroring internal/api/loki.Handler.AttrStrategies — always set
+	// through SetAttrStrategies, never assigned directly, since tempo's
+	// lang is a single long-lived unexported instance (no per-request
+	// Lang construction the way LogQL's langForRequest /
+	// langForRangeRequest build one per request), so there is exactly
+	// one inner copy to keep in sync rather than N per-request ones.
+	AttrStrategies chsql.AttrStrategies
+}
+
+// SetAttrStrategies wires AttrStrategies onto both the Handler (for
+// read-back) and the unexported traceqlLang instance the Engine actually
+// calls at query time — see the AttrStrategies field's doc for why a
+// setter method is needed here rather than the two-line direct field
+// assignment cmd/cerberus uses for LogQL's exported h.Lang: h.lang is
+// unexported (this package's own single long-lived TraceQL adapter), so
+// a caller in cmd/cerberus cannot reach into it directly.
+func (h *Handler) SetAttrStrategies(s chsql.AttrStrategies) {
+	h.AttrStrategies = s
+	h.lang.AttrStrategies = s
 }
 
 // New constructs a Handler with the seed optimizer wired in.

--- a/internal/api/tempo/lang.go
+++ b/internal/api/tempo/lang.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/schema"
 	"github.com/tsouza/cerberus/internal/telemetry"
@@ -54,6 +55,22 @@ var (
 // the meta flag.
 type traceqlLang struct {
 	schema schema.Traces
+
+	// AttrStrategies resolves how the traces attribute-map columns
+	// (schema.AttributesColumn / ResourceAttributesColumn /
+	// ScopeAttributesColumn) are physically stored, per
+	// internal/preflight's boot probe (cerberus issue #2777,
+	// Result.TracesAttrStrategies) — nil (the zero value) means every
+	// column is a genuine ClickHouse Map, rendering byte-identical to
+	// before this field existed. Wired via Handler.SetAttrStrategies,
+	// which cmd/cerberus calls once at construction (mirroring
+	// internal/api/loki's Handler.AttrStrategies + h.Lang.AttrStrategies
+	// copy) — see SetAttrStrategies's doc for why tempo needs a setter
+	// where loki needs only a field assignment. EmitAttrStrategies
+	// (below) is the duck-typed hook engine.emitForHead reads to thread
+	// it onto the emit-time context, exactly like *logql.Lang's field of
+	// the same name (cerberus issue #3062).
+	AttrStrategies chsql.AttrStrategies
 }
 
 func (l *traceqlLang) Name() string { return telemetry.QLTraceQL }
@@ -63,6 +80,15 @@ func (l *traceqlLang) Name() string { return telemetry.QLTraceQL }
 // otel_traces scan in the search / structural / nested-set / trace-by-id plans
 // is resource-bounded.
 func (l *traceqlLang) SpansTable() string { return l.schema.SpansTable }
+
+// EmitAttrStrategies returns the AttrStrategies this Lang's queries should
+// render attribute-map accesses against — see the AttrStrategies field's
+// doc. engine.emitForHead duck-types on this (the attrStrategier
+// interface) to thread it onto the emit context via
+// chsql.WithAttrStrategies, exactly as it already does for LogQL — the
+// duck-typed hook is signal-agnostic, so this method is the entire
+// remaining wiring needed on the Lang side of cerberus issue #3062.
+func (l *traceqlLang) EmitAttrStrategies() chsql.AttrStrategies { return l.AttrStrategies }
 
 func (l *traceqlLang) Parse(ctx context.Context, query string) (chplan.Node, engine.Meta, error) {
 	// Parse pipeline-stage stopwatch — mirrors the inlined handler so

--- a/internal/api/tempo/root_lookup.go
+++ b/internal/api/tempo/root_lookup.go
@@ -85,7 +85,21 @@ func (h *Handler) resolveTraceRoots(ctx context.Context, traceIDs []string) (map
 	// emit context so chsql.Emit's RequireSpansScansBounded verifies that bound
 	// is present — a regression that dropped the IN filter would fail closed
 	// rather than full-scan otel_traces.
-	sql, args, err := chsql.Emit(chsql.WithSpansTable(ctx, h.Schema.SpansTable), plan)
+	//
+	// AttrStrategies is threaded here too (cerberus issue #3062): this is
+	// a second hand-rolled direct-chsql.Emit path that bypasses
+	// engine.emitForHead's automatic threading (see
+	// buildRootLookupPlan's aggSvc, a bare chplan.MapAccess against
+	// ResourceAttributesColumn) — without this line a JSON-typed
+	// ResourceAttributes column would fail this query with
+	// ILLEGAL_TYPE_OF_ARGUMENT exactly like runStructuralPhaseA's own
+	// bypass did before it was fixed. Unlike that one, a failure here
+	// WARN-degrades (handleSearch drops root enrichment on error) rather
+	// than 502ing the whole search — but degrading a working feature by
+	// omission is still wrong to leave unfixed.
+	ctx = chsql.WithSpansTable(ctx, h.Schema.SpansTable)
+	ctx = chsql.WithAttrStrategies(ctx, h.AttrStrategies)
+	sql, args, err := chsql.Emit(ctx, plan)
 	if err != nil {
 		return nil, fmt.Errorf("root lookup: emit: %w", err)
 	}

--- a/internal/api/tempo/structural_two_phase.go
+++ b/internal/api/tempo/structural_two_phase.go
@@ -220,9 +220,28 @@ func (h *Handler) runStructuralTwoPhase(ctx context.Context, sj *chplan.Structur
 // ids, not a Sample stream — the same direct-emit pattern resolveTraceRoots
 // uses. The spans table is threaded onto the emit context so the resource-
 // bound gate verifies the closure's scans stay windowed.
+//
+// AttrStrategies is threaded here too (cerberus issue #3062) precisely
+// because this bypasses engine.emitForHead — the ONE chokepoint that
+// duck-types h.lang against attrStrategier and calls
+// chsql.WithAttrStrategies automatically. Every other emit path in this
+// package reaches emitForHead through h.Engine.QueryPlan and picks the
+// strategy up for free; this hand-rolled direct-emit path is the
+// exception the #2777 PR body's own risk note anticipated ("structural-
+// join/nested-set emitters that may not route through the emitSelect
+// chokepoint"), and a real chDB differential
+// (TestTraceQL_JSONAttrStrategy_StructuralJoin_ChDB) caught it: the
+// closure's own predicate against a JSON-typed span attribute column
+// failed with ILLEGAL_TYPE_OF_ARGUMENT until this line was added — the
+// narrow ranking query still evaluates every closure predicate (it is
+// the SAME closure, just projecting fewer columns), so a JSON-typed
+// attribute referenced anywhere in it needs the strategy exactly like
+// phase B and the single-query path do.
 func (h *Handler) runStructuralPhaseA(ctx context.Context, sj *chplan.StructuralJoin, limit int) ([]string, error) {
 	phaseA := buildStructuralPhaseAPlan(sj, h.Schema, limit)
-	sql, args, err := chsql.Emit(chsql.WithSpansTable(ctx, h.Schema.SpansTable), phaseA)
+	ctx = chsql.WithSpansTable(ctx, h.Schema.SpansTable)
+	ctx = chsql.WithAttrStrategies(ctx, h.AttrStrategies)
+	sql, args, err := chsql.Emit(ctx, phaseA)
 	if err != nil {
 		// Mirror the engine's `emit:` wrapping so ClassifyErr maps this
 		// to HTTP 500 like any other emit failure.

--- a/internal/chplan/attr_strategy.go
+++ b/internal/chplan/attr_strategy.go
@@ -36,24 +36,28 @@ const (
 	AttrStrategyMap AttrStrategy = iota
 
 	// AttrStrategyJSON means the column is ClickHouse's native JSON type.
-	// chsql's exprMapAccess and its FnMapContainsKey render hook branch on
-	// it — see their doc comments for the exact SQL shape and the
-	// missing-vs-empty semantics decision. Only applies when the map/column
-	// operand is a bare *ColumnRef (never a composed intermediate Map
-	// expression built by mapUpdate/mapConcat/map(), which really is a Map
-	// at the SQL level regardless of the strategy of the column it was
-	// seeded from) — MapAccess additionally requires a literal
-	// (*LitString) key, since ClickHouse's JSON dynamic-subcolumn path
-	// syntax is a compile-time path expression, not a bound parameter.
+	// chsql's exprMapAccess, exprFieldAccess, and the FnMapContainsKey
+	// render hook all branch on it — see their doc comments for the exact
+	// SQL shape and the missing-vs-empty semantics decision. Only applies
+	// when the map/column operand is a bare *ColumnRef (never a composed
+	// intermediate Map expression built by mapUpdate/mapConcat/map(),
+	// which really is a Map at the SQL level regardless of the strategy
+	// of the column it was seeded from) — MapAccess additionally requires
+	// a literal (*LitString) key, since ClickHouse's JSON
+	// dynamic-subcolumn path syntax is a compile-time path expression,
+	// not a bound parameter (FieldAccess's Path is always a Go string,
+	// never an Expr, so it satisfies this trivially).
 	//
-	// Scope (cerberus issue #2777, this slice): wired for LOGS only.
-	// Traces detection already ships (preflight's jsonAttrMapCompat), but
-	// query-time rendering for traces is tracked separately as cerberus
-	// issue #3062 — internal/engine never resolves a non-nil
-	// AttrStrategies for a TraceQL request in this version, so a
-	// JSON-typed traces attribute column still fails at query time
-	// exactly as before (no behaviour change, no untested accidental
-	// support). Metrics never sets this: attribute maps there carry
+	// Scope: wired for LOGS in cerberus issue #2777's original slice, and
+	// for TRACES in the #3062 follow-up (both per-key lookups AND
+	// comparisons — TraceQL's lowering builds FieldAccess, not MapAccess,
+	// for every attribute read, which is why exprFieldAccess needed its
+	// own JSON branch rather than inheriting exprMapAccess's). Full-map
+	// operations (LogQL line_format/label_format/unpack, TraceQL's
+	// compare() attribute fan-out) and the ad-hoc metadata/tag-discovery
+	// query builders that bypass chplan entirely remain unsupported for
+	// both signals — tracked as cerberus issues #3063 (logs) and #3065
+	// (traces). Metrics never sets this: attribute maps there carry
 	// series identity and preflight FATALs on anything but Map.
 	AttrStrategyJSON
 )
@@ -72,9 +76,10 @@ const (
 // resolves one map per signal (Result.LogsAttrStrategies /
 // TracesAttrStrategies), and internal/engine injects only the map for the
 // signal actually being queried (chsql.WithAttrStrategies(ctx, ...) called
-// with LogsAttrStrategies for a LogQL request, nil for PromQL/TraceQL in
-// this version) — so a chsql.Builder rendering one query only ever sees
-// that one signal's resolved strategies, never a merged cross-signal map.
+// with LogsAttrStrategies for a LogQL request, TracesAttrStrategies for a
+// TraceQL request, nil for PromQL, which never resolves either) — so a
+// chsql.Builder rendering one query only ever sees that one signal's
+// resolved strategies, never a merged cross-signal map.
 type AttrStrategies map[string]AttrStrategy
 
 // Lookup returns the AttrStrategy configured for column, or

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1688,14 +1688,53 @@ func (b *Builder) exprLineContent(l *chplan.LineContent) error {
 	return nil
 }
 
+// exprFieldAccess renders a chplan.FieldAccess. A materialized attribute
+// column reads byte-identical to the Map subscript below (see
+// chplan.FieldAccess.MaterializedColumn's doc and
+// AddColumnBuilder.Default's real-ClickHouse evidence) but avoids
+// decompressing the wide Attributes Map, so the emitter prefers it
+// whenever the lowering layer populated it — checked first,
+// unconditionally, since a materialized reference never touches the
+// carrier map at all regardless of the carrier's AttrStrategy.
+//
+// cerberus issue #3062: FieldAccess is "conceptually a generalised
+// MapAccess" (see its own doc) but is a DISTINCT chplan.Expr type, so it
+// does not automatically inherit exprMapAccess's JSON branch — TraceQL's
+// lowerAttribute (internal/traceql/lower.go) builds FieldAccess, never a
+// bare MapAccess, for every span/resource/scope attribute read, which is
+// precisely why wiring chsql.AttrStrategies end-to-end was NOT sufficient
+// on its own to make a JSON-typed traces attribute column work: this
+// method is the second half of that fix. f.Path is always a compile-time
+// Go string (not a chplan.Expr), so — unlike exprMapAccess's key, which
+// must additionally be checked for *chplan.LitString — the JSON branch
+// here needs only jsonAttrColumn's bare-JSON-strategy-column check on
+// f.Source. Renders the identical
+//
+//	coalesce(<col>.<path, backtick-quoted>.:String, '')
+//
+// shape exprMapAccess's JSON branch does, and for the same reason: every
+// TraceQL comparison lowering (coerceFieldAccess's toFloat64OrNull wrap,
+// equality, regex) is written against the Map contract of "absent key
+// reads as the empty string", so normalising the JSON path's NULL-on-
+// missing behaviour away here keeps every one of those lowerings working
+// unmodified against either physical storage — pinned by a chDB
+// differential (internal/api/tempo/attr_strategy_json_chdb_test.go)
+// exercising both
+// the FieldAccess read itself and a numeric comparison built on top of
+// it.
 func (b *Builder) exprFieldAccess(f *chplan.FieldAccess) error {
-	// A materialized attribute column reads byte-identical to the Map
-	// subscript below (see chplan.FieldAccess.MaterializedColumn's doc and
-	// AddColumnBuilder.Default's real-ClickHouse evidence) but avoids
-	// decompressing the wide Attributes Map, so the emitter prefers it
-	// whenever the lowering layer populated it.
 	if f.MaterializedColumn != "" {
 		b.Ident(f.MaterializedColumn)
+		return nil
+	}
+	if col, ok := jsonAttrColumn(b, f.Source); ok {
+		b.sb.WriteString("coalesce(")
+		if err := b.Expr(col); err != nil {
+			return err
+		}
+		b.sb.WriteByte('.')
+		b.Ident(f.Path)
+		b.sb.WriteString(".:String, '')")
 		return nil
 	}
 	if err := b.Expr(f.Source); err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -108,23 +108,29 @@ type spansTabler interface{ SpansTable() string }
 
 // attrStrategier is implemented by a Lang whose plans should render
 // attribute-map accesses against a resolved chsql.AttrStrategies (cerberus
-// issue #2777) rather than assuming every attribute column is a
-// ClickHouse Map. Only *logql.Lang implements it today — the
-// LogsAttrStrategies preflight resolves is threaded onto it by
-// internal/api/loki's Handler at construction; PromQL / TraceQL don't
-// implement this interface, so their plans render exactly as before this
-// issue's work (chsql.Emit's ctx never carries a non-nil AttrStrategies
+// issue #2777, extended to TraceQL by #3062) rather than assuming every
+// attribute column is a ClickHouse Map. *logql.Lang and the TraceQL head's
+// unexported traceqlLang (internal/api/tempo/lang.go) both implement it —
+// the LogsAttrStrategies / TracesAttrStrategies preflight resolves are
+// threaded onto them by internal/api/loki's / internal/api/tempo's
+// Handlers at construction. PromQL doesn't implement this interface (its
+// route-B sharded-pushdown fan-out is the one path that ever needs
+// AttrStrategies threaded independently of this duck-type — see
+// routeBExecCtx's callers — and metrics attribute columns are Map-only by
+// #2777's own scoping, so PromQL's plans render exactly as before this
+// issue's work: chsql.Emit's ctx never carries a non-nil AttrStrategies
 // for them, which chsql.AttrStrategies.Lookup already treats as "every
 // column is Map").
 type attrStrategier interface{ EmitAttrStrategies() chsql.AttrStrategies }
 
 // attrStrategiesForLang duck-types lang against attrStrategier and returns
 // its resolved AttrStrategies, or nil for a Lang that doesn't implement it
-// (PromQL / TraceQL today). Shared by emitForHead (route A) and every
-// route-B dispatch path (routeBExecCtx's callers) so both routes resolve
-// the identical value for the same Lang — route B's plan is a re-anchored
-// copy of route A's, and the physical column shape a chsql.MapAccess
-// renders against does not change depending on which route dispatches it.
+// (PromQL today). Shared by emitForHead (route A) and every route-B
+// dispatch path (routeBExecCtx's callers) so both routes resolve the
+// identical value for the same Lang — route B's plan is a re-anchored
+// copy of route A's, and the physical column shape a chsql.MapAccess /
+// chplan.FieldAccess renders against does not change depending on which
+// route dispatches it.
 func attrStrategiesForLang(lang Lang) chsql.AttrStrategies {
 	if as, ok := lang.(attrStrategier); ok {
 		return as.EmitAttrStrategies()

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -17,15 +17,15 @@
 //     Map(String, String) — except logs' and traces' attribute maps, which
 //     may alternatively be typed JSON (cerberus issue #2777: the upstream
 //     OTel exporter's `json:true` schema variant). A JSON-typed attribute
-//     map there boots with a WARNING rather than a FATAL and, for LOGS,
-//     also RESOLVES a chsql.AttrStrategies the query emitters actually
-//     render against for per-key lookups (Result.LogsAttrStrategies —
-//     internal/engine threads it onto the emit context; see
-//     tableReq.jsonQuerySupported). Traces detection ships too
-//     (Result.TracesAttrStrategies is resolved) but is not yet threaded
-//     into any TraceQL request (cerberus issue #3062). Metrics attribute
-//     maps carry series identity and stay Map-only per the issue's own
-//     scoping — see tableReq.jsonAttrMapCompat.
+//     map there boots with a WARNING rather than a FATAL and, for BOTH
+//     signals, also RESOLVES a chsql.AttrStrategies the query emitters
+//     actually render against for per-key lookups and comparisons
+//     (Result.LogsAttrStrategies / TracesAttrStrategies — internal/engine
+//     threads the right one onto the emit context per request; see
+//     tableReq.jsonQuerySupported). Logs shipped this in cerberus issue
+//     #2777's original PR; traces shipped it in the #3062 follow-up.
+//     Metrics attribute maps carry series identity and stay Map-only per
+//     the issue's own scoping — see tableReq.jsonAttrMapCompat.
 //   - Gate 3 (storage tiering): when a storage policy or a tiering volume is
 //     configured, the policy's volumes are read from system.storage_policies
 //     and the configuration is checked for being ACCEPTED BUT INERT — a
@@ -341,17 +341,21 @@ type Result struct {
 
 	// TracesAttrStrategies is LogsAttrStrategies's traces counterpart —
 	// resolved by the SAME boot-probe detection (tableReq.jsonAttrMapCompat
-	// covers both logs and traces) but deliberately NOT wired into
-	// internal/engine's TraceQL request context in this version: chsql's
-	// JSON rendering branch (exprMapAccess / FnMapContainsKey) has only
-	// been verified for logs' per-key lookup shapes, and traces carries
-	// its own unverified risk (TraceQL's comparison typing, the
-	// structural-join / nested-set emitters) — see cerberus issue #3062
-	// (traces JSON-attribute query support), a sub-issue of #2777. The
-	// field exists so that follow-up only
-	// has to wire cmd/cerberus + internal/engine, not touch preflight's
-	// detection again — it is always populated (or nil) exactly as
-	// LogsAttrStrategies is, from the same checkSchema pass.
+	// covers both logs and traces) and, since cerberus issue #3062, wired
+	// into internal/engine's TraceQL request context exactly like
+	// LogsAttrStrategies: cmd/cerberus threads it onto
+	// tempo.Handler.SetAttrStrategies, which the engine's attrStrategier
+	// duck-type picks up via chsql.WithAttrStrategies. #3062 verified
+	// TraceQL's own risk empirically — chsql.exprFieldAccess needed its
+	// own JSON branch (FieldAccess, not MapAccess, is what
+	// internal/traceql's lowering builds for every attribute read),
+	// comparison typing (toFloat64OrNull over the JSON path) was pinned
+	// against real ClickHouse via chDB, and the structural-join /
+	// nested-set emitters were confirmed to inherit the strategy through
+	// the shared emitter state rather than bypassing it — see
+	// internal/api/tempo/attr_strategy_json_chdb_test.go. It is always
+	// populated (or nil) exactly as LogsAttrStrategies is, from the same
+	// checkSchema pass.
 	TracesAttrStrategies AttrStrategies
 }
 
@@ -769,17 +773,30 @@ type tableReq struct {
 	// surfaced through Result.LogsAttrStrategies / TracesAttrStrategies for
 	// internal/engine to actually render queries against (cerberus issue
 	// #2777, the chsql.Builder attribute-access-strategy threading slice).
-	// True only for logs: chsql's exprMapAccess / FnMapContainsKey render
-	// hooks now have a JSON branch, wired for logs' per-key lookups (label
-	// matchers, detected_level, the OTelDottedFallbackChain candidate
-	// chain). False for traces — detection ships here, but chsql's JSON
-	// branch is not wired into any TraceQL-facing AttrStrategies in this
-	// version, so a JSON-typed traces attribute column still fails at
-	// query time exactly as before (deliberately: TraceQL's comparison
-	// typing and the structural-join emitters are unverified against the
-	// JSON path — see cerberus issue #3062, a sub-issue of #2777).
-	// requiredTables is the only place that sets this.
+	// True for both logs and traces: chsql's exprMapAccess / exprFieldAccess
+	// / FnMapContainsKey render hooks all have a JSON branch, wired for
+	// per-key lookups (LogQL label matchers / detected_level / the
+	// OTelDottedFallbackChain candidate chain; TraceQL span/resource/scope
+	// attribute matchers and comparisons — cerberus issue #3062, verified
+	// against real ClickHouse via chDB differentials, see
+	// internal/api/tempo/attr_strategy_json_chdb_test.go). requiredTables
+	// is the only place that sets this; jsonQuerySupportedGaps names what
+	// remains UNSUPPORTED for the table that sets it true.
 	jsonQuerySupported bool
+	// jsonQuerySupportedGaps names, in the boot warning, the query-time
+	// capability still missing against a jsonQuerySupported table's
+	// JSON-typed attribute column. Required whenever jsonQuerySupported is
+	// true (checkTable's message composition has no other source for this
+	// text), because the remaining gap is genuinely signal-specific: LogQL
+	// needs the full attribute map at once for line_format / label_format /
+	// unpack / keep|drop with no argument list AND its ad-hoc /labels
+	// /series /detected_fields query builders bypass chplan entirely
+	// (cerberus issue #3063); TraceQL needs it for compare()'s
+	// well-known/generic attribute fan-out AND its own ad-hoc
+	// /api/search/tags /api/search/tag/{name}/values query builders
+	// bypass chplan the same way (cerberus issue #3065). Ignored when
+	// jsonQuerySupported is false.
+	jsonQuerySupportedGaps string
 	// materializedColumns is the subset of columns that must be typed a
 	// SPECIFIC ClickHouse type rather than checked for mere existence —
 	// the materialized span/resource attribute columns an operator opted
@@ -802,6 +819,34 @@ type materializedColumnCheck struct {
 	column       string
 	expectedType string
 }
+
+// logsJSONQuerySupportedGaps / tracesJSONQuerySupportedGaps name, for
+// checkTable's boot-warning text, the query-time capability that remains
+// UNSUPPORTED against a jsonQuerySupported table's JSON-typed attribute
+// column — see tableReq.jsonQuerySupportedGaps. Declared as constants
+// (rather than composed inline in requiredTables) so the exact sentence
+// checkTable renders is reviewable in one place per signal, matching
+// invariant 13's spirit for meaning-bearing literals.
+const (
+	logsJSONQuerySupportedGaps = "operations that need the FULL attribute map at once " +
+		"(LogQL line_format / label_format / unpack / keep|drop with no argument list), " +
+		"the /labels /series /detected_fields metadata endpoints, and any table whose " +
+		"ingestion ever used json_type_escape_dots_in_keys=1 or mixed dotted-key " +
+		"encodings — those still fail at query time (tracked as cerberus issue #3063)"
+	tracesJSONQuerySupportedGaps = "operations that need the FULL attribute map at once. " +
+		"If ResourceAttributes specifically is the JSON-typed column, this includes " +
+		"/api/search's OWN baseline response shaping — every response merges " +
+		"ResourceAttributes with synthetic trace/span/parent-span-id keys, which is a " +
+		"full-map operation a JSON column cannot satisfy today (a CAST-based Map bridge " +
+		"does not work on ClickHouse; verified empirically), so /api/search fails on EVERY " +
+		"query regardless of its filter shape until this is addressed — SpanAttributes and " +
+		"ScopeAttributes are unaffected by this specific gap. Also unsupported for any " +
+		"jsonQuerySupported column: the compare() spanset-metrics operator's " +
+		"well-known/generic attribute fan-out, the /api/search/tags and " +
+		"/api/search/tag/{name}/values discovery endpoints, and any table whose ingestion " +
+		"ever used json_type_escape_dots_in_keys=1 or mixed dotted-key encodings — those " +
+		"still fail at query time (tracked as cerberus issue #3065)"
+)
 
 // requiredTables resolves the active config into the per-table shape
 // requirements. Only the columns the emitters actually read are listed —
@@ -855,9 +900,10 @@ func requiredTables(req Requirements) []tableReq {
 				l.TimestampColumn, l.BodyColumn, l.ServiceNameColumn,
 				l.AttributesColumn, l.ResourceAttributesColumn,
 			),
-			attrMap:            nonEmpty(l.AttributesColumn, l.ResourceAttributesColumn, l.ScopeAttributesColumn),
-			jsonAttrMapCompat:  true,
-			jsonQuerySupported: true,
+			attrMap:                nonEmpty(l.AttributesColumn, l.ResourceAttributesColumn, l.ScopeAttributesColumn),
+			jsonAttrMapCompat:      true,
+			jsonQuerySupported:     true,
+			jsonQuerySupportedGaps: logsJSONQuerySupportedGaps,
 		})
 	}
 
@@ -883,9 +929,11 @@ func requiredTables(req Requirements) []tableReq {
 				tr.DurationColumn, tr.StartTimeColumn,
 				tr.AttributesColumn, tr.ResourceAttributesColumn,
 			), materializedCols...),
-			attrMap:             nonEmpty(tr.AttributesColumn, tr.ResourceAttributesColumn, tr.ScopeAttributesColumn),
-			jsonAttrMapCompat:   true,
-			materializedColumns: materializedChecks,
+			attrMap:                nonEmpty(tr.AttributesColumn, tr.ResourceAttributesColumn, tr.ScopeAttributesColumn),
+			jsonAttrMapCompat:      true,
+			jsonQuerySupported:     true,
+			jsonQuerySupportedGaps: tracesJSONQuerySupportedGaps,
+			materializedColumns:    materializedChecks,
 		})
 	}
 
@@ -950,7 +998,7 @@ func nonEmpty(vals ...string) []string {
 // for, i.e. not yet provisioned — the boot-probe WARNINGS (a
 // jsonAttrMapCompat table whose attribute map is JSON-typed), and
 // jsonColsByTable, the JSON-typed attribute columns found per jsonQuerySupported
-// table name (logs today; see tableReq.jsonQuerySupported) — Run resolves
+// table name (logs and traces; see tableReq.jsonQuerySupported) — Run resolves
 // this into Result.LogsAttrStrategies / TracesAttrStrategies. An
 // entirely-absent table is transient (the schema race), so it lands in the
 // second value and is NOT a wrong-shape problem; a table that exists but has
@@ -1050,26 +1098,23 @@ func checkTable(ctx context.Context, q Querier, database string, t tableReq) (pr
 			// Boot-probe compat (cerberus issue #2777): a JSON-typed
 			// attribute map on logs/traces boots instead of FATALing. The
 			// warning's own text is the DELIBERATE per-table posture
-			// decision (never inherited by default): jsonQuerySupported
-			// tables (logs) now have a real, tested chsql JSON rendering
-			// path for per-key attribute lookups, so the warning narrows to
-			// naming the KNOWN remaining gaps rather than claiming nothing
-			// works; a table without it (traces) keeps the original
-			// "nothing works yet" text, because chsql's JSON branch is not
-			// wired into any AttrStrategies TraceQL requests carry.
+			// decision (never inherited by default): a jsonQuerySupported
+			// table now has a real, tested chsql JSON rendering path for
+			// per-key attribute lookups (logs since cerberus issue #2777's
+			// original PR, traces since #3062), so the warning narrows to
+			// naming the KNOWN remaining gaps (t.jsonQuerySupportedGaps,
+			// which differs per signal) rather than claiming nothing works;
+			// a table without query support at all would keep the original
+			// "nothing works yet" text — no current tableReq sets
+			// jsonAttrMapCompat without jsonQuerySupported, but the branch
+			// stays as the fail-safe default for a future table that does.
 			if t.jsonQuerySupported {
 				jsonCols = append(jsonCols, col)
 				warnings = append(warnings, fmt.Sprintf(
 					"table %s column %s: JSON-typed attribute schema detected (cerberus issue #2777) — "+
-						"per-key attribute lookups (label matchers, detected_level, and other bare "+
-						"MapAccess/mapContains reads against this column) are supported. NOT yet "+
-						"supported (tracked as cerberus issue #3063): operations that need the FULL "+
-						"attribute map at once (LogQL line_format / label_format / unpack / keep|drop "+
-						"with no argument list), the /labels /series /detected_fields metadata "+
-						"endpoints, and any table whose ingestion ever used "+
-						"json_type_escape_dots_in_keys=1 or mixed dotted-key encodings — those still "+
-						"fail at query time",
-					t.name, col,
+						"per-key attribute lookups and comparisons against this column are supported. "+
+						"NOT yet supported: %s",
+					t.name, col, t.jsonQuerySupportedGaps,
 				))
 			} else {
 				warnings = append(warnings, fmt.Sprintf(

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -495,12 +495,12 @@ func TestRunLogsJSONAttrMapPassesWithWarning(t *testing.T) {
 
 // TestRunTracesJSONAttrMapPassesWithWarning is the traces counterpart of
 // TestRunLogsJSONAttrMapPassesWithWarning — the other signal the boot-probe
-// compat covers. Unlike logs, chsql's JSON rendering branch is NOT wired
-// into any TraceQL-facing AttrStrategies in this version (see
-// tableReq.jsonQuerySupported's doc), so the warning keeps its original
-// "nothing works at query time yet" text, and Result.TracesAttrStrategies
-// stays nil even though the column WAS detected as JSON — a deliberate
-// choice, not an oversight: see cerberus issue #3062, a sub-issue of #2777.
+// compat covers. Since cerberus issue #3062, chsql's JSON rendering branch
+// IS wired for TraceQL too (exprFieldAccess, not just exprMapAccess — see
+// its own doc), so the warning narrows to the same "per-key lookups
+// supported, full-map operations are not" shape logs already used, and
+// Result.TracesAttrStrategies resolves to AttrStrategyJSON for the
+// detected column instead of staying nil.
 func TestRunTracesJSONAttrMapPassesWithWarning(t *testing.T) {
 	t.Parallel()
 	cols := healthyColumns()
@@ -519,14 +519,16 @@ func TestRunTracesJSONAttrMapPassesWithWarning(t *testing.T) {
 		t.Fatalf("want exactly 1 warning, got %d: %v", len(res.Warnings), res.Warnings)
 	}
 	w := res.Warnings[0]
-	for _, want := range []string{tr.SpansTable, tr.ResourceAttributesColumn, "JSON-typed attribute schema", "#2777", "not implemented"} {
+	for _, want := range []string{tr.SpansTable, tr.ResourceAttributesColumn, "JSON-typed attribute schema", "#2777", "are supported", "#3065"} {
 		if !strings.Contains(w, want) {
 			t.Errorf("warning missing %q: %s", want, w)
 		}
 	}
-	if res.TracesAttrStrategies != nil {
-		t.Errorf("TracesAttrStrategies = %v, want nil — chsql's JSON branch is not wired for traces in this version",
-			res.TracesAttrStrategies)
+	if strings.Contains(w, "not implemented") {
+		t.Errorf("traces warning must not claim query lowering is unimplemented — it is, for per-key lookups: %s", w)
+	}
+	if got := res.TracesAttrStrategies.Lookup(tr.ResourceAttributesColumn); got != chsql.AttrStrategyJSON {
+		t.Errorf("TracesAttrStrategies.Lookup(%q) = %v, want AttrStrategyJSON", tr.ResourceAttributesColumn, got)
 	}
 	if res.LogsAttrStrategies != nil {
 		t.Errorf("LogsAttrStrategies = %v, want nil (no logs column was made JSON in this test)", res.LogsAttrStrategies)


### PR DESCRIPTION
## Summary

Closes the JSON-typed-attributes capability gap for **traces** (cerberus issue #3062, sub-issue of #2777, filed as a deliberate scope split when #2777's logs slice, PR #3064, landed without traces). M5's exit criterion 1 required "logs **and traces**" — this is the remaining piece.

A cerberus configured against the OTel exporter's `json:true` traces schema now answers span/resource/scope attribute-key queries correctly (label-style matchers, numeric/duration comparisons, existence checks) instead of failing at query time with `ILLEGAL_TYPE_OF_ARGUMENT`, the same capability #3064 already shipped for logs.

## Why chsql.AttrStrategies threading alone was not enough

TraceQL's `lowerAttribute` (`internal/traceql/lower.go`) lowers every span/resource/scope attribute read to `chplan.FieldAccess` — a distinct chplan expression type, never a bare `chplan.MapAccess`. The logs slice's existing `exprMapAccess` JSON branch never fires for TraceQL plans regardless of how thoroughly `AttrStrategies` is threaded through `preflight` → `engine` → the emit context, because `exprFieldAccess` (`internal/chsql/builder.go`) had its own independent bracket-subscript rendering that never consulted the strategy. This PR gives `exprFieldAccess` the same JSON branch `exprMapAccess` has — `coalesce(<col>.<path>.:String, '')` — reusing the existing `jsonAttrColumn` helper. `f.Path` is always a compile-time Go string (never a `chplan.Expr`), so the literal-key restriction `exprMapAccess` needs for its `MapAccess.Key` doesn't apply here.

## Wiring

Mirrors the LogQL wiring exactly, adapted to TraceQL's actual (slightly different) structure discovered during implementation:
- `internal/api/tempo/lang.go`'s unexported `traceqlLang` (the actual `engine.Lang` adapter for TraceQL — there is no `internal/traceql.Lang` type; the issue's proposal text speculated one might exist there) gains an `AttrStrategies chplan.AttrStrategies` field + `EmitAttrStrategies()` method.
- `internal/api/tempo/handler.go`'s `Handler` gets an `AttrStrategies` field + a `SetAttrStrategies` setter (needed because `Handler.lang` is unexported and, unlike LogQL, TraceQL's Lang is one long-lived instance rather than built per-request — a plain two-line field assignment like loki's `h.Lang.AttrStrategies = ...` isn't reachable from `cmd/cerberus`).
- `cmd/cerberus/main.go`: `runRequirementsCheck` now returns a new `preflightAttrStrategies{Logs, Traces}` struct instead of a single `chsql.AttrStrategies` (named struct rather than two positional same-typed values, for the identical anti-transposition reason `admitLimiters` already exists in this file), threaded into `mountAPIHeads` and then `tempoHandler.SetAttrStrategies(...)`.
- `internal/engine`'s `attrStrategier` duck-type interface and `emitForHead`'s automatic threading needed **no changes** — they're already signal-agnostic; TraceQL just needed to start implementing the interface.

## Auditing the `emitSelect`/`emitForHead` chokepoint (the flagged risk)

#2777's PR body explicitly named this as TraceQL's unverified risk: "structural-join/nested-set emitters that may not route through the `emitSelect` chokepoint this PR's threading relies on." I audited every raw `NewBuilder()`/`&Builder{}` construction in `internal/chsql` and every direct `chsql.Emit(...)` call in `internal/api/tempo`.

Two **real bypasses**, caught by chDB differentials rather than code-reading alone:

- **`internal/api/tempo/structural_two_phase.go`'s `runStructuralPhaseA`** (the two-phase structural search's narrow ranking query) called `chsql.Emit` directly, never threading `chsql.WithAttrStrategies`. `TestTraceQL_JSONAttrStrategy_StructuralJoin_ChDB` caught this as a genuine `ILLEGAL_TYPE_OF_ARGUMENT` before the fix.
- **`internal/api/tempo/root_lookup.go`'s `resolveTraceRoots`** (the missing-root-span follow-up lookup) has the identical bypass — `buildRootLookupPlan` builds a bare `chplan.MapAccess` against `ResourceAttributesColumn`. This path WARN-degrades rather than 502s, so the bug would have silently dropped root-span enrichment instead of hard failing.

Both now thread `chsql.WithAttrStrategies(ctx, h.AttrStrategies)` explicitly. Everything else in `internal/chsql` that looked like a bypass on inspection (`emitUnionAll`'s `NewBuilder()`, `Render`'s DDL-only builder, `query_exemplars.go`'s metrics-only builder, `QueryBuilder.Frag()`'s builder-sharing) turned out to be safe: `Frag()` writes into the *caller's* already-stamped `Builder` rather than spinning up its own, so nested structural-join arms built via plain `NewQuery()` correctly inherit whatever strategy the outer `emitSelect` chokepoint stamped — confirmed empirically by the passing structural test, not just by reading the code.

## Comparison-typing differential (the other flagged risk)

`TestTraceQL_JSONAttrStrategy_ComparisonTyping_ChDB` runs an equality match, a numeric comparison (`{ span.http.status_code > 100 }`, exercising `coerceFieldAccess`'s `toFloat64OrNull` wrap), and an existence check against a real Map-typed and a real JSON-typed table side by side, seeded with every missing/non-numeric/present-empty shape. All three match byte-for-byte between the two physical storages, because `exprFieldAccess`'s JSON branch normalizes missing-vs-empty exactly like `exprMapAccess`'s already does.

## A real, additional gap this surfaced (scoped out, not silently dropped)

Chasing the full `/api/search` HTTP round trip (not just isolated `chsql.Emit` calls) surfaced that `canonicalSampleProjections`/`sampleProjectionsWithSelected` unconditionally build the response's `Attributes` column via `mapConcat(ResourceAttributes, map('__cerberus_traceID', ...))` — a genuine full-map merge needed on **every** `/api/search` response, not something a query's own filter can opt out of. A `CAST(json_col, 'Map(String,String)')` bridge does **not** work — verified empirically against chDB 26.5 (`TYPE_MISMATCH: Unsupported types to CAST AS Map`). So a JSON-typed `ResourceAttributes` column (as opposed to `SpanAttributes`/`ScopeAttributes`) still breaks `/api/search` entirely today, regardless of filter shape. This needs the same `JSONAllPaths`-based full-map reconstruction the compare()-operator gap and the `/api/search/tags` discovery-endpoint gap already need — filed as **cerberus issue #3065** (new sub-issue of #2777, mirroring #3063's scope for logs), with this specific finding as its highest-priority item since it blocks the baseline endpoint rather than an advanced feature. The boot-warning text and `docs/operations.md` both name this caveat explicitly rather than glossing over it.

## Boot-warning posture (preflight.go)

Traces' `tableReq` now sets `jsonQuerySupported: true` (it was `false` by omission before — meaning `Result.TracesAttrStrategies` was actually **always nil** in production despite a doc comment claiming it was "resolved"). The warning narrows from the old "nothing works at query time yet" text to naming the real, verified remaining gaps (full-map operations, the two ad-hoc discovery endpoints, the ResourceAttributes/`/api/search` caveat above, and the escape-dots-in-keys hazard) — the same posture decision #3064 made for logs, now made deliberately for traces with the actual supported surface verified rather than assumed.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go-arch-lint check` clean (verified locally per the PR's own instructions, since the logs slice's PR originally caught a violation here)
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean
- [x] `gofumpt -l .` / `goimports -l -local ... .` clean
- [x] Targeted race-detected unit tests across every touched package pass: `cmd/cerberus`, `internal/api/tempo` (+ `grpc`), `internal/chplan`, `internal/chsql`, `internal/engine`, `internal/preflight`, `internal/traceql`, `internal/logql`, `internal/api/loki`
- [x] New chDB differentials (`-tags chdb`) pass: `TestTraceQL_JSONAttrStrategy_ComparisonTyping_ChDB` (3 subtests), `TestTraceQL_JSONAttrStrategy_StructuralJoin_ChDB`
- [x] Full chdb-tagged `internal/api/tempo/...` suite passes (no regressions from the two chokepoint fixes)
- [x] `docs/operations.md` update passes markdownlint

Closes #3062
