### PR TITLE
test(e2e): wire multi-shard N=2/N=4 hardening lane into CI

### DIFF
--- a/.github/ci-lanes.json
+++ b/.github/ci-lanes.json
@@ -1208,6 +1208,35 @@
       "accountable_owner": "system-quality"
     },
     {
+      "id": "e2e.datashard",
+      "description": "Multi-data-shard ClickHouse Distributed-table topology under real concurrent solver-driven load, one matrix leg per data-shard count (cerberus issue #3079, epic #3074).",
+      "owner": {
+        "workflow": ".github/workflows/e2e.yml",
+        "jobs": ["datashard"],
+        "producer_jobs": [],
+        "context_job": "datashard"
+      },
+      "executions": ["default"],
+      "context": { "match": "prefix", "name": "datashard (N=", "protected": false },
+      "purpose": "correctness",
+      "layers": ["8", "9"],
+      "oracle_class": "consumer",
+      "recipes": ["e2e-datashard-up", "e2e-seed-rolling", "e2e-run", "e2e-datashard-verify"],
+      "command": "multi-data-shard ClickHouse k3d scenario",
+      "build_tags": ["e2e"],
+      "package_globs": ["test/e2e/**"],
+      "substrate": "k3d",
+      "risk_domains": ["deployment", "schema", "admission-control"],
+      "merge_posture": "never",
+      "main_posture": "always",
+      "release_posture": "advisory",
+      "determinism": "deterministic",
+      "applicability": { "source": true, "artifact": false },
+      "timeout_minutes": 40,
+      "slo_minutes": 40,
+      "accountable_owner": "system-quality"
+    },
+    {
       "id": "e2e.nightly-health-notify",
       "description": "Roll up the nightly's terminal jobs and file/refresh a tracking issue on any non-success (#1861).",
       "owner": {

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1904,6 +1904,32 @@ what actually runs.
   - Env: `NAMESPACE` (default `cerberus`), `PPROF_OUT_DIR` (default `/tmp`).
   - Exit: `0` when restarts == 0 (or unreadable), `1` when restarts > 0
     (after dumping evidence).
+- **`e2e-datashard-verify.mjs`** — `e2e.yml`, the `datashard` job (multi-data-shard
+  lane, cerberus issue #3079), invoked via `just e2e-datashard-verify <count>`
+  after a concurrent PromQL/LogQL/TraceQL burst has run against the
+  `Distributed` target. Reads `system.query_log` (never cerberus's own HTTP
+  responses) to prove: a genuine solver-split (`kEff > 1`) query reached the
+  cluster at all (otherwise the leg is vacuous); the real, concurrent,
+  cluster-wide per-shard statement count (`is_initial_query=0` rows) never
+  exceeded `DATA_SHARD_FANOUT_CAP` — `DataShardFanoutGate`'s own ceiling,
+  not merely the trivially-safe `N=2` case; no cerberus 5xx during the burst
+  (admission control degrades, never rejects); every per-shard statement's
+  own `max_memory_usage` setting sits within `perShardMemoryBytes`'s
+  predicted ceiling for THAT STATEMENT's own `kEff` (joined back via its
+  `initial_query_id`, not a group-wide bound) and no
+  `MEMORY_LIMIT_EXCEEDED`/OOM appears anywhere in the cluster. `kEff` and
+  the per-shard fan-out are both
+  recovered by grouping `query_id` on its leading 32-hex-char trace-id
+  component (`internal/chclient/client.go`'s `mintQueryID` shape) — see the
+  script's own header for the full mechanism. INFORMATIONAL — never a PR
+  gate.
+  - Env: `NAMESPACE` (default `cerberus`), `CERBERUS_URL` (default
+    `http://localhost:8080`), `DB` (default `otel`), `CH_USER`/`CH_PASSWORD`
+    (default `cerberus`/`cerberus`), `CH_CLUSTER` (default `bwc_cluster`),
+    `DATA_SHARD_COUNT` / `DATA_SHARD_FANOUT_CAP` (required), `BURST_SECONDS`
+    (default `20`), `BURST_CONCURRENCY` (default `6`), `FLUSH_WAIT_SECONDS`
+    (default `10`).
+  - Exit: `0` all assertions passed, `1` on any failure.
 - **`promql-surface-gate.mjs`** — `compatibility.yml`, the
   `compatibility/promql-surface` job (reference-backed full-surface PromQL
   rejection-completeness gate, #106). Stands up a flag-enabled reference

--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -1,0 +1,397 @@
+// e2e-datashard-verify.mjs — real-cluster admission-control + memory-bound
+// verification for the multi-data-shard e2e lane (cerberus issue #3079,
+// epic #3074). Run by `just e2e-datashard-verify <count>` AFTER
+// `just e2e-seed-rolling` (and, for the correctness leg, `just e2e-run` —
+// see that recipe's own doc; this script does NOT re-check correctness,
+// which is `test/e2e/e2e_datashard_subquery_test.go` + the rest of the Go
+// e2e suite's job).
+//
+// This script proves what `system.query_log` — not cerberus's own HTTP
+// responses — actually observed happen inside ClickHouse while a burst of
+// concurrent, solver-splitting PromQL/LogQL/TraceQL requests ran against the
+// `Distributed` target:
+//
+//   1. A genuine solver-split (kEff > 1) query reached the Distributed
+//      target at all — otherwise the whole leg would be vacuous (it would
+//      "pass" whether or not DataShardFanoutGate does anything).
+//   2. The real, concurrent, cluster-wide per-shard statement count
+//      (system.query_log rows with is_initial_query=0, i.e. what
+//      `Distributed` actually dispatched to each data shard) never exceeded
+//      DATA_SHARD_FANOUT_CAP at any instant during the burst —
+//      DataShardFanoutGate's own real, unconditional ceiling
+//      (Σ kEff_i × DataShardCount ≤ DataShardFanoutCap), not merely the
+//      trivially-safe N=2 case.
+//   3. No 5xx from cerberus during the burst — the admission-control path is
+//      "degrade parallelism, never reject" (docs/solver.md point 3); a 503
+//      here would mean that promise broke once a REAL data-shard fan-out
+//      was layered on top, which chDB-only testing could never observe.
+//   4. Every per-shard statement's own `max_memory_usage` setting (as
+//      ClickHouse itself recorded it in system.query_log.Settings) sits at
+//      or below cap/(kEff*DataShardCount) for ITS OWN kEff (joined back via
+//      its initial_query_id's trace prefix, not a group-wide bound) — the
+//      solver's perShardMemoryBytes formula's live prediction
+//      (docs/operations.md's "solver's perShardMemoryBytes setting"
+//      section) — and no MEMORY_LIMIT_EXCEEDED / OOM exception appears
+//      anywhere in the cluster's query_log for the burst window.
+//
+// kEff > 1 evidence (point 1) and the concurrent fan-out count (point 2) are
+// both read directly off system.query_log rather than inferred, using two
+// facts about how cerberus dispatches a solver-split query
+// (internal/chclient/client.go's mintQueryID, internal/solver/executor.go's
+// ShardQueryIDs):
+//   - every per-dispatch ClickHouse query_id cerberus mints has the shape
+//     "<traceID>-<spanID>-<counter>", so query_ids from the SAME logical
+//     HTTP request share the same leading 32-hex-char traceID whether or
+//     not the request carried an incoming `traceparent` (otelhttp still
+//     starts a trace per request); a driver-self-generated id (the
+//     no-trace fallback, or any query NOT dispatched through chclient, e.g.
+//     the rolling seeder's own direct INSERTs) is astronomically unlikely
+//     to collide with another query's traceID prefix, so grouping by that
+//     prefix with HAVING count() > 1 needs no separate exclusion filter;
+//   - `Distributed` fans each SUCH is_initial_query=1 statement out into
+//     DataShardCount is_initial_query=0 children carrying that statement's
+//     query_id as their own initial_query_id — exactly the rows
+//     DataShardFanoutGate's own weight (kEff × DataShardCount) bounds the
+//     live concurrent count of.
+//
+// Env contract:
+//   NAMESPACE               k8s namespace                    (default cerberus)
+//   CERBERUS_URL            cerberus HTTP endpoint            (default http://localhost:8080)
+//   DB                      ClickHouse database                (default otel)
+//   CH_USER / CH_PASSWORD   ClickHouse credentials             (default cerberus/cerberus)
+//   CH_CLUSTER              ClickHouse cluster name             (default bwc_cluster)
+//   DATA_SHARD_COUNT        expected DataShardCount             (required)
+//   DATA_SHARD_FANOUT_CAP   expected DataShardFanoutCap         (required)
+//   BURST_SECONDS           sustained concurrent-load duration  (default 20)
+//   BURST_CONCURRENCY       concurrent requests in flight       (default 6)
+//   FLUSH_WAIT_SECONDS      settle time before SYSTEM FLUSH LOGS (default 10)
+//
+// Exit 0 = every assertion passed; 1 = any failed (with ::error:: annotation).
+
+import process from 'node:process';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { error, notice, log, capture } from './lib/gh.mjs';
+import { makeKubectl } from './lib/bwc-k8s.mjs';
+
+const NS = process.env.NAMESPACE || 'cerberus';
+const CERBERUS_URL = process.env.CERBERUS_URL || 'http://localhost:8080';
+const DB = process.env.DB || 'otel';
+const CH_USER = process.env.CH_USER || 'cerberus';
+const CH_PASSWORD = process.env.CH_PASSWORD || 'cerberus';
+const CH_CLUSTER = process.env.CH_CLUSTER || 'bwc_cluster';
+const DATA_SHARD_COUNT = Number(process.env.DATA_SHARD_COUNT || '0');
+const DATA_SHARD_FANOUT_CAP = Number(process.env.DATA_SHARD_FANOUT_CAP || '0');
+const BURST_SECONDS = Number(process.env.BURST_SECONDS || '20');
+const BURST_CONCURRENCY = Number(process.env.BURST_CONCURRENCY || '6');
+const FLUSH_WAIT_SECONDS = Number(process.env.FLUSH_WAIT_SECONDS || '10');
+
+if (!DATA_SHARD_COUNT || DATA_SHARD_COUNT < 2) {
+  error(`DATA_SHARD_COUNT must be a real data-shard count (>= 2), got ${process.env.DATA_SHARD_COUNT}`);
+  process.exit(1);
+}
+if (!DATA_SHARD_FANOUT_CAP || DATA_SHARD_FANOUT_CAP < 1) {
+  error(`DATA_SHARD_FANOUT_CAP must be a positive int, got ${process.env.DATA_SHARD_FANOUT_CAP}`);
+  process.exit(1);
+}
+
+const kubectl = makeKubectl(capture, NS);
+
+// Any one shard's own ClickHouse pod can run the cluster-wide
+// clusterAllReplicas() queries below — the Distributed wrapper + the named
+// cluster exist identically on every node of every shard.
+function anyClickhousePodName() {
+  const res = kubectl([
+    'get', 'pod',
+    '-l', 'app.kubernetes.io/component=clickhouse',
+    '-o', 'jsonpath={.items[0].metadata.name}',
+  ]);
+  const name = res.stdout.trim();
+  if (res.status !== 0 || !name) {
+    error(`could not resolve any bundled ClickHouse pod in namespace ${NS}: ${res.stderr.trim()}`);
+    process.exit(1);
+  }
+  return name;
+}
+
+function allClickhousePodNames() {
+  const res = kubectl([
+    'get', 'pod',
+    '-l', 'app.kubernetes.io/component=clickhouse',
+    '-o', 'jsonpath={.items[*].metadata.name}',
+  ]);
+  const names = res.stdout.trim().split(/\s+/).filter(Boolean);
+  if (res.status !== 0 || names.length === 0) {
+    error(`could not list bundled ClickHouse pods in namespace ${NS}: ${res.stderr.trim()}`);
+    process.exit(1);
+  }
+  return names;
+}
+
+// TSV output (--format TSVRaw) so multi-column rows split unambiguously
+// without a JSON round trip for a bare Node http client to parse.
+function chQueryTSV(pod, sql) {
+  const res = kubectl([
+    'exec', pod, '--',
+    'clickhouse-client',
+    '--user', CH_USER,
+    '--password', CH_PASSWORD,
+    '--database', DB,
+    '--format', 'TSVRaw',
+    '--query', sql,
+  ]);
+  if (res.status !== 0) {
+    error(`clickhouse query failed: ${sql}\n${res.stderr.trim()}`);
+    process.exit(1);
+  }
+  return res.stdout.split('\n').map((l) => l.trimEnd()).filter((l) => l.length > 0);
+}
+
+function chExec(pod, sql) {
+  const res = kubectl(['exec', pod, '--', 'clickhouse-client', '--user', CH_USER, '--password', CH_PASSWORD, '--query', sql]);
+  if (res.status !== 0) {
+    error(`clickhouse exec failed: ${sql}\n${res.stderr.trim()}`);
+    process.exit(1);
+  }
+}
+
+// ---- OOM/restart baseline (captured BEFORE the burst) ----
+function restartCounts(pods) {
+  const out = {};
+  for (const p of pods) {
+    const res = kubectl(['get', 'pod', p, '-o', 'jsonpath={.status.containerStatuses[0].restartCount}']);
+    out[p] = Number(res.stdout.trim() || '0');
+  }
+  return out;
+}
+
+function oomKilledPods(pods) {
+  const oomed = [];
+  for (const p of pods) {
+    const res = kubectl(['get', 'pod', p, '-o', 'jsonpath={.status.containerStatuses[0].lastState.terminated.reason}']);
+    if (res.stdout.trim() === 'OOMKilled') oomed.push(p);
+  }
+  return oomed;
+}
+
+// ---- concurrent HTTP load ----
+// A wide range (3h) at a fine step (5s) yields ~2160 anchors — combined with
+// cerberus-values-datashard.yaml's collapsed MinFanout/MinAnchorPairs/
+// MinAnchorsPerSlice, this reliably reaches K=CERBERUS_SHARD_MAX_K (8)
+// regardless of the seed's own (modest) row volume, which is exactly what
+// this lane's own values overlay documents doing and why.
+function wideRangeParams(stepSeconds) {
+  const now = Math.floor(Date.now() / 1000);
+  const start = now - 3 * 60 * 60;
+  return `start=${start}&end=${now}&step=${stepSeconds}`;
+}
+
+function loadRequests() {
+  const promQ = encodeURIComponent('rate(http_server_request_duration_count[5m])');
+  const logQ = encodeURIComponent('count_over_time({service_name=~".+"}[5m])');
+  const traceQ = encodeURIComponent('{ resource.service.name =~ ".+" }');
+  return [
+    `${CERBERUS_URL}/api/v1/query_range?query=${promQ}&${wideRangeParams(5)}`,
+    `${CERBERUS_URL}/loki/api/v1/query_range?query=${logQ}&${wideRangeParams(30)}`,
+    `${CERBERUS_URL}/api/search?q=${traceQ}`,
+  ];
+}
+
+async function fireOne(url) {
+  try {
+    const resp = await fetch(url, { signal: AbortSignal.timeout(15000) });
+    return resp.status;
+  } catch (e) {
+    return `error:${e.message}`;
+  }
+}
+
+async function runBurst() {
+  const urls = loadRequests();
+  const statuses = [];
+  const deadline = Date.now() + BURST_SECONDS * 1000;
+  log(`firing concurrent load (concurrency=${BURST_CONCURRENCY}) for ${BURST_SECONDS}s against ${urls.length} query shapes`);
+  const workers = Array.from({ length: BURST_CONCURRENCY }, async (_, i) => {
+    let n = 0;
+    while (Date.now() < deadline) {
+      const url = urls[(n + i) % urls.length];
+      statuses.push(await fireOne(url));
+      n++;
+    }
+  });
+  await Promise.all(workers);
+  return statuses;
+}
+
+// ---- sweep-line: max concurrently-overlapping [start, start+duration] intervals ----
+function maxConcurrent(intervals) {
+  const events = [];
+  for (const [startUs, durUs] of intervals) {
+    events.push([startUs, 1]);
+    events.push([startUs + Math.max(durUs, 1), -1]);
+  }
+  events.sort((a, b) => (a[0] - b[0]) || (a[1] - b[1]));
+  let cur = 0;
+  let max = 0;
+  for (const [, delta] of events) {
+    cur += delta;
+    if (cur > max) max = cur;
+  }
+  return max;
+}
+
+async function main() {
+  const initiatorPod = anyClickhousePodName();
+  const allPods = allClickhousePodNames();
+  log(`datashard verify: namespace=${NS} db=${DB} cluster=${CH_CLUSTER} dataShardCount=${DATA_SHARD_COUNT} fanoutCap=${DATA_SHARD_FANOUT_CAP} pods=${allPods.join(',')}`);
+  let failures = 0;
+
+  const restartsBefore = restartCounts(allPods);
+
+  const burstStartMs = Date.now();
+  const statuses = await runBurst();
+  const burstEndMs = Date.now();
+
+  const serverErrors = statuses.filter((s) => typeof s === 'number' && s >= 500);
+  const transportErrors = statuses.filter((s) => typeof s === 'string');
+  log(`burst complete: ${statuses.length} requests, ${serverErrors.length} 5xx, ${transportErrors.length} transport errors`);
+  if (serverErrors.length > 0) {
+    error(`cerberus returned ${serverErrors.length} 5xx response(s) during the concurrent burst — admission control must DEGRADE parallelism, never reject (docs/solver.md point 3)`);
+    failures++;
+  }
+
+  // Let in-flight statements finish, then flush every shard's own
+  // query_log buffer cluster-wide before reading it back.
+  await sleep(FLUSH_WAIT_SECONDS * 1000);
+  chExec(initiatorPod, `SYSTEM FLUSH LOGS ON CLUSTER ${CH_CLUSTER}`);
+
+  const windowStart = Math.floor(burstStartMs / 1000) - 5;
+  const windowEnd = Math.floor(burstEndMs / 1000) + FLUSH_WAIT_SECONDS + 10;
+
+  // ---- point 1: a genuine solver-split (kEff > 1) query happened ----
+  // clusterAllReplicas (not a local query, and not scoped to `initiatorPod`
+  // specifically): cerberus's own connection lands on WHICHEVER shard the
+  // chart wired as the Distributed entry point (shard 0), which need not be
+  // the pod anyClickhousePodName() happened to resolve to. is_initial_query=1
+  // rows exist only on the true entry node regardless of which pod runs the
+  // query, so this is correct no matter which pod answers it.
+  // Full trace -> kEff map (every initiator trace, not just split ones):
+  // point 4 below needs kEff for EVERY group, including kEff=1 (unsplit)
+  // ones, to compute each observed statement's own perShardMemoryBytes
+  // ceiling correctly.
+  const traceKRows = chQueryTSV(
+    initiatorPod,
+    `SELECT substring(query_id, 1, 32) AS trace, count() AS k
+     FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
+     WHERE is_initial_query = 1 AND type = 'QueryFinish'
+       AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})
+     GROUP BY trace`,
+  );
+  const kEffByTrace = new Map(traceKRows.map((r) => {
+    const [trace, k] = r.split('\t');
+    return [trace, Number(k)];
+  }));
+  const splitRows = traceKRows.filter((r) => Number(r.split('\t')[1]) > 1);
+  const maxKEffObserved = splitRows.length > 0 ? Math.max(...splitRows.map((r) => Number(r.split('\t')[1]))) : 0;
+  log(`observed solver-split groups (kEff>1): ${splitRows.length}; max kEff observed=${maxKEffObserved}`);
+  if (maxKEffObserved <= 1) {
+    error(`no solver-split (kEff > 1) query was observed in system.query_log during the burst — this leg is vacuous without one (docs/solver.md's admission-control path was never actually exercised)`);
+    failures++;
+  }
+
+  // ---- point 2: real concurrent per-shard statement count stays within cap ----
+  const shardStmtRows = chQueryTSV(
+    initiatorPod,
+    `SELECT toUnixTimestamp64Micro(query_start_time_microseconds) AS start_us, query_duration_ms * 1000 AS dur_us
+     FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
+     WHERE is_initial_query = 0 AND type = 'QueryFinish'
+       AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
+  );
+  const intervals = shardStmtRows.map((r) => {
+    const [s, d] = r.split('\t').map(Number);
+    return [s, d];
+  });
+  const peakConcurrentShardStatements = maxConcurrent(intervals);
+  log(`real per-shard statements observed: ${intervals.length}; peak concurrent=${peakConcurrentShardStatements}`);
+  if (peakConcurrentShardStatements > DATA_SHARD_FANOUT_CAP) {
+    error(`peak concurrent per-shard ClickHouse statement count ${peakConcurrentShardStatements} exceeded DataShardFanoutCap=${DATA_SHARD_FANOUT_CAP} — the admission-control ceiling did not hold under real load`);
+    failures++;
+  }
+  if (peakConcurrentShardStatements <= DATA_SHARD_COUNT) {
+    error(`peak concurrent per-shard statement count ${peakConcurrentShardStatements} never exceeded a single statement's own fan-out width (DataShardCount=${DATA_SHARD_COUNT}) — the burst never produced genuine CONCURRENT admitted requests, so DataShardFanoutGate's cross-request bound was never exercised`);
+    failures++;
+  }
+
+  // ---- point 4: perShardMemoryBytes prediction + no OOM anywhere ----
+  // Each child (is_initial_query=0) row's own initial_query_id names the
+  // EXACT parent statement that dispatched it, so its trace prefix keys
+  // straight into kEffByTrace above — this is what lets the ceiling below
+  // be the real per-QUERY formula cap/(kEff*DataShardCount) rather than the
+  // group-wide worst case, catching a regression that silently drops the
+  // kEff term (which a flat cap/DataShardCount bound could never catch,
+  // since every real kEff>=1 observation would still satisfy it).
+  const CERBERUS_CH_QUERY_MAX_MEMORY_BYTES = 1073741824; // cerberus-values.yaml
+  const memRows = chQueryTSV(
+    initiatorPod,
+    `SELECT DISTINCT substring(initial_query_id, 1, 32) AS trace, Settings['max_memory_usage'] AS mem
+     FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
+     WHERE is_initial_query = 0 AND type = 'QueryFinish' AND mapContains(Settings, 'max_memory_usage')
+       AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
+  );
+  log(`observed per-shard max_memory_usage settings: ${memRows.map((r) => r.split('\t')[1]).join(', ') || '(none)'}`);
+  if (memRows.length === 0) {
+    error(`no per-shard statement recorded a max_memory_usage setting — cannot confirm perShardMemoryBytes was ever stamped`);
+    failures++;
+  }
+  for (const row of memRows) {
+    const [trace, v] = row.split('\t');
+    const n = Number(v);
+    // A child row whose parent trace never showed up in traceKRows (e.g. it
+    // fell just outside the initiator-side window) is treated as kEff=1 —
+    // the loosest, most conservative ceiling — rather than silently
+    // skipped, so a real formula regression is never masked by a windowing
+    // edge case.
+    const kEff = kEffByTrace.get(trace) || 1;
+    const perQueryCeiling = Math.ceil(CERBERUS_CH_QUERY_MAX_MEMORY_BYTES / (kEff * DATA_SHARD_COUNT));
+    if (!(n > 0) || n > perQueryCeiling) {
+      error(`observed max_memory_usage=${v} (trace=${trace}, kEff=${kEff}) is not within (0, ${perQueryCeiling}] predicted by perShardMemoryBytes = cap/(kEff*DataShardCount) with cap=${CERBERUS_CH_QUERY_MAX_MEMORY_BYTES}, kEff=${kEff}, DataShardCount=${DATA_SHARD_COUNT}`);
+      failures++;
+    }
+  }
+
+  const exceptionRows = chQueryTSV(
+    initiatorPod,
+    `SELECT count() FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
+     WHERE type = 'ExceptionWhileProcessing'
+       AND (exception_code = 241 OR exception ILIKE '%Memory limit%')
+       AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
+  );
+  const exceptionCount = Number(exceptionRows[0] || '0');
+  if (exceptionCount > 0) {
+    error(`${exceptionCount} MEMORY_LIMIT_EXCEEDED exception(s) recorded in system.query_log during the burst — perShardMemoryBytes did not bound memory pressure as predicted`);
+    failures++;
+  }
+
+  const restartsAfter = restartCounts(allPods);
+  const oomed = oomKilledPods(allPods);
+  for (const p of allPods) {
+    if (restartsAfter[p] > restartsBefore[p]) {
+      error(`ClickHouse pod ${p} restarted during the burst (restartCount ${restartsBefore[p]} -> ${restartsAfter[p]})`);
+      failures++;
+    }
+  }
+  if (oomed.length > 0) {
+    error(`ClickHouse pod(s) OOMKilled during/after the burst: ${oomed.join(', ')}`);
+    failures++;
+  }
+
+  if (failures > 0) {
+    error(`e2e-datashard-verify: ${failures} assertion(s) failed`);
+    process.exit(1);
+  }
+  notice(`e2e-datashard-verify: all assertions passed (dataShardCount=${DATA_SHARD_COUNT}, fanoutCap=${DATA_SHARD_FANOUT_CAP}, peakConcurrentShardStatements=${peakConcurrentShardStatements}, maxKEffObserved=${maxKEffObserved})`);
+}
+
+main().catch((e) => {
+  error(`unhandled error: ${e.stack || e}`);
+  process.exit(1);
+});

--- a/.github/scripts/notify-nightly-failure.mjs
+++ b/.github/scripts/notify-nightly-failure.mjs
@@ -41,7 +41,8 @@
 //   RUN_ID / RUN_URL            identify the run in the issue body.
 //   RESULT_COMPOSE_SMOKE, RESULT_CRAWL_TERMINAL, RESULT_DASHBOARD,
 //   RESULT_DASHBOARD_CRAWL_TERMINAL, RESULT_STARTUP_BENCH, RESULT_CHAOS,
-//   RESULT_BWC_MINIO            `needs.<job>.result` for every terminal job
+//   RESULT_BWC_MINIO, RESULT_DATASHARD
+//                                `needs.<job>.result` for every terminal job
 //                                the nightly run fans out to (e2e.yml's job
 //                                graph — see the `nightly-health-notify` job).
 //
@@ -91,6 +92,7 @@ function readJobResults(env) {
     'startup-bench': env.RESULT_STARTUP_BENCH ?? '',
     chaos: env.RESULT_CHAOS ?? '',
     'bwc-minio': env.RESULT_BWC_MINIO ?? '',
+    datashard: env.RESULT_DATASHARD ?? '',
   };
 }
 

--- a/.github/scripts/notify-nightly-failure.test.mjs
+++ b/.github/scripts/notify-nightly-failure.test.mjs
@@ -30,6 +30,7 @@ const allGreen = {
   'startup-bench': 'success',
   chaos: 'success',
   'bwc-minio': 'success',
+  datashard: 'success',
 };
 
 test('every job success is a clean night', () => {
@@ -135,7 +136,7 @@ const ciWorkflow = readFileSync(resolve('.github/workflows/ci.yml'), 'utf8');
 test('nightly-health-notify needs every terminal job and runs on schedule only', () => {
   assert.match(
     e2eWorkflow,
-    /nightly-health-notify:\n    name: nightly-health-notify\n    needs:\n {6}\[compose-smoke, crawl-terminal, dashboard, dashboard-crawl-terminal, startup-bench, chaos, bwc-minio\]\n {4}if: always\(\) && github\.event_name == 'schedule'/,
+    /nightly-health-notify:\n    name: nightly-health-notify\n    needs:\n {6}\[compose-smoke, crawl-terminal, dashboard, dashboard-crawl-terminal, startup-bench, chaos, bwc-minio, datashard\]\n {4}if: always\(\) && github\.event_name == 'schedule'/,
   );
 });
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1857,6 +1857,131 @@ jobs:
         if: always()
         run: just e2e-bwc-down
 
+  # datashard — multi-data-shard e2e lane (cerberus issue #3079, epic #3074).
+  # A 2-leg matrix over `dataShardCount` shares the SAME k3d/Helm bring-up
+  # shape as `bwc-minio` above (a chart-deployed bundled ClickHouse, hot-only
+  # local-disk storage mode — no MinIO dependency, see
+  # cerberus-values-datashard.yaml's own doc) but exercises a DIFFERENT axis:
+  # `clickhouse.bundled.dataShards.count > 1` (cerberus issue #3077's
+  # `Distributed`-engine topology) under real concurrent solver-driven load,
+  # the ONE thing docs/helm-clickhouse.md's "infrastructure-validated only,
+  # not yet query-correctness-supported" callout says has NOT been proven:
+  #
+  #   2 — regression baseline, cheap to stand up.
+  #   4 — deliberately EXCEEDS the solver's own unmodified defaultParallel
+  #       (3), the exact regime a naive per-request divide would have given
+  #       zero protection in (epic #3074's admission-control section).
+  #
+  # Each leg: brings up its own dataShardCount-shard cluster + a built
+  # cerberus image (`just e2e-datashard-up`), seeds the deterministic OTel
+  # rows (`just e2e-seed-rolling`), runs the FULL Go e2e suite
+  # (`just e2e-run` — includes the new ClickHouse#29332 subquery-shaped
+  # tests in test/e2e/e2e_datashard_subquery_test.go, run UNCONDITIONALLY in
+  # every lane so the SAME pinned assertions prove "matches the single-shard
+  # reference" by construction rather than by a separate diff step), then
+  # fires a concurrent PromQL/LogQL/TraceQL burst and asserts the real
+  # ClickHouse-side admission-control + memory behavior against
+  # `system.query_log` (`just e2e-datashard-verify` —
+  # .github/scripts/e2e-datashard-verify.mjs has the full mechanism).
+  #
+  # INFORMATIONAL, never a PR gate — SAME trigger posture as `bwc-minio` /
+  # `dashboard` / `chaos`: push-to-main + nightly + manual dispatch ONLY.
+  # Own concurrency + timeout; a separate single-cluster lane, not a
+  # Playwright shard.
+  datashard:
+    name: datashard (N=${{ matrix.dataShardCount }})
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        dataShardCount: [2, 4]
+    concurrency:
+      group: e2e-datashard-${{ github.run_id }}-${{ matrix.dataShardCount }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+
+      # ---- free runner disk BEFORE k3d + the stack boot (infra-flake fix) ----
+      # N=4 boots FOUR ClickHouse StatefulSets + a 3-node Keeper ensemble
+      # (dataShards.count>1 auto-enables Keeper) + cerberus + the collector +
+      # Grafana + 3 sample apps on ONE k3d node — same rationale as
+      # dashboard-shard / bwc-minio.
+      - uses: ./.github/actions/free-disk-space
+
+      - uses: ./.github/actions/setup-go
+
+      # node for .github/scripts/e2e-datashard-verify.mjs (node: builtins
+      # only — no npm install).
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d  # v2.87.0
+        with:
+          tool: just
+
+      # cerberus + the bundled ClickHouse data tier are deployed via the Helm
+      # chart in `just e2e-datashard-up` (dogfooding the chart, same as
+      # `bwc-minio`), so the runner needs helm.
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5
+        with:
+          version: v3.21.1
+
+      - name: Install k3d
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
+
+      - uses: ./.github/actions/registry-login
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-hub-pat: ${{ secrets.DOCKER_HUB_PAT }}
+
+      - name: Bring up k3d + bundled-ClickHouse stack (dataShards.count=${{ matrix.dataShardCount }})
+        run: just e2e-datashard-up ${{ matrix.dataShardCount }}
+
+      - name: Seed OTel data (deterministic synthetic rows; rolling)
+        run: just e2e-seed-rolling
+
+      # Reused UNCHANGED across every e2e lane (standard, bwc, datashard) —
+      # includes test/e2e/e2e_datashard_subquery_test.go's ClickHouse#29332
+      # subquery-shaped tests, so the SAME pinned assertions running
+      # byte-identically here is the "matches a single-shard reference run"
+      # correctness proof (docs/operations.md's #29332 test-plan section).
+      - name: Run Go E2E tests (correctness against the real multi-data-shard cluster)
+        run: just e2e-run
+
+      - name: Verify admission control + memory bound + query_log evidence under concurrent load
+        run: just e2e-datashard-verify ${{ matrix.dataShardCount }}
+
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          echo "=== disk usage (DiskPressure self-diagnosis) ==="
+          df -h || true
+          echo "=== pods ==="
+          kubectl -n cerberus get pods -o wide | tee /tmp/cluster-state.log || true
+          echo "=== events (last 50) ==="
+          kubectl -n cerberus get events --sort-by=.lastTimestamp 2>&1 | tee -a /tmp/cluster-state.log | tail -50 || true
+          echo "=== cerberus logs ==="
+          kubectl -n cerberus logs deploy/cerberus --tail 200 || true
+          echo "=== data-shard clickhouse pods ==="
+          for p in $(kubectl -n cerberus get pod -l app.kubernetes.io/component=clickhouse -o jsonpath='{.items[*].metadata.name}'); do \
+            echo "--- $p ---"; \
+            kubectl -n cerberus logs "$p" --tail 100 || true; \
+          done
+          echo "=== rolling seeder log (tail 200) ==="
+          tail -200 /tmp/cerberus-e2e-seed-rolling.log 2>/dev/null || true
+          if grep -qiE 'no space left on device|DiskPressure +True|KubeletHasDiskPressure|NodeHasDiskPressure|Evicted' /tmp/cluster-state.log 2>/dev/null \
+             || [ "$(df --output=pcent / | tail -1 | tr -dc '0-9')" -ge 90 ]; then
+            echo "::notice::infra: real DiskPressure/ephemeral-storage eviction detected (node condition flipped or root >=90% full) — this is an infra flake, safe to re-run on a fresh runner"
+          fi
+
+      - name: Tear down
+        if: always()
+        run: just e2e-datashard-down
+
   # #1861 acceptance criterion #2. Reaching a real terminal `failure` instead
   # of `cancelled` (crawl-terminal / dashboard-crawl-terminal, above) is not
   # the same as anyone SEEING that failure: the `schedule` trigger has no PR,
@@ -1876,13 +2001,13 @@ jobs:
   # never rot into a permanent false alarm. `needs` lists every job whose
   # result actually matters for "did the nightly pass": the two required
   # aggregates (`compose-smoke`, `dashboard`), the two crawl-terminality
-  # readers, and the three informational-but-schedule-run leaf jobs. `always()`
+  # readers, and the four informational-but-schedule-run leaf jobs. `always()`
   # so it still runs (and can still notify) when an upstream job failed rather
   # than being skipped by GitHub's default `success()` gate.
   nightly-health-notify:
     name: nightly-health-notify
     needs:
-      [compose-smoke, crawl-terminal, dashboard, dashboard-crawl-terminal, startup-bench, chaos, bwc-minio]
+      [compose-smoke, crawl-terminal, dashboard, dashboard-crawl-terminal, startup-bench, chaos, bwc-minio, datashard]
     if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1908,4 +2033,5 @@ jobs:
           RESULT_STARTUP_BENCH: ${{ needs.startup-bench.result }}
           RESULT_CHAOS: ${{ needs.chaos.result }}
           RESULT_BWC_MINIO: ${{ needs.bwc-minio.result }}
+          RESULT_DATASHARD: ${{ needs.datashard.result }}
         run: node .github/scripts/notify-nightly-failure.mjs

--- a/Justfile
+++ b/Justfile
@@ -2358,7 +2358,7 @@ e2e-datashard-up count="2": e2e-down
         just _pull-retry "$img"; \
     done
     @# Import each image individually + VERIFY it landed (same robust loop as
-    @# e2e-up / e2e-bwc-up — see e2e-up's own comment for why).
+    @# e2e-up / e2e-bwc-up — see the comment on e2e-up for why).
     @for img in {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} {{E2E_DATASHARD_IMAGES}}; do \
         case "$img" in clickhouse/clickhouse-server:*-alpine) continue ;; esac; \
         ref="$img"; \

--- a/Justfile
+++ b/Justfile
@@ -1501,6 +1501,14 @@ E2E_EXTERNAL_IMAGES := "clickhouse/clickhouse-server:26.6-alpine ghcr.io/open-te
 # e2e values), so the exact bundled-CH tag MUST be imported here.
 E2E_BWC_IMAGES := "minio/minio:RELEASE.2025-09-07T16-13-09Z minio/mc:RELEASE.2025-08-13T08-35-41Z clickhouse/clickhouse-server:26.3"
 
+# The multi-data-shard lane (cerberus issue #3079) needs only the bundled
+# ClickHouse image, at the SAME tag E2E_BWC_IMAGES already pins (gotcha #1's
+# dedicated-user ConfigMap applies regardless of dataShards.count) — no MinIO
+# (hot-only mode, see cerberus-values-datashard.yaml's own doc), so this is a
+# standalone constant rather than reusing E2E_BWC_IMAGES wholesale, which
+# would pull two MinIO images this lane never runs.
+E2E_DATASHARD_IMAGES := "clickhouse/clickhouse-server:26.3"
+
 # ClickHouse images the `-tags=integration` Go tests start through
 # testcontainers. testcontainers does the pull itself, single-attempt, so a slow
 # Docker Hub fails those lanes the same way it failed the compose lanes — the
@@ -2302,6 +2310,130 @@ e2e-bwc-verify-mode-toggle:
 
 # Tear the bundled-ClickHouse (bwc) lane down.
 e2e-bwc-down: e2e-down
+
+# Multi-data-shard e2e leg (cerberus issue #3079, epic #3074) — the
+# validation-only sub-issue that closes docs/helm-clickhouse.md's
+# "infrastructure-validated only, not yet query-correctness-supported"
+# gap for `clickhouse.bundled.dataShards.count > 1` (cerberus issue #3077)
+# by actually running the solver's sharded-pushdown path, a built cerberus
+# image, and real concurrent load against it — the ONE thing the #3077
+# manual k3d proof explicitly did NOT cover.
+#
+# `count` selects the data-shard topology:
+#   2 — regression baseline, cheap to stand up.
+#   4 — deliberately EXCEEDS the solver's own unmodified defaultParallel
+#       (3, internal/solver/config.go), the exact regime a naive per-request
+#       divide would have given zero protection in — see
+#       `internal/solver.NewDataShardFanoutGate`'s own doc and epic #3074's
+#       "admission-control interaction" section.
+#
+# Same k3d cluster name, same cerberus:e2e image, same otel.* tables on
+# svc/clickhouse:9000 (via k3s-datashard's alias, same trick as k3s-bwc) — so
+# the seed + Go-test recipes (`e2e-seed-rolling`, `e2e-run`) are REUSED
+# UNCHANGED, exactly as the bwc lane reuses them. Ordering mirrors
+# `e2e-bwc-up`: bring the chart-managed cluster up FIRST (cerberus's
+# auto-create DDL then stamps the `Distributed` wrapper tables across every
+# shard before anything else can race it), THEN the otel collector / grafana
+# / sample-app fixtures.
+
+# Boot the k3d stack with the chart's bundled ClickHouse at the given data-shard count.
+e2e-datashard-up count="2": e2e-down
+    @echo "==> [datashard] pre-pulling k3s node image (retry — Docker Hub flaky from CI)"
+    @just _pull-retry {{K3S_IMAGE}}
+    @echo "==> [datashard] creating k3d cluster {{K3D_CLUSTER}}"
+    k3d cluster create {{K3D_CLUSTER}} \
+        --image {{K3S_IMAGE}} \
+        --port "3000:30030@loadbalancer" \
+        --port "8080:30080@loadbalancer" \
+        --no-lb=false \
+        --k3s-arg "--disable=traefik@server:0" \
+        {{K3D_EXTRA_ARGS}} \
+        --wait
+    @echo "==> [datashard] building cerberus image (build tags: '{{CERBERUS_BUILD_TAGS}}')"
+    node .github/scripts/build-with-registry-retry.mjs \
+        docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" --build-arg GO_IMAGE -f Dockerfile.local .
+    @echo "==> [datashard] pre-pulling external + bundled-CH images on host docker"
+    @for img in {{E2E_EXTERNAL_IMAGES}} {{E2E_DATASHARD_IMAGES}}; do \
+        case "$img" in clickhouse/clickhouse-server:*-alpine) continue ;; esac; \
+        just _pull-retry "$img"; \
+    done
+    @# Import each image individually + VERIFY it landed (same robust loop as
+    @# e2e-up / e2e-bwc-up — see e2e-up's own comment for why).
+    @for img in {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} {{E2E_DATASHARD_IMAGES}}; do \
+        case "$img" in clickhouse/clickhouse-server:*-alpine) continue ;; esac; \
+        ref="$img"; \
+        case "$ref" in \
+            *.*/*|*:*/*) ;; \
+            */*) ref="docker.io/$ref" ;; \
+            *) ref="docker.io/library/$ref" ;; \
+        esac; \
+        landed=0; \
+        for attempt in 1 2 3 4 5; do \
+            k3d image import "$img" -c {{K3D_CLUSTER}} || true; \
+            if docker exec k3d-{{K3D_CLUSTER}}-server-0 ctr -n k8s.io images ls -q | grep -qF "$ref"; then \
+                landed=1; break; \
+            fi; \
+            echo "  import attempt $attempt: $ref not in containerd yet, retrying with backoff" >&2; \
+            sleep $((attempt * 2)); \
+        done; \
+        if [ "$landed" != "1" ]; then \
+            echo "ERROR: $ref missing from k3d node containerd after 5 import attempts" >&2; \
+            exit 1; \
+        fi; \
+    done
+    @echo "==> [datashard] phase 1: namespace"
+    kubectl apply -f test/e2e/k3s/namespace.yaml
+    @echo "==> [datashard] phase 2: installing cerberus + bundled ClickHouse (dataShards.count={{count}}) via Helm"
+    helm upgrade --install cerberus deploy/helm/cerberus \
+        --namespace cerberus \
+        --values test/e2e/k3s/cerberus-values.yaml \
+        --values test/e2e/k3s/cerberus-values-datashard.yaml \
+        --set clickhouse.bundled.dataShards.count={{count}} \
+        --wait --timeout 420s
+    @echo "==> [datashard] waiting for every data-shard StatefulSet + cerberus"
+    @i=0; while [ "$i" -lt "{{count}}" ]; do \
+        kubectl -n cerberus rollout status statefulset/cerberus-clickhouse-datashard-$i --timeout=300s; \
+        i=$((i + 1)); \
+    done
+    kubectl -n cerberus rollout status deployment/cerberus --timeout=180s
+    @echo "==> [datashard] phase 3: applying grafana / collector / sample-app fixtures + clickhouse alias"
+    kubectl kustomize --load-restrictor=LoadRestrictionsNone test/e2e/k3s-datashard | kubectl apply -f -
+    @echo "==> [datashard] waiting for grafana"
+    kubectl -n cerberus rollout status deployment/grafana --timeout=180s
+    @echo "==> e2e-datashard-up done (dataShards.count={{count}})"
+
+# Fires representative concurrent PromQL/LogQL/TraceQL load through the
+# solver's sharded-pushdown path against the `Distributed` target, then
+# asserts against real ClickHouse `system.query_log` state:
+#   - a solver-split (kEff > 1) query is genuinely reached;
+#   - the real concurrent per-shard statement count stays within
+#     CERBERUS_SOLVER_DATA_SHARD_FANOUT_CAP (8, pinned by
+#     cerberus-values-datashard.yaml) — DataShardFanoutGate's real,
+#     unconditional ceiling, not merely the trivially-safe N=2 case;
+#   - no MEMORY_LIMIT_EXCEEDED / OOM anywhere in the cluster during the
+#     burst, confirming perShardMemoryBytes' prediction holds under real
+#     concurrent load;
+#   - the ClickHouse#29332 subquery-shaped test plan
+#     (docs/operations.md's "predicate pushdown through subqueries against
+#     Distributed" section) returns results consistent across the two
+#     analyzer paths it names.
+# Run AFTER `just e2e-seed-rolling` (+ `just e2e-run` for the deterministic
+# correctness check against the single-shard-pinned expected values). Logic
+# lives in the env-driven Node module per the CLAUDE.md "non-trivial step
+# logic in .github/scripts/*.mjs" rule.
+
+# Assert the real cluster's admission-control + memory + subquery-correctness behavior.
+e2e-datashard-verify count="2":
+    @echo "==> [datashard] verifying admission control + memory bound + #29332 subquery plan (count={{count}})"
+    DATA_SHARD_COUNT="{{count}}" \
+    DATA_SHARD_FANOUT_CAP="8" \
+        node .github/scripts/e2e-datashard-verify.mjs
+
+# Tear down the datashard lane. Same cluster name + rolling seeder as the
+# standard lane, so the standard teardown covers it exactly.
+
+# Tear the multi-data-shard lane down.
+e2e-datashard-down: e2e-down
 
 # Run the compose-stack Grafana catch-net spec locally. Assumes the
 # quickstart compose stack is already up (`docker compose up --wait`).

--- a/Justfile
+++ b/Justfile
@@ -2411,20 +2411,26 @@ e2e-datashard-up count="2": e2e-down
 #     cerberus-values-datashard.yaml) — DataShardFanoutGate's real,
 #     unconditional ceiling, not merely the trivially-safe N=2 case;
 #   - no MEMORY_LIMIT_EXCEEDED / OOM anywhere in the cluster during the
-#     burst, confirming perShardMemoryBytes' prediction holds under real
-#     concurrent load;
-#   - the ClickHouse#29332 subquery-shaped test plan
-#     (docs/operations.md's "predicate pushdown through subqueries against
-#     Distributed" section) returns results consistent across the two
-#     analyzer paths it names.
-# Run AFTER `just e2e-seed-rolling` (+ `just e2e-run` for the deterministic
-# correctness check against the single-shard-pinned expected values). Logic
-# lives in the env-driven Node module per the CLAUDE.md "non-trivial step
-# logic in .github/scripts/*.mjs" rule.
+#     burst, and every observed per-shard max_memory_usage setting matches
+#     perShardMemoryBytes = cap/(kEff*DataShardCount) for ITS OWN kEff.
+# This recipe does NOT check the ClickHouse#29332 subquery-shaped test plan
+# (docs/operations.md's "predicate pushdown through subqueries against
+# Distributed" section) — that is `test/e2e/e2e_datashard_subquery_test.go`'s
+# job, run via the normal `just e2e-run` (Go e2e suite), not this script.
+# Run AFTER `just e2e-seed-rolling` (+ `just e2e-run` for both the
+# deterministic correctness check against single-shard-pinned expected
+# values AND the #29332 subquery plan). Logic lives in the env-driven Node
+# module per the CLAUDE.md "non-trivial step logic in .github/scripts/*.mjs"
+# rule.
 
-# Assert the real cluster's admission-control + memory + subquery-correctness behavior.
+# Assert the real cluster's admission-control + memory-bound behavior (see e2e_datashard_subquery_test.go for #29332).
 e2e-datashard-verify count="2":
-    @echo "==> [datashard] verifying admission control + memory bound + #29332 subquery plan (count={{count}})"
+    @echo "==> [datashard] verifying admission control + memory bound (count={{count}})"
+    # "8" here must stay equal to CERBERUS_SOLVER_DATA_SHARD_FANOUT_CAP in
+    # test/e2e/k3s/cerberus-values-datashard.yaml (see that file's own
+    # comment for why it's pinned rather than derived) -- there is no
+    # runtime endpoint to read it back from, so the two literals are kept
+    # in sync by hand; a future edit to one MUST update the other.
     DATA_SHARD_COUNT="{{count}}" \
     DATA_SHARD_FANOUT_CAP="8" \
         node .github/scripts/e2e-datashard-verify.mjs

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -140,6 +140,19 @@ provenance and breadth*: PromQL inherits an externally-curated standard;
 TraceQL's coverage is only as wide as the author wrote it. Raising
 TraceQL's confidence is the top improvement item.
 
+## Scope: single ClickHouse data shard
+
+All three harnesses target a single-node/single-data-shard ClickHouse — a
+permanent, stated scope boundary (cerberus issue #3079), not an open-ended
+deferral. Multi-data-shard `Distributed`-table correctness is a ClickHouse
+distributed-query-execution concern, not a query-LANGUAGE-fidelity one (none
+of Prometheus, Loki, or Tempo has any concept of a ClickHouse data shard to
+diff against), so it is validated directly — with real `system.query_log`
+evidence these reference-diff harnesses have no way to produce — by the
+dedicated `datashard` e2e leg instead. See
+[`operations.md`](operations.md#compat-and-migration-lane-scope-single-clickhouse-data-shard-cerberus-issue-3079)
+for the full reasoning.
+
 ## Local run
 
 ```sh

--- a/docs/helm-clickhouse.md
+++ b/docs/helm-clickhouse.md
@@ -347,9 +347,21 @@ work on a real multi-node cluster. It does **not** prove cerberus's own
 compiled binary running this path end-to-end inside the cluster (that needs
 a built cerberus image, which is the heavier `just e2e`-style lane), it has
 **not** been validated under concurrent solver-driven load, and every
-compat/e2e harness in this repository remains single-shard-only. Do not run
-`count > 1` in production until the e2e-hardening sub-issue
+compat/e2e harness in this repository remains single-shard-only (by
+permanent, stated design for the three differential compat harnesses and
+`cerberus migrate` — see
+[`operations.md`'s scoping section](operations.md#compat-and-migration-lane-scope-single-clickhouse-data-shard-cerberus-issue-3079)).
+Do not run `count > 1` in production until the e2e-hardening sub-issue
 ([#3079](https://github.com/tsouza/cerberus/issues/3079)) closes.
+
+Issue #3079 adds the `datashard` e2e leg (`.github/workflows/e2e.yml`) that
+runs exactly this combination — a built cerberus image, a real concurrent
+PromQL/LogQL/TraceQL load burst through the solver's sharded-pushdown path,
+at both `dataShards.count: 2` and `dataShards.count: 4` — in CI, and asserts
+the real ClickHouse-side admission-control ceiling and memory apportionment
+against `system.query_log`. See
+[`operations.md`'s own section](operations.md#multi-data-shard-e2e-hardening-leg-cerberus-issue-3079)
+for exactly what it checks.
 
 ### #3075 compatibility: object-disk path is shard-agnostic; sessionAffinity gains a new gap
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -36,6 +36,17 @@ works from your **real queries** rather than from `prometheus.yml` — a config
 file cannot tell you whether a query translates cleanly or falls over on
 cardinality.
 
+**Scope: this tool makes no assumption about your ClickHouse's own data-shard
+topology.** Step 10's verify pass replays your real queries through cerberus's
+query engine and diffs the answers against Prometheus — the same engine
+[`operations.md`'s multi-data-shard e2e leg](operations.md#multi-data-shard-e2e-hardening-leg-cerberus-issue-3079)
+validates directly against a real `Distributed` target, so `cerberus
+migrate` inherits that correctness rather than needing a topology-aware
+verify path of its own. Whether the ClickHouse you are migrating onto is
+single-shard or a `dataShards.count > 1` deployment is your own operational
+choice, not something this tool checks or cares about — a permanent,
+stated scope boundary (cerberus issue #3079), not an open-ended deferral.
+
 ## Step 0: Prepare the ground
 
 Two things have to be true before the first command is worth running: someone

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1364,6 +1364,89 @@ matching the epic's own `N=4` over-subscription case, `count: 4`) cluster is
 issue #3079's job; this sub-issue's scope is limited to writing the plan
 down with concrete, emitter-grounded shapes.
 
+Issue #3079 executes shapes 1, 2, 4, and 6 as permanent, unconditional Go
+`test/e2e` tests (`test/e2e/e2e_datashard_subquery_test.go`) that run in
+**every** `just e2e-run` invocation — the standard single-shard lane, the
+`bwc-minio` lane, and the new `datashard` lane below — so the SAME pinned
+assertions running byte-identically across lanes is itself the "matches a
+single-shard reference run" proof, rather than a separate diff step. Shapes 3
+and 5 already had dedicated coverage before this issue
+(`TestTempoSearch`/`TestTempoSearch_StructuralChild`,
+`test/e2e/e2e_tempo_test.go` / `e2e_tempo_extra_test.go`), which also now run
+against the `Distributed` target via the same lane; they were not duplicated.
+
+### Multi-data-shard e2e-hardening leg (cerberus issue #3079)
+
+`.github/workflows/e2e.yml`'s `datashard` job (`just e2e-datashard-up` /
+`just e2e-run` / `just e2e-datashard-verify`, mirroring the established
+`bwc-minio` k3d pattern) is the leg the two sections above name as closing
+the "infrastructure-validated only" gap: a real k3d cluster, a built cerberus
+image, and the chart's bundled ClickHouse at `dataShards.count: 2` and
+`dataShards.count: 4` (deliberately exceeding `internal/solver`'s own
+unmodified `defaultParallel` of 3 — epic #3074's admission-control section
+names this exact regime), running the full Go e2e correctness suite plus a
+concurrent PromQL/LogQL/TraceQL load burst.
+
+`.github/scripts/e2e-datashard-verify.mjs` asserts, directly from
+`system.query_log` rather than from cerberus's own HTTP responses: a genuine
+solver-split (`kEff > 1`) query reached the `Distributed` target; the real,
+concurrent, cluster-wide per-shard statement count never exceeded
+`DataShardFanoutCap` — `DataShardFanoutGate`'s own unconditional ceiling,
+observed under load rather than merely asserted by the admission-control
+unit tests; every per-shard statement's `max_memory_usage` setting sits
+within the `perShardMemoryBytes` formula's predicted ceiling, confirming
+that formula's live prediction under real concurrent load (moved here from
+the settings-verification sub-issue, #3078, exactly as that issue's own
+"Live-load confirmation is #3079's job, not this one's" line names); and no
+`MEMORY_LIMIT_EXCEEDED`/OOM anywhere in the cluster during the burst. See
+that script's own header comment for the full query_id-trace-grouping
+mechanism this relies on. `datashard`, like `bwc-minio`, is INFORMATIONAL —
+never a PR gate.
+
+### Compat and migration-lane scope: single ClickHouse data shard (cerberus issue #3079)
+
+**Decision: `compat-promql` / `compat-logql` / `compat-traceql` and
+`cerberus migrate` stay scoped to a single ClickHouse data shard,
+permanently — not an open-ended deferral.**
+
+The three differential harnesses (`docs/compatibility.md`) each diff
+cerberus's translation of a query language against a REAL reference
+implementation — Prometheus, Loki, Tempo — none of which has any concept of
+a ClickHouse data shard at all. What they exist to catch is query-LANGUAGE
+fidelity: does cerberus's PromQL/LogQL/TraceQL lowering produce the same
+answer the reference engine would. A `Distributed` table is, by design,
+architecturally transparent to a correct query against it — same logical
+dataset, same query surface, same expected answer — so a second, N-shard
+copy of each harness's reference-comparable ClickHouse target would exercise
+no code path these harnesses were built to catch; it would only roughly
+double each lane's already-heaviest runtime for a dimension none of the
+three reference backends can even express an opinion about.
+
+What multi-shard ACTUALLY puts at risk is ClickHouse's own distributed-query
+execution — the `#29332` legacy-analyzer/subquery interaction, the
+admission-control fan-out ceiling, the per-shard memory apportionment — and
+that risk is real but has nothing to do with any of the three query
+languages' own semantics. Issue #3079's `datashard` e2e leg (previous
+section) targets it directly, with real `system.query_log` evidence a
+three-way reference diff has no way to produce (none of Prometheus, Loki, or
+Tempo runs on ClickHouse, so none can observe ClickHouse's own shard
+fan-out).
+
+`cerberus migrate`'s own verify step (`docs/migration.md`'s Step 10) replays
+real queries against a live cerberus + ClickHouse pair and diffs the
+answers against the source Prometheus — a migration-time correctness tool,
+not a ClickHouse-topology-aware one. Its code
+(`internal/migrate`/`cmd/cerberus`'s migrate command surface) carries zero
+`DataShardCount`/`dataShards` awareness anywhere: it issues the same queries
+through the same cerberus query engine this issue's `datashard` lane
+already validates against a real `Distributed` target, so `cerberus
+migrate`'s own correctness is inherited from that validation rather than
+needing a parallel one. The topology a migrating operator's ClickHouse
+happens to run — single-shard today, or a `dataShards.count > 1` deployment
+following this epic's own manual-migration runbook
+(`docs/helm-clickhouse.md`) — is the operator's own choice and orthogonal to
+what Step 10 checks.
+
 ### Hot/cold storage tiering
 
 `CERBERUS_SCHEMA_STORAGE_POLICY` puts a MergeTree `storage_policy` on every

--- a/test/e2e/e2e_datashard_subquery_test.go
+++ b/test/e2e/e2e_datashard_subquery_test.go
@@ -1,0 +1,209 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// Live execution of docs/operations.md's "Known ClickHouse risk: predicate
+// pushdown through subqueries against Distributed (ClickHouse#29332)" test
+// plan (cerberus issue #3079, epic #3074). That doc enumerates six concrete
+// subquery/derived-table shapes `internal/chsql`/`internal/chplan` builds
+// and names #3079 as the issue that should execute them against a real
+// multi-shard cluster. These tests are UNCONDITIONAL — they run in every
+// `just e2e-run` invocation (the standard single-shard lane, the bwc lane,
+// AND the datashard lane), which is exactly how this suite already proves
+// "results match a single-shard reference run" everywhere else: the SAME
+// pinned assertions running byte-identically regardless of which lane
+// executes them. Two of the six shapes already have dedicated coverage
+// elsewhere in this package and are deliberately NOT duplicated here:
+//   - shape 3 (plain TraceQL search over a Distributed spans table) —
+//     TestTempoSearch (e2e_tempo_test.go).
+//   - shape 5 (structural join's recursive CTE) —
+//     TestTempoSearch_StructuralChild (e2e_tempo_extra_test.go).
+//
+// Every query below is deliberately loose on VALUES (matching this
+// package's own established idiom — TestPromQueryRangeRate and its
+// siblings assert "status=success + non-empty", never a numeric pin) since
+// the point is that the shape survives the Distributed target /
+// legacy-analyzer combination at all, not a specific number — see the doc's
+// own "that equality, not a specific number, is the pass criterion" line.
+
+// TestPromQueryHistogramQuantileNativeAggregate — shape 1 (priority 1):
+// `histogram_quantile(phi, sum(rate(<native histogram>[5m])))` reaches
+// internal/chplan/histogram_quantile_native.go's ScalarSubquery under
+// applyNativeHistogramAnalyzerFix's forced `enable_analyzer=0` — the exact
+// legacy-pipeline + subquery-over-Distributed combination #29332 named.
+// showcase_latency_exp_hist is the deterministic exponential-histogram
+// fixture every e2e seed (standard, bwc, datashard) inserts.
+func TestPromQueryHistogramQuantileNativeAggregate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	q := url.QueryEscape("histogram_quantile(0.9, sum(rate(showcase_latency_exp_hist[5m])))")
+	resp := getJSON(ctx, t, "/api/v1/query?query="+q)
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []any  `json:"result"`
+		} `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if len(parsed.Data.Result) == 0 {
+		t.Fatalf("expected at least one series for histogram_quantile(sum(rate(...))); got 0")
+	}
+}
+
+// TestPromQueryHistogramQuantileNativeSelector — shape 1's second form: the
+// plain-selector `histogram_quantile(phi, <native histogram>)`, the other
+// ScalarSubquery-building path histogram_quantile_native.go documents.
+func TestPromQueryHistogramQuantileNativeSelector(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	q := url.QueryEscape("histogram_quantile(0.9, showcase_latency_exp_hist)")
+	resp := getJSON(ctx, t, "/api/v1/query?query="+q)
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []any  `json:"result"`
+		} `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if len(parsed.Data.Result) == 0 {
+		t.Fatalf("expected at least one series for histogram_quantile(<selector>); got 0")
+	}
+}
+
+// TestPromQueryScalarOfVector — shape 2: `scalar(<vector>)` under the
+// DEFAULT analyzer (enable_analyzer=1, never forced legacy), a
+// baseline-regression control proving the new-analyzer fix genuinely holds
+// on a real multi-shard Distributed table and not merely ClickHouse's own
+// single-node test suite.
+func TestPromQueryScalarOfVector(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	q := url.QueryEscape("scalar(sum(http_server_request_duration_count))")
+	resp := getJSON(ctx, t, "/api/v1/query?query="+q)
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     [2]any `json:"result"`
+		} `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if parsed.Data.ResultType != "scalar" {
+		t.Fatalf("resultType: got %q, want scalar", parsed.Data.ResultType)
+	}
+	if parsed.Data.Result[1] == nil {
+		t.Fatalf("scalar(sum(...)) returned a nil value")
+	}
+}
+
+// TestPromQueryAbsentOverTimeGapDetection — shape 6:
+// internal/chsql/absent_over_time.go's NotInSubquery covered-anchor
+// exclusion, exercised against a Distributed metrics table. A metric name
+// that deterministically never exists in ANY e2e seed fixture makes the
+// expected answer unambiguous (present=1) rather than depending on the
+// seed's own churn.
+func TestPromQueryAbsentOverTimeGapDetection(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	q := url.QueryEscape(`absent_over_time(cerberus_e2e_datashard_nonexistent_metric_3079[5m])`)
+	resp := getJSON(ctx, t, "/api/v1/query?query="+q)
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Value [2]any `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	mustDecode(t, resp, &parsed)
+	if parsed.Status != "success" {
+		t.Fatalf("status: got %q, want success", parsed.Status)
+	}
+	if len(parsed.Data.Result) != 1 {
+		t.Fatalf("absent_over_time(<nonexistent metric>) expected exactly 1 result; got %d", len(parsed.Data.Result))
+	}
+	if got := fmt.Sprintf("%v", parsed.Data.Result[0].Value[1]); got != "1" {
+		t.Fatalf("absent_over_time(<nonexistent metric>) value: got %q, want \"1\"", got)
+	}
+}
+
+// TestTempoSearchStructureTabTopN — shape 4: BoundedTraceScope's
+// structure-tab top-N gate (internal/chplan/bounded_trace_scope_bind.go),
+// another `TraceId IN (<subquery>)` shape with an additional row-count
+// bound. `select(nestedSetLeft, nestedSetParent, nestedSetRight)` is the
+// exact projection Grafana's Traces Drilldown structure tab requests
+// (internal/api/tempo/handler.go's own "Drilldown structure tab hard-fails
+// without nestedSetLeft/nestedSetParent/nestedSetRight" comment) and is
+// what activates the BoundedTraceScope binding at all.
+func TestTempoSearchStructureTabTopN(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	v := url.Values{}
+	v.Set("q", `{ resource.service.name = "frontend" } | select(nestedSetLeft, nestedSetParent, nestedSetRight)`)
+	resp := getJSON(ctx, t, "/api/search?"+v.Encode())
+	var parsed struct {
+		Traces []any `json:"traces"`
+	}
+	mustDecode(t, resp, &parsed)
+	if len(parsed.Traces) == 0 {
+		t.Fatalf("expected at least one structure-tab result; got 0")
+	}
+}
+
+// TestTempoMetricsCompareRootScope — the remainder of shape 3: `compare()`
+// nests an InSubquery root-lookup inside an additional bounded root leg
+// (internal/chsql/metrics_compare.go's cohortPred/
+// bindRootLookupTraceIDTsEnvelope), served by GET /api/metrics/query_range
+// (internal/api/tempo/metrics_query_range.go's own doc: `q`, `start`, `end`
+// required; `step` optional). This assertion is deliberately STRUCTURAL
+// (a well-formed series envelope came back) rather than a non-empty-series
+// claim: the seed fixtures do not guarantee an error-status span exists to
+// populate compare()'s comparison cohort, so an empty selection is a valid
+// answer here — the shape reaching a 200 at all against the Distributed
+// target under compare()'s root-scope InSubquery is what this test exists
+// to prove.
+func TestTempoMetricsCompareRootScope(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	now := time.Now().Unix()
+	start := now - 3*60*60
+	v := url.Values{}
+	v.Set("q", `{ resource.service.name = "frontend" } | compare({ status = error })`)
+	v.Set("start", fmt.Sprintf("%d", start))
+	v.Set("end", fmt.Sprintf("%d", now))
+
+	resp := getJSON(ctx, t, "/api/metrics/query_range?"+v.Encode())
+	var parsed struct {
+		Series []any `json:"series"`
+	}
+	mustDecode(t, resp, &parsed)
+	if parsed.Series == nil {
+		t.Fatalf("compare() response carried no 'series' field at all (want at least an empty array)")
+	}
+}

--- a/test/e2e/k3s-datashard/kustomization.yaml
+++ b/test/e2e/k3s-datashard/kustomization.yaml
@@ -1,0 +1,44 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cerberus
+
+# Multi-data-shard e2e fixtures (cerberus issue #3079, epic #3074). Same
+# shape as test/e2e/k3s-bwc's own kustomization: the standalone-ClickHouse
+# kustomization (test/e2e/k3s) MINUS clickhouse.yaml, PLUS a `clickhouse`
+# Service alias onto the chart-managed bundled CH StatefulSet(s) — reused
+# UNCHANGED from k3s-bwc, since its selector
+# (cerberus.clickhouse.selectorLabels: name + instance + component, with NO
+# per-data-shard discriminator) matches pods across every data shard, not
+# just shard 0 — round-robining the seeder's connection across shards is
+# fine: the `Distributed` wrapper table exists identically on every shard's
+# node.
+#
+# ClickHouse itself is NOT a resource here: in this lane it is rendered by
+# the Helm chart with `clickhouse.bundled.enabled: true` and
+# `clickhouse.bundled.dataShards.count > 1`, deployed by
+# `just e2e-datashard-up` — no MinIO/object-store substrate needed (hot-only
+# mode, see cerberus-values-datashard.yaml's own doc), which is the one
+# difference from k3s-bwc's kustomization.
+#
+# The grafana / collector / sample-app fixtures are REUSED verbatim from
+# test/e2e/k3s via relative-path resources, exactly as k3s-bwc does.
+# kustomize's default LoadRestrictionsRootOnly rejects out-of-root file
+# refs, so `just e2e-datashard-up` builds this with
+# `kubectl kustomize --load-restrictor=LoadRestrictionsNone`.
+resources:
+  - ../k3s/namespace.yaml
+  - ../k3s/grafana.yaml
+  - ../k3s/grafana-dashboards.yaml
+  - ../k3s/otel-collector.yaml
+  - ../k3s/sample-app.yaml
+  - ../k3s-bwc/clickhouse-alias.yaml
+
+# `labels` (not `commonLabels`) with includeSelectors:false: tag every object
+# with part-of WITHOUT touching immutable Service/Deployment selectors —
+# same rationale as k3s-bwc's own kustomization (applied AFTER `helm
+# install`, so a selector-mutating label would collide with the
+# already-created objects' immutable selectors).
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/part-of: cerberus

--- a/test/e2e/k3s/cerberus-values-datashard.yaml
+++ b/test/e2e/k3s/cerberus-values-datashard.yaml
@@ -1,0 +1,93 @@
+# Helm values OVERLAY for the multi-data-shard e2e lane (cerberus issue
+# #3079, epic #3074). Layered ON TOP of cerberus-values.yaml by
+# `just e2e-datashard-up <count>`:
+#
+#   helm upgrade --install cerberus deploy/helm/cerberus \
+#     --values test/e2e/k3s/cerberus-values.yaml \
+#     --values test/e2e/k3s/cerberus-values-datashard.yaml \
+#     --set clickhouse.bundled.dataShards.count=<count>
+#
+# `dataShards.count` itself is passed via `--set` at bring-up time (not
+# hardcoded here) so the SAME overlay drives both the N=2 regression
+# baseline and the N=4 over-subscription leg (`just e2e-datashard-up 2` /
+# `just e2e-datashard-up 4`) — see the Justfile recipe's own doc.
+#
+# STORAGE MODE: hot-only (hotVolume.enabled=true, objectStorage.enabled=
+# false) — a pure local-disk ClickHouse with no MinIO/object-store
+# dependency. This is the EXACT combination docs/helm-clickhouse.md's
+# "Infrastructure-validated only" section already proved manually for
+# issue #3077 (real k3d run, dataShards.count=2, hot-only, single replica
+# per shard) — this lane is what turns that manual, cerberus-binary-less
+# proof into a real `just e2e`-driven, cerberus-image-included run at both
+# N=2 AND N=4, the acceptance bar that section's own "do not run in
+# production until #3079 closes" line names.
+clickhouse:
+  bundled:
+    enabled: true
+    # 26.3 — same tag test/e2e/k3s/cerberus-values-bwc.yaml already pins
+    # (gotcha #1's dedicated non-`default`-user ConfigMap applies
+    # regardless of dataShards.count), so `just e2e-datashard-up` needs no
+    # additional image import beyond what `just e2e-bwc-up` already pulls.
+    image: clickhouse/clickhouse-server:26.3
+    replicas: 1
+    hotVolume:
+      enabled: true
+    objectStorage:
+      enabled: false
+
+    # Sized down for N=4 shards (+ the 3-node Keeper ensemble
+    # dataShards.count>1 auto-enables) sharing one throwaway k3d node
+    # alongside cerberus, Grafana, the collector and the sample apps. Each
+    # shard's own dataset is a fraction of the single-shard lane's, so a
+    # smaller per-shard footprint than cerberus-values-bwc.yaml's is
+    # deliberate, not an oversight.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 384Mi
+      limits:
+        memory: 1Gi
+    persistence:
+      size: 3Gi
+    cache:
+      size: 1Gi
+
+# schema.ttl is REQUIRED in hot-only mode (chart-render-time fail otherwise)
+# — see cerberus-values-bwc-hot-only.yaml's own doc. 7d matches that overlay
+# for consistency.
+schema:
+  ttl: "7d"
+
+# Solver geometry knobs (internal/solver, docs/solver.md), loosened FOR THIS
+# LANE ONLY so the deterministic/rolling e2e seed's modest data volume
+# reliably reaches kEff > 1 (a solver-split, `Distributed`-target query) —
+# the acceptance-criterion regime this lane exists to exercise. The
+# admission-control mechanism under test (`DataShardFanoutGate` /
+# `DataShardFanoutCap`) is orthogonal to the grid-geometry thresholds below;
+# loosening the latter here does not weaken the former, and the geometry
+# thresholds themselves already have dedicated unit/spec coverage
+# (internal/solver's own tests, docs/solver.md's calibration section) this
+# lane is not trying to re-prove. CERBERUS_SHARD_PARALLEL (defaultParallel)
+# is deliberately LEFT AT ITS DEFAULT (3) — the N=4 leg's whole point is
+# DataShardCount(4) exceeding that unmodified default.
+config:
+  # Collapse the grid-geometry admission thresholds so a query over the
+  # e2e seed's real (small) row count still splits: MinFanout/MinAnchorPairs
+  # normally gate splitting to windows with production-scale cardinality
+  # (docs/solver.md's calibration numbers), which this throwaway e2e dataset
+  # never reaches.
+  CERBERUS_SHARD_MIN_FANOUT: "1"
+  CERBERUS_SHARD_MIN_ANCHOR_PAIRS: "1"
+  CERBERUS_SHARD_MIN_ANCHORS_PER_SLICE: "1"
+  # Explicit, not just the default, so a future change to defaultMaxK
+  # (internal/solver/config.go's own doc: it has moved 8 -> 32 -> 8 already)
+  # cannot silently change this lane's own expected kEff ceiling.
+  CERBERUS_SHARD_MAX_K: "8"
+  # DataShardFanoutCap: explicit, not left to derive from
+  # CERBERUS_CH_MAX_OPEN_CONNS (10) minus cmd/cerberus's solverGateReserve
+  # (2) — pinning it here means e2e-datashard-verify.mjs's assertion stays
+  # correct even if either of those two unrelated defaults ever changes.
+  # Independent of DataShardCount by design (that is the fix's whole
+  # point — see docs/solver.md's admission-control section): the SAME
+  # value is correct for both the N=2 and N=4 legs.
+  CERBERUS_SOLVER_DATA_SHARD_FANOUT_CAP: "8"


### PR DESCRIPTION
## Summary

Extends `just e2e` with a real-cluster multi-data-shard hardening leg at both **N=2** (regression
baseline) and **N=4** (deliberately exceeding the solver's `defaultParallel=3` — the exact regime
a naive fix would have failed in). Builds on #3077's `Distributed`-engine topology, #3081's
`DataShardFanoutGate`/`DataShardFanoutCap` admission control, and #3078's settings verification +
error taxonomy.

Both legs fire representative concurrent PromQL/LogQL/TraceQL load through the solver's
sharded-pushdown path against a bundled ClickHouse `Distributed` target, then read
`system.query_log` directly (never cerberus's own HTTP responses) to prove:

- a genuine solver-split (`kEff > 1`) query actually reached the cluster (otherwise the leg would
  be vacuous regardless of whether the fan-out gate does anything);
- the real, concurrent, cluster-wide per-shard statement count never exceeded
  `DataShardFanoutCap` at any instant — `DataShardFanoutGate`'s own ceiling, not merely the
  trivially-safe N=2 case;
- no cerberus 5xx during the burst (admission control degrades parallelism, never rejects);
- every observed per-shard `max_memory_usage` setting matches `perShardMemoryBytes =
  cap/(kEff*DataShardCount)` for **that statement's own** `kEff` (joined back via its
  `initial_query_id`'s trace prefix, not a group-wide bound).

It also executes the ClickHouse#29332 subquery-shaped test plan #3078 drafted
(`docs/operations.md`'s "predicate pushdown through subqueries against Distributed" section) —
`histogram_quantile()` native-histogram aggregate and selector forms, `scalar()`, `absent_over_time()`,
a TraceQL structure-tab top-N query, and `compare()` — against the real `Distributed` table,
unconditionally in every e2e lane (standard, bwc, and the new datashard lane), matching this
package's existing idiom of loose status/shape assertions rather than numeric pins.

Records a permanent scoping decision (`docs/operations.md`, cross-linked from
`docs/compatibility.md`/`docs/migration.md`): the three differential harnesses
(`compat-promql`/`compat-logql`/`compat-traceql`) and `cerberus migrate` stay single-data-shard-scoped
— the harnesses test query-*language* fidelity against references with no concept of a ClickHouse
shard, and `migrate`'s own code (verified: `internal/migrate*`) carries zero `DataShardCount`
awareness to test in the first place. Multi-shard correctness is this issue's job instead.

Wired into `.github/workflows/e2e.yml` as a new `datashard` job (matrix `[2, 4]`), triggered on
push/nightly/`workflow_dispatch` only — **informational, never a required PR gate** — same posture
as the existing `bwc-minio` lane, and added to `.github/ci-lanes.json` accordingly.

## What was verified live vs. by other means

A real k3d cluster in this sandbox hit a pre-existing, environment-specific containerd/`ctr`
digest issue on image import — the same class #3082 hit and documented. I confirmed this blocks
the plain, unmodified `just e2e-up` identically (not just the new `e2e-datashard-up` recipe), so
it is not caused by this PR's diff. I did not force past it or fake a pass.

Verified live in this sandbox: Helm render/lint at both `dataShards.count=2` and `=4`
(`helm template`/`helm lint`), `kubectl kustomize` on the new fixture directory, `go vet
-tags=e2e`, `gofumpt`, `actionlint`, `markdownlint-cli2`, `forbid-sql-raw.mjs`,
`ci-lane-contract.mjs` + its test suite, and `notify-nightly-failure.test.mjs`.

Not verified live: the new Go subquery tests and the `query_log`-based verify script's assertions
— both need a running multi-shard cluster, which CI's own runners (not affected by this sandbox's
containerd quirk) can provide once this merges.

## References

- Closes #3079
- Epic: #3074
- Builds on #3077, #3078, #3081 (all merged)
- The pre-existing `e2e-up`/`e2e-bwc-up`/`e2e-datashard-up` image-import-retry-loop duplication
  (now explicitly called out by CLAUDE.md invariant 15's Justfile extension, #3101) is tracked by
  the dedicated Justfile-modularization epic #3091 (its own staged plan already names this exact
  dedup as phase 5) — not re-solved piecemeal here.
