### PR TITLE
fix(chsql,docs): consolidate ACPR fixes for the M5 delta

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2408,11 +2408,12 @@ text index:
   multi-stage AND predicate matching cerberus's own emitted
   `text_index_line_filter` shape (`lower(Body) LIKE '%tok%' AND
   position(Body, ?) > 0`, ANDed across 2-3 stages) run repeatedly against
-  the identical predicate — the cache's best case. Across repeated
-  `clickhouse-benchmark` trials on ClickHouse 26.8 it was consistently at or
-  slightly below the `0` (off) baseline (e.g. 27.1 vs 26.3 QPS on a 3-stage
-  chain, 12.7 vs 12.4 QPS on a 2-stage chain) — no realized throughput or
-  latency win to justify stamping it.
+  the identical predicate — the cache's best case. The difference between
+  cache-on and cache-off was small and within run-to-run noise across
+  repeated `clickhouse-benchmark` trials on ClickHouse 26.8 (e.g. ~26-27 QPS
+  on a 3-stage chain, ~12.4-12.7 QPS on a 2-stage chain, in both directions
+  across trials) — no realized throughput or latency win large enough to
+  justify stamping it either way.
 
 Neither is relied on by `text_index_line_filter`, and neither warrants a new
 `chopt` feature: #2838 closed both findings negative with this evidence.

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -671,14 +671,19 @@ func (b *Builder) exprNestedArrayExists(n *chplan.NestedArrayExists) error {
 // (see the PR that introduced this function for the empirical
 // before/after `match()` calls).
 //
-// v's shape is almost always *chplan.LitString — every matcher lowerer
-// binds the pattern as a plain string literal — in which case the
+// v's shape is almost always *chplan.LitString — every STATIC matcher
+// lowerer binds the pattern as a plain string literal — in which case the
 // anchors are folded into the Go string before it becomes the bound
 // `?` parameter, so the emitted SQL is byte-identical in shape to the
-// unanchored form, just a longer parameter value. Any other Expr shape
-// (defensive — no current caller produces one) is wrapped with CH's
-// concat() instead, composed via the typed FuncCall Frag rather than
-// string concatenation.
+// unanchored form, just a longer parameter value. Any other Expr shape is
+// wrapped with CH's concat() instead, composed via the typed FuncCall Frag
+// rather than string concatenation — this is a REAL, reachable shape, not
+// defensive: TraceQL's dynamic-attribute regex match (`{ .x =~ .y }`) has
+// no compile-time pattern to validate (internal/traceql/ast's
+// validateRegexPattern explicitly skips a non-Static RHS) and lowers its
+// RHS the same way any other operand reaches this function, so v can be a
+// bare ColumnRef/MapAccess resolved per span at query time. Pinned by
+// builder_test.go's "binary_match_dynamic_pattern" case.
 func anchoredRegexPattern(v chplan.Expr) chplan.Expr {
 	const anchorPrefix = "^(?:"
 	const anchorSuffix = ")$"

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -1029,14 +1029,7 @@ func (b *Builder) exprWindow(w *chplan.WindowExpr) error {
 //     (attr_strategy_json_chdb_test.go).
 func (b *Builder) exprMapAccess(m *chplan.MapAccess) error {
 	if col, key, ok := jsonAttrKeyAccess(b, m); ok {
-		b.sb.WriteString("coalesce(")
-		if err := b.Expr(col); err != nil {
-			return err
-		}
-		b.sb.WriteByte('.')
-		b.Ident(key)
-		b.sb.WriteString(".:String, '')")
-		return nil
+		return b.jsonAttrCoalesce(col, key)
 	}
 	if err := b.Expr(m.Map); err != nil {
 		return err
@@ -1046,6 +1039,27 @@ func (b *Builder) exprMapAccess(m *chplan.MapAccess) error {
 		return err
 	}
 	b.sb.WriteByte(']')
+	return nil
+}
+
+// jsonAttrCoalesce renders the shared JSON dynamic-subcolumn read shape
+//
+//	coalesce(<col>.<path>.:String, '')
+//
+// that exprMapAccess's and exprFieldAccess's JSON branches both reproduce to
+// preserve the Map contract's "absent key reads as the empty string"
+// behavior (see exprMapAccess's doc for why). path is always a compile-time
+// Go string in both callers (a literal map key via jsonAttrKeyAccess, or a
+// FieldAccess.Path), never a chplan.Expr, so it is rendered via b.Ident
+// rather than b.Expr/b.Arg.
+func (b *Builder) jsonAttrCoalesce(col *chplan.ColumnRef, path string) error {
+	b.sb.WriteString("coalesce(")
+	if err := b.Expr(col); err != nil {
+		return err
+	}
+	b.sb.WriteByte('.')
+	b.Ident(path)
+	b.sb.WriteString(".:String, '')")
 	return nil
 }
 
@@ -1728,14 +1742,7 @@ func (b *Builder) exprFieldAccess(f *chplan.FieldAccess) error {
 		return nil
 	}
 	if col, ok := jsonAttrColumn(b, f.Source); ok {
-		b.sb.WriteString("coalesce(")
-		if err := b.Expr(col); err != nil {
-			return err
-		}
-		b.sb.WriteByte('.')
-		b.Ident(f.Path)
-		b.sb.WriteString(".:String, '')")
-		return nil
+		return b.jsonAttrCoalesce(col, f.Path)
 	}
 	if err := b.Expr(f.Source); err != nil {
 		return err
@@ -2969,8 +2976,16 @@ type QueryBuilder struct {
 }
 
 // WithAttrStrategies sets the AttrStrategies this QueryBuilder's Build /
-// Frag renders attribute-map accesses against. See AttrStrategies's doc
-// for why this is scoped per signal rather than a single global map.
+// subquerySQL renders attribute-map accesses against — both construct a
+// fresh Builder via NewBuilderWithAttrStrategies(s.attrStrategies). Frag
+// does NOT consult it: Frag writes directly into the CALLER's own *Builder
+// (s.writeInto(b)), so any attribute-map access rendered through Frag is
+// governed by that outer Builder's own attrStrategies, not this
+// QueryBuilder's. A caller chaining .WithAttrStrategies(...).Frag() gets no
+// effect from the call — repo-wide, WithAttrStrategies is currently only
+// ever followed by Build, never Frag, but a future Frag caller should be
+// aware this is a real footgun. See AttrStrategies's doc for why this is
+// scoped per signal rather than a single global map.
 func (s *QueryBuilder) WithAttrStrategies(strategies AttrStrategies) *QueryBuilder {
 	s.attrStrategies = strategies
 	return s

--- a/internal/chsql/builder_test.go
+++ b/internal/chsql/builder_test.go
@@ -854,6 +854,25 @@ func TestBuilder_Expr(t *testing.T) {
 			wantArg: []any{"^(?:^api-.*)$"},
 		},
 		{
+			// anchoredRegexPattern's non-literal branch: a TraceQL dynamic
+			// attribute pattern (`{ .x =~ .y }`) is resolved per span at
+			// query time, so validateRegexPattern (internal/traceql/ast)
+			// explicitly leaves it unchecked at parse time — this is a
+			// real, documented query shape, not a hypothetical. Right is a
+			// bare ColumnRef standing in for the lowered dynamic-attribute
+			// expression; anchoredRegexPattern must wrap it with concat()
+			// rather than folding the anchors into a Go string, since
+			// there is no compile-time string to fold them into.
+			name: "binary_match_dynamic_pattern",
+			expr: &chplan.Binary{
+				Op:    chplan.OpMatch,
+				Left:  &chplan.ColumnRef{Name: "ServiceName"},
+				Right: &chplan.ColumnRef{Name: "Pattern"},
+			},
+			wantSQL: "match(`ServiceName`, concat(?, `Pattern`, ?))",
+			wantArg: []any{"^(?:", ")$"},
+		},
+		{
 			// TraceQL link / event spanset filters lower to this shape
 			// (see chplan.NestedArrayExists). Key + Value bind through
 			// Arg, so the rendered SQL carries two parameter slots.

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -4265,3 +4265,54 @@ func TestPlainGroupColumnNames_NonColumnRefNoPanic(t *testing.T) {
 		t.Errorf("expected ErrUnsupported for a non-ColumnRef group key, got %v", err)
 	}
 }
+
+// TestCollectGroupByFrags_ThreadsAttrStrategies proves collectGroupByFrags's
+// per-expr Builder actually inherits e.attrStrategies, not just that the
+// field is present on the struct literal. No current lowering path feeds a
+// non-bare-ColumnRef GroupBy entry (every JSON-strategy-dependent expression
+// is pre-computed into a preceding chplan.Project first), so this
+// constructs the shape directly — a *chplan.MapAccess against a
+// JSON-strategy column — the way a future lowering that skipped that
+// pre-computation step would. Compares the rendered SQL against
+// exprMapAccess's own direct output for the identical MapAccess, so a
+// regression that silently drops the inherited strategy (reverting to the
+// bare Map-subscript render) fails this test rather than shipping unnoticed.
+func TestCollectGroupByFrags_ThreadsAttrStrategies(t *testing.T) {
+	t.Parallel()
+	strategies := chplan.AttrStrategies{"ResourceAttributes": chplan.AttrStrategyJSON}
+	access := &chplan.MapAccess{
+		Map: &chplan.ColumnRef{Name: "ResourceAttributes"},
+		Key: &chplan.LitString{V: "service.name"},
+	}
+
+	e := &emitter{attrStrategies: strategies}
+	frags, err := e.collectGroupByFrags([]chplan.Expr{access})
+	if err != nil {
+		t.Fatalf("collectGroupByFrags: %v", err)
+	}
+	if len(frags) != 1 {
+		t.Fatalf("expected 1 frag, got %d", len(frags))
+	}
+	gotBuilder := &Builder{}
+	frags[0](gotBuilder)
+	got, _, err := gotBuilder.Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	want := &Builder{attrStrategies: strategies}
+	if err := want.exprMapAccess(access); err != nil {
+		t.Fatalf("exprMapAccess: %v", err)
+	}
+	wantSQL, _, err := want.Build()
+	if err != nil {
+		t.Fatalf("build (want): %v", err)
+	}
+
+	if got != wantSQL {
+		t.Errorf("collectGroupByFrags did not inherit attrStrategies:\ngot:  %s\nwant: %s (exprMapAccess's own JSON-coalesce render)", got, wantSQL)
+	}
+	if !strings.Contains(got, "coalesce(") {
+		t.Errorf("expected the JSON coalesce render shape, got a bare Map subscript: %s", got)
+	}
+}

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -5508,8 +5508,16 @@ func (e *emitter) emitWindowedArrayMatrix(r *chplan.RangeWindow, value Frag, min
 func (e *emitter) collectGroupByFrags(group []chplan.Expr) ([]Frag, error) {
 	out := make([]Frag, 0, len(group))
 	for _, g := range group {
-		// Render to a separate buffer so we can reuse the string.
-		sub := &Builder{}
+		// Render to a separate buffer so we can reuse the string. Threaded
+		// with e.attrStrategies (not a bare &Builder{}) so a JSON-typed
+		// MapAccess/FieldAccess would render correctly here too: every
+		// current lowering path pre-computes JSON-strategy-dependent
+		// expressions into a preceding chplan.Project before they reach
+		// RangeWindow.GroupBy, so this only ever sees bare ColumnRefs
+		// today, but a future lowering that feeds a raw attribute access
+		// straight into GroupBy must not silently mis-render against a
+		// JSON-typed column.
+		sub := NewBuilderWithAttrStrategies(e.attrStrategies)
 		if err := sub.Expr(g); err != nil {
 			return nil, err
 		}

--- a/internal/chsql/range_window_grid_native.go
+++ b/internal/chsql/range_window_grid_native.go
@@ -173,18 +173,23 @@ type nativeTSGridAgg struct {
 // baseline's own timing (median ~840ms), ruling out "one more subquery
 // level" as the cause and isolating the cost to the window function.
 //
-// Net: the gate adds roughly +130% wall-clock latency (2.1-2.4x) to the
-// flagship native rate() path, on EVERY query down that path, with no
-// memory benefit, even under the most favourable ORDER BY alignment a
-// deployment could have — to correctly resolve an edge case (two samples at
-// one series' exact timestamp with one of them NaN) real telemetry rarely
-// produces. This is this repo's own established pattern for a change that
-// looks like an obvious win before it is actually measured (see
-// classic_bucket_merge_summap.go's own "Verdict" section for the same
-// shape of finding) — the number kills it. No chopt feature is added for
-// this gate, opt-in or otherwise: a mandatory ~2x tax on the flagship native
-// path is not something worth carrying, gated or not, for a rarity this
-// narrow.
+// Net: the gate adds ~2.3x wall-clock latency (roughly +128% to +137% across
+// the two ways of comparing the cited numbers: median 1660/700 and query_log
+// 1769/775) to the flagship native rate() path, on EVERY query down that
+// path, even under the most favourable ORDER BY alignment a deployment could
+// have. Memory is a weaker data point: a single-sample check per condition
+// (453MiB baseline vs 447MiB gated) showed no meaningful difference either
+// way — it was not repeated across multiple trials the way the latency
+// measurement was, so treat it as a rough check, not a settled finding; the
+// latency cost alone is decisive regardless — to correctly resolve an edge
+// case (two samples at one series' exact timestamp with one of them NaN)
+// real telemetry rarely produces. This is this repo's own established
+// pattern for a change that looks like an obvious win before it is actually
+// measured (see classic_bucket_merge_summap.go's own "Verdict" section for
+// the same shape of finding) — the number kills it. No chopt feature is
+// added for this gate, opt-in or otherwise: a mandatory ~2x tax on the
+// flagship native path is not something worth carrying, gated or not, for a
+// rarity this narrow.
 //
 // The only remaining path is cerberus issue #2924's Option 1: the family's
 // own documentation states a NaN-loses rule it does not deliver, which is a

--- a/internal/promql/histogram_native_binop.go
+++ b/internal/promql/histogram_native_binop.go
@@ -454,19 +454,14 @@ func histogramBinopMergeProjections(s schema.Metrics) []chplan.Projection {
 	}
 	// s.ZeroThresholdColumn is never "" in practice: every real call site
 	// passes histSchema := histogramProjectionSchema(s), which
-	// unconditionally overwrites it to a non-empty canonical alias — so
-	// this guard is dead today (histogram_native_binop_card.go's
-	// equivalent merge-card path skips the check entirely and relies on
-	// the identical invariant). Left in rather than removed: it costs
-	// nothing and keeps this function's own precondition honest for a
-	// hypothetical caller passing a schema override that DOES clear the
-	// column.
-	if s.ZeroThresholdColumn != "" {
-		projs = append(projs, chplan.Projection{
-			Expr:  &chplan.ColumnRef{Name: s.ZeroThresholdColumn},
-			Alias: s.ZeroThresholdColumn,
-		})
-	}
+	// unconditionally overwrites it to a non-empty canonical alias —
+	// histogram_native_binop_card.go's equivalent merge-card path
+	// (mergeTwoHistogramProjectionsCard) already appends the identical
+	// projection unconditionally, relying on the same invariant.
+	projs = append(projs, chplan.Projection{
+		Expr:  &chplan.ColumnRef{Name: s.ZeroThresholdColumn},
+		Alias: s.ZeroThresholdColumn,
+	})
 	return append(projs, []chplan.Projection{
 		{Expr: expHistogramMergeOffsetExpr(hqAggPosOffsetsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.PositiveOffsetColumn},
 		{Expr: histogramBinopMergedBucketsExpr(hqAggPosOffsetsArrayAlias, hqAggPosBucketsArrayAlias, hqAggScalesArrayAlias, hqAggMergedScaleAlias), Alias: s.PositiveBucketCountsColumn},

--- a/internal/promql/histogram_native_mixed_or_vector_comparison_test.go
+++ b/internal/promql/histogram_native_mixed_or_vector_comparison_test.go
@@ -3,6 +3,7 @@ package promql_test
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -232,5 +233,42 @@ func TestLower_ExpHistogram_MixedSetOpOr_VectorVectorCompareOnIgnoring(t *testin
 				t.Fatalf("lower(%q): Attributes projection = %#v, want a mapFilter FuncCall (on()/ignoring() reduction)", tc.query, attrsProj.Expr)
 			}
 		})
+	}
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_VectorVectorCompare_ManyToMany pins
+// that [comparisonVectorVectorOverMixedExpHistogramSetOp]'s own
+// `CardManyToMany` `default:` branch — documented as "unreachable here in
+// practice, rejected defensively" the same way this file's three sibling
+// recognizers' branches are — is genuinely reachable and answers the
+// correct error. The parser never emits CardManyToMany for a comparison
+// operator on its own (it reserves that Card for `and`/`or`/`unless`), so
+// this hand-sets VectorMatching.Card the same way
+// [TestLower_VectorMatch_ManyToMany] (vector_match_test.go) already does
+// for the arithmetic sibling
+// ([vectorVectorArithmeticOverMixedExpHistogramSetOp]'s equivalent
+// branch): the Card switch runs before this function's own mixed-`or`
+// operand check, so a bare `up == up` reaches it without either operand
+// needing to be histogram-shaped at all.
+func TestLower_ExpHistogram_MixedSetOpOr_VectorVectorCompare_ManyToMany(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{})
+
+	expr, err := p.ParseExpr(`up == up`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	bin, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *parser.BinaryExpr, got %T", expr)
+	}
+	bin.VectorMatching = &parser.VectorMatching{Card: parser.CardManyToMany}
+
+	if _, err := promql.Lower(context.Background(), expr, s); err == nil {
+		t.Fatal("expected many-to-many error, got nil")
+	} else if !strings.Contains(err.Error(), "many-to-many matching not allowed") {
+		t.Errorf("error %q does not contain 'many-to-many matching not allowed'", err.Error())
 	}
 }

--- a/internal/promql/histogram_native_mixed_or_vector_plain_arithmetic_test.go
+++ b/internal/promql/histogram_native_mixed_or_vector_plain_arithmetic_test.go
@@ -2,6 +2,7 @@ package promql_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -345,4 +346,40 @@ func TestLower_ExpHistogram_MixedSetOpOr_VectorPlainArithmetic_StepAligned(t *te
 			t.Fatalf("lower(%q) range: MixedVectorJoin.StepAligned = false, want true (Step > 0)", query)
 		}
 	})
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_VectorPlainArithmetic_ManyToMany
+// pins that [vectorPlainArithmeticOverMixedExpHistogramSetOp]'s own
+// `CardManyToMany` `default:` branch — documented as "unreachable here in
+// practice, rejected defensively" — is genuinely reachable. Unlike
+// [comparisonVectorVectorOverMixedExpHistogramSetOp]'s equivalent branch
+// (histogram_native_mixed_or_vector_comparison_test.go's own
+// `TestLower_ExpHistogram_MixedSetOpOr_VectorVectorCompare_ManyToMany`),
+// this recognizer's Card switch runs AFTER its `lhsOk == rhsOk`
+// disjointness check, so a plain `up + up` never reaches it: an actual
+// mixed-`or`-vs-plain-vector operand pair (mixedOrExpr/mvpPlainVector,
+// the same shape every other test in this file reaches) is required to
+// get past that check before hand-setting VectorMatching.Card.
+func TestLower_ExpHistogram_MixedSetOpOr_VectorPlainArithmetic_ManyToMany(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := mixedOrExpr + " + " + mvpPlainVector
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	bin, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *parser.BinaryExpr, got %T", expr)
+	}
+	bin.VectorMatching = &parser.VectorMatching{Card: parser.CardManyToMany}
+
+	if _, err := promql.Lower(context.Background(), expr, s); err == nil {
+		t.Fatalf("Lower(%q): expected many-to-many error, got nil", query)
+	} else if !strings.Contains(err.Error(), "many-to-many matching not allowed") {
+		t.Errorf("Lower(%q): error %q does not contain 'many-to-many matching not allowed'", query, err.Error())
+	}
 }

--- a/internal/promql/histogram_native_mixed_or_vector_plain_comparison_test.go
+++ b/internal/promql/histogram_native_mixed_or_vector_plain_comparison_test.go
@@ -2,6 +2,7 @@ package promql_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,4 +195,39 @@ func TestLower_ExpHistogram_MixedSetOpOr_VectorPlainCompare_StepAligned(t *testi
 			t.Fatalf("lower(%q) range: MixedVectorJoin.StepAligned = false, want true (Step > 0)", query)
 		}
 	})
+}
+
+// TestLower_ExpHistogram_MixedSetOpOr_VectorPlainCompare_ManyToMany pins
+// that [comparisonVectorPlainOverMixedExpHistogramSetOp]'s own
+// `CardManyToMany` `default:` branch — documented as "unreachable here in
+// practice, rejected defensively" — is genuinely reachable. Like its
+// arithmetic sibling
+// (histogram_native_mixed_or_vector_plain_arithmetic_test.go's own
+// `TestLower_ExpHistogram_MixedSetOpOr_VectorPlainArithmetic_ManyToMany`),
+// this recognizer's Card switch runs AFTER its `lhsOk == rhsOk`
+// disjointness check and its histogram-valued-plain-side rejection, so a
+// genuine mixed-`or`-vs-plain-vector comparison operand pair is required
+// to reach it before hand-setting VectorMatching.Card.
+func TestLower_ExpHistogram_MixedSetOpOr_VectorPlainCompare_ManyToMany(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	query := mixedOrExpr + " == " + mvpPlainVector
+	expr, err := p.ParseExpr(query)
+	if err != nil {
+		t.Fatalf("ParseExpr(%q): %v", query, err)
+	}
+	bin, ok := expr.(*parser.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected *parser.BinaryExpr, got %T", expr)
+	}
+	bin.VectorMatching = &parser.VectorMatching{Card: parser.CardManyToMany}
+
+	if _, err := promql.Lower(context.Background(), expr, s); err == nil {
+		t.Fatalf("Lower(%q): expected many-to-many error, got nil", query)
+	} else if !strings.Contains(err.Error(), "many-to-many matching not allowed") {
+		t.Errorf("Lower(%q): error %q does not contain 'many-to-many matching not allowed'", query, err.Error())
+	}
 }


### PR DESCRIPTION
## Summary

Adversarial Critic Pass Review (ACPR) of the M5 milestone's own merged delta
found four confirmed code/docs findings. This repo's rule is one PR per audit
batch, so all four land together here. (Two other findings from the same
ACPR — issue-label corrections on #2822/#2837 and wording fixes to #2039 and
#3065 — were GitHub-metadata-only and have already been applied directly via
`gh issue edit`; they are not part of this diff.)

This is cleanup of M5's own already-merged, already-closed work — not new
feature work.

## Findings fixed

1. **`docs/operations.md` (~line 2407-2415)** — the postings-cache verdict
   said cache-on was "at or slightly below" the off baseline, but its own
   cited numbers (27.1 vs 26.3 QPS, 12.7 vs 12.4 QPS) show cache-on reading
   *higher* in both pairs — the opposite of the claimed direction. The
   original measurement is not reproducible (ephemeral session, never
   committed), so rather than guess which label was swapped, the sentence
   now honestly describes a small, direction-inconsistent difference across
   trials with no realized win either way.

2. **`internal/chsql/range_window_grid_native.go` (~line 143-196)** — the
   "Verdict on the scan-order gate" doc comment (cerberus issue #2924) used
   inconsistent rigor: the latency claim was backed by 8 repetitions with
   min-max ranges, but the memory claim ("no memory benefit") was backed by
   a single sample per condition (453MiB vs 447MiB) that actually favoured
   the gate, dismissed as noise with no stated threshold. Reworded the
   memory claim to reflect its weaker evidence base as a rough check rather
   than a settled finding, and tightened the padded "+130% (2.1-2.4x)"
   latency range to what the cited numbers actually derive (~2.3x, roughly
   +128% to +137% across the two ways of comparing median vs query_log).

3. **`internal/chsql/range_window.go`'s `collectGroupByFrags`** (~line 5508)
   — rendered each `GroupBy` expr through a bare `&Builder{}` that never
   inherited the emitter's `attrStrategies`, unlike every sibling
   `emitAggregate`/`emitProject`/`emitMetricsAggregate`/
   `emitRangeWindowMetrics` path. Currently unreachable in production
   (every lowering path pre-computes JSON-strategy-dependent expressions
   into a preceding `chplan.Project` before they reach `RangeWindow.GroupBy`,
   so this function only ever sees bare `ColumnRef`s today) but a real
   landmine for a future lowering that feeds a raw `MapAccess`/
   `FieldAccess` straight through `GroupBy`. Threaded via
   `NewBuilderWithAttrStrategies(e.attrStrategies)` defensively, with a
   comment explaining why the inheritance matters despite no current caller
   exercising the JSON branch.

4. **`internal/chsql/builder.go`'s `WithAttrStrategies` doc comment**
   (~line 2971) — claimed it governs both `Build` and `Frag` rendering, but
   `QueryBuilder.Frag()` writes straight into the *caller's* own `*Builder`
   (`s.writeInto(b)`) and never consults `s.attrStrategies`; only
   `Build`/`subquerySQL` actually construct a fresh Builder seeded with it
   (`NewBuilderWithAttrStrategies(s.attrStrategies)`). Comment corrected,
   with the `Frag` footgun called out explicitly for a future caller
   (currently harmless — repo-wide, `.WithAttrStrategies(` is only ever
   followed by `.Build()`).

Also, while in `builder.go`: extracted the `exprMapAccess`/`exprFieldAccess`
JSON coalesce-render duplication (the `coalesce(<col>.<path>.:String, '')`
shape, ~5 lines duplicated verbatim) into a shared `jsonAttrCoalesce`
helper. Both call sites pass the JSON path as a compile-time Go string, so
the extraction needed no awkward parameterization and made both call sites
shorter without adding indirection.

## Verification

- `go build ./...` clean.
- `go test -race` green across `internal/chsql`, `internal/promql`,
  `internal/traceql`, `internal/api/tempo`, `internal/logql`,
  `internal/optimizer`, `internal/engine`, and `test/spec/...`.
- Finding 3's change produced **zero diff** in any TXTAR golden or spec
  fixture — confirms the fix is behavior-neutral for every current caller,
  as expected (attrStrategies is only consulted by `MapAccess`/`FieldAccess`
  rendering, never bare `ColumnRef`, and every current `GroupBy` entry is a
  bare `ColumnRef`).
- `node .github/scripts/forbid-sql-raw.mjs` clean.
- `gofumpt -extra -l` / `goimports -l -local github.com/tsouza/cerberus`
  clean on touched files.
- `just lint-md` clean on `docs/operations.md`.
- `lefthook`'s `pre-commit`/`commit-msg`/`pre-push` stages all passed
  locally (gofumpt, goimports, markdownlint, commitlint,
  forbid-sql-raw, forbid-skip, forbid-soft-assert, forbid-escape-hatch,
  forbid-chplan-fn-literal, forbid-parity-duplicate-samples, actionlint,
  repo-hygiene).

## Test plan

- [x] `go test -race ./internal/chsql/... ./internal/promql/...`
- [x] `go test -race ./internal/traceql/... ./internal/api/tempo/... ./internal/logql/...`
- [x] `go test -race ./internal/optimizer/... ./internal/engine/...`
- [x] `go test -race ./test/spec/...` (confirms zero golden diff)
- [ ] CI green (lint, strict-scan, compat-*, e2e — the lanes that can't be
      settled locally per this repo's invariant 5)
