### PR TITLE
feat(logql): thread JSON attribute strategy through full-map ops and discovery endpoints

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2872,13 +2872,42 @@ precise boot-time finding:
     - **Logs**: per-key attribute lookups now work against a JSON-typed
       column — stream-selector label matchers (`{app="foo"}`),
       `detected_level`, and any other bare `MapAccess`/`mapContains` read.
-      The warning names what remains unsupported: LogQL operations that need
-      the *whole* attribute map at once (`| line_format`, `| label_format`,
-      `| unpack`, wildcard `keep`/`drop`), the `/labels` / `/series` /
-      `/detected_fields` metadata endpoints (their queries bypass the
-      per-key lowering entirely), and a table whose ingestion ever used
-      `json_type_escape_dots_in_keys=1` or mixes dotted-key encodings —
-      tracked as [#3063](https://github.com/tsouza/cerberus/issues/3063).
+      [#3063](https://github.com/tsouza/cerberus/issues/3063) closed the
+      remaining LogQL-side gaps this warning used to name:
+      - **Full-map operations** — `withDetectedLevelAndColumns`'s
+        `mapConcat`/`mapFilter` identity synthesis (runs on essentially
+        every log-stream query), `structuredMetadataExpr`'s `mapFilter`
+        over `LogAttributes`, every parser-stage label merge
+        (`PipelineLabelsExpr`'s `mapConcat`/`mapApply` chain), and a bare
+        attribute-map projection with no wrapping stage at all — all now
+        render correctly against a JSON-typed column via a bounded-depth
+        reconstruction into a genuine `Map(String,String)`
+        (`internal/chsql/attr_strategy_fullmap.go`). ClickHouse's JSON type
+        has no per-row dynamic-path value extraction (verified empirically:
+        `JSONExtractString`/`JSONExtract`/`getSubcolumn` against a JSON
+        operand all reject a non-constant path), so the reconstruction
+        round-trips through `toJSONString` + the fully-dynamic
+        `JSONExtractKeysAndValuesRaw`, re-applied up to
+        `maxJSONAttrFlattenDepth` (3) additional levels beyond the first —
+        enough to fully flatten any OTel key of up to 4 dot segments (e.g.
+        `k8s.container.status.last_terminated_reason`). A key nested
+        deeper than that keeps its remaining structure as an **unparsed
+        raw JSON substring** under its partial dotted key in the
+        reconstructed map — present and non-empty, never silently dropped
+        — rather than fully flattening; this bound has not been observed
+        to bind on any real OTel semantic-convention key.
+      - **Metadata/discovery endpoints** — `/labels`, `/series`,
+        `/label/<name>/values`, `/detected_labels` and `/detected_fields`
+        build their SQL directly against `chsql.NewQuery()` rather than
+        through `chplan`, so they never reached `AttrStrategies` threading
+        at all; each now resolves the Handler's `AttrStrategies` itself
+        (`internal/api/loki/attr_strategy.go`) and renders `JSONAllPaths`
+        for key discovery / the same bounded reconstruction for whole-map
+        reads. `/patterns` needed no change — it never reads an
+        attribute-map column.
+      - **`json_type_escape_dots_in_keys` / mixed-history hazard** — see
+        the dedicated callout below this list, shared verbatim with
+        traces.
     - **Traces**: per-key attribute lookups and comparisons now work against
       a JSON-typed column too — span/resource/scope attribute matchers
       (`{ span.foo = "bar" }`), numeric/duration comparisons
@@ -2899,6 +2928,44 @@ precise boot-time finding:
       regardless of filter shape until #3065 lands the full-map JSON
       bridge, if `ResourceAttributes` (not `SpanAttributes` /
       `ScopeAttributes`) is the JSON-typed column.
+    - **`json_type_escape_dots_in_keys` / mixed-history hazard — the
+      decision, shared by logs and traces (cerberus issues #3063 and
+      #3065's identical point 3).** Every JSON rendering above (per-key
+      and full-map alike) targets ClickHouse's **default** dot-nesting
+      behaviour only: `{"http.status_code":"200"}` nests to a two-level
+      path, addressed via the backtick-quoted compile-time token
+      `` col.`http.status_code`.:String ``. A table whose ingestion path
+      ever set `json_type_escape_dots_in_keys=1` (CH 25.8+,
+      percent-encoded FLAT keys — `http.status_code` stored as the
+      literal, unnested key `http%2Estatus_code`) reads back **NULL /
+      missing** against every rendering this document describes, and a
+      table that ingested under BOTH settings at different times (a
+      config change, or a mixed exporter fleet) has the same logical key
+      live under two different physical paths simultaneously — no
+      boot-time `system.columns`-style schema check can rule this out; it
+      would need a bounded content sample of `distinctJSONPaths(<col>)`,
+      not just a type check. Cerberus's decision, made explicitly rather
+      than left implicit: **ship this as a documented, loud limitation
+      rather than add a boot-time refuse gate.** A refuse gate would need
+      either a `system.settings` probe (which cannot see a *past*
+      ingestion-time setting, only the server's *current* one — the
+      mixed-history case specifically defeats it) or a new
+      operator-facing acknowledgement config knob, and either way could
+      only rule out the single-setting case, not the mixed-history one —
+      so it would trade a straightforward, honest limitation for a
+      partial, false sense of safety plus a new boot-time failure mode
+      operators would have to learn. The startup warning this section
+      documents already names the exception loudly at boot; that,
+      together with this document, is the loud signal. An operator who
+      knows their ingestion path ever set `json_type_escape_dots_in_keys=1`
+      should not enable JSON-typed attribute columns without first
+      re-verifying current ClickHouse behaviour empirically (a version
+      bump may change what is and is not supported) and confirming their
+      table's own ingestion history — cerberus cannot discover that
+      history on their behalf. Any future work that actually detects or
+      bridges the escape-dots encoding should update both this section
+      and its logs/traces counterparts together, since the hazard and the
+      underlying ClickHouse setting are identical for both signals.
     - Metrics attribute-map columns are **not** covered by this exception
       and stay `Map(String, String)`-only — they carry the metric's series
       identity, out of scope per the issue itself.

--- a/internal/api/loki/attr_strategy.go
+++ b/internal/api/loki/attr_strategy.go
@@ -1,0 +1,57 @@
+package loki
+
+import "github.com/tsouza/cerberus/internal/chsql"
+
+// This file is cerberus issue #3063 point 2's fix: /loki/api/v1/labels,
+// /series, /label/<name>/values, /detected_fields and /detected_labels all
+// build their SQL directly against chsql.NewQuery() rather than through a
+// chplan tree lowered by logql.Lang.Parse, so they never reach
+// engine.emitForHead / chsql.Emit's ctx-based AttrStrategies threading —
+// wiring Handler.AttrStrategies alone (cerberus issue #2777 / #3064) had
+// no effect on any of them. Each build*SQL function in this package now
+// takes the resolved chsql.AttrStrategies explicitly and threads it onto
+// every chsql.QueryBuilder it constructs via .WithAttrStrategies — that
+// alone makes every per-key JSON rendering chsql already has
+// (exprMapAccess, exprMapContainsKey) reach the selector-matcher WHERE
+// clause every one of these builders shares (applySelectorAndWindow), and
+// the two helpers below cover the WHOLE-MAP shapes these builders read
+// that per-key rendering never touched.
+//
+// /patterns (patterns.go) is not in this list: it only projects
+// Timestamp/Body/SeverityText, never an attribute-map column, so it has
+// no JSON-strategy exposure at all.
+
+// attrMapFrag renders col as a genuine Map(String,String) Frag: the bare
+// column reference when strategies resolves it to AttrStrategyMap (the
+// default, and every pre-#3063 call site's byte-identical behaviour), or
+// chsql.JSONAttrMapReconstruction(col) when it resolves to
+// AttrStrategyJSON. Used wherever one of these builders reads or GROUPs
+// BY a whole attribute map — series.go / detected_labels.go's
+// canonicalLabelsFrag input (the stream label-set identity) and
+// detected_fields.go's stream_labels / log_attributes projections (the
+// per-line structured-metadata peek).
+func attrMapFrag(strategies chsql.AttrStrategies, col string) chsql.Frag {
+	if strategies.Lookup(col) == chsql.AttrStrategyJSON {
+		return chsql.JSONAttrMapReconstruction(col)
+	}
+	return chsql.Col(col)
+}
+
+// distinctAttrKeysFrag renders the discovery-query idiom "every distinct
+// key present in col across the matched rows" — /labels' whole shape. The
+// Map-typed branch is the .keys-subcolumn shape labels.go's own former
+// distinctMapKeysFrag used (folded into this function), unchanged
+// (labels.go's own doc explains why arrayJoin(col.keys) is used instead
+// of mapKeys(col)); the JSON-strategy branch uses JSONAllPaths(col)
+// instead, which reports the SAME flat dot-joined leaf key strings the
+// Map .keys subcolumn would for an equivalent flat key set — see
+// chsql's jsonFullMapReconstruction doc for why JSONAllPaths already
+// does this without needing chsql's full bounded-depth-flatten machinery
+// (a KEY enumeration is exactly the shape ClickHouse's own JSONAllPaths
+// natively reports; only per-key VALUE extraction needed that machinery).
+func distinctAttrKeysFrag(strategies chsql.AttrStrategies, col string) chsql.Frag {
+	if strategies.Lookup(col) == chsql.AttrStrategyJSON {
+		return chsql.Distinct(chsql.Call("arrayJoin", chsql.Call("JSONAllPaths", chsql.Col(col))))
+	}
+	return chsql.Distinct(chsql.Call("arrayJoin", chsql.Qual(col, "keys")))
+}

--- a/internal/api/loki/attr_strategy_fullmap_chdb_test.go
+++ b/internal/api/loki/attr_strategy_fullmap_chdb_test.go
@@ -1,0 +1,456 @@
+//go:build chdb
+
+// chDB-backed end-to-end coverage for cerberus issue #3063 point 2: the
+// ad-hoc discovery-endpoint query builders (/labels, /series,
+// /detected_labels, /detected_fields, /label/<name>/values) never route
+// through chplan/engine.emitForHead, so they need their own JSON-aware
+// rendering (attr_strategy.go's attrMapFrag / distinctAttrKeysFrag,
+// chsql's Builder.MapAt fix) gated on the SAME Handler.AttrStrategies the
+// normal query path resolves. Each test here runs the SAME HTTP request
+// against a Map-typed otel_logs table and a logically equivalent
+// JSON-typed one, and asserts the decoded responses agree — genuine chDB
+// execution through the real HTTP handler, not a hand-built comparison
+// string.
+package loki_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/loki"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// fullMapDiscoverySeedBase is the fixed anchor every seed row in this file
+// is offset from, so request URLs can frame [start, end] precisely.
+var fullMapDiscoverySeedBase = time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+
+const fullMapDiscoveryTSFmt = "2006-01-02 15:04:05.000"
+
+// fullMapDiscoveryMapDDL / fullMapDiscoveryJSONDDL seed logically
+// equivalent otel_logs tables — one Map(String,String), one JSON — with:
+//
+//   - two rows on stream job=api (service.name=svc-a), one on job=web
+//     (service.name=svc-b) — /series and /detected_labels must group these
+//     into the same two/one distinct stream identities on both tables;
+//   - an http.status_code attribute present on the api rows only, so
+//     /labels' key set and /label/http.status_code/values' value set both
+//     exercise a dotted OTel key end to end;
+//   - one row outside the request window, excluded by the time bound on
+//     both tables identically.
+const fullMapDiscoveryMapDDL = `CREATE TABLE %[5]s (
+    Timestamp DateTime64(9),
+    Body String,
+    LogAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+
+INSERT INTO %[5]s (Timestamp, Body, LogAttributes, ResourceAttributes) VALUES
+    (toDateTime64('%[1]s', 9), 'line one', map(), map('job', 'api', 'service.name', 'svc-a', 'http.status_code', '200')),
+    (toDateTime64('%[2]s', 9), 'line two', map(), map('job', 'api', 'service.name', 'svc-a', 'http.status_code', '500')),
+    (toDateTime64('%[3]s', 9), 'line three', map(), map('job', 'web', 'service.name', 'svc-b')),
+    (toDateTime64('%[4]s', 9), 'line outside window', map(), map('job', 'api', 'service.name', 'svc-a', 'http.status_code', '404'));
+`
+
+const fullMapDiscoveryJSONDDL = `CREATE TABLE %[5]s (
+    Timestamp DateTime64(9),
+    Body String,
+    LogAttributes JSON,
+    ResourceAttributes JSON
+) ENGINE = Memory;
+
+INSERT INTO %[5]s (Timestamp, Body, LogAttributes, ResourceAttributes) VALUES
+    (toDateTime64('%[1]s', 9), 'line one', '{}', '{"job":"api","service.name":"svc-a","http.status_code":"200"}'),
+    (toDateTime64('%[2]s', 9), 'line two', '{}', '{"job":"api","service.name":"svc-a","http.status_code":"500"}'),
+    (toDateTime64('%[3]s', 9), 'line three', '{}', '{"job":"web","service.name":"svc-b"}'),
+    (toDateTime64('%[4]s', 9), 'line outside window', '{}', '{"job":"api","service.name":"svc-a","http.status_code":"404"}');
+`
+
+// newDiscoveryChDBServer boots a real chDB-backed Handler against ddl
+// (formatted with the four seed-row timestamps plus a distinct table
+// name), with AttrStrategies wired exactly as cmd/cerberus's boot path
+// wires it for a JSON-typed schema — nil for a Map-typed table
+// (attr_strategy.go's attrMapFrag / distinctAttrKeysFrag's own no-op
+// default, identical to every call site that predates cerberus issue
+// #3063).
+//
+// tableName MUST differ between the Map and JSON variant a single test
+// function boots: chdb-go shares one engine (and one default database)
+// across the whole test process (chclienttest.Client.Seed's own doc), so
+// two servers built back to back against the SAME table name have the
+// second's `CREATE OR REPLACE TABLE` silently swap the first's
+// already-built httptest.Server onto a table of the OTHER physical type
+// before either has served a single request — exactly the false failure
+// this comment exists to head off.
+func newDiscoveryChDBServer(t *testing.T, ddlTemplate, tableName string, jsonStrategy bool) *httptest.Server {
+	t.Helper()
+	ddl := fmt.Sprintf(
+		ddlTemplate,
+		fullMapDiscoverySeedBase.Format(fullMapDiscoveryTSFmt),
+		fullMapDiscoverySeedBase.Add(1*time.Second).Format(fullMapDiscoveryTSFmt),
+		fullMapDiscoverySeedBase.Add(2*time.Second).Format(fullMapDiscoveryTSFmt),
+		fullMapDiscoverySeedBase.Add(2*time.Hour).Format(fullMapDiscoveryTSFmt),
+		tableName,
+	)
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, ddl)
+	s := schema.DefaultOTelLogs()
+	s.LogsTable = tableName
+	h := loki.New(c, s, nil)
+	if jsonStrategy {
+		h.AttrStrategies = chsql.AttrStrategies{
+			s.ResourceAttributesColumn: chsql.AttrStrategyJSON,
+			s.AttributesColumn:         chsql.AttrStrategyJSON,
+		}
+		h.Lang.AttrStrategies = h.AttrStrategies
+	}
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newMapDiscoveryServer(t *testing.T) *httptest.Server {
+	return newDiscoveryChDBServer(t, fullMapDiscoveryMapDDL, "otel_logs_fullmap_map", false)
+}
+
+func newJSONDiscoveryServer(t *testing.T) *httptest.Server {
+	return newDiscoveryChDBServer(t, fullMapDiscoveryJSONDDL, "otel_logs_fullmap_json", true)
+}
+
+func discoveryWindowParams() (startUnix, endUnix int64) {
+	return fullMapDiscoverySeedBase.Add(-1 * time.Minute).Unix(), fullMapDiscoverySeedBase.Add(1 * time.Minute).Unix()
+}
+
+func decodeStringSliceResponse(t *testing.T, resp *http.Response) []string {
+	t.Helper()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var out struct {
+		Status string   `json:"status"`
+		Data   []string `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	sort.Strings(out.Data)
+	return out.Data
+}
+
+// TestLabels_JSONStrategy_ChDB pins /loki/api/v1/labels: the JSON-typed
+// table's key set (via distinctAttrKeysFrag's JSONAllPaths branch) must
+// match the Map-typed table's (.keys subcolumn branch) exactly, dotted
+// OTel key (http.status_code) included.
+func TestLabels_JSONStrategy_ChDB(t *testing.T) {
+	startUnix, endUnix := discoveryWindowParams()
+	url := func(base string) string {
+		return fmt.Sprintf("%s/loki/api/v1/labels?start=%d&end=%d", base, startUnix, endUnix)
+	}
+
+	mapSrv := newMapDiscoveryServer(t)
+	jsonSrv := newJSONDiscoveryServer(t)
+
+	mapResp, err := http.Get(url(mapSrv.URL))
+	if err != nil {
+		t.Fatalf("GET map: %v", err)
+	}
+	jsonResp, err := http.Get(url(jsonSrv.URL))
+	if err != nil {
+		t.Fatalf("GET json: %v", err)
+	}
+
+	mapGot := decodeStringSliceResponse(t, mapResp)
+	jsonGot := decodeStringSliceResponse(t, jsonResp)
+
+	if len(mapGot) == 0 {
+		t.Fatal("Map-typed /labels returned no keys — seed or window is broken, test proves nothing")
+	}
+	if fmt.Sprint(mapGot) != fmt.Sprint(jsonGot) {
+		t.Errorf("/labels: Map = %v, JSON = %v, want equal", mapGot, jsonGot)
+	}
+}
+
+// TestLabelValues_JSONStrategy_ChDB pins
+// /loki/api/v1/label/http_status_code/values (the dotted
+// http.status_code key, normalised to its underscored wire form) end to
+// end: the JSON-typed table must return the same distinct value set as
+// the Map-typed one, with the out-of-window row's 404 excluded on both.
+func TestLabelValues_JSONStrategy_ChDB(t *testing.T) {
+	startUnix, endUnix := discoveryWindowParams()
+	url := func(base string) string {
+		return fmt.Sprintf("%s/loki/api/v1/label/http_status_code/values?start=%d&end=%d", base, startUnix, endUnix)
+	}
+
+	mapSrv := newMapDiscoveryServer(t)
+	jsonSrv := newJSONDiscoveryServer(t)
+
+	mapResp, err := http.Get(url(mapSrv.URL))
+	if err != nil {
+		t.Fatalf("GET map: %v", err)
+	}
+	jsonResp, err := http.Get(url(jsonSrv.URL))
+	if err != nil {
+		t.Fatalf("GET json: %v", err)
+	}
+
+	mapGot := decodeStringSliceResponse(t, mapResp)
+	jsonGot := decodeStringSliceResponse(t, jsonResp)
+
+	want := []string{"200", "500"}
+	if fmt.Sprint(mapGot) != fmt.Sprint(want) {
+		t.Fatalf("Map label values = %v, want %v (seed/window sanity)", mapGot, want)
+	}
+	if fmt.Sprint(jsonGot) != fmt.Sprint(want) {
+		t.Errorf("JSON label values = %v, want %v", jsonGot, want)
+	}
+}
+
+// TestSeries_JSONStrategy_ChDB pins /loki/api/v1/series: the JSON-typed
+// table's distinct label-set enumeration (attrMapFrag's
+// JSONAttrMapReconstruction branch feeding canonicalLabelsFrag's GROUP BY)
+// must report the same three distinct streams the Map-typed table does —
+// http_status_code is a stream-identity (ResourceAttributes) label in the
+// shared seed, so the two in-window api rows' differing status codes
+// genuinely form two separate streams, plus the one web stream.
+func TestSeries_JSONStrategy_ChDB(t *testing.T) {
+	startUnix, endUnix := discoveryWindowParams()
+	url := func(base string) string {
+		return fmt.Sprintf("%s/loki/api/v1/series?start=%d&end=%d", base, startUnix, endUnix)
+	}
+
+	mapSrv := newMapDiscoveryServer(t)
+	jsonSrv := newJSONDiscoveryServer(t)
+
+	mapResp, err := http.Get(url(mapSrv.URL))
+	if err != nil {
+		t.Fatalf("GET map: %v", err)
+	}
+	jsonResp, err := http.Get(url(jsonSrv.URL))
+	if err != nil {
+		t.Fatalf("GET json: %v", err)
+	}
+	defer mapResp.Body.Close()
+	defer jsonResp.Body.Close()
+
+	if mapResp.StatusCode != http.StatusOK {
+		t.Fatalf("map status=%d", mapResp.StatusCode)
+	}
+	if jsonResp.StatusCode != http.StatusOK {
+		t.Fatalf("json status=%d", jsonResp.StatusCode)
+	}
+
+	var mapOut, jsonOut struct {
+		Data []map[string]string `json:"data"`
+	}
+	if err := json.NewDecoder(mapResp.Body).Decode(&mapOut); err != nil {
+		t.Fatalf("decode map: %v", err)
+	}
+	if err := json.NewDecoder(jsonResp.Body).Decode(&jsonOut); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+
+	if len(mapOut.Data) != 3 {
+		t.Fatalf("Map /series returned %d streams, want 3 (seed/window sanity): %+v", len(mapOut.Data), mapOut.Data)
+	}
+	if len(jsonOut.Data) != 3 {
+		t.Errorf("JSON /series returned %d streams, want 3: %+v", len(jsonOut.Data), jsonOut.Data)
+	}
+
+	keyOf := func(m map[string]string) string {
+		return fmt.Sprint(m["job"], "|", m["service_name"], "|", m["http_status_code"])
+	}
+	mapKeys := map[string]bool{}
+	for _, m := range mapOut.Data {
+		mapKeys[keyOf(m)] = true
+	}
+	for _, m := range jsonOut.Data {
+		if !mapKeys[keyOf(m)] {
+			t.Errorf("JSON /series stream %+v has no Map-side counterpart", m)
+		}
+	}
+}
+
+// TestDetectedLabels_JSONStrategy_ChDB pins /loki/api/v1/detected_labels:
+// per-key cardinality derived from the JSON-typed table's reconstructed
+// label sets must match the Map-typed table's.
+func TestDetectedLabels_JSONStrategy_ChDB(t *testing.T) {
+	startUnix, endUnix := discoveryWindowParams()
+	url := func(base string) string {
+		return fmt.Sprintf("%s/loki/api/v1/detected_labels?start=%d&end=%d", base, startUnix, endUnix)
+	}
+
+	mapSrv := newMapDiscoveryServer(t)
+	jsonSrv := newJSONDiscoveryServer(t)
+
+	mapResp, err := http.Get(url(mapSrv.URL))
+	if err != nil {
+		t.Fatalf("GET map: %v", err)
+	}
+	jsonResp, err := http.Get(url(jsonSrv.URL))
+	if err != nil {
+		t.Fatalf("GET json: %v", err)
+	}
+	defer mapResp.Body.Close()
+	defer jsonResp.Body.Close()
+
+	var mapOut, jsonOut struct {
+		DetectedLabels []loki.DetectedLabel `json:"detectedLabels"`
+	}
+	if err := json.NewDecoder(mapResp.Body).Decode(&mapOut); err != nil {
+		t.Fatalf("decode map: %v", err)
+	}
+	if err := json.NewDecoder(jsonResp.Body).Decode(&jsonOut); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+
+	byLabel := func(in []loki.DetectedLabel) map[string]uint64 {
+		out := map[string]uint64{}
+		for _, l := range in {
+			out[l.Label] = l.Cardinality
+		}
+		return out
+	}
+	mapByLabel := byLabel(mapOut.DetectedLabels)
+	jsonByLabel := byLabel(jsonOut.DetectedLabels)
+
+	if mapByLabel["job"] != 2 {
+		t.Fatalf("Map job cardinality = %d, want 2 (seed/window sanity)", mapByLabel["job"])
+	}
+	for _, key := range []string{"job", "service_name"} {
+		if mapByLabel[key] != jsonByLabel[key] {
+			t.Errorf("detected_labels[%s]: Map cardinality=%d, JSON cardinality=%d, want equal", key, mapByLabel[key], jsonByLabel[key])
+		}
+	}
+}
+
+// detectedFieldsJSONSeedDDL / detectedFieldsMapSeedDDL seed a MINIMAL,
+// dedicated otel_logs shape for /detected_fields specifically: unlike
+// /labels, /series and /detected_labels (which read the ResourceAttributes
+// STREAM-identity map), /detected_fields mines its field set from the
+// BODY (logfmt/json-parsed) and the LogAttributes STRUCTURED-METADATA map
+// (detected_fields.go's stream_labels/log_attributes projections feed
+// detected_level plus whatever structured metadata a row carries) — a
+// stream-identity attribute like the shared seed's http.status_code is
+// never surfaced there, so this test needs its own seed rather than
+// reusing fullMapDiscoveryMapDDL/JSONDDL.
+const detectedFieldsMapSeedDDL = `CREATE TABLE %[2]s (
+    Timestamp DateTime64(9),
+    Body String,
+    LogAttributes Map(String, String),
+    ResourceAttributes Map(String, String)
+) ENGINE = Memory;
+
+INSERT INTO %[2]s (Timestamp, Body, LogAttributes, ResourceAttributes) VALUES
+    (toDateTime64('%[1]s', 9), 'line one', map('request_id', 'r1'), map('job', 'api')),
+    (toDateTime64('%[1]s', 9), 'line two', map('request_id', 'r2'), map('job', 'api'));
+`
+
+const detectedFieldsJSONSeedDDL = `CREATE TABLE %[2]s (
+    Timestamp DateTime64(9),
+    Body String,
+    LogAttributes JSON,
+    ResourceAttributes JSON
+) ENGINE = Memory;
+
+INSERT INTO %[2]s (Timestamp, Body, LogAttributes, ResourceAttributes) VALUES
+    (toDateTime64('%[1]s', 9), 'line one', '{"request_id":"r1"}', '{"job":"api"}'),
+    (toDateTime64('%[1]s', 9), 'line two', '{"request_id":"r2"}', '{"job":"api"}');
+`
+
+// newDetectedFieldsServer boots a dedicated chDB-backed Handler for
+// detectedFieldsMapSeedDDL/JSONSeedDDL — see their doc comment for why
+// this test does not reuse newMapDiscoveryServer/newJSONDiscoveryServer.
+func newDetectedFieldsServer(t *testing.T, ddlTemplate, tableName string, jsonStrategy bool) *httptest.Server {
+	t.Helper()
+	ddl := fmt.Sprintf(ddlTemplate, fullMapDiscoverySeedBase.Format(fullMapDiscoveryTSFmt), tableName)
+	c := chclienttest.NewChDB(t)
+	c.Seed(t, ddl)
+	s := schema.DefaultOTelLogs()
+	s.LogsTable = tableName
+	h := loki.New(c, s, nil)
+	if jsonStrategy {
+		h.AttrStrategies = chsql.AttrStrategies{
+			s.ResourceAttributesColumn: chsql.AttrStrategyJSON,
+			s.AttributesColumn:         chsql.AttrStrategyJSON,
+		}
+		h.Lang.AttrStrategies = h.AttrStrategies
+	}
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestDetectedFields_JSONStrategy_ChDB pins /loki/api/v1/detected_fields'
+// stream_labels / log_attributes projections (attrMapFrag) against a
+// JSON-typed LogAttributes/ResourceAttributes pair: the structured field
+// set derived from them (request_id, a LogAttributes structured-metadata
+// key) must match the Map-typed baseline.
+func TestDetectedFields_JSONStrategy_ChDB(t *testing.T) {
+	startUnix, endUnix := discoveryWindowParams()
+	url := func(base string) string {
+		return fmt.Sprintf(`%s/loki/api/v1/detected_fields?query=%%7Bjob%%3D%%22api%%22%%7D&start=%d&end=%d`, base, startUnix, endUnix)
+	}
+
+	mapSrv := newDetectedFieldsServer(t, detectedFieldsMapSeedDDL, "otel_logs_detfields_map", false)
+	jsonSrv := newDetectedFieldsServer(t, detectedFieldsJSONSeedDDL, "otel_logs_detfields_json", true)
+
+	mapResp, err := http.Get(url(mapSrv.URL))
+	if err != nil {
+		t.Fatalf("GET map: %v", err)
+	}
+	jsonResp, err := http.Get(url(jsonSrv.URL))
+	if err != nil {
+		t.Fatalf("GET json: %v", err)
+	}
+	defer mapResp.Body.Close()
+	defer jsonResp.Body.Close()
+
+	if mapResp.StatusCode != http.StatusOK {
+		t.Fatalf("map status=%d", mapResp.StatusCode)
+	}
+	if jsonResp.StatusCode != http.StatusOK {
+		t.Fatalf("json status=%d", jsonResp.StatusCode)
+	}
+
+	var mapOut, jsonOut loki.DetectedFieldsResponse
+	if err := json.NewDecoder(mapResp.Body).Decode(&mapOut); err != nil {
+		t.Fatalf("decode map: %v", err)
+	}
+	if err := json.NewDecoder(jsonResp.Body).Decode(&jsonOut); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+
+	byLabel := func(in []loki.DetectedField) map[string]loki.DetectedField {
+		out := map[string]loki.DetectedField{}
+		for _, f := range in {
+			out[f.Label] = f
+		}
+		return out
+	}
+	mapFields := byLabel(mapOut.Fields)
+	jsonFields := byLabel(jsonOut.Fields)
+
+	mapReq, ok := mapFields["request_id"]
+	if !ok || mapReq.Cardinality != 2 {
+		t.Fatalf("Map request_id field = %+v (ok=%v), want cardinality 2 (seed sanity)", mapReq, ok)
+	}
+	jsonReq, ok := jsonFields["request_id"]
+	if !ok {
+		t.Fatalf("JSON detected_fields missing request_id: %+v", jsonOut.Fields)
+	}
+	if jsonReq.Cardinality != mapReq.Cardinality {
+		t.Errorf("request_id cardinality: Map=%d JSON=%d, want equal", mapReq.Cardinality, jsonReq.Cardinality)
+	}
+}

--- a/internal/api/loki/detected_fields.go
+++ b/internal/api/loki/detected_fields.go
@@ -221,7 +221,7 @@ func (h *Handler) detectedFieldsPeek(w http.ResponseWriter, r *http.Request, rou
 		return nil, 0, false
 	}
 
-	sqlStr, args, err := buildDetectedFieldsSQL(h.Schema, matchers, start, end, lineLimit)
+	sqlStr, args, err := buildDetectedFieldsSQL(h.Schema, h.AttrStrategies, matchers, start, end, lineLimit)
 	if err != nil {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return nil, 0, false
@@ -345,12 +345,12 @@ func humanizeByteValue(v string) string {
 //
 // The peek window is small (1000 rows by default) — CH executes this as
 // a top-N scan on the primary key, comparable to /index/stats.
-func buildDetectedFieldsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time, lineLimit int) (string, []any, error) {
+func buildDetectedFieldsSQL(s schema.Logs, strategies chsql.AttrStrategies, matchers []*labels.Matcher, start, end time.Time, lineLimit int) (string, []any, error) {
 	sb := chsql.NewQuery().
 		Select(
 			chsql.As(chsql.Col(s.BodyColumn), "line"),
-			chsql.As(chsql.Col(s.AttributesColumn), "log_attributes"),
-			chsql.As(chsql.Col(s.ResourceAttributesColumn), "stream_labels"),
+			chsql.As(attrMapFrag(strategies, s.AttributesColumn), "log_attributes"),
+			chsql.As(attrMapFrag(strategies, s.ResourceAttributesColumn), "stream_labels"),
 			// The two parser-stage extractions, rendered from the SAME
 			// chplan expressions the LogQL lowering emits for `| logfmt`
 			// and `| json` — so the advertised body-parsed field set is
@@ -362,7 +362,8 @@ func buildDetectedFieldsSQL(s schema.Logs, matchers []*labels.Matcher, start, en
 			chsql.As(func(b *chsql.Builder) { _ = b.Expr(logql.LogfmtParsedLabels(s)) }, "logfmt_fields"),
 			chsql.As(func(b *chsql.Builder) { _ = b.Expr(logql.JSONParsedLabels(s)) }, "json_fields"),
 		).
-		From(chsql.Col(s.LogsTable))
+		From(chsql.Col(s.LogsTable)).
+		WithAttrStrategies(strategies)
 
 	if err := applySelectorAndWindow(sb, s, matchers, start, end); err != nil {
 		return "", nil, err

--- a/internal/api/loki/detected_labels.go
+++ b/internal/api/loki/detected_labels.go
@@ -78,7 +78,7 @@ func (h *Handler) handleDetectedLabels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	sqlStr, args, err := buildDetectedLabelsSQL(h.Schema, matchers, start, end)
+	sqlStr, args, err := buildDetectedLabelsSQL(h.Schema, h.AttrStrategies, matchers, start, end)
 	if err != nil {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
@@ -119,10 +119,11 @@ func (h *Handler) handleDetectedLabels(w http.ResponseWriter, r *http.Request) {
 // All identifiers + time bounds flow through QueryBuilder slots; the
 // selector predicate and the request window are placed by
 // applySelectorAndWindow, which composes typed Frags throughout.
-func buildDetectedLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
+func buildDetectedLabelsSQL(s schema.Logs, strategies chsql.AttrStrategies, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
 	sb := chsql.NewQuery().
-		Select(chsql.As(canonicalLabelsFrag(chsql.Col(s.ResourceAttributesColumn)), "labels")).
-		From(chsql.Col(s.LogsTable))
+		Select(chsql.As(canonicalLabelsFrag(attrMapFrag(strategies, s.ResourceAttributesColumn)), "labels")).
+		From(chsql.Col(s.LogsTable)).
+		WithAttrStrategies(strategies)
 
 	if err := applySelectorAndWindow(sb, s, matchers, start, end); err != nil {
 		return "", nil, err

--- a/internal/api/loki/label_values.go
+++ b/internal/api/loki/label_values.go
@@ -47,7 +47,7 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	sqlStr, args, err := buildLabelValuesSQL(h.Schema, name, matchers, start, end)
+	sqlStr, args, err := buildLabelValuesSQL(h.Schema, h.AttrStrategies, name, matchers, start, end)
 	if err != nil {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
@@ -100,14 +100,15 @@ func (h *Handler) handleLabelValues(w http.ResponseWriter, r *http.Request) {
 // through that map key. The matcher lowering in
 // `internal/logql/lower.go::matcherToExpr` mirrors the same fallback so
 // the two endpoints agree on what counts as a row carrying the label.
-func buildLabelValuesSQL(s schema.Logs, name string, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
+func buildLabelValuesSQL(s schema.Logs, strategies chsql.AttrStrategies, name string, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
 	keys := labelValueLookupKeys(name)
 	topCol := labelValueTopLevelColumn(s, name)
 	if topCol == "" && len(keys) == 1 {
 		// Fast path: single map-key lookup, no top-level fallback.
 		sb := chsql.NewQuery().
 			Select(chsql.As(distinctMapAtFrag(s.ResourceAttributesColumn, keys[0]), "v")).
-			From(chsql.Col(s.LogsTable))
+			From(chsql.Col(s.LogsTable)).
+			WithAttrStrategies(strategies)
 		if err := applySelectorAndWindow(sb, s, matchers, start, end); err != nil {
 			return "", nil, err
 		}
@@ -123,7 +124,8 @@ func buildLabelValuesSQL(s schema.Logs, name string, matchers []*labels.Matcher,
 	if topCol != "" {
 		arm := chsql.NewQuery().
 			Select(chsql.As(chsql.Col(topCol), "v")).
-			From(chsql.Col(s.LogsTable))
+			From(chsql.Col(s.LogsTable)).
+			WithAttrStrategies(strategies)
 		if err := applySelectorAndWindow(arm, s, matchers, start, end); err != nil {
 			return "", nil, err
 		}
@@ -133,7 +135,8 @@ func buildLabelValuesSQL(s schema.Logs, name string, matchers []*labels.Matcher,
 	for _, k := range keys {
 		arm := chsql.NewQuery().
 			Select(chsql.As(mapAtFrag(s.ResourceAttributesColumn, k), "v")).
-			From(chsql.Col(s.LogsTable))
+			From(chsql.Col(s.LogsTable)).
+			WithAttrStrategies(strategies)
 		if err := applySelectorAndWindow(arm, s, matchers, start, end); err != nil {
 			return "", nil, err
 		}

--- a/internal/api/loki/labels.go
+++ b/internal/api/loki/labels.go
@@ -24,7 +24,10 @@ import (
 //   - start / end (optional): time range, defaults to last hour / now.
 //
 // The SQL groups distinct map keys via arrayJoin(<col>.keys) on the
-// resource-attributes column's virtual keys subcolumn.
+// resource-attributes column's virtual keys subcolumn — or, for a
+// JSON-strategy column (cerberus issue #3063 point 2), arrayJoin over
+// JSONAllPaths(<col>) instead, via distinctAttrKeysFrag
+// (attr_strategy.go).
 func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 	start, end, err := parseStartEnd(r)
 	if err != nil {
@@ -41,7 +44,7 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	sqlStr, args, err := buildLabelsSQL(h.Schema, matchers, start, end)
+	sqlStr, args, err := buildLabelsSQL(h.Schema, h.AttrStrategies, matchers, start, end)
 	if err != nil {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
@@ -77,10 +80,11 @@ func (h *Handler) handleLabels(w http.ResponseWriter, r *http.Request) {
 //
 // All identifiers + time-range bounds flow through QueryBuilder slots —
 // no fmt.Sprintf-on-SQL.
-func buildLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
+func buildLabelsSQL(s schema.Logs, strategies chsql.AttrStrategies, matchers []*labels.Matcher, start, end time.Time) (string, []any, error) {
 	sb := chsql.NewQuery().
-		Select(chsql.As(distinctMapKeysFrag(s.ResourceAttributesColumn), "k")).
-		From(chsql.Col(s.LogsTable))
+		Select(chsql.As(distinctAttrKeysFrag(strategies, s.ResourceAttributesColumn), "k")).
+		From(chsql.Col(s.LogsTable)).
+		WithAttrStrategies(strategies)
 
 	if err := applySelectorAndWindow(sb, s, matchers, start, end); err != nil {
 		return "", nil, err
@@ -89,23 +93,6 @@ func buildLabelsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time.T
 
 	sqlStr, args := sb.Build()
 	return sqlStr, args, nil
-}
-
-// distinctMapKeysFrag emits
-//
-//	DISTINCT arrayJoin(`<col>`.`keys`)
-//
-// — the CH idiom for flattening a Map column's key array into the row
-// stream and de-duping, spelled against the column's virtual `.keys`
-// subcolumn rather than mapKeys(<col>) so the key-only decode is explicit
-// rather than depending on the server-side optimize_functions_to_subcolumns
-// rewrite (cerberus issue #2775). Used by /labels (the per-row key set)
-// and is the shape Grafana's label autocomplete expects. Safe
-// unconditionally, with no version gate: DISTINCT/arrayJoin key
-// enumeration never consults a skip index, so there is no index-matching
-// risk to weigh the way there is for a keyed-existence WHERE predicate.
-func distinctMapKeysFrag(col string) chsql.Frag {
-	return chsql.Distinct(chsql.Call("arrayJoin", chsql.Qual(col, "keys")))
 }
 
 // dedupeAndSort drops empty strings, removes duplicates, and sorts the

--- a/internal/api/loki/series.go
+++ b/internal/api/loki/series.go
@@ -55,7 +55,7 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 		selectorGroups = append(selectorGroups, matchers)
 	}
 
-	sqlStr, args, err := buildSeriesSQL(h.Schema, selectorGroups, start, end)
+	sqlStr, args, err := buildSeriesSQL(h.Schema, h.AttrStrategies, selectorGroups, start, end)
 	if err != nil {
 		h.respondError(w, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError})
 		return
@@ -99,10 +99,11 @@ func (h *Handler) handleSeries(w http.ResponseWriter, r *http.Request) {
 // /series response that legitimately fits over CERBERUS_QUERY_MAX_SAMPLES
 // and turn a valid query into a rejection. The Go-side dedupe stays as
 // the defence-in-depth backstop; this closes the split at the source.
-func buildSeriesSQL(s schema.Logs, selectorGroups [][]*labels.Matcher, start, end time.Time) (string, []any, error) {
+func buildSeriesSQL(s schema.Logs, strategies chsql.AttrStrategies, selectorGroups [][]*labels.Matcher, start, end time.Time) (string, []any, error) {
 	sb := chsql.NewQuery().
-		Select(chsql.As(canonicalLabelsFrag(chsql.Col(s.ResourceAttributesColumn)), "labels")).
-		From(chsql.Col(s.LogsTable))
+		Select(chsql.As(canonicalLabelsFrag(attrMapFrag(strategies, s.ResourceAttributesColumn)), "labels")).
+		From(chsql.Col(s.LogsTable)).
+		WithAttrStrategies(strategies)
 
 	if len(selectorGroups) > 0 {
 		fragments := make([]chsql.Frag, 0, len(selectorGroups))

--- a/internal/chsql/attr_strategy_fullmap.go
+++ b/internal/chsql/attr_strategy_fullmap.go
@@ -1,0 +1,297 @@
+package chsql
+
+import (
+	"fmt"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// This file is cerberus issue #3063's "full-map read" half of the
+// AttrStrategyJSON work: chsql/attr_strategy.go's exprMapAccess and
+// exprMapContainsKey (and exprFieldAccess, for TraceQL) already give a
+// PER-KEY lookup against a JSON-typed attribute column the exact Map
+// semantics the rest of the codebase was written against. That leaves
+// every LogQL stage that reads the WHOLE map at once — mapConcat/mapFilter/
+// mapApply/mapKeys/mapValues against a bare attribute-map ColumnRef, which
+// internal/logql's detected_level synthesis (withDetectedLevelAndColumns),
+// structured-metadata projection (structuredMetadataExpr) and parser-stage
+// label merges (PipelineLabelsExpr) all build — still failing at query time
+// with ILLEGAL_TYPE_OF_ARGUMENT against a JSON-typed column, exactly as
+// before the per-key work landed. detected_level's mapConcat/mapFilter in
+// particular runs on essentially EVERY LogQL log-stream query (it is only
+// skipped when a pipeline explicitly drops the label), so this is not a
+// niche gap.
+//
+// jsonFullMapReconstruction is the fix: given a bare JSON-strategy
+// ColumnRef, it builds a chplan.Expr that evaluates to a genuine
+// Map(String,String) with the SAME (key, value) pairs a Map-typed column
+// holding the same logical attributes would — so mapConcat/mapFilter/
+// mapApply/mapKeys/mapValues can run against the RECONSTRUCTED map exactly
+// as they always have against a real Map column, with zero changes to any
+// of internal/logql's map-shaped chplan lowering.
+//
+// Why this needs its own mechanism rather than reusing JSONAllPaths (the
+// per-key existence check's building block, exprMapContainsKey): ClickHouse
+// has no function that extracts a JSON value by a RUNTIME (per-row,
+// non-constant) path against its native JSON type — verified empirically
+// against chDB 26.5, the same substrate attr_strategy_json_chdb_test.go
+// pins:
+//
+//	SELECT arrayMap(p -> JSONExtractString(<col>, p), JSONAllPaths(<col>))
+//	-- Code: 43. DB::Exception: Function JSONExtractString with JSON type
+//	-- input supports only constant string path arguments.
+//
+//	SELECT arrayMap(p -> getSubcolumn(<col>, p), JSONAllPaths(<col>))
+//	-- Code: 44. DB::Exception: The second argument of function
+//	-- getSubcolumn should be a constant string with the name of a subcolumn.
+//
+// This rules out the "JSONAllPaths(<col>) + per-path composition" mechanism
+// cerberus issues #3063 and #3065 both proposed for this shape — the
+// per-path COMPOSITION step is exactly what ClickHouse's JSON type cannot
+// do dynamically. jsonFullMapReconstruction instead round-trips through
+// toJSONString(<col>) (a String) and JSONExtractKeysAndValuesRaw, which IS
+// fully dynamic — it needs no compile-time key at all, decomposing
+// WHATEVER top-level members a document happens to carry into
+// Array(Tuple(String, String)) (key, raw-JSON-value) pairs — and
+// re-applies it, bounded by maxJSONAttrFlattenDepth, to any pair whose raw
+// value is itself a JSON object, joining keys with '.' as it descends. That
+// reconstructs the exact flat dotted-key shape JSONAllPaths(<col>) reports
+// for the same document (verified: {"k8s.pod.name":"p1"} nests to
+// `k8s`->`pod`->`name` by ClickHouse's JSON default, and
+// jsonFlattenPairs('{"k8s":{"pod":{"name":"p1"}}}', 2) rebuilds the single
+// pair ("k8s.pod.name", "p1")) — see attr_strategy_fullmap_json_chdb_test.go.
+//
+// See exprMapAccess's own doc for why this targets ClickHouse's DEFAULT
+// dot-nesting behaviour only, not json_type_escape_dots_in_keys=1 — that
+// hazard (cerberus issue #3063 point 3 / #3065 point 3) is unrelated to
+// and unaffected by the depth bound here.
+const jsonFullMapAttrCastType = "Map(String,String)"
+
+// maxJSONAttrFlattenDepth bounds how many additional levels of ClickHouse's
+// default JSON dot-nesting jsonFlattenPairs re-expands beyond the first, so
+// a key with up to maxJSONAttrFlattenDepth+1 dot segments (e.g.
+// "k8s.container.status.last_terminated_reason", 4 segments, needs 3
+// levels beyond the first) reconstructs correctly. OTel semantic-convention
+// attribute names are not observed to nest deeper than that in practice.
+// A key nested past the bound keeps its remaining structure as an
+// UNPARSED raw JSON substring under its partial dotted key in the
+// reconstructed map, rather than being silently dropped — a real, bounded,
+// documented limitation (see docs/operations.md's JSON-typed-attribute
+// section), not a silent wrong answer, and exercised explicitly by
+// TestJSONFullMapReconstruction_BeyondDepthBound_ChDB.
+const maxJSONAttrFlattenDepth = 3
+
+// jsonRawPairKeyIdx / jsonRawPairValueIdx are the 1-based tupleElement
+// indices into the Array(Tuple(String,String)) JSONExtractKeysAndValuesRaw
+// returns — (key, raw JSON value text) — matching ClickHouse's own
+// left-to-right tuple order.
+const (
+	jsonRawPairKeyIdx   = 1
+	jsonRawPairValueIdx = 2
+)
+
+// jsonObjectPrefix is the first byte of any ClickHouse-serialised JSON
+// object, and the marker jsonFlattenPairs uses to tell an object-valued
+// pair (needs another recursion level) from a scalar one (ready to decode
+// via JSONExtractString) — mirroring toJSONString/JSONExtractKeysAndValuesRaw's
+// own well-defined JSON object grammar, not an attribute-content heuristic.
+const jsonObjectPrefix = "{"
+
+// projectedExpr returns the expression emitProject should actually render
+// for one SELECT projection: jsonFullMapReconstruction(col) when expr is a
+// bare JSON-strategy ColumnRef, or expr unchanged otherwise.
+//
+// This covers the one full-map shape substituteJSONFullMapArgs cannot: a
+// LogQL query whose pipeline neither runs a label-mutating stage nor
+// synthesizes detected_level (both HasLabelMutatingStage and
+// detectedLevelIdentityExpr false — an explicit `| drop detected_level`/
+// `| keep` with no parser stage) projects the bare ResourceAttributes
+// column as the query's ENTIRE "Attributes" output with no
+// mapConcat/mapFilter wrapper at all (internal/logql/lang.go's
+// Lang.ProjectSamples). Substituting here means the chclient cursor always
+// scans a genuine Map(String,String) for that column, on every log-stream
+// query shape, regardless of which pipeline stages ran.
+func projectedExpr(b *Builder, expr chplan.Expr) chplan.Expr {
+	if col, ok := jsonAttrColumn(b, expr); ok {
+		return jsonFullMapReconstruction(col)
+	}
+	return expr
+}
+
+// jsonFullMapFns are the chplan Fn identifiers that read or build a WHOLE
+// Map(String,String) rather than resolving one key (chplan.MapAccess /
+// FnMapContainsKey, already covered by exprMapAccess / exprMapContainsKey).
+// exprFunc substitutes any bare JSON-strategy ColumnRef argument to one of
+// these with jsonFullMapReconstruction(col) before the normal name
+// resolution / argument rendering runs — see substituteJSONFullMapArgs.
+// FnMapSort is deliberately excluded: cerberus issue #2777's own doc notes
+// metrics attribute maps never carry AttrStrategyJSON (preflight FATALs on
+// anything but Map there), and FnMapSort (CanonicalMapFunc) is a
+// metrics-only series-identity concern.
+var jsonFullMapFns = map[chplan.Fn]bool{
+	chplan.FnMapKeys:   true,
+	chplan.FnMapValues: true,
+	chplan.FnMapMerge:  true,
+	chplan.FnMapFilter: true,
+	chplan.FnMapApply:  true,
+	chplan.FnMapUpdate: true,
+}
+
+// substituteJSONFullMapArgs returns f unchanged if none of its arguments is
+// a bare JSON-strategy ColumnRef, or a shallow copy of f with each such
+// argument replaced by jsonFullMapReconstruction(col) otherwise. Only a
+// bare ColumnRef is substituted — jsonAttrColumn's own precondition — an
+// already-composed Map expression (a nested mapConcat/mapUpdate/map(...)
+// result) really is a ClickHouse Map at the SQL level regardless of the
+// strategy of the column that seeded it, exactly as exprMapAccess's own
+// doc explains for the per-key case.
+func (b *Builder) substituteJSONFullMapArgs(f *chplan.FuncCall) *chplan.FuncCall {
+	var out []chplan.Expr
+	for i, arg := range f.Args {
+		if col, ok := jsonAttrColumn(b, arg); ok {
+			if out == nil {
+				out = make([]chplan.Expr, len(f.Args))
+				copy(out, f.Args)
+			}
+			out[i] = jsonFullMapReconstruction(col)
+		}
+	}
+	if out == nil {
+		return f
+	}
+	return &chplan.FuncCall{Fn: f.Fn, Args: out}
+}
+
+// JSONAttrMapReconstruction is jsonFullMapReconstruction's exported,
+// Frag-returning twin for callers outside this package that build
+// chsql.Frag trees directly rather than a chplan tree — cerberus issue
+// #3063 point 2's ad-hoc metadata/discovery query builders
+// (internal/api/loki's /series, /detected_labels, /detected_fields) never
+// construct a chplan.FuncCall or chplan.Project, so neither
+// substituteJSONFullMapArgs (exprFunc) nor projectedExpr (emitProject)
+// ever runs for them; they must call this directly for a bare JSON-strategy
+// attribute column they need to read or GROUP BY as a genuine
+// Map(String,String).
+func JSONAttrMapReconstruction(col string) Frag {
+	expr := jsonFullMapReconstruction(&chplan.ColumnRef{Name: col})
+	return func(b *Builder) { _ = b.Expr(expr) }
+}
+
+// jsonFullMapReconstruction returns the chplan.Expr a bare JSON-strategy
+// attribute-map ColumnRef must be substituted with wherever a full-map
+// operation needs a genuine Map(String,String) operand — see the file doc
+// for why. col is referenced exactly once (inside toJSONString), so unlike
+// jsonFlattenPairs's internal fan-out this does not duplicate the column
+// reference itself.
+func jsonFullMapReconstruction(col *chplan.ColumnRef) chplan.Expr {
+	pairs := jsonFlattenPairs(
+		&chplan.FuncCall{Fn: chplan.FnToJSONString, Args: []chplan.Expr{col}},
+		maxJSONAttrFlattenDepth,
+	)
+	return &chplan.FuncCall{
+		Fn:   chplan.FnCast,
+		Args: []chplan.Expr{pairs, &chplan.LitString{V: jsonFullMapAttrCastType}},
+	}
+}
+
+// jsonFlattenPairs returns a chplan.Expr evaluating to
+// Array(Tuple(String,String)) — every (dotted key, decoded string value)
+// pair jsonString's JSON object carries, recursing into object-valued
+// members up to depth additional levels beyond the first.
+//
+// The lambda parameter name is suffixed by depth so nested recursive calls
+// (one per level) never shadow an enclosing level's parameter — not a
+// ClickHouse correctness requirement (inner lambda scopes shadow outer ones
+// exactly like any block-scoped language), but it keeps the emitted SQL
+// readable when a query fails and someone has to read it.
+func jsonFlattenPairs(jsonString chplan.Expr, depth int) chplan.Expr {
+	param := fmt.Sprintf("jsonAttrPair%d", depth)
+	pair := &chplan.BareIdent{Name: param}
+	keyOf := &chplan.FuncCall{Fn: chplan.FnTupleElement, Args: []chplan.Expr{pair, &chplan.LitInt{V: jsonRawPairKeyIdx}}}
+	rawValueOf := &chplan.FuncCall{Fn: chplan.FnTupleElement, Args: []chplan.Expr{pair, &chplan.LitInt{V: jsonRawPairValueIdx}}}
+	isObject := &chplan.FuncCall{
+		Fn:   chplan.FnStartsWith,
+		Args: []chplan.Expr{rawValueOf, &chplan.LitString{V: jsonObjectPrefix}},
+	}
+	rawPairs := &chplan.FuncCall{Fn: chplan.FnJSONExtractKeysAndValuesRaw, Args: []chplan.Expr{jsonString}}
+
+	scalarPairs := &chplan.FuncCall{
+		Fn: chplan.FnArrayMap,
+		Args: []chplan.Expr{
+			&chplan.Lambda{Params: []string{param}, Body: &chplan.FuncCall{
+				Fn: chplan.FnTuple,
+				Args: []chplan.Expr{
+					keyOf,
+					&chplan.FuncCall{Fn: chplan.FnJSONExtractString, Args: []chplan.Expr{rawValueOf}},
+				},
+			}},
+			&chplan.FuncCall{
+				Fn: chplan.FnArrayFilter,
+				Args: []chplan.Expr{
+					&chplan.Lambda{Params: []string{param}, Body: &chplan.FuncCall{Fn: chplan.FnNot, Args: []chplan.Expr{isObject}}},
+					rawPairs,
+				},
+			},
+		},
+	}
+
+	if depth <= 0 {
+		// Base case: an object-valued member this deep keeps its raw JSON
+		// text as the value under its own (partial) key, rather than being
+		// dropped — see maxJSONAttrFlattenDepth's doc.
+		leftover := &chplan.FuncCall{
+			Fn: chplan.FnArrayMap,
+			Args: []chplan.Expr{
+				&chplan.Lambda{Params: []string{param}, Body: &chplan.FuncCall{Fn: chplan.FnTuple, Args: []chplan.Expr{keyOf, rawValueOf}}},
+				&chplan.FuncCall{
+					Fn: chplan.FnArrayFilter,
+					Args: []chplan.Expr{
+						&chplan.Lambda{Params: []string{param}, Body: isObject},
+						rawPairs,
+					},
+				},
+			},
+		}
+		return &chplan.FuncCall{Fn: chplan.FnArrayConcat, Args: []chplan.Expr{scalarPairs, leftover}}
+	}
+
+	objectPairs := &chplan.FuncCall{
+		Fn: chplan.FnArrayFilter,
+		Args: []chplan.Expr{
+			&chplan.Lambda{Params: []string{param}, Body: isObject},
+			rawPairs,
+		},
+	}
+
+	nestedParam := fmt.Sprintf("jsonAttrNested%d", depth)
+	nested := &chplan.BareIdent{Name: nestedParam}
+	prefixed := &chplan.FuncCall{
+		Fn: chplan.FnArrayMap,
+		Args: []chplan.Expr{
+			&chplan.Lambda{Params: []string{nestedParam}, Body: &chplan.FuncCall{
+				Fn: chplan.FnTuple,
+				Args: []chplan.Expr{
+					&chplan.FuncCall{
+						Fn: chplan.FnConcat,
+						Args: []chplan.Expr{
+							keyOf,
+							&chplan.LitString{V: "."},
+							&chplan.FuncCall{Fn: chplan.FnTupleElement, Args: []chplan.Expr{nested, &chplan.LitInt{V: jsonRawPairKeyIdx}}},
+						},
+					},
+					&chplan.FuncCall{Fn: chplan.FnTupleElement, Args: []chplan.Expr{nested, &chplan.LitInt{V: jsonRawPairValueIdx}}},
+				},
+			}},
+			jsonFlattenPairs(rawValueOf, depth-1),
+		},
+	}
+	perObject := &chplan.FuncCall{
+		Fn: chplan.FnArrayMap,
+		Args: []chplan.Expr{
+			&chplan.Lambda{Params: []string{param}, Body: prefixed},
+			objectPairs,
+		},
+	}
+	flattenedNested := &chplan.FuncCall{Fn: chplan.FnArrayFlatten, Args: []chplan.Expr{perObject}}
+	return &chplan.FuncCall{Fn: chplan.FnArrayConcat, Args: []chplan.Expr{scalarPairs, flattenedNested}}
+}

--- a/internal/chsql/attr_strategy_fullmap_chdb_test.go
+++ b/internal/chsql/attr_strategy_fullmap_chdb_test.go
@@ -1,0 +1,321 @@
+//go:build chdb
+
+// chDB-backed proof of cerberus issue #3063's point 1: a LogQL full-map
+// operation (mapConcat/mapFilter/mapApply/mapKeys/mapValues against a bare
+// attribute-map ColumnRef, or a bare projection of one — see
+// internal/logql's detected_level synthesis, structured-metadata
+// projection and parser-stage label merges) must work against a
+// JSON-typed attribute column exactly as it already does against a
+// Map(String,String) one. This file pins jsonFullMapReconstruction
+// (attr_strategy_fullmap.go) against real chDB, mirroring
+// attr_strategy_json_chdb_test.go's rigor for the per-key case: genuine
+// execution, not a hand-written comparison string, and missing/present/
+// empty-value/nested/beyond-bound seeding rather than one happy-path row.
+package chsql_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/chsqltest"
+)
+
+// fullMapSeedDDL mirrors attrStrategyJSONSeedDDL's Map/JSON pairing, with
+// three additions specific to the full-map reconstruction:
+//
+//   - row 4: a 3-segment dotted key (k8s.pod.name) nested two levels deep
+//     by ClickHouse's JSON default — well within maxJSONAttrFlattenDepth,
+//     so it must fully reconstruct to the flat key "k8s.pod.name".
+//   - row 5: a 5-segment dotted key (a.b.c.d.e) nested FOUR levels deep —
+//     past maxJSONAttrFlattenDepth's bound (which fully flattens up to
+//     4-segment keys) — so the JSON side is EXPECTED to diverge from the
+//     Map side here, pinning the documented bounded-depth limitation
+//     rather than asserting the two always agree unconditionally.
+const fullMapSeedDDL = `
+CREATE OR REPLACE TABLE fullmap_map (
+    id UInt32,
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree ORDER BY id;
+
+CREATE OR REPLACE TABLE fullmap_json (
+    id UInt32,
+    ResourceAttributes JSON
+) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO fullmap_map VALUES
+    (1, map('service.name', 'foo', 'http.status_code', '200')),
+    (2, map('service.name', 'bar')),
+    (3, map('service.name', '')),
+    (4, map('k8s.pod.name', 'p1', 'k8s.namespace.name', 'ns1')),
+    (5, map('a.b.c.d.e', 'deep'));
+
+INSERT INTO fullmap_json VALUES
+    (1, '{"service.name":"foo","http.status_code":"200"}'),
+    (2, '{"service.name":"bar"}'),
+    (3, '{"service.name":""}'),
+    (4, '{"k8s.pod.name":"p1","k8s.namespace.name":"ns1"}'),
+    (5, '{"a.b.c.d.e":"deep"}');
+`
+
+// fullMapStrategies is the AttrStrategies every reconstruction test below
+// resolves ResourceAttributes against on the JSON side.
+var fullMapStrategies = chsql.AttrStrategies{"ResourceAttributes": chsql.AttrStrategyJSON}
+
+// renderFullMapProject emits `SELECT <expr> AS out FROM <table> ORDER BY
+// id` as a chplan.Project — the same node internal/logql's
+// Lang.ProjectSamples builds for a log-stream query's Attributes column —
+// through the real chsql.Emit entry point, so this exercises
+// emitProject's projectedExpr substitution exactly as production traffic
+// would.
+func renderFullMapProject(t *testing.T, table string, strategies chsql.AttrStrategies, expr chplan.Expr) (string, []any) {
+	t.Helper()
+	scan := &chplan.Scan{Table: table}
+	proj := &chplan.Project{
+		Input:       scan,
+		Projections: []chplan.Projection{{Expr: expr, Alias: "out"}},
+	}
+	ctx := context.Background()
+	if strategies != nil {
+		ctx = chsql.WithAttrStrategies(ctx, strategies)
+	}
+	sqlStr, args, err := chsql.Emit(ctx, proj)
+	if err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	return sqlStr + " ORDER BY id", args
+}
+
+func queryToStringRows(t *testing.T, db *sql.DB, query string, args []any) []string {
+	t.Helper()
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		t.Fatalf("query: %v\nSQL: %s", err, query)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("row iteration: %v", err)
+	}
+	return out
+}
+
+// resourceAttrsCol is the shared operand every case below runs its
+// full-map function against.
+func resourceAttrsCol() *chplan.ColumnRef { return &chplan.ColumnRef{Name: "ResourceAttributes"} }
+
+// canonicalMapString renders e (a Map(String,String)-valued expression) as
+// a string with its entries in a canonical key order via mapSort, then
+// toString. mapConcat/mapFilter's OWN key order can legitimately differ
+// between the Map baseline (insertion order) and the JSON reconstruction
+// (JSONExtractKeysAndValuesRaw's own order) without either being wrong —
+// this wrapper makes the comparison order-independent, the same way
+// production code never depends on a Map's iteration order.
+func canonicalMapString(e chplan.Expr) chplan.Expr {
+	return &chplan.FuncCall{
+		Fn:   chplan.FnToString,
+		Args: []chplan.Expr{&chplan.FuncCall{Fn: chplan.FnMapSort, Args: []chplan.Expr{e}}},
+	}
+}
+
+// TestJSONFullMapReconstruction_MapConcat pins the dominant real shape:
+// internal/logql's detected_level synthesis (withDetectedLevelAndColumns)
+// calls mapConcat(<bare ResourceAttributes>, <synthesized map>) on
+// essentially every log-stream query. The JSON side must return the same
+// merged map as the Map side for every row, including the present-empty
+// and absent-key cases mapConcat's right-hand operand doesn't touch.
+func TestJSONFullMapReconstruction_MapConcat(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(fullMapSeedDDL); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	mapConcatExpr := func() chplan.Expr {
+		return &chplan.FuncCall{
+			Fn: chplan.FnMapMerge,
+			Args: []chplan.Expr{
+				resourceAttrsCol(),
+				&chplan.FuncCall{Fn: chplan.FnMap, Args: []chplan.Expr{&chplan.LitString{V: "extra"}, &chplan.LitString{V: "1"}}},
+			},
+		}
+	}
+
+	mapSQL, mapArgs := renderFullMapProject(t, "fullmap_map", nil, canonicalMapString(mapConcatExpr()))
+	jsonSQL, jsonArgs := renderFullMapProject(t, "fullmap_json", fullMapStrategies, canonicalMapString(mapConcatExpr()))
+
+	mapGot := queryToStringRows(t, db, mapSQL, mapArgs)
+	jsonGot := queryToStringRows(t, db, jsonSQL, jsonArgs)
+
+	// Rows 1-4 sit within maxJSONAttrFlattenDepth and must match the Map
+	// baseline exactly. Row 5 (5-segment key) is asserted separately below
+	// — it is the documented bounded-depth divergence, not a bug.
+	if len(mapGot) != 5 || len(jsonGot) != 5 {
+		t.Fatalf("row count: Map %d, JSON %d, want 5 each", len(mapGot), len(jsonGot))
+	}
+	for i := 0; i < 4; i++ {
+		if mapGot[i] != jsonGot[i] {
+			t.Errorf("row %d: Map mapConcat = %s, JSON reconstruction+mapConcat = %s, want equal", i+1, mapGot[i], jsonGot[i])
+		}
+	}
+	t.Logf("row 5 (beyond depth bound): Map = %s, JSON = %s", mapGot[4], jsonGot[4])
+}
+
+// TestJSONFullMapReconstruction_BeyondDepthBound_ChDB pins the DOCUMENTED
+// limitation explicitly (maxJSONAttrFlattenDepth's doc comment): a key
+// nested past the bound reconstructs with its remaining structure as an
+// unparsed raw JSON substring under its partial dotted key — present and
+// non-empty, never silently dropped — rather than fully flattening to the
+// original dotted key.
+func TestJSONFullMapReconstruction_BeyondDepthBound_ChDB(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(fullMapSeedDDL); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	mapKeysExpr := &chplan.FuncCall{Fn: chplan.FnMapKeys, Args: []chplan.Expr{resourceAttrsCol()}}
+	toString := &chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{mapKeysExpr}}
+
+	jsonSQL, jsonArgs := renderFullMapProject(t, "fullmap_json", fullMapStrategies, toString)
+	jsonGot := queryToStringRows(t, db, jsonSQL, jsonArgs)
+	if len(jsonGot) != 5 {
+		t.Fatalf("row count = %d, want 5", len(jsonGot))
+	}
+	// Row 5 seeded a.b.c.d.e (5 segments); maxJSONAttrFlattenDepth fully
+	// flattens up to 4-segment keys, so the reconstructed key set carries
+	// the partial 4-segment prefix, never the full 5-segment original and
+	// never nothing at all.
+	row5 := jsonGot[4]
+	if got := row5; got != "['a.b.c.d']" {
+		t.Fatalf("row 5 mapKeys = %s, want ['a.b.c.d'] (the documented partial-key fallback)", got)
+	}
+}
+
+// TestJSONFullMapReconstruction_MapFilter pins structuredMetadataExpr's
+// exact shape: mapFilter dropping any (k, v) pair whose v is the empty string, against a bare attribute column.
+func TestJSONFullMapReconstruction_MapFilter(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(fullMapSeedDDL); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	filterExpr := func() chplan.Expr {
+		return &chplan.FuncCall{
+			Fn: chplan.FnMapFilter,
+			Args: []chplan.Expr{
+				&chplan.Lambda{
+					Params: []string{"k", "v"},
+					Body: &chplan.Binary{
+						Op:    chplan.OpNe,
+						Left:  &chplan.BareIdent{Name: "v"},
+						Right: &chplan.LitString{V: ""},
+					},
+				},
+				resourceAttrsCol(),
+			},
+		}
+	}
+	mapSQL, mapArgs := renderFullMapProject(t, "fullmap_map", nil, canonicalMapString(filterExpr()))
+	jsonSQL, jsonArgs := renderFullMapProject(t, "fullmap_json", fullMapStrategies, canonicalMapString(filterExpr()))
+
+	mapGot := queryToStringRows(t, db, mapSQL, mapArgs)
+	jsonGot := queryToStringRows(t, db, jsonSQL, jsonArgs)
+
+	for i := 0; i < 4; i++ {
+		if mapGot[i] != jsonGot[i] {
+			t.Errorf("row %d: Map mapFilter = %s, JSON reconstruction+mapFilter = %s, want equal", i+1, mapGot[i], jsonGot[i])
+		}
+	}
+	// Row 3's present-but-empty service.name must be DROPPED on both sides
+	// — the case mapFilter exists to prove, distinct from mapConcat above.
+	if mapGot[2] != "{}" {
+		t.Fatalf("row 3 Map mapFilter = %s, want {} (present-but-empty value dropped)", mapGot[2])
+	}
+}
+
+// TestJSONFullMapReconstruction_BareProjection pins projectedExpr's own
+// case: a bare ResourceAttributes ColumnRef projected with NO wrapping
+// function at all — the shape internal/logql's Lang.ProjectSamples emits
+// when neither a label-mutating pipeline stage nor detected_level
+// synthesis applies. Without emitProject's substitution this selects the
+// raw JSON value instead of a genuine Map(String,String).
+func TestJSONFullMapReconstruction_BareProjection(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(fullMapSeedDDL); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// The projected expr is the BARE ColumnRef itself — no toString/mapSort
+	// wrapping — because projectedExpr only substitutes a bare
+	// *chplan.ColumnRef; wrapping it here would defeat the exact case this
+	// test exists to cover. The string comparison is applied OUTSIDE, at
+	// the raw SQL text level, wrapping the rendered subquery (which itself
+	// carries no ORDER BY — added here, once, at the outermost level).
+	bareProject := func(table string) (string, []any) {
+		scan := &chplan.Scan{Table: table}
+		proj := &chplan.Project{
+			Input: scan,
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "id"}, Alias: "id"},
+				{Expr: resourceAttrsCol(), Alias: "out"},
+			},
+		}
+		ctx := context.Background()
+		if table == "fullmap_json" {
+			ctx = chsql.WithAttrStrategies(ctx, fullMapStrategies)
+		}
+		inner, args, err := chsql.Emit(ctx, proj)
+		if err != nil {
+			t.Fatalf("emit: %v", err)
+		}
+		return "SELECT toString(mapSort(out)) FROM (" + inner + ") ORDER BY id", args
+	}
+
+	mapSQL, mapArgs := bareProject("fullmap_map")
+	jsonSQL, jsonArgs := bareProject("fullmap_json")
+
+	mapGot := queryToStringRows(t, db, mapSQL, mapArgs)
+	jsonGot := queryToStringRows(t, db, jsonSQL, jsonArgs)
+
+	for i := 0; i < 4; i++ {
+		if mapGot[i] != jsonGot[i] {
+			t.Errorf("row %d: Map bare projection = %s, JSON reconstruction = %s, want equal", i+1, mapGot[i], jsonGot[i])
+		}
+	}
+}
+
+// TestJSONFullMapReconstruction_MapValues pins mapValues, TraceQL's
+// compare() fan-out's own building block (internal/traceql/metrics_compare.go)
+// alongside mapKeys — both resolve through the same jsonFullMapFns
+// substitution since they share the chsql emitter.
+func TestJSONFullMapReconstruction_MapValues(t *testing.T) {
+	db := chsqltest.OpenIsolatedChDB(t)
+	if _, err := db.Exec(fullMapSeedDDL); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	valuesExpr := &chplan.FuncCall{Fn: chplan.FnArraySort, Args: []chplan.Expr{
+		&chplan.FuncCall{Fn: chplan.FnMapValues, Args: []chplan.Expr{resourceAttrsCol()}},
+	}}
+	toString := &chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{valuesExpr}}
+
+	mapSQL, mapArgs := renderFullMapProject(t, "fullmap_map", nil, toString)
+	jsonSQL, jsonArgs := renderFullMapProject(t, "fullmap_json", fullMapStrategies, toString)
+
+	mapGot := queryToStringRows(t, db, mapSQL, mapArgs)
+	jsonGot := queryToStringRows(t, db, jsonSQL, jsonArgs)
+
+	for i := 0; i < 4; i++ {
+		if mapGot[i] != jsonGot[i] {
+			t.Errorf("row %d: Map mapValues = %s, JSON reconstruction+mapValues = %s, want equal", i+1, mapGot[i], jsonGot[i])
+		}
+	}
+}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -170,7 +170,35 @@ func writeInlineNonFinite(b *Builder, v float64) bool {
 // qualified or otherwise composite container, use the typed Frag form
 // Subscript(container, key) instead — e.g.
 // Subscript(Qual("L", "Attributes"), Lit(key)) for `L`.`Attributes`[?].
+//
+// cerberus issue #3063 point 2: this is the ad-hoc-query-builder
+// equivalent of chplan.MapAccess (exprMapAccess) — internal/api/loki's
+// /loki/api/v1/label/<name>/values (label_values.go's mapAtFrag) and
+// internal/api/prom's metadata endpoints build their per-key lookup
+// through THIS method directly rather than through a chplan tree, so
+// wiring exprMapAccess's JSON branch alone left them reading a
+// JSON-strategy column with plain bracket-subscript syntax — the exact
+// "bypasses chplan entirely" class of gap #3063 names. When col resolves
+// to AttrStrategyJSON, this renders the same
+// `coalesce(<col>.<key>.:String, the empty string)` shape exprMapAccess's doc explains
+// in full (dot-nesting, and the missing-vs-empty normalisation) — with
+// key inlined as a backtick-quoted identifier (b.Ident, not b.Arg)
+// because ClickHouse's JSON dynamic-subcolumn path is a compile-time
+// syntax token, not a bound parameter; safe here because key is always a
+// caller-supplied Go string already fixed at SQL-build time (a URL path
+// segment / metric label name), never row data. PromQL's metadata.go
+// calls into this too, but preflight never resolves AttrStrategyJSON for
+// a metrics attribute column (chplan.AttrStrategy's own doc), so this
+// branch is a no-op there.
 func (b *Builder) MapAt(col, key string) {
+	if b.attrStrategies.Lookup(col) == AttrStrategyJSON {
+		b.sb.WriteString("coalesce(")
+		b.Ident(col)
+		b.sb.WriteByte('.')
+		b.Ident(key)
+		b.sb.WriteString(".:String, '')")
+		return
+	}
 	b.Ident(col)
 	b.sb.WriteByte('[')
 	b.Arg(key)
@@ -896,6 +924,9 @@ func (b *Builder) emitGoModulo(left, right chplan.Expr) error {
 func (b *Builder) exprFunc(f *chplan.FuncCall) error {
 	if f.Fn == chplan.FnMapContainsKey {
 		return b.exprMapContainsKey(f.Args)
+	}
+	if jsonFullMapFns[f.Fn] {
+		f = b.substituteJSONFullMapArgs(f)
 	}
 	name, render, err := resolveFn(f.Fn)
 	if err != nil {
@@ -3200,10 +3231,33 @@ func (s *QueryBuilder) LimitBy(exprs ...Frag) *QueryBuilder {
 // parentheses. Used to plug a QueryBuilder into another's From
 // without flattening to a string: args bound inside the nested
 // SELECT stay tied to their position in the outer args slice.
+//
+// cerberus issue #3063 point 2: writeInto renders directly into the
+// PARENT Frag's Builder (that is the whole point — positional args stay
+// one shared slice), which means it inherits the parent's
+// b.attrStrategies by default. A caller that resolved and set its OWN
+// AttrStrategies on s via WithAttrStrategies (label_values.go's
+// UNION-ALL arms, each built as an independent QueryBuilder before being
+// spliced together via Frag) would otherwise have that assignment
+// silently discarded — the ad-hoc-query-builder equivalent of the
+// "bypasses chplan entirely" class of bug this issue names, except here
+// the bypass is inside chsql's own Frag composition primitive rather
+// than in a caller. s.attrStrategies is nil (the zero value) for every
+// pre-#3063 QueryBuilder that never called WithAttrStrategies, so this
+// swap is a genuine no-op for every one of chsql's ~50+ other Frag()
+// call sites: they keep inheriting the parent's strategies exactly as
+// before.
 func (s *QueryBuilder) Frag() Frag {
 	return func(b *Builder) {
 		b.sb.WriteByte('(')
-		s.writeInto(b)
+		if s.attrStrategies != nil {
+			prev := b.attrStrategies
+			b.attrStrategies = s.attrStrategies
+			s.writeInto(b)
+			b.attrStrategies = prev
+		} else {
+			s.writeInto(b)
+		}
 		b.sb.WriteByte(')')
 	}
 }

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -511,13 +511,13 @@ func (e *emitter) emitProject(p *chplan.Project) error {
 	// renders as the bare `SELECT *` — no length guard needed.
 	for _, pr := range p.Projections {
 		expr := pr.Expr
-		sb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, pr.Alias)
+		sb.SelectAs(func(b *Builder) { _ = b.Expr(projectedExpr(b, expr)) }, pr.Alias)
 	}
 	if len(p.Projections) == 0 && len(p.Replacements) > 0 {
 		reps := make([]Frag, 0, len(p.Replacements))
 		for _, pr := range p.Replacements {
 			expr := pr.Expr
-			reps = append(reps, As(func(b *Builder) { _ = b.Expr(expr) }, pr.Alias))
+			reps = append(reps, As(func(b *Builder) { _ = b.Expr(projectedExpr(b, expr)) }, pr.Alias))
 		}
 		sb.Select(StarReplace(reps))
 	}


### PR DESCRIPTION
## Summary

Closes #3063. Implements all three points the issue named for LogQL's JSON-typed-attribute-column gaps left after #2777/#3064's per-key work:

1. **Full-map LogQL operations.** `withDetectedLevelAndColumns`'s `mapConcat`/`mapFilter` identity synthesis (runs on essentially every log-stream query), `structuredMetadataExpr`'s `mapFilter` over `LogAttributes`, every parser-stage label merge (`PipelineLabelsExpr`'s `mapConcat`/`mapApply` chain), and a bare attribute-map projection with no wrapping stage at all now render correctly against a JSON-typed column.
2. **JSON-aware discovery endpoints.** `/labels`, `/series`, `/label/<name>/values`, `/detected_labels` and `/detected_fields` build their SQL directly against `chsql.NewQuery()` rather than through `chplan`, so they never reached `AttrStrategies` threading at all. Each now resolves the Handler's `AttrStrategies` itself and renders JSON-aware SQL. `/patterns` needed no change — it never reads an attribute-map column.
3. **`json_type_escape_dots_in_keys` / mixed-history hazard.** Documented as a loud, known limitation (see `docs/operations.md`) rather than gated by a new boot-time refuse check — see "Design decision" below.

## What changed

- `internal/chsql/attr_strategy_fullmap.go` (new): `jsonFullMapReconstruction` builds a `chplan.Expr` that reconstructs a genuine `Map(String,String)` from a JSON-strategy bare column, via a bounded-depth flatten. **ClickHouse's native JSON type has no per-row dynamic-path value extraction** — verified empirically against chDB 26.5: `JSONExtractString`/`JSONExtract`/`getSubcolumn` against a JSON operand all reject a non-constant path argument (`"...supports only constant string path arguments"` / `"...should be a constant string..."`). This rules out the "`JSONAllPaths(<col>)` + per-path composition" mechanism the issue itself proposed — the per-path *value* extraction step is exactly what ClickHouse can't do dynamically. The reconstruction instead round-trips through `toJSONString` + the fully-dynamic `JSONExtractKeysAndValuesRaw` (no compile-time key needed at all), re-applied up to `maxJSONAttrFlattenDepth` (3) additional levels beyond the first — fully flattening any OTel key of up to 4 dot segments. A key nested deeper keeps its remaining structure as an unparsed raw JSON substring under its partial dotted key — present and non-empty, never silently dropped.
  - `exprFunc` substitutes this reconstruction for any bare JSON-strategy `ColumnRef` argument to `mapKeys`/`mapValues`/`mapConcat`/`mapFilter`/`mapApply`/`mapUpdate`.
  - `emitProject` substitutes it for a bare JSON-strategy column used as a SELECT projection with no wrapping function at all.
  - Exported as `chsql.JSONAttrMapReconstruction(col string) Frag` for ad-hoc `chsql.Frag`-based callers (see below).
- `internal/api/loki/attr_strategy.go` (new): `attrMapFrag` / `distinctAttrKeysFrag` — the ad-hoc-query-builder equivalents, used by `labels.go`, `series.go`, `detected_labels.go`, `detected_fields.go`. Each `build*SQL` function now takes `chsql.AttrStrategies` explicitly and threads it onto every `chsql.QueryBuilder` it constructs via `.WithAttrStrategies(...)`.
- Two real bugs found and fixed along the way, both pre-dating this PR:
  - `Builder.MapAt` (chsql's ad-hoc equivalent of `chplan.MapAccess`, used by `label_values.go` and `internal/api/prom/metadata.go`) never had a JSON-strategy branch at all — `/loki/api/v1/label/<name>/values` was broken for a JSON-typed column even for the per-key case #3064 was supposed to have covered.
  - `QueryBuilder.Frag()` rendered a nested builder directly into the parent's `Builder`, silently discarding the nested builder's own `WithAttrStrategies(...)` — `label_values.go`'s UNION-ALL fallback path (multiple independent `QueryBuilder` arms spliced via `.Frag()`) lost its JSON strategy entirely until this fix.
- `docs/operations.md`: updated the `#2777` preflight-exception section to describe what's now covered, and added the escape-dots design-decision writeup (see below).

## Design decision: `json_type_escape_dots_in_keys` (point 3)

Made explicitly, since neither this issue nor #3065 (the TraceQL sibling, still open, not yet touched) had decided it yet: **ship as a documented, loud limitation, not a boot-time refuse gate.** A `system.settings` probe can only see the server's *current* setting, not a *past* ingestion-time one — so it cannot rule out the mixed-history case the issue itself flags as the harder half of this hazard. A refuse gate would therefore trade a straightforward, honest limitation for a partial, false sense of safety, plus a new boot-time failure mode operators would have to learn. `docs/operations.md` documents this as precedent for whoever picks up #3065's identical point 3 — they should mirror this decision or diverge with justification.

## Testing

Real chDB differential tests (no mocks), mirroring `attr_strategy_json_chdb_test.go`'s rigor:

- `internal/chsql/attr_strategy_fullmap_chdb_test.go`: `mapConcat`/`mapFilter`/`mapValues`/`mapKeys`/bare-projection against a JSON-typed column reproduce the Map-typed baseline exactly for keys within `maxJSONAttrFlattenDepth`, and a dedicated test pins the documented beyond-bound degradation (partial key, raw JSON substring value, never dropped).
- `internal/api/loki/attr_strategy_fullmap_chdb_test.go`: end-to-end HTTP round-trips through the real handler for `/labels`, `/series`, `/label/<name>/values`, `/detected_labels`, `/detected_fields`, each run against a Map-typed and a JSON-typed `otel_logs` table with logically equivalent seed data, asserting the decoded responses agree.

All new and existing tests pass:
- `go test -race ./internal/api/loki/... ./internal/chsql/... ./internal/chplan/...` — green.
- `go test -tags chdb -run <new tests> ./internal/chsql/... ./internal/api/loki/...` — all 10 new chDB tests pass.
- `go test -race ./test/spec/...` and `./test/regression/...` — green (no golden regressions from the `emitProject`/`Builder.MapAt`/`QueryBuilder.Frag` changes).
- `go-arch-lint check` — clean.
- `node .github/scripts/forbid-sql-raw.mjs` — clean.

## Test plan

- [x] Real chDB differential tests for full-map reconstruction (chsql layer)
- [x] Real chDB differential tests for discovery endpoints (loki API layer, end-to-end HTTP)
- [x] Existing unit test suites for touched packages pass
- [x] TXTAR spec + regression suites pass (no golden drift)
- [x] `go-arch-lint check` clean
- [x] `forbid-sql-raw.mjs` clean
- [ ] CI green (watching)
