### PR TITLE
docs: extend invariant 15 to cover Justfile recipe bodies

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,9 +1,9 @@
 # `.github/scripts/` — reusable CI step logic (Node ESM)
 
-Non-trivial CI step logic (multi-line `bash` / `jq` / `awk` / `perl`
-embedded in workflow `run:` blocks) lives here as dependency-light Node
-ESM (`.mjs`) modules, not inline YAML. See the **CI / workflow scripts**
-rule in the repo `CLAUDE.md` for the why.
+Non-trivial step logic — multi-line `bash` / `jq` / `awk` / `perl` embedded
+in a workflow `run:` block, or in a Justfile recipe body — lives here as
+dependency-light Node ESM (`.mjs`) modules, not inline YAML or `just`
+recipes. See invariant 15 in the repo `CLAUDE.md` for the why.
 
 Each module:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,10 +190,16 @@ per-layer "catches X / misses Y" guidance.
     reimplementations exist so the Apache-2.0 binary never links them. They survive only as
     test-only oracles behind the `agpl_oracle` build tag, quarantined in the `test/oracle` nested
     module. The `agpl-clean` gate fails the build if any AGPL package reaches `cmd/cerberus`.
-15. **Non-trivial CI step logic lives in `.github/scripts/*.mjs`, not inline YAML.**
-    Dependency-light Node ESM, `node:` builtins only, env-driven inputs documented at the top of the
-    file, `::error::` / `::notice::` workflow commands, and `process.exit(1)` on failure. Trivial
-    one-liners and official Actions usage stay inline. See `.github/scripts/README.md`.
+15. **Non-trivial step logic — a CI workflow step or a Justfile recipe body — lives in
+    `.github/scripts/*.mjs`, never inline.** Dependency-light Node ESM, `node:` builtins only,
+    env-driven inputs documented at the top of the file, `::error::` / `::notice::` workflow
+    commands, and `process.exit(1)` on failure. A trivial one-liner — a single `go test` /
+    `cargo` / `docker`-style command, a pure `just` dependency composition (`recipe: dep1 dep2`),
+    or official Actions usage — stays inline; anything with a branch, a loop, a retry,
+    string/format parsing, or logic duplicated across two or more recipes or workflow steps moves
+    to a script, and logic duplicated across two or more scripts moves to
+    `.github/scripts/lib/*.mjs` rather than being copy-pasted per script. See
+    `.github/scripts/README.md`.
 16. **A new `internal/**` package must be declared in `.go-arch-lint.yml`, and — when it carries
     statements — enrolled in the `test/coverage-floor/` ledger.** Two registrations, one change.
     Both gates are CI-only, so a package missing either one passes locally and fails on the PR. The


### PR DESCRIPTION
## Summary

Extends invariant 15 (`.github/scripts/*.mjs` for non-trivial logic) to explicitly cover Justfile
recipe bodies, not just CI workflow YAML — the gap the Justfile modularization epic (#3091) is
built on. Also updates `.github/scripts/README.md`'s own framing to match, since that directory
will now also house Justfile-recipe scripts per the epic.

Doc-only change, first step of #3091, no dependency on any other sub-issue.

Closes #3092
