### PR TITLE
fix(promql): route sub-second Step/Range/Offset off the ts_grid_resample native path

### DIFF
--- a/internal/promql/gremlins_kill_native_grid_guard_test.go
+++ b/internal/promql/gremlins_kill_native_grid_guard_test.go
@@ -193,6 +193,74 @@ func TestNativeLastOverTimeNode_GridGuardRejectsEachUnpinnedClause(t *testing.T)
 	}
 }
 
+// TestNativeTSGridMatrixNode_WholeSecondsConjunction and
+// TestNativeLastOverTimeNode_WholeSecondsConjunction pin the sub-second
+// carve-out added for issue #3068, mirroring
+// TestNativeClassicHistogramEligible_WholeSecondsConjunction (the sibling
+// guard [nativeClassicHistogramEligible] already applied via its own
+// `wholeSeconds` conjunction): a non-whole-second Step, Range, or Offset must
+// each independently reject, one clause at a time so a `&&` collapsed to
+// `||` cannot hide behind the other two staying whole-second.
+//
+// Every field these two funnels gate flows into the timeSeries*ToGrid
+// family's whole-second integer/DateTime parameters (see
+// nativeGridTimeBoundFrag's own doc and this package's use of
+// int64(d.Seconds()) in the chsql emitters). A sub-second Step that reached
+// the native path used to truncate via int64(d.Seconds()) — e.g. 500ms to
+// int64(0.5) == 0 — which ClickHouse rejects outright ("Step should be
+// greater than zero", code 36; the exact issue #3068 rejection, reproduced
+// directly against chDB). Passing the duration through unchanged instead of
+// truncating it is not an option either: chDB also rejects a Float64 step_s
+// argument to timeSeriesRange / timeSeriesResampleToGridWithStaleness with
+// ILLEGAL_TYPE_OF_ARGUMENT, so the family has no faithful sub-second
+// representation at all — the fan-out path these funnels fall back to on
+// rejection fans out at nanosecond precision instead.
+func TestNativeTSGridMatrixNode_WholeSecondsConjunction(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	for _, tc := range []struct {
+		name string
+		mut  func(*chplan.RangeWindow)
+	}{
+		{"step_sub_second", func(rw *chplan.RangeWindow) { rw.Step = 30*time.Second + 500*time.Millisecond }},
+		{"range_sub_second", func(rw *chplan.RangeWindow) { rw.Range = 5*time.Minute + 500*time.Millisecond }},
+		{"offset_sub_second", func(rw *chplan.RangeWindow) { rw.Offset = 500 * time.Millisecond }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := acceptedGridWindow(s)
+			tc.mut(rw)
+			if got := nativeTSGridMatrixNode(rw, "rate", s, false); got != nil {
+				t.Errorf("nativeTSGridMatrixNode accepted a %s window: %#v; want nil so the fan-out path answers it at full precision", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestNativeLastOverTimeNode_WholeSecondsConjunction(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+
+	for _, tc := range []struct {
+		name string
+		mut  func(*chplan.RangeWindow)
+	}{
+		{"step_sub_second", func(rw *chplan.RangeWindow) { rw.Step = 30*time.Second + 500*time.Millisecond }},
+		{"range_sub_second", func(rw *chplan.RangeWindow) { rw.Range = 5*time.Minute + 500*time.Millisecond }},
+		{"offset_sub_second", func(rw *chplan.RangeWindow) { rw.Offset = 500 * time.Millisecond }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rw := acceptedLastOverTimeWindow(s)
+			tc.mut(rw)
+			if got := nativeLastOverTimeNode(rw, s); got != nil {
+				t.Errorf("nativeLastOverTimeNode accepted a %s window: %#v; want nil so the fan-out path answers it at full precision", tc.name, got)
+			}
+		})
+	}
+}
+
 // TestNativeLastOverTimeNode_RequiresSoleIdentityGroupKey pins BOTH halves of
 // the series-identity precondition, which is a disjunction of two independently
 // sufficient rejections.

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -3666,6 +3666,16 @@ func nativeTSGridMatrixNode(rw *chplan.RangeWindow, wantFunc string, s schema.Me
 	if rw.Identity || rw.Step <= 0 || rw.Start.IsZero() || rw.End.IsZero() {
 		return nil
 	}
+	// timeSeries*ToGrid (here timeSeriesRateToGrid / timeSeriesPredictLinearToGrid
+	// per wantFunc) takes grid_step and window as whole-second integers and its
+	// start/end as whole-second DateTime bounds (nativeGridTimeBoundFrag), so a
+	// sub-second Step, matrix [range] (rw.Range), or Offset has no faithful
+	// native representation — see NativeStalenessLowerer.LowerStaleness for the
+	// verified failure mode (issue #3068). Falling back to nil routes to the
+	// fan-out RangeWindow, which fans out at nanosecond precision instead.
+	if !wholeSeconds(rw.Step) || !wholeSeconds(rw.Range) || !wholeSeconds(rw.Offset) {
+		return nil
+	}
 	if !isNativeRateInput(rw.Input, s) {
 		return nil
 	}
@@ -3847,6 +3857,17 @@ func nativeLastOverTimeNode(rw *chplan.RangeWindow, s schema.Metrics) *chplan.Ra
 		return nil
 	}
 	if rw.Identity || rw.Step <= 0 || rw.Start.IsZero() || rw.End.IsZero() {
+		return nil
+	}
+	// The timeSeries*ToGrid family (this node renders through
+	// timeSeriesResampleToGridWithStaleness) takes step_s/window_s as
+	// whole-second integers, so a sub-second Step or Range (last_over_time's
+	// matrix [range] literal, which becomes this node's Lookback) has no
+	// faithful native representation — see NativeStalenessLowerer.LowerStaleness
+	// for the verified failure mode (issue #3068). The fan-out RangeWindow this
+	// function's caller (NativeLastOverTimeLowerer.LowerLastOverTime) falls back
+	// to on nil fans out at nanosecond precision instead.
+	if !wholeSeconds(rw.Step) || !wholeSeconds(rw.Range) || !wholeSeconds(rw.Offset) {
 		return nil
 	}
 	if !isNativeRateInput(rw.Input, s) {

--- a/internal/promql/lower_strategy.go
+++ b/internal/promql/lower_strategy.go
@@ -1019,10 +1019,10 @@ type NativeStalenessLowerer struct {
 }
 
 // LowerStaleness returns a RangeWindowStaleResample for the range-mode staleness
-// input, or delegates to the embedded Fallback for the one shape the native
+// input, or delegates to the embedded Fallback for a shape the native
 // aggregate cannot express.
 //
-// That carve-out is `in.sampleTimestamp`.
+// The first carve-out is `in.sampleTimestamp`.
 // timeSeriesResampleToGridWithStaleness returns ONLY the resampled VALUE per
 // grid point (an Array(Nullable(Float64))); the timestamp of the sample each
 // grid point carried forward is not among its outputs, and no member of the
@@ -1032,8 +1032,21 @@ type NativeStalenessLowerer struct {
 // carve-out delegates rather than emitting an answer the native shape would
 // have to fake from the anchor. Both paths therefore agree on
 // `timestamp(<selector>)`; they simply reach the agreement on the fan-out.
+//
+// The second carve-out is a sub-second step/lookback/offset (checked with the
+// same wholeSeconds helper nativeClassicHistogramEligible uses). The whole
+// timeSeries*ToGrid family takes step_s/window_s as whole-second integers and
+// start/end as whole-second DateTime literals (see nativeGridTimeBoundFrag),
+// so a sub-second value has no faithful native representation — passing a
+// Float64 step_s is rejected outright (ILLEGAL_TYPE_OF_ARGUMENT), and
+// chsql.emitRangeWindowStaleResample instead truncates it via
+// int64(d.Seconds()), which silently collapses e.g. a 500ms step to 0 and
+// ClickHouse then rejects with "Step should be greater than zero" (issue
+// #3068 — both failure modes verified against chDB). The fan-out RangeLWR
+// fans out at nanosecond precision (toIntervalNanosecond), so it answers a
+// sub-second shape correctly instead of merely avoiding the crash.
 func (n NativeStalenessLowerer) LowerStaleness(in stalenessLowerInput) chplan.Node {
-	if in.sampleTimestamp {
+	if in.sampleTimestamp || !wholeSeconds(in.step) || !wholeSeconds(in.lookback) || !wholeSeconds(in.offset) {
 		return n.Fallback.LowerStaleness(in)
 	}
 	return &chplan.RangeWindowStaleResample{

--- a/internal/promql/native_staleness_lowerer_internal_test.go
+++ b/internal/promql/native_staleness_lowerer_internal_test.go
@@ -1,0 +1,105 @@
+package promql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// acceptedStalenessInput is a stalenessLowerInput [NativeStalenessLowerer]
+// accepts — mirrors acceptedGridWindow/acceptedLastOverTimeWindow in
+// gremlins_kill_native_grid_guard_test.go, but for the bare-selector
+// staleness shape (the exact `cerb:project;rwr;union` shape reported in
+// issue #3068, which reaches RangeWindowStaleResample via LowerStaleness
+// rather than via last_over_time).
+func acceptedStalenessInput() stalenessLowerInput {
+	s := schema.DefaultOTelMetrics()
+	return stalenessLowerInput{
+		input:         nativeGuardInput(s),
+		start:         nativeGuardStart(),
+		end:           nativeGuardEnd(),
+		step:          nativeGuardStep,
+		lookback:      5 * time.Minute,
+		offset:        0,
+		metricNameCol: s.MetricNameColumn,
+		attributesCol: s.AttributesColumn,
+		timestampCol:  s.TimestampColumn,
+		valueCol:      s.ValueColumn,
+	}
+}
+
+// TestNativeStalenessLowerer_WholeSecondsConjunction pins the sub-second
+// carve-out NativeStalenessLowerer.LowerStaleness applies on top of its
+// pre-existing sampleTimestamp carve-out: a sub-second step, lookback, or
+// offset must each independently route to the Fallback (fan-out RangeLWR),
+// never to the native RangeWindowStaleResample node.
+//
+// Before this carve-out existed, a sub-second step reached
+// chsql.emitRangeWindowStaleResample's `int64(r.Step.Seconds())` truncation,
+// which collapses e.g. 500ms to stepSeconds == 0 — silently producing the
+// exact ClickHouse rejection issue #3068 reported ("Step should be greater
+// than zero", code 36; verified directly against chDB: passing a Float64
+// step_s to timeSeriesRange/timeSeriesResampleToGridWithStaleness is
+// ALSO rejected outright with ILLEGAL_TYPE_OF_ARGUMENT, so the family
+// genuinely has no faithful sub-second representation at all — the fix must
+// avoid the native path, not widen its argument type).
+func TestNativeStalenessLowerer_WholeSecondsConjunction(t *testing.T) {
+	t.Parallel()
+	l := NativeStalenessLowerer{Fallback: FanoutStalenessLowerer{}}
+
+	baseline := l.LowerStaleness(acceptedStalenessInput())
+	if _, ok := baseline.(*chplan.RangeWindowStaleResample); !ok {
+		t.Fatalf("baseline whole-second staleness input did not reach the native node (%T); the rejection cases below would be vacuous", baseline)
+	}
+
+	for _, tc := range []struct {
+		name string
+		mut  func(*stalenessLowerInput)
+	}{
+		{"step_sub_second", func(in *stalenessLowerInput) { in.step = 30*time.Second + 500*time.Millisecond }},
+		{"lookback_sub_second", func(in *stalenessLowerInput) { in.lookback = 90*time.Second + 500*time.Millisecond }},
+		{"offset_sub_second", func(in *stalenessLowerInput) { in.offset = 500 * time.Millisecond }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := acceptedStalenessInput()
+			tc.mut(&in)
+			got := l.LowerStaleness(in)
+			if _, ok := got.(*chplan.RangeWindowStaleResample); ok {
+				t.Errorf("LowerStaleness(%s) returned the native node; want the fan-out RangeLWR so a sub-second value is answered instead of truncated to an invalid step_s=0", tc.name)
+			}
+			if _, ok := got.(*chplan.RangeLWR); !ok {
+				t.Errorf("LowerStaleness(%s) = %T, want *chplan.RangeLWR (the Fallback)", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestNativeStalenessLowerer_WholeSecondStepRendersNoInvalidZero is the
+// end-to-end regression guard: it exercises the SAME emit path issue #3068
+// pinned (emitRangeWindowStaleResample via a RangeWindowStaleResample node),
+// proving a sub-second step never reaches it (case a) while a normal
+// >=1s step still does, unaffected (case b).
+func TestNativeStalenessLowerer_WholeSecondStepRendersNoInvalidZero(t *testing.T) {
+	t.Parallel()
+	l := NativeStalenessLowerer{Fallback: FanoutStalenessLowerer{}}
+
+	subSecond := acceptedStalenessInput()
+	subSecond.step = 500 * time.Millisecond
+	if got := l.LowerStaleness(subSecond); isRangeWindowStaleResample(got) {
+		t.Fatalf("a sub-second Step reached RangeWindowStaleResample: %#v — it would render stepSeconds=int64(0.5)=0, the exact issue #3068 ClickHouse rejection", got)
+	}
+
+	wholeSecond := acceptedStalenessInput()
+	wholeSecond.step = 30 * time.Second
+	if got := l.LowerStaleness(wholeSecond); !isRangeWindowStaleResample(got) {
+		t.Fatalf("a normal >=1s Step no longer reaches RangeWindowStaleResample: %T; the whole-seconds carve-out must not regress the native fast path", got)
+	}
+}
+
+func isRangeWindowStaleResample(n chplan.Node) bool {
+	_, ok := n.(*chplan.RangeWindowStaleResample)
+	return ok
+}


### PR DESCRIPTION
## Summary

Fixes issue #3068: a sub-second PromQL `step` (Grafana can compute one for a
short auto time range) that reached the `RangeWindowStaleResample`
(`cerb:project;rwr;union` shape) native lowering silently truncated to
`stepSeconds == 0` via `int64(r.Step.Seconds())` in
`internal/chsql/range_window_stale_resample.go`, which ClickHouse rejects
outright with `code: 36, message: Step should be greater than zero` — the
exact recurring nightly `compose-smoke` WARN the issue pinned.

## Root cause

The `timeSeries*ToGrid` ClickHouse function family
(`timeSeriesRange`, `timeSeriesResampleToGridWithStaleness`,
`timeSeriesRateToGrid`, `timeSeriesPredictLinearToGrid`) takes
`step_s`/`window_s` as whole-second integers and `start`/`end` as
whole-second `DateTime` bounds (`internal/chsql/range_window.go`'s
`nativeGridTimeBoundFrag` doc). `internal/promql`'s eligibility funnels for
this family only guarded `Step <= 0`, not sub-second — so a genuinely
sub-second `Step` (or matrix `[range]`/`Offset`) reached the native emitter,
which truncates via `int64(d.Seconds())`.

**Verified directly against chDB** (not assumed):

```
[int-step-timeSeriesRange]       OK
[frac-step-timeSeriesRange-0.5]  ERROR Code 43 ILLEGAL_TYPE_OF_ARGUMENT (ClickHouse rejects a Float64 step_s outright)
[zero-step-timeSeriesRange]      ERROR Code 36 "Step should be greater than zero"
[truncated-step-timeSeriesRange] ERROR Code 36 "Step should be greater than zero"  <- reproduces int64(0.5)==0, i.e. #3068 exactly
[frac-step-resample]             ERROR Code 43 ILLEGAL_TYPE_OF_ARGUMENT (same on the aggregate form)
[int-step-resample]              OK
```

This confirms the family has **no faithful sub-second representation at
all** — not even via a float argument. So the correct fix is not "round up
to 1s" (that would silently answer at the wrong precision) nor "widen the
argument type" (ClickHouse itself refuses it) — it's to keep a genuinely
sub-second window off this native path entirely, the same way this codebase
already treats the identical constraint for its `RangeBucketGridNative`
sibling.

## Why this shape of fix

`internal/promql/histogram_quantile_classic_native.go`'s
`nativeClassicHistogramEligible` **already** gates exactly this constraint
with a `wholeSeconds(step) && wholeSeconds(lookback) && wholeSeconds(offset)`
conjunction (added for the classic-histogram native lowering), with a doc
comment describing this precise failure mode. That guard was correct and
already proven — it was simply never extended to the two sibling native
lowering funnels that share the same constraint:

- `NativeStalenessLowerer.LowerStaleness` (`internal/promql/lower_strategy.go`)
  — the exact bare-selector shape from the issue (`RangeWindowStaleResample`
  reached via `LowerStaleness`, not `last_over_time`).
- `nativeLastOverTimeNode` (`internal/promql/lower.go`) — `last_over_time`'s
  own path to the same `RangeWindowStaleResample` node.
- `nativeTSGridMatrixNode` (`internal/promql/lower.go`) — the
  `rate`/`increase`/`changes`/`resets`/`deriv`/`predict_linear` family
  (`RangeWindowGridNative`), which truncates `Step`/`Range` the identical
  way (`internal/chsql/range_window_grid_native.go`).

This PR reuses the same already-tested `wholeSeconds` helper (DRY — no new
logic invented) to close all three, so a sub-second `Step`, matrix `Range`,
or `Offset` now falls back to the fan-out path (`RangeLWR` / `RangeWindow`),
which fans out at **nanosecond** precision (`toIntervalNanosecond`) and
answers the query *correctly* instead of merely avoiding the crash.

## Tests

- `internal/promql/native_staleness_lowerer_internal_test.go` (new):
  `TestNativeStalenessLowerer_WholeSecondsConjunction` proves a sub-second
  step/lookback/offset each independently routes
  `NativeStalenessLowerer.LowerStaleness` to the fan-out `RangeLWR`, one
  clause at a time. `TestNativeStalenessLowerer_WholeSecondStepRendersNoInvalidZero`
  is the end-to-end regression guard requested by the issue: (a) a 500ms
  step never reaches `RangeWindowStaleResample` (so it can never render the
  invalid `stepSeconds=0`), and (b) a normal 30s step still does
  (no regression to the native fast path).
- `internal/promql/gremlins_kill_native_grid_guard_test.go`: added
  `TestNativeTSGridMatrixNode_WholeSecondsConjunction` and
  `TestNativeLastOverTimeNode_WholeSecondsConjunction`, mirroring the
  existing `TestNativeClassicHistogramEligible_WholeSecondsConjunction`
  pattern for the two other funnels.
- Confirmed all four new tests **fail** against the pre-fix code (`git
  stash` on `lower.go`/`lower_strategy.go` only) — they are not vacuous.
- Existing native-resample/native-last_over_time fixtures
  (`test/spec/promql/native_resample_*.txtar`,
  `native_last_over_time_range_step.txtar`, etc.) still pass unchanged,
  confirming whole-second steps are unaffected.
- `go test ./internal/promql/...` — full package green.
- `node .github/scripts/forbid-sql-raw.mjs` — clean (no chsql touched by
  this PR).

Closes #3068
