### PR TITLE
fix(logql): don't push the log-line Timestamp LIMIT onto a metric query

### DIFF
--- a/internal/logql/limit_pushdown_test.go
+++ b/internal/logql/limit_pushdown_test.go
@@ -208,12 +208,21 @@ func TestLogLineLimitPushdown_DirectionMapsToOrderDirection(t *testing.T) {
 //   - LogLineLimit<=0 (every non-Opts entry point, and every caller that
 //     hasn't parsed a request `limit`) never pushes.
 //   - A metric query (RangeAggregationExpr et al.) never pushes even
-//     when LogLineLimit is positive — [maybePushLogLineLimit] only fires
-//     when the TOP-level parsed expr is itself a syntax.LogSelectorExpr,
-//     which a metric query's top-level expr never is (see
-//     logql.IsMetricQuery). This is what keeps a metric query's inner
-//     selector (reached recursively while lowering the range
-//     aggregation) from ever being wrapped.
+//     when LogLineLimit is positive. [maybePushLogLineLimit] guards this
+//     explicitly with [logql.IsMetricQuery] — NOT merely by the
+//     TOP-level expr failing the `syntax.LogSelectorExpr` assertion, since
+//     `*syntax.LiteralExpr` and `*syntax.VectorExpr` are both genuine
+//     top-level metric queries (see IsMetricQuery) that ALSO implement
+//     `isLogSelectorExpr()` (needed for their dual role as a `SampleExpr`
+//     binary-expression leg). A `count_over_time(...)` top-level expr
+//     happens to fail that assertion on its own and would pass even
+//     without the explicit guard; `vector(1)` and a bare literal do not,
+//     and regressed into a wrong `ORDER BY Timestamp …` wrap ClickHouse
+//     rejected with `Unknown expression identifier 'Timestamp'` — the
+//     synthetic one-row plan [logql.lowerVector] / [logql.lowerLiteral]
+//     build carries no Timestamp column (cerberus issue #3047). All three
+//     shapes are exercised below so the explicit guard cannot regress
+//     silently again.
 func TestLogLineLimitPushdown_NoOpWhenLimitZeroOrMetricQuery(t *testing.T) {
 	s := schema.DefaultOTelLogs()
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -237,24 +246,37 @@ func TestLogLineLimitPushdown_NoOpWhenLimitZeroOrMetricQuery(t *testing.T) {
 		}
 	})
 
-	t.Run("metric query is never wrapped", func(t *testing.T) {
-		expr, err := logql.ParseExprPermissive(`count_over_time({app="x"}[5m])`)
-		if err != nil {
-			t.Fatalf("ParseExprPermissive: %v", err)
-		}
-		base, err := logql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
-		if err != nil {
-			t.Fatalf("LowerAtRange: %v", err)
-		}
-		pushed, err := logql.LowerAtRangeOpts(context.Background(), expr, s, start, end, time.Minute, logql.LowerOpts{LogLineLimit: 50, LogLineBackward: true})
-		if err != nil {
-			t.Fatalf("LowerAtRangeOpts: %v", err)
-		}
-		if !pushed.Equal(base) {
-			t.Errorf("a metric query's plan changed when LogLineLimit was set; want byte-identical — the limit must never reach a metric query's plan")
-		}
-		if _, ok := pushed.(*chplan.Limit); ok {
-			t.Errorf("metric query plan's top node is *chplan.Limit; must never be wrapped")
-		}
-	})
+	for _, tc := range []struct {
+		name string
+		// query is parsed as a top-level expr. vector(1) and the bare
+		// literal both implement isLogSelectorExpr() despite being
+		// metric queries (see the function doc comment above) — the
+		// two shapes that actually exercised the #3047 regression.
+		query string
+	}{
+		{name: "range aggregation (count_over_time)", query: `count_over_time({app="x"}[5m])`},
+		{name: "vector(1) — implements LogSelectorExpr despite being a metric query", query: `vector(1)`},
+		{name: "bare literal — implements LogSelectorExpr despite being a metric query", query: `1`},
+	} {
+		t.Run("metric query is never wrapped: "+tc.name, func(t *testing.T) {
+			expr, err := logql.ParseExprPermissive(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExprPermissive(%q): %v", tc.query, err)
+			}
+			base, err := logql.LowerAtRange(context.Background(), expr, s, start, end, time.Minute)
+			if err != nil {
+				t.Fatalf("LowerAtRange: %v", err)
+			}
+			pushed, err := logql.LowerAtRangeOpts(context.Background(), expr, s, start, end, time.Minute, logql.LowerOpts{LogLineLimit: 50, LogLineBackward: true})
+			if err != nil {
+				t.Fatalf("LowerAtRangeOpts: %v", err)
+			}
+			if !pushed.Equal(base) {
+				t.Errorf("a metric query's plan changed when LogLineLimit was set; want byte-identical — the limit must never reach a metric query's plan")
+			}
+			if _, ok := pushed.(*chplan.Limit); ok {
+				t.Errorf("metric query plan's top node is *chplan.Limit; must never be wrapped")
+			}
+		})
+	}
 }

--- a/internal/logql/lower.go
+++ b/internal/logql/lower.go
@@ -233,12 +233,23 @@ func lowerWithCtx(ctx context.Context, expr syntax.Expr, s schema.Logs, lc lower
 // inside [lower]'s recursive dispatch — so a metric query's inner selector
 // (RangeAggregationExpr.Left, reached via lowerRangeAggregation calling
 // lowerMatchers/lowerPipelineWithLabels directly, never through this
-// function) can never be wrapped: [syntax.LogSelectorExpr] is only ever the
-// TOP-level expr for a genuine log-line query (see logql.IsMetricQuery's
-// type list — every metric-query expr type is a SampleExpr, not a
-// LogSelectorExpr), and lc.LogLineLimit is threaded only by
-// internal/api/loki's Lang.Parse for the request it is actually building a
-// response for.
+// function) can never be wrapped. lc.LogLineLimit is threaded
+// unconditionally by internal/api/loki's Lang.Parse — including for a
+// metric query, since the handler doesn't know which shape it's building
+// until the lowering classifies the parsed expression — so this function,
+// not the caller, is responsible for rejecting every non-log-line shape.
+//
+// The explicit [IsMetricQuery] guard below is required and NOT redundant
+// with the `syntax.LogSelectorExpr` type-assertion that follows:
+// `*syntax.LiteralExpr` and `*syntax.VectorExpr` both implement
+// `isLogSelectorExpr()` (needed so they satisfy `Selector()` when used as
+// a `SampleExpr` leg of a binary expression) while ALSO being genuine
+// top-level metric queries per [IsMetricQuery]. Without this guard, a
+// top-level `vector(1)` or bare-literal query — [logql.lowerVector] /
+// [logql.lowerLiteral]'s one-row synthetic-scalar plan, which carries no
+// Timestamp column — passed the `LogSelectorExpr` assertion and got
+// wrapped in `ORDER BY Timestamp …`, and ClickHouse rejected the SQL with
+// `Unknown expression identifier 'Timestamp'` (cerberus issue #3047).
 //
 // This is a strictly ADDITIVE fast path: internal/api/loki/handler.go's
 // clampLogRows keeps sorting + truncating every decoded row exactly as it
@@ -248,6 +259,9 @@ func lowerWithCtx(ctx context.Context, expr syntax.Expr, s schema.Logs, lc lower
 // byte-identical to before this change, never wrong.
 func maybePushLogLineLimit(expr syntax.Expr, plan chplan.Node, s schema.Logs, lc lowerCtx) chplan.Node {
 	if lc.LogLineLimit <= 0 {
+		return plan
+	}
+	if IsMetricQuery(expr) {
 		return plan
 	}
 	sel, ok := expr.(syntax.LogSelectorExpr)


### PR DESCRIPTION
## Summary

- `maybePushLogLineLimit` (`internal/logql/lower.go`) used
  `expr.(syntax.LogSelectorExpr)` as a proxy for "this is a genuine
  log-line query." `*syntax.LiteralExpr` and `*syntax.VectorExpr` both
  implement `isLogSelectorExpr()` too (needed so they satisfy
  `Selector()` when used as a `SampleExpr` leg of a binary expression),
  while ALSO being genuine top-level metric queries per
  `logql.IsMetricQuery`. A request `limit` param (threaded
  unconditionally by `internal/api/loki/handler.go`'s
  `langForRangeRequest`, even for metric queries) therefore made a
  top-level `vector(1)` (or bare numeric literal) query wrongly get
  wrapped in a real SQL `ORDER BY Timestamp {DESC|ASC} LIMIT N` on top
  of the synthetic one-row plan `lowerVector`/`lowerLiteral` build — a
  plan that carries only `ResourceAttributes` and `Value`, no
  `Timestamp` column at all — and ClickHouse rejected the query
  (`code: 47, Unknown expression identifier 'Timestamp'`), surfaced to
  clients as a generic HTTP 502.
- Fix: guard `maybePushLogLineLimit` with `IsMetricQuery(expr)` before
  the `LogSelectorExpr` type assertion.
- The existing `TestLogLineLimitPushdown_NoOpWhenLimitZeroOrMetricQuery`
  test's own doc comment made the same false assumption ("a metric
  query's top-level expr never [implements LogSelectorExpr]") and only
  exercised `count_over_time(...)`, which happens not to implement that
  marker interface — so it never exercised the two shapes
  (`vector(1)`, bare literal) that actually regress. Corrected the
  comment and added both shapes as subtests.

## Root cause, with evidence

`showcase-logql`'s `vector()` panel (`expr: vector(1)`, `queryType:
range`) failed identically in the two most recent nightly `e2e`
schedule runs — not a flake, a 100%-reproducible bug:

- Run `33851124650` (2026-09-04, issue #3047): 3 retries × 2 spec files
  = 6 attempts, every one failing the exact same panel with the exact
  same error.
- Run `33953157271` (2026-09-05): reproduced again, same panel, same
  error.

The generic client-facing error (`ClickHouse rejected the query`)
masked the real ClickHouse rejection, found in the `cerberus`
container's own logs:

```
level=WARN msg="cerberus query failed" cerberus_ql=logql
shape_id=cerb:project;limit decision_reason=non-promql exit_class=error
err="chclient: query: code: 47, message: Unknown expression identifier
`Timestamp` in scope SELECT * FROM (SELECT CAST(map(), 'Map(String,String)')
AS ResourceAttributes, toFloat64(CAST(1, 'Float64')) AS Value FROM
(SELECT 1)) ORDER BY Timestamp DESC"
```

That SQL is exactly `logql.syntheticLogScalar`'s one-row `Project`
(`ResourceAttributes`, `Value` — no `Timestamp`) with an `ORDER BY
Timestamp DESC` wrongly appended by `maybePushLogLineLimit`.

## Verification

- `go test -run '^TestLogLineLimitPushdown_NoOpWhenLimitZeroOrMetricQuery$' ./internal/logql/...`
  — new subtests fail without the fix (confirmed by stashing the
  `lower.go` change and re-running: both `vector(1)` and bare-literal
  cases fail with "top node = *chplan.Limit; must never be wrapped"),
  pass with it.
- `go test ./internal/logql/...` and `go test ./internal/api/loki/...`
  — full packages green.
- `go build ./...`, `go vet ./internal/logql/...` — clean.
- `gofumpt` / `goimports -local` — no diffs.

No generated artefact touched (this is a plan-shape defect gated purely
by the API-layer `LogLineLimit` option, which the pre-optimizer
`test/spec/logql` TXTAR lane never threads — no golden regen needed).

## Also found, filed separately as #3068 (not fixed here)

While reading the same nightly logs I found a second, unrelated,
recurring ClickHouse rejection (`code: 36, Step should be greater than
zero`, shape `cerb:project;rwr;union`) in both nightly runs. It did not
fail any test assertion and has a different root cause
(`internal/chsql/range_window_stale_resample.go` truncating a
sub-second `Step` to `0` via `int64(r.Step.Seconds())`). Filed as
tsouza/cerberus#3068 per invariant 3, left for its own fix/PR.

## Test plan

- [x] `go test -run '^TestLogLineLimitPushdown_NoOpWhenLimitZeroOrMetricQuery$' ./internal/logql/...`
- [x] `go test ./internal/logql/...`
- [x] `go test ./internal/api/loki/...`
- [x] `go build ./...`
- [ ] CI: full `just ci` equivalent (lint, test, build) + `compose-smoke`
      nightly lane will confirm the `vector()` panel now passes.

