### PR TITLE
feat(traceql): thread JSON attribute strategy through full-map ops and discovery endpoints

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2913,22 +2913,50 @@ precise boot-time finding:
       a JSON-typed column too — span/resource/scope attribute matchers
       (`{ span.foo = "bar" }`), numeric/duration comparisons
       (`{ span.http.status_code > 100 }`), and existence checks
-      (`{ span.foo != nil }`). The warning names what remains unsupported:
-      the `compare()` spanset-metrics operator's well-known/generic
-      attribute fan-out, the `/api/search/tags` /
-      `/api/search/tag/{name}/values` discovery endpoints (their queries
-      bypass the per-key lowering entirely, like logs' metadata endpoints
-      above), and a table whose ingestion ever used
-      `json_type_escape_dots_in_keys=1` or mixes dotted-key encodings —
-      tracked as [#3065](https://github.com/tsouza/cerberus/issues/3065).
-      One further caveat specific to `ResourceAttributes`: `/api/search`'s
-      own baseline response shaping merges `ResourceAttributes` with
-      synthetic trace/span/parent-span-id keys on every response, which is
-      itself a full-map operation a JSON-typed `ResourceAttributes` column
-      cannot satisfy yet — so `/api/search` fails on every query
-      regardless of filter shape until #3065 lands the full-map JSON
-      bridge, if `ResourceAttributes` (not `SpanAttributes` /
-      `ScopeAttributes`) is the JSON-typed column.
+      (`{ span.foo != nil }`).
+      [#3065](https://github.com/tsouza/cerberus/issues/3065) closed the
+      remaining TraceQL-side gaps this warning used to name:
+      - **`/api/search`'s baseline response** — `canonicalSampleProjections`
+        / `sampleProjectionsWithSelected` (`internal/api/tempo/handler.go`)
+        unconditionally merge `ResourceAttributes` with synthetic
+        trace/span/parent-span-id keys on **every** response via
+        `mapConcat`/`chplan.FnMapMerge` — a full-map read a JSON-typed
+        `ResourceAttributes` column could not satisfy before this fixed it,
+        which broke the baseline endpoint on every query regardless of
+        filter shape (the highest-priority gap the issue named). No
+        `internal/api/tempo` code change was needed here: the same
+        bounded-depth reconstruction the Logs full-map fix above added to
+        `chsql`'s generic `FnMapMerge`/`FnMapKeys`/`FnMapValues` handling
+        already covers any chplan tree built from those Fn identifiers,
+        TraceQL's included.
+      - **`compare()`'s generic attribute fan-out** — the spanset-metrics
+        operator's well-known/generic attribute enumeration
+        (`compareAttrPairsExpr`, `internal/traceql/metrics_compare.go`)
+        builds its fan-out from the same `FnMapKeys`/`FnMapValues` shape, so
+        it too benefited from the generic `chsql` fix — but the
+        `/api/metrics/query_range` and `/api/metrics/query` pipeline's own
+        `Engine.Lang` adapter (`metricsLang`, `internal/api/tempo/
+        metrics_query_range.go`) never implemented the `EmitAttrStrategies`
+        hook `traceqlLang` (the `/api/search` path) already had — every
+        metrics-pipeline plan silently rendered with `AttrStrategyMap`
+        regardless of the resolved column strategy, a real gap found and
+        fixed by wiring the missing hook (`metricsLang.attrStrategies` +
+        `EmitAttrStrategies()`) onto its three `metricsLang{...}`
+        construction sites.
+      - **`/api/search/tags` / `/api/v2/search/tags` /
+        `/api/search/tag/{name}/values`** — these discovery endpoints
+        build their SQL directly against `chsql.NewQuery()` rather than
+        through `chplan`, so they never reached `AttrStrategies` threading
+        at all — the identical gap Logs' metadata endpoints had. Each now
+        resolves the Handler's `AttrStrategies` itself
+        (`internal/api/tempo/attr_strategy.go`) and threads it onto every
+        `chsql.QueryBuilder` it builds, reaching `chsql.Builder.MapAt` /
+        the new `Builder.MapContains` (the ad-hoc-query-builder
+        equivalents of `chplan.MapAccess` / `FnMapContainsKey`) for
+        per-key value/existence lookups, and `distinctAttrKeysFrag`'s
+        `JSONAllPaths`-based rendering for key discovery.
+      - **`json_type_escape_dots_in_keys` / mixed-history hazard** — see
+        the dedicated callout below this list, shared verbatim with logs.
     - **`json_type_escape_dots_in_keys` / mixed-history hazard — the
       decision, shared by logs and traces (cerberus issues #3063 and
       #3065's identical point 3).** Every JSON rendering above (per-key

--- a/internal/api/tempo/attr_strategy.go
+++ b/internal/api/tempo/attr_strategy.go
@@ -1,0 +1,58 @@
+package tempo
+
+import "github.com/tsouza/cerberus/internal/chsql"
+
+// This file is cerberus issue #3065 point 2's fix: /api/search/tags,
+// /api/v2/search/tags, /api/search/tag/{name}/values and
+// /api/v2/search/tag/{name}/values (search_tags.go / search_tag_values.go)
+// all build their SQL directly against chsql.NewQuery() rather than
+// through a chplan tree lowered by traceqlLang.Parse, so they never reach
+// engine.emitForHead / chsql.Emit's ctx-based AttrStrategies threading at
+// all — wiring Handler.AttrStrategies alone (cerberus issue #3062) had no
+// effect on any of them, mirroring internal/api/loki's identical gap
+// (cerberus issue #3063 point 2, internal/api/loki/attr_strategy.go).
+//
+// Every build*SQL function in search_tags.go / search_tag_values.go now
+// takes the resolved chsql.AttrStrategies explicitly and threads it onto
+// every chsql.QueryBuilder it constructs via .WithAttrStrategies. That
+// alone makes chsql.Builder.MapAt / Builder.MapContains (the ad-hoc
+// equivalents of chplan.MapAccess / FnMapContainsKey — see MapAt's own
+// doc in internal/chsql/builder.go) render correctly against a
+// JSON-strategy column wherever mapAtFrag / mapContainsFrag
+// (search_tag_values.go) already delegate to them, and
+// distinctAttrKeysFrag below covers the one WHOLE-MAP discovery shape
+// (search_tags.go's per-scope key enumeration) that per-key rendering
+// never touched.
+//
+// The Nested Events.Attributes / Links.Attributes families
+// (attrMapScopeEvent / attrMapScopeLink, distinctNestedMapKeysFrag /
+// buildNestedAttributeValuesSQL) are NOT in scope here: cerberus issue
+// #2777's JSON-strategy work only ever resolves AttrStrategyJSON for a
+// flat Map(String, String) attribute column
+// (SpanAttributes/ResourceAttributes/ScopeAttributes), never for a Nested
+// column's per-element Array(Map(...)) subfield — there is no JSON
+// encoding decision to make for those at all. Threading .WithAttrStrategies
+// onto their QueryBuilders below is still done, for the same reason
+// internal/api/loki threads it onto every builder regardless of whether a
+// given call site touches an attribute-map column: a byte-identical
+// no-op today, and one less place a future column addition could forget.
+
+// distinctAttrKeysFrag renders the discovery-query idiom "every distinct
+// key present in col across the matched rows" — /api/search/tags' per-scope
+// key-enumeration shape. The Map-typed branch is the .keys-subcolumn shape
+// distinctMapKeysFrag always used (kept byte-identical); the JSON-strategy
+// branch uses JSONAllPaths(col) instead, which reports the SAME flat
+// dot-joined leaf key strings the Map .keys subcolumn would for an
+// equivalent flat key set — see chsql's jsonFullMapReconstruction doc
+// (internal/chsql/attr_strategy_fullmap.go) for why JSONAllPaths already
+// does this without needing chsql's full bounded-depth-flatten machinery
+// (a KEY enumeration is exactly the shape ClickHouse's own JSONAllPaths
+// natively reports; only per-key VALUE extraction needed that machinery).
+// Mirrors internal/api/loki/attr_strategy.go's distinctAttrKeysFrag
+// exactly.
+func distinctAttrKeysFrag(strategies chsql.AttrStrategies, col string) chsql.Frag {
+	if strategies.Lookup(col) == chsql.AttrStrategyJSON {
+		return chsql.Distinct(chsql.Call("arrayJoin", chsql.Call("JSONAllPaths", chsql.Col(col))))
+	}
+	return distinctMapKeysFrag(col)
+}

--- a/internal/api/tempo/grpc_exports.go
+++ b/internal/api/tempo/grpc_exports.go
@@ -84,7 +84,7 @@ func (h *Handler) CollectAttributeTagScopes(
 	if err != nil {
 		return nil, err
 	}
-	return h.collectAttributeTagScopes(ctx, scope, filter, start, end)
+	return h.collectAttributeTagScopes(ctx, scope, filter, start, end, h.AttrStrategies)
 }
 
 // SortedUnique returns the de-duplicated, lexicographically sorted
@@ -157,10 +157,10 @@ func (h *Handler) FetchTagValues(
 		args   []any
 	)
 	if r.IsIntrinsic {
-		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, r.IntrinsicCol, filter, start, end)
+		sqlStr, args = buildIntrinsicValuesSQL(h.Schema, r.IntrinsicCol, filter, start, end, h.AttrStrategies)
 		valueType = intrinsicType(r.IntrinsicName)
 	} else {
-		sqlStr, args = buildAttributeValuesSQL(h.Schema, r.Key, r.mapScope, filter, start, end)
+		sqlStr, args = buildAttributeValuesSQL(h.Schema, r.Key, r.mapScope, filter, start, end, h.AttrStrategies)
 		valueType = "string"
 	}
 	raw, err := h.Client.QueryStrings(ctx, sqlStr, args...)

--- a/internal/api/tempo/metrics_compare_json_chdb_test.go
+++ b/internal/api/tempo/metrics_compare_json_chdb_test.go
@@ -1,0 +1,199 @@
+//go:build chdb
+
+// chDB-backed proof of cerberus issue #3065 item 1: does `| compare()`'s
+// generic attribute fan-out (compareAttrPairsExpr's `generic()` closure in
+// internal/traceql/metrics_compare.go, which builds
+// arrayZip(mapKeys(<col>), mapValues(<col>)) then arrayFilter/arrayMap over
+// it) work against a JSON-typed SpanAttributes column?
+//
+// The issue names this as a standing gap: "the compare() spanset-metrics
+// operator's well-known/generic attribute fan-out reads the WHOLE attribute
+// map at once via mapKeys/mapValues/arrayZip/arrayFilter to project every
+// attribute as a labeled column ... against a JSON-typed column this still
+// fails at query time with ILLEGAL_TYPE_OF_ARGUMENT". That gap existed
+// before cerberus issue #3063's PR (#3071) generalised
+// internal/chsql/attr_strategy_fullmap.go's bounded-depth reconstruction:
+// exprFunc now substitutes ANY bare JSON-strategy chplan.ColumnRef argument
+// to chplan.FnMapKeys / FnMapValues (jsonFullMapFns) with
+// jsonFullMapReconstruction(col) before the normal Fn-name resolution runs
+// — a mechanism generic over every chplan tree, not specific to LogQL's own
+// full-map call sites. compareAttrPairsExpr's generic() closure already
+// builds its fan-out out of exactly those two Fn identifiers
+// (chplan.FnMapKeys / chplan.FnMapValues) applied to a bare
+// *chplan.ColumnRef, so #3065's item 1 needs NO code change in
+// internal/traceql/metrics_compare.go — this file is the empirical proof
+// that the shared #3071 substitution already closes it, run against
+// compare()'s real emitted SQL end-to-end (parse -> lower -> emit ->
+// ClickHouse -> BaselineAggregator-style post-processing), not merely
+// re-derived by reading exprFunc's dispatch order.
+package tempo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// compareTracesDDL renders an otel_traces-shaped table with an independent
+// SpanAttributes type, matching the columns compareAttrPairsExpr and the
+// compare() lowering read (status/kind/name intrinsics, Duration,
+// Timestamp, the two attribute maps).
+func compareTracesDDL(table, spanAttrType string) string {
+	return fmt.Sprintf(`CREATE TABLE %s (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    SpanKind LowCardinality(String),
+    StatusCode LowCardinality(String),
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String,
+    ServiceName String,
+    Duration Int64,
+    Timestamp DateTime64(9),
+    SpanAttributes %s,
+    ResourceAttributes Map(String, String)
+) ENGINE = MergeTree() ORDER BY (Timestamp);`, table, spanAttrType)
+}
+
+// compareSeed seeds three single-span traces exercising the compare()
+// selection/baseline split (`{status = error}`) plus a generic (not in
+// wellKnownSpanAttrs) SpanAttributes key so the test proves the GENERIC
+// mapKeys/mapValues fan-out — not the well-known dedicated-column path,
+// which #3062's own attr_strategy_json_chdb_test.go already covers via
+// FieldAccess/FnMapContainsKey — reconstructs correctly against JSON:
+//
+//	s1 status=Error   custom_tag="checkout"  -> selection cohort
+//	s2 status=Unset   custom_tag="checkout"  -> baseline cohort
+//	s3 status=Unset   custom_tag absent      -> baseline cohort, attr absent
+func compareSeed(table, presentAttrLit, absentAttrLit string) string {
+	return fmt.Sprintf(`INSERT INTO %s VALUES
+    ('e0000000000000000000000000000001', '5000000000000001', '', 'checkout', 'Server', 'Error', '', '', '', 'svc', 200000000, toDateTime64('2026-05-12 10:01:00.000000000', 9), %s, map()),
+    ('e0000000000000000000000000000002', '5000000000000002', '', 'checkout', 'Server', 'Unset', '', '', '', 'svc', 150000000, toDateTime64('2026-05-12 10:01:30.000000000', 9), %s, map()),
+    ('e0000000000000000000000000000003', '5000000000000003', '', 'other', 'Server', 'Unset', '', '', '', 'svc', 100000000, toDateTime64('2026-05-12 10:02:00.000000000', 9), %s, map());`,
+		table, presentAttrLit, presentAttrLit, absentAttrLit)
+}
+
+// compareServer builds a tempo.Handler over a compare-shaped otel_traces
+// table with attrStrategies wired the same way
+// attr_strategy_json_chdb_test.go's newAttrStrategyChDBServer does.
+func compareServer(t *testing.T, c *chclienttest.Client, table, spanAttrType, presentAttrLit, absentAttrLit string, strategies chsql.AttrStrategies) *httptest.Server {
+	t.Helper()
+	c.Seed(t, compareTracesDDL(table, spanAttrType))
+	c.Seed(t, compareSeed(table, presentAttrLit, absentAttrLit))
+	s := schema.DefaultOTelTraces()
+	s.SpansTable = table
+	h := tempo.New(c, s, "v-test", nil)
+	h.SetAttrStrategies(strategies)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestTraceQL_JSONAttrStrategy_CompareGenericFanOut_ChDB runs
+// `{} | compare({status = error})` against a Map-typed control table and a
+// JSON-typed (SpanAttributes) table seeded identically, and asserts both
+// surface the SAME generic `span.custom_tag` series in both the selection
+// and baseline cohorts — proving compareAttrPairsExpr's generic()
+// mapKeys/mapValues/arrayZip/arrayFilter fan-out reconstructs a JSON-typed
+// column's full attribute set exactly like a genuine Map column, with no
+// query-time ILLEGAL_TYPE_OF_ARGUMENT.
+func TestTraceQL_JSONAttrStrategy_CompareGenericFanOut_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	const mapTable, jsonTable = "attr_strategy_compare_map", "attr_strategy_compare_json"
+	strategies := chsql.AttrStrategies{"SpanAttributes": chsql.AttrStrategyJSON}
+
+	mapSrv := compareServer(t, c, mapTable, "Map(String, String)",
+		"map('custom_tag', 'checkout')", "map()", nil)
+	jsonSrv := compareServer(t, c, jsonTable, "JSON",
+		`'{"custom_tag":"checkout"}'`, `'{}'`, strategies)
+
+	start := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC)
+	params := map[string]string{
+		"start": fmt.Sprintf("%d", start.Unix()),
+		"end":   fmt.Sprintf("%d", end.Unix()),
+		"step":  "180s",
+	}
+
+	mapGot := customTagSeries(t, mapSrv, metricsQueryRangeURL(mapSrv.URL, `{} | compare({status = error}, 10)`, params))
+	jsonGot := customTagSeries(t, jsonSrv, metricsQueryRangeURL(jsonSrv.URL, `{} | compare({status = error}, 10)`, params))
+
+	want := map[string]float64{
+		"selection:checkout": 1,
+		"baseline:checkout":  1,
+	}
+	if !floatMapEq(mapGot, want) {
+		t.Fatalf("Map compare() custom_tag series = %v, want %v (test's own expectation, not just Map==JSON)", mapGot, want)
+	}
+	if !floatMapEq(jsonGot, want) {
+		t.Errorf("JSON compare() custom_tag series = %v, want %v — compareAttrPairsExpr's generic "+
+			"mapKeys/mapValues fan-out must reconstruct a JSON-typed column exactly like Map", jsonGot, want)
+	}
+}
+
+// customTagSeries issues the compare() query and returns, for every series
+// carrying a "span.custom_tag" label, a "<meta>:<value>" -> total-count map
+// (summed across the zero-filled grid) — the shape the test compares
+// between the Map and JSON variants.
+func customTagSeries(t *testing.T, srv *httptest.Server, u string) map[string]float64 {
+	t.Helper()
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var out tempo.MetricsQueryRangeResponse
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	got := map[string]float64{}
+	for _, s := range out.Series {
+		var meta, attrVal string
+		hasCustomTag := false
+		for _, l := range s.Labels {
+			switch l.Key {
+			case "__meta_type":
+				meta = l.Value
+			case "span.custom_tag":
+				hasCustomTag = true
+				attrVal = l.Value
+			}
+		}
+		if !hasCustomTag || (meta != "selection" && meta != "baseline") {
+			continue
+		}
+		var total float64
+		for _, sm := range s.Samples {
+			total += sm.Value
+		}
+		got[meta+":"+attrVal] = total
+	}
+	return got
+}
+
+func floatMapEq(a, b map[string]float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/tempo/metrics_exec.go
+++ b/internal/api/tempo/metrics_exec.go
@@ -129,7 +129,7 @@ func (h *Handler) execMetricsRangeHistogram(
 	}
 	wrapped := wrapHistogramForSample(rw, hist)
 
-	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{spansTable: h.Schema.SpansTable}, wrapped, engine.Meta{
+	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{spansTable: h.Schema.SpansTable, attrStrategies: h.AttrStrategies}, wrapped, engine.Meta{
 		IsMetric:      true,
 		ResponseShape: shape,
 	})
@@ -209,7 +209,7 @@ func (h *Handler) runMetricsWindow(
 	// metricsLang.ProjectSamples is a passthrough (the Sample
 	// projection is already wrapped above) so engine.QueryPlan runs
 	// optimize → emit → execute without re-wrapping the shape.
-	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{spansTable: h.Schema.SpansTable}, wrapped, engine.Meta{
+	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{spansTable: h.Schema.SpansTable, attrStrategies: h.AttrStrategies}, wrapped, engine.Meta{
 		IsMetric:      true,
 		ResponseShape: shape,
 	})

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tsouza/cerberus/internal/api/httperr"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/telemetry"
 	traceql_lower "github.com/tsouza/cerberus/internal/traceql"
@@ -162,7 +163,27 @@ type MetricsSample struct {
 // lower + wrap) before calling engine.QueryPlan, so Parse is unused
 // and ProjectSamples is a passthrough (the matrix-shape Project is
 // already on top of the plan).
-type metricsLang struct{ spansTable string }
+//
+// cerberus issue #3065 item 1: attrStrategies carries the Handler's
+// resolved chsql.AttrStrategies (h.AttrStrategies, wired via
+// SetAttrStrategies exactly like traceqlLang.AttrStrategies) — every
+// metricsLang{...} construction (metrics_exec.go's two call sites, this
+// file's histogram path, metrics_query_range_compare.go's compare() path)
+// must set it, or a metrics-pipeline plan silently loses attribute-map
+// JSON-strategy rendering even though the SAME schema.Traces columns
+// resolved to AttrStrategyJSON for /api/search's traceqlLang-routed
+// plans. Before this field existed, EmitAttrStrategies() below did not
+// exist either, so engine.attrStrategiesForLang's duck-type check found
+// no attrStrategier implementation for metricsLang and threaded a bare
+// nil onto every metrics-pipeline emit context — the confirmed root cause
+// of `| compare()`'s generic mapKeys/mapValues fan-out
+// (internal/traceql/metrics_compare.go's compareAttrPairsExpr) rendering
+// plain mapKeys/mapContains against a JSON-typed column and failing with
+// ILLEGAL_TYPE_OF_ARGUMENT (see metrics_compare_json_chdb_test.go).
+type metricsLang struct {
+	spansTable     string
+	attrStrategies chsql.AttrStrategies
+}
 
 func (metricsLang) Name() string { return "traceql" }
 
@@ -172,6 +193,11 @@ func (metricsLang) Name() string { return "traceql" }
 // metrics-emitter subtree), but threading it means the chokepoint still runs
 // over the rest of a metrics plan.
 func (l metricsLang) SpansTable() string { return l.spansTable }
+
+// EmitAttrStrategies duck-types metricsLang against engine's attrStrategier
+// interface, exactly like traceqlLang.EmitAttrStrategies — see this type's
+// own doc for why the metrics pipeline needs this method at all.
+func (l metricsLang) EmitAttrStrategies() chsql.AttrStrategies { return l.attrStrategies }
 
 func (metricsLang) Parse(_ context.Context, _ string) (chplan.Node, engine.Meta, error) {
 	// Engine.QueryPlan never calls Parse; the error keeps the adapter

--- a/internal/api/tempo/metrics_query_range_compare.go
+++ b/internal/api/tempo/metrics_query_range_compare.go
@@ -371,7 +371,7 @@ func (h *Handler) execCompareRange(
 	}
 	wrapped := wrapCompareForSample(rw, cmp)
 
-	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{spansTable: h.Schema.SpansTable}, wrapped, engine.Meta{
+	res, qerr := h.Engine.QueryPlan(ctx, metricsLang{spansTable: h.Schema.SpansTable, attrStrategies: h.AttrStrategies}, wrapped, engine.Meta{
 		IsMetric:      true,
 		ResponseShape: shape,
 	})

--- a/internal/api/tempo/scope_completeness_test.go
+++ b/internal/api/tempo/scope_completeness_test.go
@@ -115,7 +115,7 @@ func TestBuildAttributeValuesSQL_HandlesEveryScope(t *testing.T) {
 	for _, scope := range allAttrMapScopes {
 		t.Run(scope.String(), func(t *testing.T) {
 			t.Parallel()
-			sqlStr, _ := buildAttributeValuesSQL(s, "some.key", scope, nil, time.Time{}, time.Time{})
+			sqlStr, _ := buildAttributeValuesSQL(s, "some.key", scope, nil, time.Time{}, time.Time{}, nil)
 			if sqlStr == "" {
 				t.Errorf("buildAttributeValuesSQL(%v) produced empty SQL", scope)
 			}
@@ -129,7 +129,7 @@ func TestBuildAttributeValuesSQL_HandlesEveryScope(t *testing.T) {
 				t.Fatal("expected buildAttributeValuesSQL to panic for an unrecognised attrMapScope")
 			}
 		}()
-		buildAttributeValuesSQL(s, "some.key", attrMapScope(99), nil, time.Time{}, time.Time{})
+		buildAttributeValuesSQL(s, "some.key", attrMapScope(99), nil, time.Time{}, time.Time{}, nil)
 	})
 }
 

--- a/internal/api/tempo/search_baseline_json_chdb_test.go
+++ b/internal/api/tempo/search_baseline_json_chdb_test.go
@@ -24,9 +24,9 @@
 //
 // attr_strategy_json_chdb_test.go's own package doc explicitly named this
 // gap and deliberately kept ResourceAttributes Map-typed in every table it
-// seeds "even the JSON variant" — flagging this exact follow-up. This file
-// is that follow-up: it flips ResourceAttributes (not SpanAttributes) to
-// JSON and re-runs /api/search end-to-end.
+// seeds "even the JSON variant". Resolved in this change: this file flips
+// ResourceAttributes (not SpanAttributes) to JSON and re-runs /api/search
+// end-to-end.
 package tempo_test
 
 import (

--- a/internal/api/tempo/search_baseline_json_chdb_test.go
+++ b/internal/api/tempo/search_baseline_json_chdb_test.go
@@ -1,0 +1,230 @@
+//go:build chdb
+
+// chDB-backed proof of cerberus issue #3065 item 0 (the issue's highest
+// priority item, filed ahead of compare()/tag-discovery specifically
+// because it blocks the /api/search baseline endpoint rather than an
+// advanced operator): canonicalSampleProjections / sampleProjectionsWithSelected
+// (handler.go) unconditionally build every /api/search response's
+// Attributes column via
+//
+//	mapConcat(ResourceAttributes, map('__cerberus_traceID', ..., ...))
+//
+// — a chplan.FuncCall{Fn: chplan.FnMapMerge, ...} whose first argument is a
+// bare *chplan.ColumnRef. cerberus issue #3063's PR (#3071) generalised
+// internal/chsql/attr_strategy_fullmap.go's bounded-depth JSON
+// reconstruction into exprFunc's dispatch for EVERY chplan tree using one
+// of the jsonFullMapFns identifiers (FnMapMerge included), not merely
+// LogQL's own call sites — so unlike item 1
+// (metrics_compare_json_chdb_test.go, which needed a real fix:
+// metricsLang was missing EmitAttrStrategies entirely), /api/search routes
+// through traceqlLang, which already implements EmitAttrStrategies
+// (cerberus issue #3062) — so this file is the empirical proof that item 0
+// needs NO further code change, only this test, once #3071's generic
+// chsql-layer substitution is in place.
+//
+// attr_strategy_json_chdb_test.go's own package doc explicitly named this
+// gap and deliberately kept ResourceAttributes Map-typed in every table it
+// seeds "even the JSON variant" — flagging this exact follow-up. This file
+// is that follow-up: it flips ResourceAttributes (not SpanAttributes) to
+// JSON and re-runs /api/search end-to-end.
+package tempo_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// searchBaselineTracesDDL renders an otel_traces-shaped table with an
+// independent ResourceAttributes type — the column canonicalSampleProjections'
+// mapConcat/FnMapMerge always reads in full for every /api/search response,
+// regardless of the query's own filter shape.
+func searchBaselineTracesDDL(table, resourceAttrType string) string {
+	return fmt.Sprintf(`CREATE TABLE %s (
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    SpanName String,
+    SpanKind LowCardinality(String),
+    Duration Int64,
+    Timestamp DateTime64(9),
+    StatusCode LowCardinality(String),
+    StatusMessage String,
+    ScopeName String,
+    ScopeVersion String,
+    SpanAttributes Map(String, String),
+    ResourceAttributes %s
+) ENGINE = MergeTree() ORDER BY (Timestamp);`, table, resourceAttrType)
+}
+
+// searchBaselineSeed seeds one single-span trace whose ResourceAttributes
+// carries two generic keys — service.name (also read via the well-known
+// synthesis elsewhere in the package, here just an ordinary generic key)
+// and a second, arbitrary key — so the reconstructed map must surface BOTH
+// alongside the synthetic __cerberus_traceID / __cerberus_parentSpanID /
+// __cerberus_spanID entries mapConcat/FnMapMerge always adds.
+func searchBaselineSeed(table, resourceAttrLit string) string {
+	return fmt.Sprintf(`INSERT INTO %s VALUES
+    ('f0000000000000000000000000000001', '6000000000000001', '', 'checkout', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000001', 9), 'Unset', '', '', '', map(), %s);`,
+		table, resourceAttrLit)
+}
+
+// newSearchBaselineServer mirrors attr_strategy_json_chdb_test.go's
+// newAttrStrategyChDBServer, kept as a distinct helper in this file since
+// it flips ResourceAttributes rather than SpanAttributes.
+func newSearchBaselineServer(t *testing.T, c *chclienttest.Client, table, ddl, seed string, attrStrategies chsql.AttrStrategies) *httptest.Server {
+	t.Helper()
+	c.Seed(t, ddl)
+	c.Seed(t, seed)
+	s := schema.DefaultOTelTraces()
+	s.SpansTable = table
+	h := tempo.New(c, s, "v-test", nil)
+	h.SetAttrStrategies(attrStrategies)
+	mux := http.NewServeMux()
+	h.Mount(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestSearch_JSONResourceAttributes_BaselineResponse_ChDB runs a
+// match-everything /api/search (`q={}`, no filter beyond the time window)
+// against a Map-typed
+// control table and a JSON-typed (ResourceAttributes) table seeded
+// identically, and asserts both surface the SAME TraceID/SpanID —
+// populated via the SAME mergedAttrs mapConcat(ResourceAttributes, ...)
+// FnMapMerge this file targets, through its `__cerberus_traceID` /
+// `__cerberus_spanID` reserved-key extraction (toTraceSummaries /
+// observeSpan; observeSpan DROPS a row outright when
+// `__cerberus_spanID` fails to extract, so a wrong/absent reconstruction
+// would silently shrink the response rather than merely mis-render one
+// attribute value). A query-time TYPE_MISMATCH / ILLEGAL_TYPE_OF_ARGUMENT
+// against the JSON-typed column — item 0's pre-#3071 failure mode — would
+// instead surface as a 500 for every query regardless of filter shape,
+// which searchBaselineIDs' status check catches directly.
+//
+// A second case adds `| select(resource.deploy.env)` to prove the
+// generic ResourceAttributes content actually reaches the wire too (via
+// selectedAttrKVPairs' `__cerberus_sel_str_*` reserved-key convention,
+// itself folded into the SAME mergedAttrs map) — not merely the three
+// fixed reserved keys every response carries regardless of content.
+func TestSearch_JSONResourceAttributes_BaselineResponse_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	const mapTable, jsonTable = "search_baseline_resattr_map", "search_baseline_resattr_json"
+	strategies := chsql.AttrStrategies{"ResourceAttributes": chsql.AttrStrategyJSON}
+
+	mapSrv := newSearchBaselineServer(t, c, mapTable,
+		searchBaselineTracesDDL(mapTable, "Map(String, String)"),
+		searchBaselineSeed(mapTable, "map('service.name', 'checkout-svc', 'deploy.env', 'prod')"), nil)
+	jsonSrv := newSearchBaselineServer(t, c, jsonTable,
+		searchBaselineTracesDDL(jsonTable, "JSON"),
+		searchBaselineSeed(jsonTable, `'{"service.name":"checkout-svc","deploy.env":"prod"}'`), strategies)
+
+	const wantTraceID = "f0000000000000000000000000000001"
+	const wantSpanID = "6000000000000001"
+
+	t.Run("bare_query_reserved_keys", func(t *testing.T) {
+		const bareQuery = `{}`
+		mapID, mapSpan := searchBaselineIDs(t, mapSrv, bareQuery)
+		if mapID != wantTraceID || mapSpan != wantSpanID {
+			t.Fatalf("Map /api/search TraceID/SpanID = %q/%q, want %q/%q (test's own expectation, not just Map==JSON)",
+				mapID, mapSpan, wantTraceID, wantSpanID)
+		}
+		jsonID, jsonSpan := searchBaselineIDs(t, jsonSrv, bareQuery)
+		if jsonID != wantTraceID || jsonSpan != wantSpanID {
+			t.Errorf("JSON /api/search TraceID/SpanID = %q/%q, want %q/%q — canonicalSampleProjections' "+
+				"mapConcat(ResourceAttributes, ...) must reconstruct the __cerberus_traceID/__cerberus_spanID "+
+				"reserved keys exactly like Map", jsonID, jsonSpan, wantTraceID, wantSpanID)
+		}
+	})
+
+	t.Run("select_generic_resource_attribute", func(t *testing.T) {
+		q := `{} | select(resource.deploy.env)`
+		mapAttrs := searchBaselineSelectedAttrs(t, mapSrv, q)
+		if mapAttrs["deploy.env"] != "prod" {
+			t.Fatalf("Map /api/search select(resource.deploy.env) = %v, want deploy.env=prod (test's own expectation, not just Map==JSON)", mapAttrs)
+		}
+		jsonAttrs := searchBaselineSelectedAttrs(t, jsonSrv, q)
+		if jsonAttrs["deploy.env"] != "prod" {
+			t.Errorf("JSON /api/search select(resource.deploy.env) = %v, want deploy.env=prod — the generic "+
+				"ResourceAttributes content must reach the wire through the JSON reconstruction too", jsonAttrs)
+		}
+	})
+}
+
+// searchBaselineIDs issues /api/search with query q and returns the
+// single expected trace's TraceID and its single span's SpanID. Fails the
+// test outright on a non-200 or an unexpected trace/span count, since a
+// TYPE_MISMATCH / ILLEGAL_TYPE_OF_ARGUMENT failure surfaces as a 5xx with
+// no IDs to compare at all, and observeSpan silently drops a row whose
+// __cerberus_spanID extraction failed rather than erroring.
+func searchBaselineIDs(t *testing.T, srv *httptest.Server, q string) (traceID, spanID string) {
+	t.Helper()
+	reqURL := srv.URL + "/api/search?q=" + url.QueryEscape(q) + "&" + jsonAttrSearchWindowQS
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var sr tempo.SearchResponse
+	if err := json.Unmarshal([]byte(body), &sr); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	if len(sr.Traces) != 1 {
+		t.Fatalf("expected exactly 1 trace, got %d: %s", len(sr.Traces), body)
+	}
+	tr := sr.Traces[0]
+	var spans []tempo.SpanSetSpan
+	for _, ss := range tr.SpanSets {
+		spans = append(spans, ss.Spans...)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected exactly 1 span, got %d: %s", len(spans), body)
+	}
+	return tr.TraceID, spans[0].SpanID
+}
+
+// searchBaselineSelectedAttrs issues /api/search with query q and returns
+// the flattened `| select(...)` Attributes of the single expected span.
+func searchBaselineSelectedAttrs(t *testing.T, srv *httptest.Server, q string) map[string]string {
+	t.Helper()
+	resp, err := http.Get(srv.URL + "/api/search?q=" + url.QueryEscape(q) + "&" + jsonAttrSearchWindowQS)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var sr tempo.SearchResponse
+	if err := json.Unmarshal([]byte(body), &sr); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	var spans []tempo.SpanSetSpan
+	for _, tr := range sr.Traces {
+		for _, ss := range tr.SpanSets {
+			spans = append(spans, ss.Spans...)
+		}
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected exactly 1 span, got %d: %s", len(spans), body)
+	}
+	out := map[string]string{}
+	for _, kv := range spans[0].Attributes {
+		if kv.Value.StringValue != nil {
+			out[kv.Key] = *kv.Value.StringValue
+		}
+	}
+	return out
+}

--- a/internal/api/tempo/search_tag_values.go
+++ b/internal/api/tempo/search_tag_values.go
@@ -177,10 +177,10 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, route
 			args   []any
 		)
 		if resolved.IsIntrinsic {
-			sqlStr, args = buildIntrinsicValuesSQL(h.Schema, resolved.IntrinsicCol, filter, start, end)
+			sqlStr, args = buildIntrinsicValuesSQL(h.Schema, resolved.IntrinsicCol, filter, start, end, h.AttrStrategies)
 			valueTyp = intrinsicType(resolved.IntrinsicName)
 		} else {
-			sqlStr, args = buildAttributeValuesSQL(h.Schema, resolved.Key, resolved.MapScope, filter, start, end)
+			sqlStr, args = buildAttributeValuesSQL(h.Schema, resolved.Key, resolved.MapScope, filter, start, end, h.AttrStrategies)
 		}
 		h.Logger.Debug("cerberus tempo /search/tag/values",
 			"tag", name,
@@ -225,10 +225,11 @@ func (h *Handler) respondTagValues(w http.ResponseWriter, r *http.Request, route
 // `filter` is the optional `?q=` span-row predicate (see
 // search_tags_filter.go); a nil filter appends no clause, so a request
 // without `q` renders exactly the SQL it always did.
-func buildIntrinsicValuesSQL(s schema.Traces, col string, filter chsql.Frag, start, end time.Time) (string, []any) {
+func buildIntrinsicValuesSQL(s schema.Traces, col string, filter chsql.Frag, start, end time.Time, strategies chsql.AttrStrategies) (string, []any) {
 	sb := chsql.NewQuery().
 		Select(distinctToStringFrag(col)).
-		From(chsql.Col(s.SpansTable))
+		From(chsql.Col(s.SpansTable)).
+		WithAttrStrategies(strategies)
 	if !start.IsZero() {
 		sb.Where(tempoTimeGteFrag(s.TimestampColumn, start))
 	}
@@ -305,21 +306,21 @@ func buildIntrinsicValuesSQL(s schema.Traces, col string, filter chsql.Frag, sta
 // it short-circuits to an empty result instead, the same treatment
 // attributeTagScopes() already gives an unconfigured instrumentation
 // bucket for /search/tags.
-func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, filter chsql.Frag, start, end time.Time) (string, []any) {
+func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, filter chsql.Frag, start, end time.Time, strategies chsql.AttrStrategies) (string, []any) {
 	switch scope {
 	case attrMapScopeEvent:
-		return buildNestedAttributeValuesSQL(s, s.EventsColumn, name, filter, start, end)
+		return buildNestedAttributeValuesSQL(s, s.EventsColumn, name, filter, start, end, strategies)
 	case attrMapScopeLink:
-		return buildNestedAttributeValuesSQL(s, s.LinksColumn, name, filter, start, end)
+		return buildNestedAttributeValuesSQL(s, s.LinksColumn, name, filter, start, end, strategies)
 	}
 	switch scope {
 	case attrMapScopeResource:
 		if col, ok := s.MaterializedResourceAttributeColumns[name]; ok {
-			return buildMaterializedAttributeValuesSQL(s, col, materializedColumnNumeric(name), filter, start, end)
+			return buildMaterializedAttributeValuesSQL(s, col, materializedColumnNumeric(name), filter, start, end, strategies)
 		}
 	case attrMapScopeSpan:
 		if col, ok := s.MaterializedSpanAttributeColumns[name]; ok {
-			return buildMaterializedAttributeValuesSQL(s, col, materializedColumnNumeric(name), filter, start, end)
+			return buildMaterializedAttributeValuesSQL(s, col, materializedColumnNumeric(name), filter, start, end, strategies)
 		}
 	case attrMapScopeAny:
 		spanCol, spanMaterialized := s.MaterializedSpanAttributeColumns[name]
@@ -329,7 +330,7 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 				s, name,
 				spanCol, spanMaterialized,
 				resCol, resMaterialized,
-				filter, start, end,
+				filter, start, end, strategies,
 			)
 		}
 	}
@@ -379,7 +380,8 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 	inner := chsql.NewQuery().
 		Select(selFrag).
 		From(chsql.Col(s.SpansTable)).
-		Where(whereFrag)
+		Where(whereFrag).
+		WithAttrStrategies(strategies)
 	if !start.IsZero() {
 		inner.Where(tempoTimeGteFrag(s.TimestampColumn, start))
 	}
@@ -393,7 +395,8 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 	outer := chsql.NewQuery().
 		Select(chsql.Distinct(chsql.Col("v"))).
 		From(inner.Frag()).
-		Where(nonEmptyFrag("v"))
+		Where(nonEmptyFrag("v")).
+		WithAttrStrategies(strategies)
 	return outer.Build()
 }
 
@@ -420,7 +423,7 @@ func buildAttributeValuesSQL(s schema.Traces, name string, scope attrMapScope, f
 // auto-scope form — an event./link. prefix is always a single-scope
 // request (see resolveTagName) — so unlike its flat-Map sibling this
 // builder has no attrMapScopeAny-shaped union branch to consider.
-func buildNestedAttributeValuesSQL(s schema.Traces, nestedCol, name string, filter chsql.Frag, start, end time.Time) (string, []any) {
+func buildNestedAttributeValuesSQL(s schema.Traces, nestedCol, name string, filter chsql.Frag, start, end time.Time, strategies chsql.AttrStrategies) (string, []any) {
 	inner := chsql.NewQuery().
 		Select(chsql.Col("v")).
 		From(chsql.Col(s.SpansTable)).
@@ -428,7 +431,8 @@ func buildNestedAttributeValuesSQL(s schema.Traces, nestedCol, name string, filt
 			chsql.As(nestedMapKeysFlatFrag(nestedCol), "k"),
 			chsql.As(nestedMapValuesFlatFrag(nestedCol), "v"),
 		).
-		Where(chsql.Eq(chsql.Col("k"), chsql.Lit(name)))
+		Where(chsql.Eq(chsql.Col("k"), chsql.Lit(name))).
+		WithAttrStrategies(strategies)
 	if !start.IsZero() {
 		inner.Where(tempoTimeGteFrag(s.TimestampColumn, start))
 	}
@@ -442,7 +446,8 @@ func buildNestedAttributeValuesSQL(s schema.Traces, nestedCol, name string, filt
 	outer := chsql.NewQuery().
 		Select(chsql.Distinct(chsql.Col("v"))).
 		From(inner.Frag()).
-		Where(nonEmptyFrag("v"))
+		Where(nonEmptyFrag("v")).
+		WithAttrStrategies(strategies)
 	return outer.Build()
 }
 
@@ -493,11 +498,12 @@ func materializedColumnPresenceFrag(col string, numeric bool) chsql.Frag {
 // buildAttributeValuesSQL's map-backed shape, this needs no arrayJoin
 // fan-out, no mapContains pre-filter, and no inner/outer query split: a
 // direct DISTINCT read is both the correct and the cheapest shape.
-func buildMaterializedAttributeValuesSQL(s schema.Traces, col string, numeric bool, filter chsql.Frag, start, end time.Time) (string, []any) {
+func buildMaterializedAttributeValuesSQL(s schema.Traces, col string, numeric bool, filter chsql.Frag, start, end time.Time, strategies chsql.AttrStrategies) (string, []any) {
 	sb := chsql.NewQuery().
 		Select(distinctToStringFrag(col)).
 		From(chsql.Col(s.SpansTable)).
-		Where(materializedColumnPresenceFrag(col, numeric))
+		Where(materializedColumnPresenceFrag(col, numeric)).
+		WithAttrStrategies(strategies)
 	if !start.IsZero() {
 		sb.Where(tempoTimeGteFrag(s.TimestampColumn, start))
 	}
@@ -568,15 +574,17 @@ func buildAutoScopeUnionAttributeValuesSQL(
 	spanCol string, spanMaterialized bool,
 	resCol string, resMaterialized bool,
 	filter chsql.Frag, start, end time.Time,
+	strategies chsql.AttrStrategies,
 ) (string, []any) {
 	numeric := materializedColumnNumeric(name)
-	spanArm := attrValueArmFrag(s, s.AttributesColumn, spanCol, spanMaterialized, numeric, name, filter, start, end)
-	resArm := attrValueArmFrag(s, s.ResourceAttributesColumn, resCol, resMaterialized, numeric, name, filter, start, end)
+	spanArm := attrValueArmFrag(s, s.AttributesColumn, spanCol, spanMaterialized, numeric, name, filter, start, end, strategies)
+	resArm := attrValueArmFrag(s, s.ResourceAttributesColumn, resCol, resMaterialized, numeric, name, filter, start, end, strategies)
 
 	outer := chsql.NewQuery().
 		Select(chsql.Distinct(chsql.Col("v"))).
 		From(chsql.Paren(chsql.UnionAll(spanArm, resArm))).
-		Where(nonEmptyFrag("v"))
+		Where(nonEmptyFrag("v")).
+		WithAttrStrategies(strategies)
 	return outer.Build()
 }
 
@@ -596,8 +604,8 @@ func buildAutoScopeUnionAttributeValuesSQL(
 // (mirrors buildAttributeValuesSQL's single-scope map-backed branch,
 // already String). materializedCol and numeric are both ignored when
 // materialized is false.
-func attrValueArmFrag(s schema.Traces, mapCol, materializedCol string, materialized, numeric bool, name string, filter chsql.Frag, start, end time.Time) chsql.Frag {
-	arm := chsql.NewQuery().From(chsql.Col(s.SpansTable))
+func attrValueArmFrag(s schema.Traces, mapCol, materializedCol string, materialized, numeric bool, name string, filter chsql.Frag, start, end time.Time, strategies chsql.AttrStrategies) chsql.Frag {
+	arm := chsql.NewQuery().From(chsql.Col(s.SpansTable)).WithAttrStrategies(strategies)
 	if materialized {
 		arm.Select(chsql.As(chsql.Call("toString", chsql.Col(materializedCol)), "v")).
 			Where(materializedColumnPresenceFrag(materializedCol, numeric))
@@ -833,35 +841,45 @@ func mapContainsAnyFrag(attrCol, resCol, key string) chsql.Frag {
 	))
 }
 
-// mapContainsFrag emits "mapContains(`<col>`, ?)" with key bound as a
-// positional argument. Composes through the typed Call constructor;
-// column / key operands flow through Col / Lit.
+// mapContainsFrag adapts Builder.MapContains into a Frag — emits
+// "mapContains(`<col>`, ?)" with key bound as a positional argument, or
+// (cerberus issue #3065 point 2) the "has(JSONAllPaths(`<col>`), ?)" shape
+// when col resolves to AttrStrategyJSON on the enclosing QueryBuilder's
+// threaded .WithAttrStrategies. Delegating to Builder.MapContains rather
+// than chsql.Call directly is what makes that threading take effect
+// here — see Builder.MapContains's own doc (internal/chsql/builder.go)
+// for the full rationale.
 //
-// Deliberately NOT spelled as the explicit has(<col>.keys, ?) subcolumn
-// form: cerberus issue #2775 verified (chDB 26.5.1.1, EXPLAIN QUERY TREE)
-// that ClickHouse's analyzer already rewrites mapContains(<col>, ?) into
-// exactly that has(<col>.keys, ?) shape internally, AND — unlike a
-// hand-written has(<col>.keys, ?) — the analyzer-rewritten form is the
-// ONLY one confirmed (via EXPLAIN indexes=1) to still match a
-// conventionally-declared `INDEX ... mapKeys(<col>) TYPE bloom_filter`
-// skip index; a directly-authored has(<col>.keys, ?) showed NO Skip
-// section at all against that same index. So mapContains(<col>, ?) is
-// strictly no worse (same key-only decode once the default-on
+// Map-branch rationale, preserved from the pre-#3065 direct-Call
+// spelling: deliberately NOT spelled as the explicit has(<col>.keys, ?)
+// subcolumn form — cerberus issue #2775 verified (chDB 26.5.1.1, EXPLAIN
+// QUERY TREE) that ClickHouse's analyzer already rewrites
+// mapContains(<col>, ?) into exactly that has(<col>.keys, ?) shape
+// internally, AND — unlike a hand-written has(<col>.keys, ?) — the
+// analyzer-rewritten form is the ONLY one confirmed (via EXPLAIN
+// indexes=1) to still match a conventionally-declared
+// `INDEX ... mapKeys(<col>) TYPE bloom_filter` skip index; a
+// directly-authored has(<col>.keys, ?) showed NO Skip section at all
+// against that same index. So mapContains(<col>, ?) is strictly no worse
+// (same key-only decode once the default-on
 // optimize_functions_to_subcolumns fires) and strictly safer
 // (index-compatible) than the subcolumn spelling the issue originally
 // proposed — see the issue for the full investigation.
 func mapContainsFrag(col, key string) chsql.Frag {
-	return chsql.Call("mapContains", chsql.Col(col), chsql.Lit(key))
+	return func(b *chsql.Builder) { b.MapContains(col, key) }
 }
 
-// mapAtFrag emits "`<col>`[?]" — CH's Map column access shape — with
-// key bound as a positional argument. Composed via the typed
-// typed chsql.Subscript constructor, with the column flowing through
-// Col (backtick-quoted) and the key through Lit
-// (`?`-bound). Equivalent to Builder.MapAt but exposed as a typed
-// Frag for QueryBuilder slot composition.
+// mapAtFrag adapts Builder.MapAt into a Frag — emits "`<col>`[?]" with
+// the key bound as a positional argument, or (cerberus issue #3065 point
+// 2) the JSON dynamic-subcolumn coalesce shape when col resolves to
+// AttrStrategyJSON on the enclosing QueryBuilder's threaded
+// .WithAttrStrategies. Delegating to Builder.MapAt rather than
+// chsql.Subscript directly is what makes that threading take effect here
+// — see Builder.MapAt's own doc (internal/chsql/builder.go) for the full
+// rationale, mirroring internal/api/loki/label_values.go's identical
+// mapAtFrag.
 func mapAtFrag(col, key string) chsql.Frag {
-	return chsql.Subscript(chsql.Col(col), chsql.Lit(key))
+	return func(b *chsql.Builder) { b.MapAt(col, key) }
 }
 
 // nonEmptyFrag emits "`<col>` != ?" binding the empty string as a

--- a/internal/api/tempo/search_tag_values_autoscope_chdb_test.go
+++ b/internal/api/tempo/search_tag_values_autoscope_chdb_test.go
@@ -189,10 +189,10 @@ func TestBuildAutoScopeUnionAttributeValuesSQL_ChDB_MatchesUnroutedMapOnlyResult
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			unroutedSQL, unroutedArgs := tempo.BuildAttributeValuesSQLForTest(
-				unroutedSchema, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end,
+				unroutedSchema, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end, nil,
 			)
 			routedSQL, routedArgs := tempo.BuildAttributeValuesSQLForTest(
-				routedSchema, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end,
+				routedSchema, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end, nil,
 			)
 
 			unroutedGot, err := c.QueryStrings(ctx, unroutedSQL, unroutedArgs...)

--- a/internal/api/tempo/search_tag_values_autoscope_materialized_test.go
+++ b/internal/api/tempo/search_tag_values_autoscope_materialized_test.go
@@ -78,7 +78,7 @@ func TestBuildAttributeValuesSQL_AutoScopeMaterializedColumnRouting(t *testing.T
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			sqlStr, _ := tempo.BuildAttributeValuesSQLForTest(s, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end)
+			sqlStr, _ := tempo.BuildAttributeValuesSQLForTest(s, tc.key, tempo.AttrMapScopeAnyForTest, nil, start, end, nil)
 
 			for _, marker := range tc.wantMaterializedMarkers {
 				if !strings.Contains(sqlStr, marker) {
@@ -124,8 +124,8 @@ func TestBuildAttributeValuesSQL_AutoScopeMaterializedUnchangedForConfiguredOthe
 	start := time.Unix(1000, 0).UTC()
 	end := time.Unix(2000, 0).UTC()
 
-	gotWith, _ := tempo.BuildAttributeValuesSQLForTest(withRegistry, "rpc.method", tempo.AttrMapScopeAnyForTest, nil, start, end)
-	gotWithout, _ := tempo.BuildAttributeValuesSQLForTest(without, "rpc.method", tempo.AttrMapScopeAnyForTest, nil, start, end)
+	gotWith, _ := tempo.BuildAttributeValuesSQLForTest(withRegistry, "rpc.method", tempo.AttrMapScopeAnyForTest, nil, start, end, nil)
+	gotWithout, _ := tempo.BuildAttributeValuesSQLForTest(without, "rpc.method", tempo.AttrMapScopeAnyForTest, nil, start, end, nil)
 	if gotWith != gotWithout {
 		t.Errorf("unconfigured key's auto-scope SQL differs based on registry presence:\nwith registry:    %s\nwithout registry: %s", gotWith, gotWithout)
 	}

--- a/internal/api/tempo/search_tag_values_instrumentation_chdb_test.go
+++ b/internal/api/tempo/search_tag_values_instrumentation_chdb_test.go
@@ -79,7 +79,7 @@ func TestBuildAttributeValuesSQL_ChDB_InstrumentationScope_IsolatedFromSpanResou
 	s.ScopeAttributesColumn = "ScopeAttributes"
 
 	sqlStr, args := tempo.BuildAttributeValuesSQLForTest(
-		s, "otel.scope.name", tempo.AttrMapScopeInstrumentationForTest, nil, start, end,
+		s, "otel.scope.name", tempo.AttrMapScopeInstrumentationForTest, nil, start, end, nil,
 	)
 
 	got, err := c.QueryStrings(context.Background(), sqlStr, args...)

--- a/internal/api/tempo/search_tag_values_materialized_test.go
+++ b/internal/api/tempo/search_tag_values_materialized_test.go
@@ -42,7 +42,7 @@ func TestBuildAttributeValuesSQL_MaterializedColumnRouting(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			sqlStr, _ := tempo.BuildAttributeValuesSQLForTest(s, tc.key, tc.scope, nil, start, end)
+			sqlStr, _ := tempo.BuildAttributeValuesSQLForTest(s, tc.key, tc.scope, nil, start, end, nil)
 			isMaterialized := strings.Contains(sqlStr, "__cerberus_materialized")
 			if isMaterialized != tc.wantMaterialized {
 				t.Errorf("materialized routing = %v, want %v; SQL: %s", isMaterialized, tc.wantMaterialized, sqlStr)
@@ -71,8 +71,8 @@ func TestBuildAttributeValuesSQL_UnmaterializedSchemaUnchanged(t *testing.T) {
 
 	// A DIFFERENT key than the one configured in withRegistry must render
 	// identically regardless of whether the registry exists at all.
-	gotWith, _ := tempo.BuildAttributeValuesSQLForTest(withRegistry, "rpc.method", tempo.AttrMapScopeSpanForTest, nil, start, end)
-	gotWithout, _ := tempo.BuildAttributeValuesSQLForTest(without, "rpc.method", tempo.AttrMapScopeSpanForTest, nil, start, end)
+	gotWith, _ := tempo.BuildAttributeValuesSQLForTest(withRegistry, "rpc.method", tempo.AttrMapScopeSpanForTest, nil, start, end, nil)
+	gotWithout, _ := tempo.BuildAttributeValuesSQLForTest(without, "rpc.method", tempo.AttrMapScopeSpanForTest, nil, start, end, nil)
 	if gotWith != gotWithout {
 		t.Errorf("unconfigured key's SQL differs based on registry presence:\nwith registry:    %s\nwithout registry: %s", gotWith, gotWithout)
 	}

--- a/internal/api/tempo/search_tag_values_numeric_materialized_chdb_test.go
+++ b/internal/api/tempo/search_tag_values_numeric_materialized_chdb_test.go
@@ -321,7 +321,7 @@ func TestBuildAutoScopeUnionAttributeValuesSQL_NumericArmUnionsWithMapFallbackAr
 	// this key: the resource side must fall back to the map subscript,
 	// which is the map-fallback arm this test targets.
 
-	sqlStr, args := tempo.BuildAttributeValuesSQLForTest(s, "http.status_code", tempo.AttrMapScopeAnyForTest, nil, start, end)
+	sqlStr, args := tempo.BuildAttributeValuesSQLForTest(s, "http.status_code", tempo.AttrMapScopeAnyForTest, nil, start, end, nil)
 	got, err := c.QueryStrings(ctx, sqlStr, args...)
 	if err != nil {
 		t.Fatalf("UNION ALL of numeric materialized arm + map-fallback arm failed (likely a ClickHouse NO_COMMON_TYPE / arm-type mismatch): %v\nSQL: %s", err, sqlStr)

--- a/internal/api/tempo/search_tags.go
+++ b/internal/api/tempo/search_tags.go
@@ -217,7 +217,7 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, route Tags
 		scopes, ok = h.tagsFromCatalog(ctx, scope)
 	}
 	if !ok {
-		scopes, err = h.collectAttributeTagScopes(ctx, scope, filter, start, end)
+		scopes, err = h.collectAttributeTagScopes(ctx, scope, filter, start, end, h.AttrStrategies)
 		if err != nil {
 			writeError(w, tagsErrStatus(err), "", "", err)
 			return
@@ -258,14 +258,14 @@ func (h *Handler) respondTags(w http.ResponseWriter, r *http.Request, route Tags
 // layer actually reported, so emitting an empty one would put cerberus
 // a scope ahead of reference Tempo.
 func (h *Handler) collectAttributeTagScopes(
-	ctx context.Context, scope string, filter chsql.Frag, start, end time.Time,
+	ctx context.Context, scope string, filter chsql.Frag, start, end time.Time, strategies chsql.AttrStrategies,
 ) ([]TagScope, error) {
 	var scopes []TagScope
-	for _, src := range attributeTagScopes(h.Schema) {
+	for _, src := range attributeTagScopes(h.Schema, strategies) {
 		if scope != tagScopeNone && scope != src.name {
 			continue
 		}
-		tags, err := h.fetchTagKeys(ctx, src.name, src.keys, filter, start, end)
+		tags, err := h.fetchTagKeys(ctx, src.name, src.keys, filter, start, end, strategies)
 		if err != nil {
 			h.Logger.Error("cerberus tempo tag-key lookup failed", "scope", src.name, "err", err)
 			return nil, err
@@ -296,19 +296,19 @@ type attributeTagScope struct {
 // point ScopeAttributesColumn at one, which puts the bucket back).
 // Requesting such a scope is still a 200 — upstream accepts the value
 // and answers with whatever its storage reports, which is nothing.
-func attributeTagScopes(s schema.Traces) []attributeTagScope {
+func attributeTagScopes(s schema.Traces, strategies chsql.AttrStrategies) []attributeTagScope {
 	out := make([]attributeTagScope, 0, 5)
 	add := func(name string, keys chsql.Frag) {
 		out = append(out, attributeTagScope{name: name, keys: keys})
 	}
 	if s.ResourceAttributesColumn != "" {
-		add(tagScopeResource, distinctMapKeysFrag(s.ResourceAttributesColumn))
+		add(tagScopeResource, distinctAttrKeysFrag(strategies, s.ResourceAttributesColumn))
 	}
 	if s.ScopeAttributesColumn != "" {
-		add(tagScopeInstrumentation, distinctMapKeysFrag(s.ScopeAttributesColumn))
+		add(tagScopeInstrumentation, distinctAttrKeysFrag(strategies, s.ScopeAttributesColumn))
 	}
 	if s.AttributesColumn != "" {
-		add(tagScopeSpan, distinctMapKeysFrag(s.AttributesColumn))
+		add(tagScopeSpan, distinctAttrKeysFrag(strategies, s.AttributesColumn))
 	}
 	if s.EventsColumn != "" {
 		add(tagScopeEvent, distinctNestedMapKeysFrag(s.EventsColumn))
@@ -352,8 +352,9 @@ func (h *Handler) fetchTagKeys(
 	scope string,
 	keys, filter chsql.Frag,
 	start, end time.Time,
+	strategies chsql.AttrStrategies,
 ) ([]string, error) {
-	sqlStr, args := buildSearchTagsSQL(h.Schema, keys, filter, start, end)
+	sqlStr, args := buildSearchTagsSQL(h.Schema, keys, filter, start, end, strategies)
 	h.Logger.Debug("cerberus tempo /search/tags", "scope", scope, "sql", sqlStr,
 		"args", telemetry.SanitizeArgsForLog(args))
 	return h.Client.QueryStrings(ctx, sqlStr, args...)
@@ -366,10 +367,11 @@ func (h *Handler) fetchTagKeys(
 // `filter` is the optional `?q=` span-row predicate (see
 // search_tags_filter.go); a nil filter appends no clause, so a request
 // without `q` renders exactly the SQL it always did.
-func buildSearchTagsSQL(s schema.Traces, keys, filter chsql.Frag, start, end time.Time) (string, []any) {
+func buildSearchTagsSQL(s schema.Traces, keys, filter chsql.Frag, start, end time.Time, strategies chsql.AttrStrategies) (string, []any) {
 	sb := chsql.NewQuery().
 		Select(keys).
-		From(chsql.Col(s.SpansTable))
+		From(chsql.Col(s.SpansTable)).
+		WithAttrStrategies(strategies)
 	if !start.IsZero() {
 		sb.Where(tempoTimeGteFrag(s.TimestampColumn, start))
 	}

--- a/internal/api/tempo/search_tags_json_chdb_test.go
+++ b/internal/api/tempo/search_tags_json_chdb_test.go
@@ -1,0 +1,196 @@
+//go:build chdb
+
+// chDB-backed proof of cerberus issue #3065 item 2: /api/search/tags,
+// /api/v2/search/tags and /api/search/tag/{name}/values
+// (search_tags.go / search_tag_values.go) build their SQL directly
+// against chsql.NewQuery() rather than through a chplan tree, so they
+// never reached engine.emitForHead / chsql.Emit's ctx-based
+// AttrStrategies threading at all — Handler.AttrStrategies (cerberus
+// issue #3062) had no effect on them. internal/api/tempo/attr_strategy.go
+// (distinctAttrKeysFrag) plus threading chsql.AttrStrategies explicitly
+// onto every chsql.QueryBuilder these two files build (mirroring
+// internal/api/loki/attr_strategy.go's identical fix for cerberus issue
+// #3063 point 2) is this file's target.
+//
+// Both a Resource-scope and a Span-scope JSON-typed column are exercised
+// (not just one), since #3065 point 2 names BOTH /search/tags' per-scope
+// key discovery AND /search/tag/{name}/values' per-scope, auto-scope
+// (leading-dot union) and existence-pre-filter shapes — every one of
+// which reads through a DIFFERENT ad-hoc Frag helper
+// (distinctAttrKeysFrag / mapAtFrag / mapContainsFrag /
+// attrValueArrayJoinFrag / mapContainsAnyFrag) that must all resolve the
+// SAME threaded AttrStrategies to agree with each other and with the
+// query path's own per-key JSON rendering (cerberus issue #3062).
+package tempo_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/api/tempo"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+// tagDiscoverySeedMap / tagDiscoverySeedJSON seed three single-span traces
+// exercising every missing/present/empty shape the discovery endpoints
+// must handle identically to the Map baseline:
+//
+//	s1 span.custom_tag="alpha"  resource.deploy.env="prod"   (both present)
+//	s2 span.custom_tag absent   resource.deploy.env="canary" (span key
+//	                            missing entirely; resource key present)
+//	s3 span.custom_tag=""       resource.deploy.env=""       (present but
+//	                            empty on both sides — /tags must still
+//	                            report the KEY; /tag/values must NOT
+//	                            report the empty string as a value)
+func tagDiscoverySeedMap(table string) string {
+	return `INSERT INTO ` + table + ` VALUES
+    ('a1000000000000000000000000000001', '7000000000000001', '', 'op1', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000001', 9), 'Unset', '', '', '', map('custom_tag', 'alpha'), map('deploy.env', 'prod')),
+    ('a1000000000000000000000000000002', '7000000000000002', '', 'op2', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000002', 9), 'Unset', '', '', '', map(), map('deploy.env', 'canary')),
+    ('a1000000000000000000000000000003', '7000000000000003', '', 'op3', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000003', 9), 'Unset', '', '', '', map('custom_tag', ''), map('deploy.env', ''));`
+}
+
+func tagDiscoverySeedJSON(table string) string {
+	return `INSERT INTO ` + table + ` VALUES
+    ('a1000000000000000000000000000001', '7000000000000001', '', 'op1', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000001', 9), 'Unset', '', '', '', '{"custom_tag":"alpha"}', '{"deploy.env":"prod"}'),
+    ('a1000000000000000000000000000002', '7000000000000002', '', 'op2', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000002', 9), 'Unset', '', '', '', '{}', '{"deploy.env":"canary"}'),
+    ('a1000000000000000000000000000003', '7000000000000003', '', 'op3', 'Server', 100, toDateTime64('2026-05-01 11:00:00.000000003', 9), 'Unset', '', '', '', '{"custom_tag":""}', '{"deploy.env":""}');`
+}
+
+// tagDiscoveryWindowQS is this file's fixed discovery-request window,
+// wide enough to cover the 2026-05-01 seed above.
+const tagDiscoveryWindowQS = "start=1777593600&end=1777680000"
+
+// TestTags_JSONAttrStrategy_KeyDiscovery_ChDB proves /api/search/tags
+// (V1, both scope=span and scope=resource) surfaces the SAME key set for
+// a JSON-typed SpanAttributes/ResourceAttributes column as it does for a
+// Map-typed one — including the empty-value row (s3), which must still
+// contribute its key (key PRESENCE, not value non-emptiness, is what
+// /tags reports).
+func TestTags_JSONAttrStrategy_KeyDiscovery_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	const mapTable, jsonTable = "tags_discovery_map", "tags_discovery_json"
+	strategies := chsql.AttrStrategies{"SpanAttributes": chsql.AttrStrategyJSON, "ResourceAttributes": chsql.AttrStrategyJSON}
+
+	mapSrv := newAttrStrategyChDBServer(t, c, mapTable,
+		jsonAttrTracesDDL(mapTable, "Map(String, String)", "Map(String, String)"), tagDiscoverySeedMap(mapTable), nil)
+	jsonSrv := newAttrStrategyChDBServer(t, c, jsonTable,
+		jsonAttrTracesDDL(jsonTable, "JSON", "JSON"), tagDiscoverySeedJSON(jsonTable), strategies)
+
+	for _, scope := range []string{"span", "resource"} {
+		t.Run(scope, func(t *testing.T) {
+			mapTags := searchTags(t, mapSrv, scope)
+			jsonTags := searchTags(t, jsonSrv, scope)
+
+			var wantKey string
+			switch scope {
+			case "span":
+				wantKey = "custom_tag"
+			case "resource":
+				wantKey = "deploy.env"
+			}
+			if !containsStr(mapTags, wantKey) {
+				t.Fatalf("Map /api/search/tags?scope=%s = %v, want it to contain %q (test's own expectation, not just Map==JSON)", scope, mapTags, wantKey)
+			}
+			if !containsStr(jsonTags, wantKey) {
+				t.Errorf("JSON /api/search/tags?scope=%s = %v, want it to contain %q — distinctAttrKeysFrag's "+
+					"JSONAllPaths branch must report every key a Map .keys subcolumn would", scope, jsonTags, wantKey)
+			}
+		})
+	}
+}
+
+// searchTags issues GET /api/search/tags?scope=<scope> and returns the
+// sorted tagNames list.
+func searchTags(t *testing.T, srv *httptest.Server, scope string) []string {
+	t.Helper()
+	resp, err := http.Get(srv.URL + "/api/search/tags?scope=" + scope + "&" + tagDiscoveryWindowQS)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var sr tempo.SearchTagsResponse
+	if err := json.Unmarshal([]byte(body), &sr); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	sort.Strings(sr.TagNames)
+	return sr.TagNames
+}
+
+func containsStr(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestTagValues_JSONAttrStrategy_ChDB proves /api/search/tag/{name}/values
+// against a JSON-typed SpanAttributes/ResourceAttributes column
+// reproduces the Map baseline exactly for every discovery shape #3065
+// point 2 names: single-scope (span./resource.), auto-scope (leading-dot
+// union of both maps), and the empty-value exclusion (s3's empty string
+// must never surface as a value).
+func TestTagValues_JSONAttrStrategy_ChDB(t *testing.T) {
+	c := chclienttest.NewChDB(t)
+	const mapTable, jsonTable = "tag_values_discovery_map", "tag_values_discovery_json"
+	strategies := chsql.AttrStrategies{"SpanAttributes": chsql.AttrStrategyJSON, "ResourceAttributes": chsql.AttrStrategyJSON}
+
+	mapSrv := newAttrStrategyChDBServer(t, c, mapTable,
+		jsonAttrTracesDDL(mapTable, "Map(String, String)", "Map(String, String)"), tagDiscoverySeedMap(mapTable), nil)
+	jsonSrv := newAttrStrategyChDBServer(t, c, jsonTable,
+		jsonAttrTracesDDL(jsonTable, "JSON", "JSON"), tagDiscoverySeedJSON(jsonTable), strategies)
+
+	cases := []struct {
+		name string
+		tag  string
+		want []string
+	}{
+		{"span_scoped", "span.custom_tag", []string{"alpha"}},
+		{"resource_scoped", "resource.deploy.env", []string{"canary", "prod"}},
+		{"auto_scope_leading_dot", ".deploy.env", []string{"canary", "prod"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mapGot := tagValues(t, mapSrv, tc.tag)
+			if !equalStrSlices(mapGot, tc.want) {
+				t.Fatalf("Map /api/search/tag/%s/values = %v, want %v (test's own expectation, not just Map==JSON)", tc.tag, mapGot, tc.want)
+			}
+			jsonGot := tagValues(t, jsonSrv, tc.tag)
+			if !equalStrSlices(jsonGot, tc.want) {
+				t.Errorf("JSON /api/search/tag/%s/values = %v, want %v — mapAtFrag/mapContainsFrag's "+
+					"Builder.MapAt/MapContains delegation must reconstruct the JSON column exactly like Map",
+					tc.tag, jsonGot, tc.want)
+			}
+		})
+	}
+}
+
+// tagValues issues GET /api/search/tag/<name>/values and returns the
+// sorted tagValues list.
+func tagValues(t *testing.T, srv *httptest.Server, name string) []string {
+	t.Helper()
+	resp, err := http.Get(srv.URL + "/api/search/tag/" + url.PathEscape(name) + "/values?" + tagDiscoveryWindowQS)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var sr tempo.SearchTagValuesResponse
+	if err := json.Unmarshal([]byte(body), &sr); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, body)
+	}
+	sort.Strings(sr.TagValues)
+	return sr.TagValues
+}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -205,6 +205,41 @@ func (b *Builder) MapAt(col, key string) {
 	b.sb.WriteByte(']')
 }
 
+// MapContains appends "mapContains(<col>, ?)" with key bound as a
+// positional argument — CH's Map key-existence check.
+//
+// cerberus issue #3065 point 2: this is the ad-hoc-query-builder
+// equivalent of chplan.FnMapContainsKey (exprMapContainsKey) — MapAt's
+// own doc explains why internal/api/loki's ad-hoc query builders need
+// their own JSON branch rather than relying on the chplan-level fix
+// alone; internal/api/tempo's /api/search/tag/{name}/values
+// (search_tag_values.go's mapContainsFrag) has the identical shape: it
+// builds its per-key existence pre-filter through THIS method directly
+// rather than through a chplan tree. When col resolves to
+// AttrStrategyJSON, this renders the same
+//
+//	has(JSONAllPaths(<col>), ?)
+//
+// shape exprMapContainsKey's doc explains in full — unlike MapAt's JSON
+// branch, key flows through b.Arg (a bound `?` placeholder) exactly like
+// the Map branch, since has() takes a runtime argument rather than a
+// compile-time dynamic-subcolumn path token.
+func (b *Builder) MapContains(col, key string) {
+	if b.attrStrategies.Lookup(col) == AttrStrategyJSON {
+		b.sb.WriteString("has(JSONAllPaths(")
+		b.Ident(col)
+		b.sb.WriteString("), ")
+		b.Arg(key)
+		b.sb.WriteByte(')')
+		return
+	}
+	b.sb.WriteString("mapContains(")
+	b.Ident(col)
+	b.sb.WriteString(", ")
+	b.Arg(key)
+	b.sb.WriteByte(')')
+}
+
 // MapKeys appends "mapKeys(<col>)" — CH's built-in for extracting the
 // key set of a Map column. Used by the metadata SQL stack to derive the
 // list of attribute names known for a metric.

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -787,15 +787,13 @@ type tableReq struct {
 	// capability still missing against a jsonQuerySupported table's
 	// JSON-typed attribute column. Required whenever jsonQuerySupported is
 	// true (checkTable's message composition has no other source for this
-	// text), because the remaining gap is genuinely signal-specific: LogQL
-	// needs the full attribute map at once for line_format / label_format /
-	// unpack / keep|drop with no argument list AND its ad-hoc /labels
-	// /series /detected_fields query builders bypass chplan entirely
-	// (cerberus issue #3063); TraceQL needs it for compare()'s
-	// well-known/generic attribute fan-out AND its own ad-hoc
-	// /api/search/tags /api/search/tag/{name}/values query builders
-	// bypass chplan the same way (cerberus issue #3065). Ignored when
-	// jsonQuerySupported is false.
+	// text). Cerberus issues #3063 (LogQL) and #3065 (TraceQL) closed every
+	// query-time gap each signal's full-map operations and ad-hoc discovery
+	// query builders used to have; the one gap that remains for BOTH — a
+	// table whose ingestion ever used json_type_escape_dots_in_keys=1 or
+	// mixed dotted-key encodings — is signal-agnostic, so
+	// logsJSONQuerySupportedGaps / tracesJSONQuerySupportedGaps below name
+	// only that. Ignored when jsonQuerySupported is false.
 	jsonQuerySupportedGaps string
 	// materializedColumns is the subset of columns that must be typed a
 	// SPECIFIC ClickHouse type rather than checked for mere existence —
@@ -828,24 +826,16 @@ type materializedColumnCheck struct {
 // checkTable renders is reviewable in one place per signal, matching
 // invariant 13's spirit for meaning-bearing literals.
 const (
-	logsJSONQuerySupportedGaps = "operations that need the FULL attribute map at once " +
-		"(LogQL line_format / label_format / unpack / keep|drop with no argument list), " +
-		"the /labels /series /detected_fields metadata endpoints, and any table whose " +
-		"ingestion ever used json_type_escape_dots_in_keys=1 or mixed dotted-key " +
-		"encodings — those still fail at query time (tracked as cerberus issue #3063)"
-	tracesJSONQuerySupportedGaps = "operations that need the FULL attribute map at once. " +
-		"If ResourceAttributes specifically is the JSON-typed column, this includes " +
-		"/api/search's OWN baseline response shaping — every response merges " +
-		"ResourceAttributes with synthetic trace/span/parent-span-id keys, which is a " +
-		"full-map operation a JSON column cannot satisfy today (a CAST-based Map bridge " +
-		"does not work on ClickHouse; verified empirically), so /api/search fails on EVERY " +
-		"query regardless of its filter shape until this is addressed — SpanAttributes and " +
-		"ScopeAttributes are unaffected by this specific gap. Also unsupported for any " +
-		"jsonQuerySupported column: the compare() spanset-metrics operator's " +
-		"well-known/generic attribute fan-out, the /api/search/tags and " +
-		"/api/search/tag/{name}/values discovery endpoints, and any table whose ingestion " +
-		"ever used json_type_escape_dots_in_keys=1 or mixed dotted-key encodings — those " +
-		"still fail at query time (tracked as cerberus issue #3065)"
+	logsJSONQuerySupportedGaps = "a table whose ingestion ever used " +
+		"json_type_escape_dots_in_keys=1 or mixed dotted-key encodings — every rendering " +
+		"targets ClickHouse's DEFAULT dot-nesting behaviour only, and no boot-time schema " +
+		"check can rule out a past or mixed ingestion-time setting (tracked as cerberus " +
+		"issue #3063; see docs/operations.md for the full design rationale)"
+	tracesJSONQuerySupportedGaps = "a table whose ingestion ever used " +
+		"json_type_escape_dots_in_keys=1 or mixed dotted-key encodings — every rendering " +
+		"targets ClickHouse's DEFAULT dot-nesting behaviour only, and no boot-time schema " +
+		"check can rule out a past or mixed ingestion-time setting (tracked as cerberus " +
+		"issue #3065; see docs/operations.md for the full design rationale)"
 )
 
 // requiredTables resolves the active config into the per-table shape

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -453,12 +453,13 @@ func TestRunWrongAttributeTypeFails(t *testing.T) {
 // boot-probe compat AND its deliberate boot-warning-posture decision: a
 // logs table whose attribute-map columns are typed JSON (the upstream OTel
 // exporter's `json:true` schema variant) boots instead of FATALing, with a
-// WARNING that — now that chsql actually has a JSON rendering path for
-// logs' per-key lookups — says what IS supported (not "nothing works
-// yet") and still names what remains unsupported (full-map operations,
-// escape-dots-in-keys schemas). Result.LogsAttrStrategies must resolve the
-// column to AttrStrategyJSON so internal/engine can thread it into a LogQL
-// request's ctx.
+// WARNING that — now that chsql has a JSON rendering path for both logs'
+// per-key lookups AND its full-map operations (cerberus issue #3063) —
+// says what IS supported (not "nothing works yet") and still names the one
+// remaining signal-agnostic gap (escape-dots-in-keys / mixed-history
+// schemas). Result.LogsAttrStrategies must resolve the column to
+// AttrStrategyJSON so internal/engine can thread it into a LogQL request's
+// ctx.
 func TestRunLogsJSONAttrMapPassesWithWarning(t *testing.T) {
 	t.Parallel()
 	cols := healthyColumns()
@@ -495,12 +496,14 @@ func TestRunLogsJSONAttrMapPassesWithWarning(t *testing.T) {
 
 // TestRunTracesJSONAttrMapPassesWithWarning is the traces counterpart of
 // TestRunLogsJSONAttrMapPassesWithWarning — the other signal the boot-probe
-// compat covers. Since cerberus issue #3062, chsql's JSON rendering branch
-// IS wired for TraceQL too (exprFieldAccess, not just exprMapAccess — see
-// its own doc), so the warning narrows to the same "per-key lookups
-// supported, full-map operations are not" shape logs already used, and
-// Result.TracesAttrStrategies resolves to AttrStrategyJSON for the
-// detected column instead of staying nil.
+// compat covers. Since cerberus issues #3062 and #3065, chsql's JSON
+// rendering is wired for TraceQL's per-key lookups (exprFieldAccess) AND
+// full-map operations (compare()'s fan-out, /api/search's baseline
+// response, the /api/search/tags discovery endpoints), so the warning
+// narrows to the one remaining signal-agnostic gap — the
+// json_type_escape_dots_in_keys / mixed-history hazard, shared verbatim
+// with logs — and Result.TracesAttrStrategies resolves to AttrStrategyJSON
+// for the detected column instead of staying nil.
 func TestRunTracesJSONAttrMapPassesWithWarning(t *testing.T) {
 	t.Parallel()
 	cols := healthyColumns()


### PR DESCRIPTION
## Summary

Closes cerberus issue #3065's four gaps in the JSON-typed traces
attribute-column work (#2777/#3062), the TraceQL sibling of #3063/#3071
(LogQL). Depended on and built on top of #3071's generic chsql-layer
infrastructure (`internal/chsql/attr_strategy_fullmap.go`), which is why
this branch was built off `main` after merging #3071.

- **Item 0 (highest priority — blocks the baseline endpoint):**
  `/api/search`'s `canonicalSampleProjections` / `sampleProjectionsWithSelected`
  merge `ResourceAttributes` with synthetic trace/span/parent-span-id keys
  via `mapConcat`/`chplan.FnMapMerge` on every response. This already
  renders correctly against a JSON-typed `ResourceAttributes` column with
  **no code change** in `internal/api/tempo` — #3071 generalised
  `exprFunc`'s dispatch so any chplan tree using `FnMapMerge`/`FnMapKeys`/
  `FnMapValues` against a bare JSON-strategy `ColumnRef` gets the
  bounded-depth reconstruction, not just LogQL's own call sites. Pinned
  end-to-end by `search_baseline_json_chdb_test.go`.
- **Item 1:** `compare()`'s generic `mapKeys`/`mapValues`/`arrayZip`/
  `arrayFilter` attribute fan-out (`compareAttrPairsExpr`,
  `internal/traceql/metrics_compare.go`) also builds on those same Fn
  identifiers, so it benefited from #3071's fix too — but empirically it
  still failed with `ILLEGAL_TYPE_OF_ARGUMENT`. Root cause: `metricsLang`
  (the `Engine.Lang` adapter `/api/metrics/query_range` and
  `/api/metrics/query` use) never implemented the `EmitAttrStrategies`
  hook `traceqlLang` (the `/api/search` path) already had, so every
  metrics-pipeline plan silently rendered with `AttrStrategyMap`
  regardless of the resolved column strategy. Fixed by adding
  `attrStrategies` + `EmitAttrStrategies()` to `metricsLang` and wiring
  `h.AttrStrategies` onto its three construction sites
  (`metrics_exec.go` x2, `metrics_query_range_compare.go`). Pinned by
  `metrics_compare_json_chdb_test.go`.
- **Item 2:** `/api/search/tags`, `/api/v2/search/tags` and
  `/api/search/tag/{name}/values` build their SQL directly against
  `chsql.NewQuery()` rather than through `chplan`, so they never reached
  `AttrStrategies` threading at all. `internal/api/tempo/attr_strategy.go`
  (mirroring `internal/api/loki/attr_strategy.go`'s #3063 fix exactly)
  adds `distinctAttrKeysFrag` for key discovery; a new
  `chsql.Builder.MapContains` (the existence-check sibling of the
  already-fixed `Builder.MapAt`) backs `mapContainsFrag`; both
  `search_tags.go` and `search_tag_values.go` now thread the resolved
  `chsql.AttrStrategies` explicitly onto every `chsql.QueryBuilder` they
  construct. Pinned by `search_tags_json_chdb_test.go`.
- **Item 3 (`json_type_escape_dots_in_keys` / mixed-history hazard):**
  Mirrors #3063/#3071's exact precedent, not an independent re-decision —
  a documented, loud limitation in `docs/operations.md`, not a boot-time
  refuse gate (a `system.settings` probe can only see the *current*
  setting, not a past ingestion-time one, so it can't rule out the
  mixed-history case either — a refuse gate would trade an honest
  limitation for a false sense of safety). The shared escape-dots callout
  in `docs/operations.md` already covered both signals from #3071; this
  PR updates the **Traces** bullet block above it to describe what #3065
  actually closed. Also refreshed `internal/preflight/preflight.go`'s
  boot-warning text, which was stale for **both** signals since #3071
  never updated it (it still claimed logs' full-map ops / metadata
  endpoints were unsupported after #3071 had already fixed them) — both
  `logsJSONQuerySupportedGaps` and `tracesJSONQuerySupportedGaps` now name
  only the one gap that actually remains.

## Test plan

- [x] `go build ./...` — whole tree, untagged.
- [x] `go vet ./...` — whole tree, untagged; `go vet -tags chdb
      ./internal/api/tempo/... ./internal/chsql/...` — tagged.
- [x] `go test -race ./internal/api/tempo/... ./internal/chsql/...
      ./internal/preflight/...` — untagged, race-detected.
- [x] `go test -tags chdb -race ./internal/api/tempo/...
      ./internal/chsql/...` — real chDB execution, race-detected.
- [x] New real chDB differential tests (Map vs JSON, missing/present/empty
      seeding), one per item:
  - `search_baseline_json_chdb_test.go` (item 0)
  - `metrics_compare_json_chdb_test.go` (item 1)
  - `search_tags_json_chdb_test.go` (item 2)
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `go-arch-lint check` — clean (no new package).
- [x] `node .github/scripts/markdownlint-run.mjs` — clean.
- [ ] CI (lint, strict-scan, compat lanes — cannot be settled locally per
      `CLAUDE.md` invariant 5).

Closes #3065
