### PR TITLE
feat(chclient,docs): verify ClickHouse Distributed settings and extend error taxonomy

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1100,6 +1100,270 @@ for what has actually been proven, and epic #3074's later
 [e2e-hardening](https://github.com/tsouza/cerberus/issues/3079) sub-issues
 for what closes that gap.
 
+### ClickHouse Distributed-query settings, error taxonomy, and known risks (cerberus issue #3078)
+
+This is the static/docs verification the epic's settings-verification sub-issue
+scopes: for every `internal/chopt`-stamped ClickHouse setting, whether it
+forwards to a `Distributed` table's data shards as-is, is remapped, or does
+not apply — confirmed against ClickHouse's own source and docs for **25.8**,
+the version `deploy/helm/cerberus/values.yaml`'s bundled
+`clickhouse.bundled.image` pins (`clickhouse/clickhouse-server:25.8`).
+Confirming the formulas below hold under real concurrent load against a real
+multi-shard cluster is explicitly out of scope here — that is issue #3079's
+job (chDB is single-node and cannot exercise `Distributed` fan-out at all).
+
+Two source-level facts anchor every row below, verified directly against
+`ClickHouse/ClickHouse` rather than assumed:
+
+- **Per-query settings forward to every shard by default.**
+  `Connection::sendQuery` (`src/Client/Connection.cpp`) serialises the
+  session's live `Settings` object onto the wire immediately before the query
+  text itself ("`/// Per query settings.`"), and this is the SAME `Connection`
+  class a `Distributed` table's `ClusterProxy` dispatch opens to each shard —
+  so any setting a query carries rides along to every shard's connection
+  unless something explicitly strips or overrides it first.
+- **A small, named set of settings IS stripped or remapped before that
+  forward, and none of cerberus's stamped settings are in it.** Fetched
+  `src/Interpreters/ClusterProxy/executeQuery.cpp` at the exact pinned tag
+  (`v25.8.1.5101-lts`, matching the `clickhouse/clickhouse-server:25.8` image)
+  rather than `master` — the file has no `stripInitiatorOnlySettings` at this
+  version; that helper is a later refactor. At 25.8, all of the stripping and
+  remapping lives in one function, `updateSettingsAndClientInfoForCluster`:
+  it zeroes `offset` and `limit` (query-shaping settings that make sense only
+  once, on the initiator's own merge), zeroes `max_concurrent_queries_for_user`
+  / `max_memory_usage_for_user` (a different-user note: "Does not matter on
+  remote servers, because queries are sent under different user"), derives
+  `queue_max_wait_ms` from `max_execution_time`, appends to
+  `additional_table_filters`, adjusts `allow_experimental_parallel_reading_from_replicas`
+  / `load_balancing` for parallel-replicas clusters, and — only when the QUERY
+  itself left it unset — substitutes `skip_unavailable_shards` from the
+  `Distributed` table's own DDL-level `distributed_settings` default. None of
+  cerberus's stamped settings appear anywhere in this function.
+
+#### Per-query setting → `Distributed` behavior
+
+Column 3 is a fact about `Distributed`-forwarding mechanics, independent of
+whether cerberus's own `internal/chopt` registry ever actually stamps the
+setting on the pinned image. Column 4 is that second, separate fact,
+cross-checked against each feature's `MinVersion` in
+`internal/chopt/registry.go` against the pinned 25.8 image. Four of the
+seven feature rows below are gated behind a floor ABOVE 25.8 — cerberus's
+own registry never stamps them on the bundled ClickHouse today, regardless
+of how the setting itself would forward once stamped. That is not a defect
+in either the registry (the floors are independently justified in-tree,
+next to each `Feature*` constant) or in this table — it means those rows
+describe correctness at the version each stamp actually activates, not a
+live protection today. An operator reading only column 3 could otherwise
+conclude all seven are active now, which is false for four of them.
+
+| Setting(s)                                                                                                                        | `internal/chopt` feature                                       | Behavior under `Distributed`                                                                                                                                                                                                                                           | Reachable on pinned 25.8?                                                                                                                                                                         | Source/doc citation                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `optimize_aggregation_in_order`                                                                                                   | `aggregation_in_order`                                         | Forwards as-is; each shard applies it to its own local `GROUP BY`, which is exactly the granularity the setting already targets                                                                                                                                        | Yes — floor 24.8                                                                                                                                                                                  | [docs: optimize-aggregation-in-order](https://clickhouse.com/docs/reference/settings/session-settings/optimize-aggregation-in-order) — "Enables GROUP BY optimization … for aggregating data in corresponding order in MergeTree tables"; absent from `updateSettingsAndClientInfoForCluster` (verified against `executeQuery.cpp` at tag `v25.8.1.5101-lts`)                                         |
+| `use_query_condition_cache` (+ co-stamped `enable_analyzer=1`)                                                                    | `condition_cache`                                              | Forwards as-is; the condition cache is a per-part server-side cache, so each shard populates and reads its OWN cache for its OWN local parts — no cross-shard sharing is expected or needed                                                                            | Yes — floor 25.3                                                                                                                                                                                  | [docs: use_query_condition_cache](https://clickhouse.com/docs/reference/settings/session-settings/use-query#use_query_condition_cache) — "The cache stores ranges of granules in data parts …"; `allow_experimental_analyzer` (alias `enable_analyzer`) confirmed via `src/Core/Settings.cpp` (`DECLARE_WITH_ALIAS(Bool, allow_experimental_analyzer, true, …, enable_analyzer)`, marked `IMPORTANT`) |
+| `max_bytes_before_external_join`                                                                                                  | `join_spill`                                                   | Forwards as-is BY NAME, but — like `max_memory_usage` below — the threshold is evaluated independently by each shard's own local join build, so a K-way fan-out gets K independent spill decisions at the SAME threshold, not one shared one                           | **No — floor 26.4** (`FeatureJoinSpill`); the setting is absent from 25.8's own `src/Core/Settings.cpp` entirely, not merely un-stamped                                                           | [docs: max_bytes_before_external_join](https://clickhouse.com/docs/reference/settings/session-settings/max-bytes#max_bytes_before_external_join)                                                                                                                                                                                                                                                      |
+| `min_table_rows_to_use_projection_index`                                                                                          | `trace_id_bitmap_filter`                                       | Forwards as-is; each shard evaluates its OWN local table's row count against the threshold, which is correct — a shard's local `_local` table is what actually carries the projection                                                                                  | **No — floor 25.11** (`FeatureTraceIDBitmapFilter`); the setting is absent from 25.8's own `src/Core/Settings.cpp` entirely, not merely un-stamped                                                | [docs: min_table_rows_to_use_projection_index](https://clickhouse.com/docs/reference/settings/session-settings/min#min_table_rows_to_use_projection_index)                                                                                                                                                                                                                                            |
+| `query_plan_optimize_lazy_materialization` + `query_plan_max_limit_for_lazy_materialization` (+ co-stamped `enable_analyzer=1`)   | `lazy_materialization`                                         | Forwards as-is; lazy materialisation is a per-shard read-order optimization over that shard's own local `ORDER BY … LIMIT N`, composing normally with the initiator's own merge-and-re-limit of the per-shard results                                                  | **No — floor 25.11** (`FeatureLazyMaterialization`); the ClickHouse setting itself already exists at 25.8 (default `true`/`10`), but cerberus's OWN registry gate withholds the stamp until 25.11 | [docs: query_plan_optimize_lazy_materialization](https://clickhouse.com/docs/reference/settings/session-settings/query-plan#query_plan_optimize_lazy_materialization)                                                                                                                                                                                                                                 |
+| `use_query_cache` + `query_cache_ttl` + `query_cache_nondeterministic_function_handling`                                          | `result_cache`                                                 | Forwards as-is; ClickHouse's query result cache keys and stores the INITIATOR's final merged result (not a per-shard partial), so caching composes with `Distributed` exactly as it does with a plain table                                                            | Yes — floor 24.8                                                                                                                                                                                  | [docs: use_query_cache](https://clickhouse.com/docs/reference/settings/session-settings/use-query#use_query_cache), [query_cache_ttl](https://clickhouse.com/docs/reference/settings/session-settings/query-cache#query_cache_ttl)                                                                                                                                                                    |
+| `allow_experimental_time_series_aggregate_functions`                                                                              | the `ts_grid_*` family (native `timeSeries*ToGrid` aggregates) | Forwards as-is; each shard evaluates the aggregate over its own local rows and returns a normal partial aggregate STATE, which the initiator merges exactly as it merges any other `AggregateFunction` state across shards — no `Distributed`-specific interaction     | **No — floor 25.9** (`FeatureTSGridRange`, the family's own gate)                                                                                                                                 | [docs: allow_experimental_time_series_aggregate_functions](https://clickhouse.com/docs/reference/settings/session-settings/allow-experimental#allow_experimental_time_series_aggregate_functions)                                                                                                                                                                                                     |
+| `skip_unavailable_shards`                                                                                                         | pinned in `internal/chclient` (this issue)                     | Forwards as-is; because cerberus stamps it on EVERY query, ClickHouse's `!settings[skip_unavailable_shards].changed` guard never fires, so cerberus's own `0` always wins over any DDL-level `distributed_settings` default the `Distributed` table itself might carry | Yes — unconditional, no chopt floor                                                                                                                                                               | [docs: skip_unavailable_shards](https://clickhouse.com/docs/reference/settings/session-settings/skip-unavailable-shards#skip_unavailable_shards); the changed-flag gate is `src/Interpreters/ClusterProxy/executeQuery.cpp`'s `updateSettingsAndClientInfoForCluster`, confirmed at line 170 of the pinned `v25.8.1.5101-lts` tag                                                                     |
+| `fallback_to_stale_replicas_for_distributed_queries`                                                                              | pinned in `internal/chclient` (this issue)                     | Forwards as-is; consumed directly by `ConnectionPoolWithFailover`/`PoolWithFailoverBase` at replica-selection time, one shard at a time                                                                                                                                | Yes — unconditional, no chopt floor                                                                                                                                                               | [docs: fallback_to_stale_replicas_for_distributed_queries](https://clickhouse.com/docs/reference/settings/session-settings/other#fallback_to_stale_replicas_for_distributed_queries) — "Forces a query to an out-of-date replica if updated data is not available … By default, 1 (enabled)"; consumption site is `src/Common/PoolWithFailoverBase.h`                                                 |
+
+No `internal/chopt`-stamped setting was found to be unsafe or produce wrong
+results under `Distributed`, at any version — every row above is
+**forwards-as-is**, and the taxonomy has no `disabled-until-fixed` row.
+But only three rows (`aggregation_in_order`, `condition_cache`,
+`result_cache`) plus the two unconditional distributed-query pins are
+actually reachable against the bundled 25.8 image today; the other four
+(`join_spill`, `trace_id_bitmap_filter`, `lazy_materialization`, the
+`ts_grid_*` family) describe behavior that only starts applying once the
+bundled image is bumped past each row's own floor. If a future ClickHouse
+version changes any of the above, or the bundled image crosses one of
+these floors, `just gen-opt-docs`'s own registry table
+(`docs/clickhouse-optimizations.md`) and this table are the two places to
+re-verify.
+
+#### The solver's `perShardMemoryBytes` setting: `max_memory_usage`
+
+`internal/solver/executor.go`'s `perShardMemoryBytes = cap / (kEff *
+DataShardCount)` (cerberus issue #3081, already merged) is stamped as
+`max_memory_usage` (`internal/solver/executor.go`, `chclient.WithQuerySetting(pctx,
+"max_memory_usage", perShardMemoryBytes)`). The literal setting name and its
+Distributed semantics are confirmed against
+[docs: max_memory_usage](https://clickhouse.com/docs/reference/settings/session-settings/max-memory-usage#max_memory_usage):
+
+> The maximum amount of RAM to use for running a query on a single server.
+> … This setting does not consider the volume of available memory or the
+> total volume of memory on the machine. **The restriction applies to a
+> single query within a single server.**
+
+That last sentence is the whole reason the formula divides by
+`DataShardCount`: the setting name forwards to every shard UNCHANGED (per the
+two source facts above), but its enforcement is **per shard, independently**
+— each of the `DataShardCount` shards a fan-out touches gets its OWN,
+separate `max_memory_usage` budget at the SAME value, not one budget shared
+across them. Sending the un-apportioned `cap` value would let a `K`-way
+`kEff` fan-out against `N` data shards use up to `K × N × cap` bytes of
+aggregate ClickHouse-side memory before any single query hits its own limit —
+exactly the amplification `perShardMemoryBytes` exists to divide back out.
+Live-load confirmation that the formula holds under real concurrent
+multi-shard traffic is issue #3079's job, not this one's.
+
+#### `skip_unavailable_shards` / `fallback_to_stale_replicas_for_distributed_queries` policy
+
+Both are pinned to the fail-loud value in `internal/chclient/
+distributed_query_settings.go`, unconditionally on every data-plane
+read-path query (`Client.querySettings`) — harmless no-ops against a
+single-shard deployment, and the correct posture once
+`dataShards.count > 1`:
+
+- **`skip_unavailable_shards=0`** — ClickHouse's own default already, pinned
+  explicitly so the decision survives a future ClickHouse default change. A
+  fully-unreachable data shard aborts the query rather than silently
+  answering "based on partial data" (the documented `=1` behavior) —
+  a correctness-focused gateway must not return a silently incomplete
+  answer for a `Distributed`-backed panel.
+- **`fallback_to_stale_replicas_for_distributed_queries=0`** — the OPPOSITE
+  of ClickHouse's own default (`1`, "forces a query to an out-of-date
+  replica if updated data is not available"). Pinned to `0` so a shard whose
+  reachable replicas are ALL stale aborts the query instead of silently
+  answering from data that may be missing recent writes.
+
+#### Distributed-query error taxonomy
+
+`internal/chclient/distributed_shard_error.go` extends the existing typed
+ClickHouse-error-wrapping pattern (`memlimit.go`, `timeout.go`) with the two
+error codes a `Distributed` query under the policy above can actually raise
+— verified against `src/Common/PoolWithFailoverBase.h`'s
+`PoolWithFailoverBase<TNestedPool>::getMany()`, the connection-acquisition
+path every shard fan-out runs through:
+
+- **`ALL_CONNECTION_TRIES_FAILED` (code 279)** — `*chclient.ShardUnavailableError`
+  — thrown when a shard's usable-replica count falls below `min_entries`
+  (`1`, since cerberus pins `skip_unavailable_shards=0`): "All connection
+  tries failed." Mapped by `prom`/`loki`/`tempo` to a `503`
+  `errorType=unavailable` response — the same class as a tripped circuit
+  breaker, since ClickHouse's initiator is healthy and one data shard is not.
+  It is already classified `breakerScopeServerHealth` in
+  `internal/chclient/breaker_classify.go` (pre-existing).
+- **`ALL_REPLICAS_ARE_STALE` (code 369)** — `*chclient.StaleReplicaFallbackDeniedError`
+  — thrown when a shard's reachable replicas are all stale AND
+  `fallback_to_stale_replicas_for_distributed_queries=0`: "Could not find
+  enough connections to up-to-date replicas." Same `503`
+  `errorType=unavailable` mapping. This issue additionally enrols it in
+  `breakerServerHealthCodes` (it was not there before) — a replication-lag
+  condition that outlives the statement, matching the criterion every other
+  entry in that set already documents.
+
+**A note on the issue's own third named code.** The issue's Problem
+statement named `SHARD_HAS_NO_REPLICAS` as the third error to cover. A
+`search/code` sweep of `github.com/ClickHouse/ClickHouse` found **zero**
+matches for that identifier anywhere in the codebase — it does not exist.
+The nearest same-shaped name, `SHARD_HAS_NO_CONNECTIONS` (code 297,
+`src/Interpreters/Cluster.cpp`), is a cluster-CONFIG parse-time error ("No
+cluster elements (shard, node) specified in config"), never raised by a
+running query, so using it here would misrepresent a config-loading bug as a
+query-time failure. `ALL_CONNECTION_TRIES_FAILED` (already named correctly
+elsewhere in the same issue sentence) is the real runtime "a shard has no
+usable replica" code, and `ALL_REPLICAS_ARE_STALE` is the real "replica
+staleness path" the issue also asked for — both are covered above.
+`TOO_MANY_UNAVAILABLE_SHARDS` (code 904) exists too, but is unreachable under
+cerberus's own `skip_unavailable_shards=0` pin (it only fires when skipping
+is ENABLED and too many shards get skipped), so it is not wired into the
+taxonomy.
+
+New fixtures proving wire-format-correct translation of both codes exist per
+head: `internal/api/prom/handler_distributed_shard_error_test.go`,
+`internal/api/loki/handler_distributed_shard_error_test.go`,
+`internal/api/tempo/handler_distributed_shard_error_test.go`.
+
+#### Known ClickHouse risk: predicate pushdown through subqueries against `Distributed` (ClickHouse#29332)
+
+[ClickHouse#29332](https://github.com/ClickHouse/ClickHouse/issues/29332),
+"Pushdown of predicate may produce wrong queries with subqueries to
+distributed tables", is real but **already closed** — verified by reading
+the issue directly rather than assuming the epic's own summary was complete.
+It is specific to the **legacy** query pipeline's `enable_optimize_predicate_expression`
+rewrite (pre-analyzer): a `WHERE`/`HAVING` predicate pushed through a
+subquery over a `Distributed` table got inconsistently rewritten to `GLOBAL
+IN` in one scope but plain (shard-local) `IN` in another, producing wrong or
+inconsistent results. ClickHouse's own maintainer closed it in comments:
+*"This was an issue with the legacy analyzer's `enable_optimize_predicate_expression`
+optimization. The new analyzer (default since 24.3+) handles predicate
+pushdown completely differently and does not have this issue."*
+
+**Why this is still a genuine, concrete risk for cerberus, not a closed
+non-issue.** `enable_analyzer` defaults to `1` (the new analyzer) on every
+ClickHouse version cerberus supports (>= 24.8, well past the 24.3+ fix), so
+ordinary cerberus queries are not exposed. But
+`internal/engine/query_settings_rules.go`'s `applyNativeHistogramAnalyzerFix`
+**unconditionally forces `enable_analyzer=0`** — reactivating the exact
+legacy pipeline `#29332` lived in — for every query whose plan reaches a
+`chplan.HistogramQuantileNative` or `chplan.HistogramProjection` node (the
+native/exponential-histogram `histogram_quantile()`/`sum()`/`avg()`/
+`rate()`/`increase()` family). And that SAME family routinely builds
+`chplan.ScalarSubquery` nodes — `internal/chplan/histogram_quantile.go` and
+`histogram_quantile_native.go` both document the cross-series total as
+"typically a `ScalarSubquery` built from `scalar(<vector>)`" — the exact
+subquery-over-predicate shape `#29332`'s class of bug targets. This
+combination (forced legacy analyzer + a subquery cerberus's own emitter
+routinely builds) exists ONLY once a `Distributed` table is the scan target,
+so it has never been exercisable before epic #3074 and chDB's single-node
+substrate cannot exercise it either.
+
+**Concrete subquery/derived-table shapes in `internal/chsql`/`internal/chplan`
+issue #3079 should execute against a real multi-shard cluster**, expected
+results in parentheses (every shape below must match its single-shard/chDB
+answer exactly — that equality, not a specific number, is the pass
+criterion):
+
+1. **Priority 1 — native-histogram `histogram_quantile()` over a
+   `Distributed` table** (`internal/chplan/histogram_quantile_native.go:39`'s
+   `ScalarSubquery`, reached with `enable_analyzer=0` forced by
+   `applyNativeHistogramAnalyzerFix`): `histogram_quantile(0.9,
+   sum(rate(demo_exp_hist[5m])))` and the plain
+   `histogram_quantile(0.9, demo_exp_hist)` selector form, both against a
+   `dataShards.count: 2+` cluster with series distributed across shards by
+   the sharding key. (Expected: identical quantile to the same query against
+   a single-shard/chDB copy of the same data — this is the shape most
+   directly analogous to `#29332`'s own reproduction, a `WHERE`/aggregate
+   wrapping a `ScalarSubquery` over a `Distributed` table under the legacy
+   analyzer.)
+2. **`scalar(<vector>)` PromQL queries in general**
+   (`internal/promql`'s lowering into `chplan.ScalarSubquery`, e.g.
+   `internal/chplan/range_window.go:210`'s range-window scalar argument) —
+   under the DEFAULT analyzer (`enable_analyzer=1`), as a baseline-regression
+   control proving the new-analyzer fix genuinely holds on a real multi-shard
+   cluster and not just on ClickHouse's own single-node test suite. (Expected:
+   identical to single-shard.)
+3. **TraceQL `/api/search` root-lookup `InSubquery`**
+   (`internal/chsql/metrics_compare.go`'s `cohortPred`/`bindRootLookupTraceIDTsEnvelope`,
+   `TraceId IN (<subquery>)`) against a `Distributed` spans table, both a
+   plain search and a `compare()` query (which nests the InSubquery inside
+   an additional bounded root leg). (Expected: identical trace set to
+   single-shard.)
+4. **`BoundedTraceScope`'s structure-tab top-N gate**
+   (`internal/chplan/bounded_trace_scope_bind.go`, another `TraceId IN
+   (<subquery>)` shape with an additional row-count bound) against a
+   `Distributed` spans table. (Expected: identical bounded trace set.)
+5. **TraceQL structural join's recursive CTE**
+   (`internal/chsql/structural_join.go`'s `WITH RECURSIVE`, reached by every
+   `>`/`<`/`>>`/`<<` structural query) against a `Distributed` spans table —
+   not the same predicate-pushdown mechanism `#29332` names, but the other
+   large recursive/derived-table shape in the emitter, worth a pass since
+   recursive CTEs interacting with `Distributed` fan-out have no ClickHouse
+   documentation either way. (Expected: identical structural match set to
+   single-shard; see also this doc's own [Recursive-CTE parallelism
+   section](#recursive-cte-parallelism--recommend-clickhouse--266-for-trace-structure)
+   for an unrelated, already-tracked recursive-CTE caveat.)
+6. **`NotInSubquery` gap-detection** (`internal/chsql/absent_over_time.go:129`,
+   `absent_over_time()`'s covered-anchor exclusion) against a `Distributed`
+   metrics table. (Expected: identical gap set to single-shard.)
+
+Live execution of this plan against a real `dataShards.count: 2` (and,
+matching the epic's own `N=4` over-subscription case, `count: 4`) cluster is
+issue #3079's job; this sub-issue's scope is limited to writing the plan
+down with concrete, emitter-grounded shapes.
+
 ### Hot/cold storage tiering
 
 `CERBERUS_SCHEMA_STORAGE_POLICY` puts a MergeTree `storage_policy` on every

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -689,6 +689,27 @@ func classifyEngineErr(err error) error {
 			Status: http.StatusServiceUnavailable,
 		}
 	}
+	// ClickHouse Distributed-query partial-shard-failure / stale-replica
+	// rejection (cerberus issue #3078): a data shard with no reachable
+	// replica at all (ErrShardUnavailable, CH code 279
+	// ALL_CONNECTION_TRIES_FAILED, cerberus's own skip_unavailable_shards=0
+	// pin), or one whose reachable replicas are all stale and cerberus's
+	// own fallback_to_stale_replicas_for_distributed_queries=0 pin refuses
+	// to silently serve one anyway (ErrStaleReplicaFallbackDenied, CH code
+	// 369 ALL_REPLICAS_ARE_STALE). HTTP 503 errorType=unavailable, the same
+	// class as a tripped circuit breaker: ClickHouse itself is healthy, one
+	// data shard behind the Distributed table is not.
+	if errors.Is(err, chclient.ErrShardUnavailable) || errors.Is(err, chclient.ErrStaleReplicaFallbackDenied) {
+		msg := "distributed shard unavailable: ClickHouse could not reach any replica of at least one data shard"
+		if errors.Is(err, chclient.ErrStaleReplicaFallbackDenied) {
+			msg = "distributed shard unavailable: every reachable replica of at least one data shard is stale; refusing to silently serve stale data"
+		}
+		return &apiError{
+			Kind:   ErrUnavailable,
+			Err:    errors.New(msg),
+			Status: http.StatusServiceUnavailable,
+		}
+	}
 	// Caller-initiated cancellation: the client closed the connection (a
 	// browser tab shutting on a slow panel, an aborted fetch, a dashboard
 	// refresh superseding its own in-flight request), so net/http cancels

--- a/internal/api/loki/handler_distributed_shard_error_test.go
+++ b/internal/api/loki/handler_distributed_shard_error_test.go
@@ -1,0 +1,106 @@
+package loki_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// assertShardUnavailable503 decodes a Loki error envelope and pins the
+// ClickHouse Distributed-query partial-shard-failure wire contract
+// (cerberus issue #3078): HTTP 503, errorType "unavailable" — the same
+// class as a tripped circuit breaker, because ClickHouse itself is healthy
+// and one data shard behind the Distributed table is not.
+func assertShardUnavailable503(t *testing.T, resp *http.Response, wantSubstr string) {
+	t.Helper()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503", resp.StatusCode)
+	}
+	var body struct {
+		Status    string `json:"status"`
+		ErrorType string `json:"errorType"`
+		Error     string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Status != "error" {
+		t.Fatalf("status field: got %q, want \"error\"", body.Status)
+	}
+	if body.ErrorType != "unavailable" {
+		t.Fatalf("errorType: got %q, want \"unavailable\"", body.ErrorType)
+	}
+	if !strings.Contains(body.Error, wantSubstr) {
+		t.Fatalf("error message %q does not mention %q", body.Error, wantSubstr)
+	}
+}
+
+func queryRangeURL(base string) string {
+	end := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
+	return fmt.Sprintf(
+		"%s/loki/api/v1/query_range?query=%s&start=%d&end=%d",
+		base, "%7Bjob%3D%22api%22%7D",
+		end.Add(-time.Hour).UnixNano(), end.UnixNano(),
+	)
+}
+
+// TestQueryRange_ShardUnavailable503 — when ClickHouse aborts a
+// Distributed query with ALL_CONNECTION_TRIES_FAILED (code 279 — every
+// replica of at least one data shard is unreachable, cerberus's own
+// skip_unavailable_shards=0 pin refusing to silently answer from partial
+// data), the Loki head must answer 503 errorType=unavailable — never the
+// 400 bad_data rejection a resource-budget error gets, and never a 5xx
+// internal fault.
+func TestQueryRange_ShardUnavailable503(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.ShardUnavailableError{
+		Cause: &clickhouse.Exception{
+			Code:    279,
+			Name:    "ALL_CONNECTION_TRIES_FAILED",
+			Message: "All connection tries failed. Log: \n\nCode: 210. DB::NetException: ...\n",
+		},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(queryRangeURL(srv.URL))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertShardUnavailable503(t, resp, "reach any replica")
+}
+
+// TestQueryRange_StaleReplicaFallbackDenied503 — when ClickHouse aborts a
+// Distributed query with ALL_REPLICAS_ARE_STALE (code 369 — every
+// reachable replica of at least one data shard is stale, and cerberus's
+// own fallback_to_stale_replicas_for_distributed_queries=0 pin refuses to
+// silently serve one anyway), the Loki head must answer 503
+// errorType=unavailable.
+func TestQueryRange_StaleReplicaFallbackDenied503(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.StaleReplicaFallbackDeniedError{
+		Cause: &clickhouse.Exception{
+			Code:    369,
+			Name:    "ALL_REPLICAS_ARE_STALE",
+			Message: "Could not find enough connections to up-to-date replicas. Got: 0, needed: 1",
+		},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(queryRangeURL(srv.URL))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertShardUnavailable503(t, resp, "stale")
+}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1095,6 +1095,39 @@ func isQueryTimeout(err error) bool {
 	return errors.Is(err, chclient.ErrQueryTimeout) || errors.Is(err, context.DeadlineExceeded)
 }
 
+// isDistributedShardErr reports whether err is one of the ClickHouse
+// Distributed-query error taxonomy's two partial-shard-failure classes
+// (cerberus issue #3078): a data shard with no reachable replica at all
+// (chclient.ErrShardUnavailable, CH code 279 ALL_CONNECTION_TRIES_FAILED)
+// or one whose reachable replicas are all stale and cerberus's own
+// fallback_to_stale_replicas_for_distributed_queries=0 pin refuses to
+// silently serve one anyway (chclient.ErrStaleReplicaFallbackDenied, CH
+// code 369 ALL_REPLICAS_ARE_STALE).
+func isDistributedShardErr(err error) bool {
+	return errors.Is(err, chclient.ErrShardUnavailable) || errors.Is(err, chclient.ErrStaleReplicaFallbackDenied)
+}
+
+// distributedShardAPIError is the head-idiomatic rejection for a
+// partial ClickHouse Distributed-cluster outage — HTTP 503, errorType
+// "unavailable", the same wire shape as a tripped circuit breaker or a
+// timed-out backend: ClickHouse itself is healthy, one data shard behind
+// the Distributed table is not, and the client should back off and retry
+// rather than treat this as a query-shape problem or a cerberus fault.
+func distributedShardAPIError(err error) *apiError {
+	msg := "distributed shard unavailable"
+	switch {
+	case errors.Is(err, chclient.ErrShardUnavailable):
+		msg = "ClickHouse could not reach any replica of at least one data shard"
+	case errors.Is(err, chclient.ErrStaleReplicaFallbackDenied):
+		msg = "every reachable replica of at least one ClickHouse data shard is stale; refusing to silently serve stale data"
+	}
+	return &apiError{
+		Kind:   ErrUnavailable,
+		Err:    errors.New(msg),
+		Status: http.StatusServiceUnavailable,
+	}
+}
+
 // isQueryCanceled reports whether err is a caller-initiated cancellation:
 // the client closed the connection (a browser tab shutting on a slow
 // panel, an aborted fetch, a dashboard refresh superseding its own
@@ -1474,6 +1507,15 @@ func classifyEngineError(err error) error {
 	// query ran exactly as long as it was allowed to.
 	if isQueryTimeout(err) {
 		return queryTimeoutAPIError(err)
+	}
+	// ClickHouse Distributed-query partial-shard-failure / stale-replica
+	// rejection (cerberus issue #3078): a data shard cerberus's own
+	// skip_unavailable_shards=0 / fallback_to_stale_replicas_for_
+	// distributed_queries=0 pins refuse to silently paper over. 503
+	// errorType=unavailable, the same class as a tripped circuit breaker —
+	// ClickHouse is healthy, one shard is not.
+	if isDistributedShardErr(err) {
+		return distributedShardAPIError(err)
 	}
 	// Caller-initiated cancellation (open path): the client hung up
 	// before the cursor opened. 503 errorType=canceled; never a 5xx —

--- a/internal/api/prom/handler_distributed_shard_error_test.go
+++ b/internal/api/prom/handler_distributed_shard_error_test.go
@@ -1,0 +1,90 @@
+package prom_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// assertDistributedShardUnavailable503 decodes a Prom error envelope and
+// pins the ClickHouse Distributed-query partial-shard-failure wire
+// contract (cerberus issue #3078): HTTP 503, errorType "unavailable" — the
+// same class as a tripped circuit breaker, because ClickHouse itself is
+// healthy and one data shard behind the Distributed table is not.
+func assertDistributedShardUnavailable503(t *testing.T, resp *http.Response, wantSubstr string) {
+	t.Helper()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want 503", resp.StatusCode)
+	}
+	var body queryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	_ = resp.Body.Close()
+	if body.Status != "error" {
+		t.Fatalf("status field: got %q, want \"error\"", body.Status)
+	}
+	if body.ErrorType != "unavailable" {
+		t.Fatalf("errorType: got %q, want \"unavailable\"", body.ErrorType)
+	}
+	if !strings.Contains(body.Error, wantSubstr) {
+		t.Fatalf("error message %q does not mention %q", body.Error, wantSubstr)
+	}
+}
+
+// TestQuery_ShardUnavailable503 — when ClickHouse aborts a Distributed
+// query with ALL_CONNECTION_TRIES_FAILED (code 279 — every replica of at
+// least one data shard is unreachable, cerberus's own
+// skip_unavailable_shards=0 pin refusing to silently answer from partial
+// data), the Prom head must answer 503 errorType=unavailable, never a 5xx
+// internal fault or a 422 resource rejection.
+func TestQuery_ShardUnavailable503(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.ShardUnavailableError{
+		Cause: &clickhouse.Exception{
+			Code:    279,
+			Name:    "ALL_CONNECTION_TRIES_FAILED",
+			Message: "All connection tries failed. Log: \n\nCode: 210. DB::NetException: ...\n",
+		},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertDistributedShardUnavailable503(t, resp, "reach any replica")
+}
+
+// TestQuery_StaleReplicaFallbackDenied503 — when ClickHouse aborts a
+// Distributed query with ALL_REPLICAS_ARE_STALE (code 369 — every
+// reachable replica of at least one data shard is stale, and cerberus's
+// own fallback_to_stale_replicas_for_distributed_queries=0 pin refuses to
+// silently serve one anyway), the Prom head must answer 503
+// errorType=unavailable.
+func TestQuery_StaleReplicaFallbackDenied503(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.StaleReplicaFallbackDeniedError{
+		Cause: &clickhouse.Exception{
+			Code:    369,
+			Name:    "ALL_REPLICAS_ARE_STALE",
+			Message: "Could not find enough connections to up-to-date replicas. Got: 0, needed: 1",
+		},
+	}}
+	srv := newServer(q)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/v1/query?query=up")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	assertDistributedShardUnavailable503(t, resp, "stale")
+}

--- a/internal/api/tempo/errclass.go
+++ b/internal/api/tempo/errclass.go
@@ -108,7 +108,16 @@ func ClassifyErr(err error) ErrClass {
 		return ErrClassCanceled
 	case errors.Is(err, chclient.ErrCircuitOpen),
 		errors.Is(err, chclient.ErrQueryTimeout),
-		errors.Is(err, context.DeadlineExceeded):
+		errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, chclient.ErrShardUnavailable),
+		errors.Is(err, chclient.ErrStaleReplicaFallbackDenied):
+		// Partial ClickHouse Distributed-cluster infrastructure trouble
+		// (cerberus issue #3078: a data shard with no reachable replica at
+		// all, or one whose reachable replicas are all stale and
+		// cerberus's own fallback_to_stale_replicas_for_distributed_queries=0
+		// pin refuses to silently serve). Same 503 "back off, try again"
+		// class as a circuit-open or timed-out backend — ClickHouse itself
+		// is healthy, one shard behind the Distributed table is not.
 		return ErrClassUnavailable
 	case errors.Is(err, chclient.ErrTooManySamples),
 		errors.Is(err, chclient.ErrDrainBytesExceeded),

--- a/internal/api/tempo/handler_distributed_shard_error_test.go
+++ b/internal/api/tempo/handler_distributed_shard_error_test.go
@@ -1,0 +1,75 @@
+package tempo_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// TestSearchRecent_ShardUnavailable503 — when ClickHouse aborts a
+// Distributed query with ALL_CONNECTION_TRIES_FAILED (code 279 — every
+// replica of at least one data shard is unreachable, cerberus's own
+// skip_unavailable_shards=0 pin refusing to silently answer from partial
+// data), the Tempo head must answer 503 (ErrClassUnavailable — the same
+// class as a tripped circuit breaker or a timed-out backend) rather than
+// the 422 a per-query resource rejection gets, or a 5xx internal fault.
+func TestSearchRecent_ShardUnavailable503(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.ShardUnavailableError{
+		Cause: &clickhouse.Exception{
+			Code:    279,
+			Name:    "ALL_CONNECTION_TRIES_FAILED",
+			Message: "All connection tries failed. Log: \n\nCode: 210. DB::NetException: ...\n",
+		},
+	}}
+	srv := newServer(q, "v-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/recent")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d (body %q), want 503", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "reach any replica") {
+		t.Fatalf("body %q does not carry the shard-unavailable message", body)
+	}
+}
+
+// TestSearchRecent_StaleReplicaFallbackDenied503 — when ClickHouse aborts a
+// Distributed query with ALL_REPLICAS_ARE_STALE (code 369 — every
+// reachable replica of at least one data shard is stale, and cerberus's
+// own fallback_to_stale_replicas_for_distributed_queries=0 pin refuses to
+// silently serve one anyway), the Tempo head must answer 503.
+func TestSearchRecent_StaleReplicaFallbackDenied503(t *testing.T) {
+	t.Parallel()
+
+	q := &stubQuerier{err: &chclient.StaleReplicaFallbackDeniedError{
+		Cause: &clickhouse.Exception{
+			Code:    369,
+			Name:    "ALL_REPLICAS_ARE_STALE",
+			Message: "Could not find enough connections to up-to-date replicas. Got: 0, needed: 1",
+		},
+	}}
+	srv := newServer(q, "v-test")
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/api/search/recent")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d (body %q), want 503", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "stale") {
+		t.Fatalf("body %q does not carry the stale-replica-fallback message", body)
+	}
+}

--- a/internal/chclient/breaker_classify.go
+++ b/internal/chclient/breaker_classify.go
@@ -232,6 +232,9 @@ var breakerServerHealthCodes = map[chproto.Error]string{
 		"cluster topology is degraded",
 	chproto.ErrAllReplicasLost: "every replica for the data is gone; the condition is total and statement-" +
 		"independent",
+	chproto.ErrAllReplicasAreStale: "cerberus's own fallback_to_stale_replicas_for_distributed_queries=0 pin " +
+		"(cerberus issue #3078) found every reachable replica of a shard behind on replication; a " +
+		"replication-lag condition that outlives the statement, not something a different query text would avoid",
 	chproto.ErrSystemError: "a syscall-level failure inside the server; the process itself is in trouble",
 	chproto.ErrCannotScheduleTask: "the server's thread pool could not accept the work; it is saturated and the " +
 		"next statement will be too",

--- a/internal/chclient/client.go
+++ b/internal/chclient/client.go
@@ -810,9 +810,15 @@ func assembleClientFromConn(cfg Config, conn driver.Conn, m *connMetrics) *Clien
 }
 
 // querySettings returns the per-query ClickHouse settings map applied
-// to every data-plane query, or nil when no setting is configured.
+// to every data-plane query. It always carries at least the two
+// distributed-query pins below (cerberus issue #3078), so it is never nil.
 // It carries:
 //
+//   - `skip_unavailable_shards=0` +
+//     `fallback_to_stale_replicas_for_distributed_queries=0` —
+//     UNCONDITIONAL, version-safe, fail-loud pins for Distributed-engine
+//     queries (see distributed_query_settings.go for the full citation);
+//     harmless no-ops against a single-shard/non-Distributed deployment.
 //   - `max_memory_usage` — ClickHouse's per-query memory cap, from
 //     Config.MaxQueryMemoryBytes (when > 0).
 //   - `max_execution_time` + `timeout_overflow_mode=throw` — the
@@ -838,10 +844,18 @@ func (c *Client) querySettings(ctx context.Context) clickhouse.Settings {
 	perQuery := querySettingsFromContext(ctx)
 	timeout := c.effectiveQueryTimeout(ctx)
 	blockSize := maxBlockSizeFromContext(ctx)
-	if c.maxMemory <= 0 && timeout <= 0 && len(perQuery) == 0 && blockSize == 0 {
-		return nil
+	// skip_unavailable_shards=0 and
+	// fallback_to_stale_replicas_for_distributed_queries=0 are pinned
+	// UNCONDITIONALLY (cerberus issue #3078 — see
+	// distributed_query_settings.go for the full citation of both
+	// settings' documented behavior and why 0 is the correct value for a
+	// correctness-focused gateway), so this map is never empty and the
+	// old "nothing configured, return nil" short-circuit no longer
+	// applies.
+	s := clickhouse.Settings{
+		settingSkipUnavailableShards:                        0,
+		settingFallbackToStaleReplicasForDistributedQueries: 0,
 	}
-	s := clickhouse.Settings{}
 	if c.maxMemory > 0 {
 		s["max_memory_usage"] = c.maxMemory
 	}
@@ -915,26 +929,25 @@ var queryIDCounter atomic.Uint64
 // Exec (DDL / DML) deliberately does NOT go through this — see
 // Config.MaxQueryMemoryBytes.
 func (c *Client) queryContext(ctx context.Context) context.Context {
+	// querySettings always returns a non-nil, non-empty map (cerberus issue
+	// #3078's two distributed-query pins ride on EVERY data-plane query —
+	// see its own doc), so unlike queryID below there is no "nothing to
+	// apply" case left to short-circuit here.
 	s := c.querySettings(ctx)
 	queryID, ctx := ensureQueryID(ctx)
 	ctx = hiddenDeadlineContext(ctx)
-	if s == nil && queryID == "" {
-		return ctx
-	}
 	opts := make([]clickhouse.QueryOption, 0, 3)
-	if s != nil {
-		opts = append(opts, clickhouse.WithSettings(s))
-		if resultCacheStamped(s) {
-			// This dispatch is one the engine's result-cache rule marked
-			// eligible (SettingUseQueryCache=1 on the settings map just
-			// wrapped above): wire the ProfileEvents observer so the real
-			// server-reported QueryCacheHits/QueryCacheMisses counters (not
-			// merely cerberus's own eligibility count) feed ResultCacheStats,
-			// the /info hit-rate signal (issue #2781). Scoped to exactly the
-			// queries that carry the setting, mirroring how WithTSGridSetting
-			// rides only the queries that need it.
-			opts = append(opts, clickhouse.WithProfileEvents(observeResultCacheProfileEvents))
-		}
+	opts = append(opts, clickhouse.WithSettings(s))
+	if resultCacheStamped(s) {
+		// This dispatch is one the engine's result-cache rule marked
+		// eligible (SettingUseQueryCache=1 on the settings map just
+		// wrapped above): wire the ProfileEvents observer so the real
+		// server-reported QueryCacheHits/QueryCacheMisses counters (not
+		// merely cerberus's own eligibility count) feed ResultCacheStats,
+		// the /info hit-rate signal (issue #2781). Scoped to exactly the
+		// queries that carry the setting, mirroring how WithTSGridSetting
+		// rides only the queries that need it.
+		opts = append(opts, clickhouse.WithProfileEvents(observeResultCacheProfileEvents))
 	}
 	if queryID != "" {
 		opts = append(opts, clickhouse.WithQueryID(queryID))

--- a/internal/chclient/cursor.go
+++ b/internal/chclient/cursor.go
@@ -380,6 +380,16 @@ func (c *rowsCursor) Next() bool {
 			// of a 502 (k3d run 27277793810 surfaced the memory case
 			// mid-stream; a long-window matrix can hit max_execution_time
 			// the same way).
+			//
+			// distributed_shard_error.go's two codes (279, 369) are
+			// deliberately NOT in this chain: both fire during a
+			// Distributed query's shard CONNECTION acquisition
+			// (PoolWithFailoverBase::getMany, see that file's own doc),
+			// which completes before ClickHouse emits the first data
+			// block — an OPEN-time failure, never a mid-stream one, so
+			// classifyDriverErr's chain (the open-time wrap site) is
+			// where it belongs, not this drain-time one. wrapThrowIf is
+			// similarly absent from this mid-stream chain already.
 			c.err = fmt.Errorf("chclient: rows.Err: %w", wrapQueryTimeout(wrapMemoryLimit(err, c.maxMemoryBytes), c.queryTimeout))
 		}
 		return false

--- a/internal/chclient/distributed_query_settings.go
+++ b/internal/chclient/distributed_query_settings.go
@@ -1,0 +1,51 @@
+package chclient
+
+// settingSkipUnavailableShards / settingFallbackToStaleReplicasForDistributedQueries
+// name the two ClickHouse settings that decide what a Distributed-engine
+// query does when it cannot reach every shard/replica it fans out to.
+// Cerberus issue #3078 pins BOTH to the fail-loud value, and this file is
+// that pin, cited inline exactly as the issue's own acceptance criteria
+// require:
+//
+//   - skip_unavailable_shards=0 — ClickHouse's own default is already 0
+//     (verified against docs/reference/settings/session-settings/
+//     skip-unavailable-shards.mdx in github.com/ClickHouse/ClickHouse), so
+//     this pin changes no server behavior today; it is stamped explicitly
+//     so the decision survives a future ClickHouse default change rather
+//     than being left to chance. With it, a Distributed data shard that
+//     has NO reachable replica at all aborts the whole query with
+//     ALL_CONNECTION_TRIES_FAILED (chclient's own *ShardUnavailableError,
+//     see distributed_shard_error.go) instead of silently answering from
+//     whichever shards happened to respond (skip_unavailable_shards=1's
+//     documented "returns a result based on partial data" behavior) — a
+//     silent partial answer is a worse failure mode for a correctness-
+//     focused gateway than a loud one.
+//   - fallback_to_stale_replicas_for_distributed_queries=0 — the OPPOSITE
+//     of ClickHouse's own default, which is 1 (verified against
+//     docs/reference/settings/session-settings/other.mdx: "Forces a query
+//     to an out-of-date replica if updated data is not available ... By
+//     default, 1 (enabled)"). Cerberus overrides it to 0 so a shard whose
+//     reachable replicas are ALL stale aborts the query with
+//     ALL_REPLICAS_ARE_STALE (chclient's own
+//     *StaleReplicaFallbackDeniedError) instead of silently answering from
+//     data that may be missing recent writes. This is the same "fail
+//     loud, never silently wrong" posture cerberus already applies
+//     elsewhere (skip_unavailable_shards above, timeout_overflow_mode=
+//     throw in this same package) — an operator who genuinely wants
+//     eventual-consistency-tolerant reads over a lagging replica can still
+//     override this via a server-side settings profile; cerberus's own
+//     default never chooses that trade-off silently.
+//
+// Both settings are stamped UNCONDITIONALLY on every data-plane read-path
+// query (see Client.querySettings), mirroring how settingTimeoutOverflowMode
+// is pinned outright rather than exposed as an operator knob: they are
+// harmless, version-safe no-ops against a single-shard/non-Distributed
+// deployment (cerberus's default, and every deployment before epic #3074) —
+// ClickHouse accepts and simply never consults either setting on a query
+// that touches no Distributed-engine table — so pinning them unconditionally
+// costs nothing on the common case and only changes behavior once
+// internal/chopt.ClusterTopology.DataShardCount > 1 (cerberus issue #3077).
+const (
+	settingSkipUnavailableShards                        = "skip_unavailable_shards"
+	settingFallbackToStaleReplicasForDistributedQueries = "fallback_to_stale_replicas_for_distributed_queries"
+)

--- a/internal/chclient/distributed_shard_error.go
+++ b/internal/chclient/distributed_shard_error.go
@@ -1,0 +1,165 @@
+package chclient
+
+import (
+	"errors"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// This file is cerberus issue #3078's ClickHouse Distributed-query error
+// taxonomy extension. It follows the exact typed-wrap pattern memlimit.go
+// (code 241) and timeout.go (code 159) already establish: a chCode<Name>
+// constant naming the verified ClickHouse ErrorCodes.cpp entry, an
+// Err<Name> sentinel matched via errors.Is, a <Name>Error wrapper carrying
+// the underlying *clickhouse.Exception (errors.As still reaches it), and a
+// wrap<Name> converter consulted from classifyDriverErr. Detection is
+// always typed (errors.As against *clickhouse.Exception), never string
+// matching against err.Error().
+//
+// The two codes below were verified against ClickHouse's own source
+// (src/Common/PoolWithFailoverBase.h's getMany(), which every Distributed
+// query's connection-acquisition path runs through), not assumed from the
+// issue's own description: the issue named a third code,
+// "SHARD_HAS_NO_REPLICAS", that DOES NOT EXIST anywhere in the ClickHouse
+// codebase (a `search/code` sweep of github.com/ClickHouse/ClickHouse
+// returned zero hits) — the nearest same-named constant,
+// SHARD_HAS_NO_CONNECTIONS (297, src/Interpreters/Cluster.cpp), is a
+// cluster-config PARSE-time error ("No cluster elements (shard, node)
+// specified in config"), never raised by a running query, so it is not
+// used here. The real runtime "a shard has no usable replica" code is
+// ALL_CONNECTION_TRIES_FAILED (279), already named correctly elsewhere in
+// the same issue sentence — this file uses that one, and separately covers
+// the issue's own "replica-staleness path" with ALL_REPLICAS_ARE_STALE
+// (369), which getMany() throws from the SAME function for the distinct
+// "reachable but stale" condition.
+
+// chCodeAllConnectionTriesFailed is ClickHouse's ALL_CONNECTION_TRIES_FAILED
+// server error code (src/Common/ErrorCodes.cpp: 279). Verified directly
+// against src/Common/PoolWithFailoverBase.h's
+// PoolWithFailoverBase<TNestedPool>::getMany(): once fewer than min_entries
+// replicas of a shard came back usable, it throws
+// `NetException(ALL_CONNECTION_TRIES_FAILED, "All connection tries failed.
+// Log: \n\n{}\n", fail_messages)`. With cerberus's own pinned
+// skip_unavailable_shards=0 (settingSkipUnavailableShards's own doc) every
+// shard's min_entries is 1, so this fires the instant one Distributed data
+// shard has NO reachable replica at all — the partial-shard-failure
+// scenario this issue's error taxonomy exists to translate.
+//
+// It is ALREADY a breakerScopeServerHealth code in breaker_classify.go
+// (chproto.ErrAllConnectionTriesFailed) — a real per-shard outage is
+// exactly the "backend cannot serve this replica's traffic" condition the
+// breaker exists to trip on — so this file adds no breaker-classification
+// change for it, only the typed wrapper the API heads consume.
+const chCodeAllConnectionTriesFailed = 279
+
+// chCodeAllReplicasAreStale is ClickHouse's ALL_REPLICAS_ARE_STALE server
+// error code (src/Common/ErrorCodes.cpp: 369). Verified against the same
+// getMany(): when up_to_date_count stays below min_entries AND
+// fallback_to_stale_replicas_for_distributed_queries is false, it throws
+// `Exception(ALL_REPLICAS_ARE_STALE, "Could not find enough connections to
+// up-to-date replicas. Got: {}, needed: {}", ...)` instead of silently
+// widening the candidate set to stale replicas. This is the "replica-
+// staleness path" this issue's Problem statement names, and it is only
+// REACHABLE at all because of cerberus's own
+// settingFallbackToStaleReplicasForDistributedQueries=0 pin — ClickHouse's
+// OWN default for that setting is 1 (silently serve a stale replica), under
+// which this code can never surface.
+const chCodeAllReplicasAreStale = 369
+
+// ErrShardUnavailable is the sentinel matched (via errors.Is) when a
+// Distributed-engine query aborted because ClickHouse could not reach any
+// replica of at least one data shard (CH error code 279,
+// ALL_CONNECTION_TRIES_FAILED). It signals partial ClickHouse-cluster
+// infrastructure trouble, not a cerberus fault and not a resource-limit
+// rejection — the initiator is healthy, one data shard behind the
+// Distributed wrapper table is not. The concrete error is
+// *ShardUnavailableError.
+var ErrShardUnavailable = errors.New("distributed shard has no reachable replica")
+
+// ShardUnavailableError is the concrete error chclient surfaces when
+// ClickHouse rejects a data-plane query with ALL_CONNECTION_TRIES_FAILED
+// (code 279). It wraps [ErrShardUnavailable] (errors.Is matches) and the
+// underlying *clickhouse.Exception (errors.As still reaches it), whose
+// Message carries ClickHouse's own per-replica connection-failure log.
+type ShardUnavailableError struct {
+	// Cause is the underlying ClickHouse error — the *clickhouse.Exception
+	// carrying code 279 and the server's "All connection tries failed"
+	// message.
+	Cause error
+}
+
+func (e *ShardUnavailableError) Error() string {
+	return "chclient: distributed shard unavailable: ClickHouse could not reach any replica of at least one data shard (skip_unavailable_shards=0 — cerberus issue #3078)"
+}
+
+// Unwrap exposes both the sentinel (for errors.Is) and the underlying
+// ClickHouse exception (for errors.As against *clickhouse.Exception).
+func (e *ShardUnavailableError) Unwrap() []error {
+	if e.Cause == nil {
+		return []error{ErrShardUnavailable}
+	}
+	return []error{ErrShardUnavailable, e.Cause}
+}
+
+// ErrStaleReplicaFallbackDenied is the sentinel matched (via errors.Is)
+// when a Distributed-engine query aborted because every reachable replica
+// of at least one data shard was stale and cerberus's own
+// fallback_to_stale_replicas_for_distributed_queries=0 pin forbids silently
+// answering from one anyway (CH error code 369, ALL_REPLICAS_ARE_STALE).
+// ClickHouse is healthy — a replica genuinely lagged replication — and this
+// is cerberus's own correctness posture (fail loud, never silently stale)
+// doing its job, not an outage. The concrete error is
+// *StaleReplicaFallbackDeniedError.
+var ErrStaleReplicaFallbackDenied = errors.New("distributed replica staleness fallback denied")
+
+// StaleReplicaFallbackDeniedError is the concrete error chclient surfaces
+// when ClickHouse rejects a data-plane query with ALL_REPLICAS_ARE_STALE
+// (code 369). It wraps [ErrStaleReplicaFallbackDenied] (errors.Is matches)
+// and the underlying *clickhouse.Exception (errors.As still reaches it).
+type StaleReplicaFallbackDeniedError struct {
+	// Cause is the underlying ClickHouse error — the *clickhouse.Exception
+	// carrying code 369 and the server's "Could not find enough
+	// connections to up-to-date replicas" message.
+	Cause error
+}
+
+func (e *StaleReplicaFallbackDeniedError) Error() string {
+	return "chclient: distributed replica staleness fallback denied: every reachable replica of at least one data shard is stale and fallback_to_stale_replicas_for_distributed_queries=0 (cerberus issue #3078)"
+}
+
+// Unwrap exposes both the sentinel (for errors.Is) and the underlying
+// ClickHouse exception (for errors.As against *clickhouse.Exception).
+func (e *StaleReplicaFallbackDeniedError) Unwrap() []error {
+	if e.Cause == nil {
+		return []error{ErrStaleReplicaFallbackDenied}
+	}
+	return []error{ErrStaleReplicaFallbackDenied, e.Cause}
+}
+
+// wrapDistributedShardErr converts a raw driver error into a
+// *ShardUnavailableError or *StaleReplicaFallbackDeniedError when (and only
+// when) the error chain carries a ClickHouse exception with a matching
+// code. Every other error passes through untouched.
+//
+// Detection is typed — errors.As against *clickhouse.Exception, mirroring
+// wrapMemoryLimit / wrapQueryTimeout — never string matching, so a query
+// whose result data happens to contain either error's own wording cannot be
+// misclassified. The two codes are mutually exclusive (ClickHouse raises at
+// most one per getMany() call), so check order does not matter.
+func wrapDistributedShardErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var ex *clickhouse.Exception
+	if !errors.As(err, &ex) {
+		return err
+	}
+	switch ex.Code {
+	case chCodeAllConnectionTriesFailed:
+		return &ShardUnavailableError{Cause: err}
+	case chCodeAllReplicasAreStale:
+		return &StaleReplicaFallbackDeniedError{Cause: err}
+	default:
+		return err
+	}
+}

--- a/internal/chclient/distributed_shard_error_test.go
+++ b/internal/chclient/distributed_shard_error_test.go
@@ -1,0 +1,154 @@
+package chclient
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// chShardUnavailableException builds the typed driver exception ClickHouse
+// raises for ALL_CONNECTION_TRIES_FAILED — the shape
+// PoolWithFailoverBase<TNestedPool>::getMany() throws once a Distributed
+// data shard's usable-replica count falls below min_entries.
+func chShardUnavailableException() *clickhouse.Exception {
+	return &clickhouse.Exception{
+		Code:    279,
+		Name:    "ALL_CONNECTION_TRIES_FAILED",
+		Message: "All connection tries failed. Log: \n\nCode: 209. DB::NetException: Timeout exceeded while connecting to socket",
+	}
+}
+
+// chStaleReplicaException builds the typed driver exception ClickHouse
+// raises for ALL_REPLICAS_ARE_STALE — the same getMany() call, thrown
+// instead when every reachable replica is stale and
+// fallback_to_stale_replicas_for_distributed_queries=0 forbids serving one.
+func chStaleReplicaException() *clickhouse.Exception {
+	return &clickhouse.Exception{
+		Code:    369,
+		Name:    "ALL_REPLICAS_ARE_STALE",
+		Message: "Could not find enough connections to up-to-date replicas. Got: 0, needed: 1",
+	}
+}
+
+// TestWrapDistributedShardErr_Code279 — a CH exception with code 279
+// becomes a *ShardUnavailableError, matchable both via errors.Is (the
+// ErrShardUnavailable sentinel) and errors.As (the underlying
+// *clickhouse.Exception still reachable).
+func TestWrapDistributedShardErr_Code279(t *testing.T) {
+	t.Parallel()
+
+	got := wrapDistributedShardErr(chShardUnavailableException())
+
+	var shardErr *ShardUnavailableError
+	if !errors.As(got, &shardErr) {
+		t.Fatalf("wrapDistributedShardErr returned %T (%v); want *ShardUnavailableError", got, got)
+	}
+	if !errors.Is(got, ErrShardUnavailable) {
+		t.Error("errors.Is(got, ErrShardUnavailable) = false; want true")
+	}
+	if errors.Is(got, ErrStaleReplicaFallbackDenied) {
+		t.Error("errors.Is(got, ErrStaleReplicaFallbackDenied) = true; want false (codes are mutually exclusive)")
+	}
+	var ex *clickhouse.Exception
+	if !errors.As(got, &ex) || ex.Code != 279 {
+		t.Errorf("underlying *clickhouse.Exception not reachable via errors.As (ex=%v)", ex)
+	}
+}
+
+// TestWrapDistributedShardErr_Code369 — a CH exception with code 369
+// becomes a *StaleReplicaFallbackDeniedError, matchable both via errors.Is
+// (the ErrStaleReplicaFallbackDenied sentinel) and errors.As (the
+// underlying *clickhouse.Exception still reachable).
+func TestWrapDistributedShardErr_Code369(t *testing.T) {
+	t.Parallel()
+
+	got := wrapDistributedShardErr(chStaleReplicaException())
+
+	var staleErr *StaleReplicaFallbackDeniedError
+	if !errors.As(got, &staleErr) {
+		t.Fatalf("wrapDistributedShardErr returned %T (%v); want *StaleReplicaFallbackDeniedError", got, got)
+	}
+	if !errors.Is(got, ErrStaleReplicaFallbackDenied) {
+		t.Error("errors.Is(got, ErrStaleReplicaFallbackDenied) = false; want true")
+	}
+	if errors.Is(got, ErrShardUnavailable) {
+		t.Error("errors.Is(got, ErrShardUnavailable) = true; want false (codes are mutually exclusive)")
+	}
+	var ex *clickhouse.Exception
+	if !errors.As(got, &ex) || ex.Code != 369 {
+		t.Errorf("underlying *clickhouse.Exception not reachable via errors.As (ex=%v)", ex)
+	}
+}
+
+// TestWrapDistributedShardErr_PassThrough — nil, non-exception errors, and
+// exceptions with other codes (including the adjacent 241/159 codes the
+// sibling wrappers own) pass through unchanged: classification is typed
+// code-279/369-only, never string matching, and never steals a code that
+// belongs to wrapMemoryLimit/wrapQueryTimeout.
+func TestWrapDistributedShardErr_PassThrough(t *testing.T) {
+	t.Parallel()
+
+	if got := wrapDistributedShardErr(nil); got != nil {
+		t.Errorf("wrapDistributedShardErr(nil) = %v; want nil", got)
+	}
+
+	plain := errors.New("dial tcp: connection refused, mentioning All connection tries failed")
+	if got := wrapDistributedShardErr(plain); got != plain {
+		t.Errorf("plain error was rewritten to %v; want pass-through (no string matching)", got)
+	}
+
+	for _, ex := range []*clickhouse.Exception{
+		{Code: 60, Name: "UNKNOWN_TABLE", Message: "Table otel.missing does not exist"},
+		chMemLimitException(),
+		chTimeoutException(),
+	} {
+		got := wrapDistributedShardErr(ex)
+		if !errors.Is(got, error(ex)) {
+			t.Errorf("code-%d exception was rewritten to %v; want pass-through", ex.Code, got)
+		}
+		if errors.Is(got, ErrShardUnavailable) || errors.Is(got, ErrStaleReplicaFallbackDenied) {
+			t.Errorf("code-%d exception classified as a distributed-shard error; want only codes 279/369", ex.Code)
+		}
+	}
+}
+
+// TestShardUnavailableError_Unwrap — Unwrap exposes both the sentinel and
+// the underlying cause, with and without a Cause set.
+func TestShardUnavailableError_Unwrap(t *testing.T) {
+	t.Parallel()
+
+	withCause := &ShardUnavailableError{Cause: chShardUnavailableException()}
+	if !errors.Is(withCause, ErrShardUnavailable) {
+		t.Error("errors.Is(withCause, ErrShardUnavailable) = false; want true")
+	}
+	var ex *clickhouse.Exception
+	if !errors.As(withCause, &ex) {
+		t.Error("errors.As(withCause, &ex) = false; want true")
+	}
+
+	bare := &ShardUnavailableError{}
+	if !errors.Is(bare, ErrShardUnavailable) {
+		t.Error("errors.Is(bare, ErrShardUnavailable) = false; want true even with a nil Cause")
+	}
+}
+
+// TestStaleReplicaFallbackDeniedError_Unwrap — Unwrap exposes both the
+// sentinel and the underlying cause, with and without a Cause set.
+func TestStaleReplicaFallbackDeniedError_Unwrap(t *testing.T) {
+	t.Parallel()
+
+	withCause := &StaleReplicaFallbackDeniedError{Cause: chStaleReplicaException()}
+	if !errors.Is(withCause, ErrStaleReplicaFallbackDenied) {
+		t.Error("errors.Is(withCause, ErrStaleReplicaFallbackDenied) = false; want true")
+	}
+	var ex *clickhouse.Exception
+	if !errors.As(withCause, &ex) {
+		t.Error("errors.As(withCause, &ex) = false; want true")
+	}
+
+	bare := &StaleReplicaFallbackDeniedError{}
+	if !errors.Is(bare, ErrStaleReplicaFallbackDenied) {
+		t.Error("errors.Is(bare, ErrStaleReplicaFallbackDenied) = false; want true even with a nil Cause")
+	}
+}

--- a/internal/chclient/memlimit_test.go
+++ b/internal/chclient/memlimit_test.go
@@ -97,9 +97,17 @@ func TestMemoryLimitError_NoCapConfigured(t *testing.T) {
 	}
 }
 
+// distributedPinCount is the number of settings distributed_query_settings.go
+// pins UNCONDITIONALLY on every querySettings() call (cerberus issue #3078:
+// skip_unavailable_shards + fallback_to_stale_replicas_for_distributed_queries).
+// Every exact-entry-count assertion in this file adds this in, so a future
+// third unconditional pin only needs updating here.
+const distributedPinCount = 2
+
 // TestQuerySettings_MaxMemoryUsage — the per-query settings map carries
-// max_memory_usage with the configured byte value, and is nil (setting
-// not sent at all) when the cap is 0/unset.
+// max_memory_usage with the configured byte value, and carries ONLY the
+// two unconditional distributed-query pins (never max_memory_usage) when
+// the cap is 0/unset.
 func TestQuerySettings_MaxMemoryUsage(t *testing.T) {
 	t.Parallel()
 
@@ -115,13 +123,19 @@ func TestQuerySettings_MaxMemoryUsage(t *testing.T) {
 	if got != int64(1<<30) {
 		t.Errorf("max_memory_usage = %v (%T); want %d (int64)", got, got, int64(1<<30))
 	}
-	if len(settings) != 1 {
-		t.Errorf("settings carries %d entries (%v); want exactly max_memory_usage", len(settings), settings)
+	if len(settings) != 1+distributedPinCount {
+		t.Errorf("settings carries %d entries (%v); want exactly max_memory_usage plus the %d distributed pins",
+			len(settings), settings, distributedPinCount)
 	}
 
 	unset := &Client{}
-	if s := unset.querySettings(context.Background()); s != nil {
-		t.Errorf("querySettings() with cap 0 = %v; want nil (setting not sent)", s)
+	s := unset.querySettings(context.Background())
+	if _, ok := s["max_memory_usage"]; ok {
+		t.Errorf("querySettings() with cap 0 = %v; want max_memory_usage absent", s)
+	}
+	if len(s) != distributedPinCount {
+		t.Errorf("querySettings() with cap 0 carries %d entries (%v); want exactly the %d unconditional distributed pins",
+			len(s), s, distributedPinCount)
 	}
 }
 
@@ -148,8 +162,9 @@ func TestQuerySettings_TSGridSetting(t *testing.T) {
 	if marked["max_memory_usage"] != int64(1<<30) {
 		t.Errorf("max_memory_usage = %v; want %d (the merge must not drop the cap)", marked["max_memory_usage"], int64(1<<30))
 	}
-	if len(marked) != 2 {
-		t.Errorf("marked settings carries %d entries (%v); want exactly the two knobs", len(marked), marked)
+	if len(marked) != 2+distributedPinCount {
+		t.Errorf("marked settings carries %d entries (%v); want exactly the two knobs plus the %d distributed pins",
+			len(marked), marked, distributedPinCount)
 	}
 
 	// Marked ctx with NO memory cap → only the experimental knob, no
@@ -161,8 +176,9 @@ func TestQuerySettings_TSGridSetting(t *testing.T) {
 	if _, ok := bare["max_memory_usage"]; ok {
 		t.Errorf("bare client carries max_memory_usage; want it absent (cap is 0)")
 	}
-	if len(bare) != 1 {
-		t.Errorf("bare settings carries %d entries (%v); want exactly the experimental knob", len(bare), bare)
+	if len(bare) != 1+distributedPinCount {
+		t.Errorf("bare settings carries %d entries (%v); want exactly the experimental knob plus the %d distributed pins",
+			len(bare), bare, distributedPinCount)
 	}
 }
 
@@ -183,16 +199,19 @@ func TestSettingExperimentalTSGridAggregate_ExactName(t *testing.T) {
 	}
 }
 
-// TestQueryContext_Derivation — queryContext derives a new context only
-// when a cap is configured; with cap 0 the caller's ctx is returned
-// verbatim so the unconfigured path stays allocation-free.
+// TestQueryContext_Derivation — queryContext ALWAYS derives a new context,
+// with or without a configured memory cap: cerberus issue #3078's two
+// distributed-query pins (skip_unavailable_shards +
+// fallback_to_stale_replicas_for_distributed_queries) ride on every
+// data-plane query unconditionally, so querySettings is never empty and
+// there is no longer an "unconfigured, pass ctx through verbatim" path.
 func TestQueryContext_Derivation(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	unset := &Client{}
-	if got := unset.queryContext(ctx); got != ctx {
-		t.Error("queryContext with cap 0 derived a new ctx; want pass-through")
+	if got := unset.queryContext(ctx); got == ctx {
+		t.Error("queryContext with cap 0 returned ctx verbatim; want a derived ctx carrying the two unconditional distributed pins")
 	}
 	capped := &Client{maxMemory: 1 << 30}
 	if got := capped.queryContext(ctx); got == ctx {

--- a/internal/chclient/query_settings_test.go
+++ b/internal/chclient/query_settings_test.go
@@ -55,8 +55,9 @@ func TestQuerySettings_GeneralisedCarrierCoexists(t *testing.T) {
 	if s["max_memory_usage"] != int64(1<<30) {
 		t.Errorf("max_memory_usage = %v; want the cap (no clobber)", s["max_memory_usage"])
 	}
-	if len(s) != 3 {
-		t.Errorf("settings carries %d entries (%v); want the three knobs", len(s), s)
+	if len(s) != 3+distributedPinCount {
+		t.Errorf("settings carries %d entries (%v); want the three knobs plus the %d distributed pins",
+			len(s), s, distributedPinCount)
 	}
 }
 

--- a/internal/chclient/timeout.go
+++ b/internal/chclient/timeout.go
@@ -181,23 +181,24 @@ func QueryTimeoutFromContext(ctx context.Context) (time.Duration, bool) {
 
 // classifyDriverErr maps a raw clickhouse-go driver error onto the typed
 // per-query resource rejections chclient surfaces — *MemoryLimitError
-// (code 241), *ThrowIfError (code 395 or 768), and *QueryTimeoutError
-// (code 159) — so the API heads can map each onto its head-idiomatic wire
-// shape. Any other error (or nil) passes through untouched. The three
-// ERROR TYPES are mutually exclusive, so the order of the checks does not
-// matter, even though ThrowIfError itself now spans two distinct
-// ClickHouse codes (395 for throwIf, 768 for
-// timeSeriesThrowDuplicateSeriesIf — see throwif.go); the timeout wrapper
-// is given the effective per-query cap (ctx override min'd with the
-// configured default) so its message names the real budget the query ran
-// under.
+// (code 241), *ThrowIfError (code 395 or 768), *ShardUnavailableError
+// (code 279), *StaleReplicaFallbackDeniedError (code 369, see
+// distributed_shard_error.go), and *QueryTimeoutError (code 159) — so the
+// API heads can map each onto its head-idiomatic wire shape. Any other
+// error (or nil) passes through untouched. The five ERROR TYPES are
+// mutually exclusive, so the order of the checks does not matter, even
+// though ThrowIfError itself now spans two distinct ClickHouse codes (395
+// for throwIf, 768 for timeSeriesThrowDuplicateSeriesIf — see throwif.go);
+// the timeout wrapper is given the effective per-query cap (ctx override
+// min'd with the configured default) so its message names the real budget
+// the query ran under.
 //
 // It is the single wrap site every data-plane query method routes its
 // open-time and drain-time errors through, replacing the bare
-// wrapMemoryLimit call so the memory + throwIf + timeout classifications
-// stay in lock-step across all of them.
+// wrapMemoryLimit call so the memory + throwIf + distributed-shard +
+// timeout classifications stay in lock-step across all of them.
 func (c *Client) classifyDriverErr(ctx context.Context, err error) error {
-	return wrapQueryTimeout(wrapThrowIf(wrapMemoryLimit(err, c.maxMemory)), c.effectiveQueryTimeout(ctx))
+	return wrapQueryTimeout(wrapThrowIf(wrapDistributedShardErr(wrapMemoryLimit(err, c.maxMemory))), c.effectiveQueryTimeout(ctx))
 }
 
 // hiddenDeadlineContext hides ctx's own Deadline() from anything reading it


### PR DESCRIPTION
## Summary

Static/docs verification of every `internal/chopt`-stamped ClickHouse setting's
behavior under a `Distributed` table (the epic's settings-verification
sub-issue), plus the real error-taxonomy extension and settings pins the
issue's acceptance criteria required:

- **Settings table** (`docs/operations.md`) — every `internal/chopt`-stamped
  setting's `Distributed`-forwarding behavior, cited against ClickHouse's own
  source (`src/Interpreters/ClusterProxy/executeQuery.cpp`,
  `src/Client/Connection.cpp`) and docs, fetched at the exact pinned tag
  (`v25.8.1.5101-lts`, matching `deploy/helm/cerberus/values.yaml`'s
  `clickhouse/clickhouse-server:25.8`) rather than assumed or checked against
  `master`. A new column marks which rows are actually reachable on the
  pinned 25.8 image today versus gated behind a higher `MinVersion` floor in
  `internal/chopt/registry.go` (`join_spill` 26.4, `trace_id_bitmap_filter`
  25.11, `lazy_materialization` 25.11, the `ts_grid_*` family 25.9) — an
  operator reading only the behavior column could otherwise assume all seven
  rows are live protections today, which is false for four of them.
- **`perShardMemoryBytes`** (issue #3081, already merged) confirmed against
  `max_memory_usage`'s own docs: "The restriction applies to a single query
  within a single server" — the reason the formula divides by
  `DataShardCount`.
- **Error taxonomy** — `internal/chclient/distributed_shard_error.go` adds
  `*ShardUnavailableError` (CH 279, `ALL_CONNECTION_TRIES_FAILED`) and
  `*StaleReplicaFallbackDeniedError` (CH 369, `ALL_REPLICAS_ARE_STALE`),
  following the exact typed-wrap pattern `memlimit.go`/`timeout.go` already
  establish, wired into `classifyDriverErr` and into each head's classifier
  (`prom`, `loki`, `tempo`) mapping to 503 `errorType=unavailable`. Also adds
  `ALL_REPLICAS_ARE_STALE` to the breaker's `breakerServerHealthCodes` (a
  real pre-existing gap). The issue's own named third code,
  `SHARD_HAS_NO_REPLICAS`, does not exist anywhere in ClickHouse (verified via
  a `search/code` sweep) — `ALL_REPLICAS_ARE_STALE` is the real
  "replica-staleness path" the issue asked for, documented explicitly rather
  than silently substituted.
- **Settings pin** — `internal/chclient/distributed_query_settings.go` pins
  `skip_unavailable_shards=0` and
  `fallback_to_stale_replicas_for_distributed_queries=0` unconditionally on
  every data-plane query, each with an inline citation of this issue and the
  ClickHouse doc default it overrides or confirms.
- **Subquery test plan** for issue #3079 — `ClickHouse#29332` (predicate
  pushdown through subqueries against `Distributed`) is real but **closed**,
  legacy-analyzer-only (verified by reading the issue and the maintainer's
  closing comment directly). The actual, non-obvious risk:
  `internal/engine`'s `applyNativeHistogramAnalyzerFix` forces
  `enable_analyzer=0` for native-histogram queries, reactivating the exact
  legacy pipeline the bug lived in — reachable now only because a
  `Distributed` table exists. Six concrete shapes with file:line citations are
  written down in `docs/operations.md` for #3079 to execute.

## ACPR fixes applied after independent verification

Three parallel adversarial passes verified this against the live repo and
ClickHouse's real source/docs. Two findings were real and are fixed in this
PR; one was a false positive (refuted below); one gap was closed
proactively.

- **Fixed — anachronistic source citation.** The settings table's "Two
  source-level facts" block cited `stripInitiatorOnlySettings` in
  `executeQuery.cpp`, verified against ClickHouse `master`/HEAD rather than
  the pinned **25.8**. Refetched `executeQuery.cpp` at tag
  `v25.8.1.5101-lts` directly: that helper does not exist at 25.8 (introduced
  ~10 months later). Rewrote the block to describe what 25.8's
  `updateSettingsAndClientInfoForCluster` actually does (zeroes `offset`/
  `limit`, not a `select`/`order`/`sort`/`format` set) — the core conclusion
  (none of cerberus's stamped settings are touched) still holds and is now
  correctly sourced.
- **Fixed — missing reachability caveat.** Four of the seven feature-setting
  rows (`join_spill`, `trace_id_bitmap_filter`, `lazy_materialization`, the
  `ts_grid_*` family) are gated in `internal/chopt/registry.go` behind a
  `MinVersion` above the pinned 25.8, so cerberus never actually stamps them
  on the bundled image today — a fact the original table didn't surface.
  Added a "Reachable on pinned 25.8?" column plus a lead-in paragraph and
  closing summary making this explicit, so the table can't be misread as
  "all seven of these are live protections right now."
- **Refuted — `cohortPred` citation.** One reviewer claimed `cohortPred`
  "does not appear in `internal/chsql/metrics_compare.go` at all." Grepped
  the file directly: `cohortPred := &chplan.InSubquery{...}` is real, live
  code at `metrics_compare.go:438` (independently confirmed by the other two
  review passes too). No change made — the doc's citation was accurate.
- **Closed proactively — untested code-detection path.** A second reviewer
  correctly noted `wrapDistributedShardErr`'s own `switch ex.Code` had no
  direct unit test, unlike its siblings `wrapMemoryLimit`
  (`TestWrapMemoryLimit_Code241`) and `wrapQueryTimeout`. Added
  `internal/chclient/distributed_shard_error_test.go` mirroring that exact
  pattern: code-279/369 classification, pass-through for nil/plain/other-code
  errors (including the adjacent 241/159 codes owned by the sibling
  wrappers), and `Unwrap()` coverage for both error types.

## Verification

- `go build ./...` and `go build -tags chdb ./...` — clean.
- `go test -race ./internal/chclient/... ./internal/api/prom/... ./internal/api/loki/... ./internal/api/tempo/...` — all green, including the 5 new `wrapDistributedShardErr` unit tests and the 6 existing per-head wire-format fixtures.
- `just vet-tagged` — clean.
- `just lint-md` — 0 issues.
- `node .github/scripts/forbid-sql-raw.mjs` — clean.

Closes #3078

Cross-references epic #3074. Live-load confirmation of the settings/formulas
above under real concurrent multi-shard traffic remains issue #3079's job,
per this issue's own scope.
