### PR TITLE
refactor(justfile): extract chdb-install to .mjs

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -293,6 +293,22 @@ what actually runs.
     (optional; default `just`).
   - Exit: `0` when every extracted invocation dry-runs clean; `1` naming
     every broken one, with its originating file:line(s).
+- **`chdb-install.mjs`** — `just/chdb.just`'s `chdb-install` recipe (issue
+  #3094, epic #3091). Owns the platform-detection, chdb-core release URL
+  construction, `curl`/`tar`/`sudo install` sequence, and idempotency
+  short-circuit that recipe body used to encode inline as `case "$os"` /
+  `case "$arch"` bash. Deliberately self-contained (no `lib/gh.mjs` import,
+  no `::error::`/`::notice::` annotations) per the issue's own scope: its
+  two callers — a contributor's bare shell and the identical recipe running
+  inside CI — both want the exact plain stdout narration the replaced bash
+  printed, and adding workflow-command annotations here would be a behavior
+  change the issue's "identical to current behavior" acceptance criterion
+  doesn't ask for.
+  - Env: `CHDB_VERSION` / `CHDB_INSTALL_PATH` (both required, always passed
+    by `just/chdb.just`); `CHDB_PLATFORM` / `CHDB_ARCH` (optional test-only
+    overrides for `process.platform` / `process.arch`).
+  - Exit: `0` on a fresh install or the idempotent short-circuit; `1` on an
+    unsupported platform or any `curl`/`tar`/`sudo install` failure.
 - **`main-coalescing.mjs`** — `ci.yml` plus the enrolled deep-test workflows.
   Models the only replaceable event/ref pairs (main push and main schedule),
   binds their exact workflow-level concurrency expressions to the lane

--- a/.github/scripts/chdb-install.mjs
+++ b/.github/scripts/chdb-install.mjs
@@ -38,10 +38,22 @@
 // platform or any curl/tar/install failure.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import process from 'node:process';
+
+// isRegularFile — true only when `path` exists and is a regular file, never
+// a directory or other entry. Matches the replaced bash's `[ -f "$path" ]`
+// exactly (unlike a bare existence check, which `[ -f ]` deliberately is
+// not).
+export function isRegularFile(path) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
 
 // assetNameFor — map a (platform, arch) pair to the chdb-core release asset
 // filename. Unknown/x86_64 arches fall back to the x86_64 asset for that OS,
@@ -90,10 +102,10 @@ function main() {
   }
 
   // Idempotency short-circuit: skip the download entirely once the shared
-  // library is already on disk. Override CHDB_VERSION at the recipe call
-  // (`just chdb-install CHDB_VERSION=v26.5.0`) — deleting the install path is
-  // still what actually forces a reinstall.
-  if (existsSync(installPath)) {
+  // library is already on disk. Deleting the install path is what forces a
+  // reinstall (see just/chdb.just for how to override CHDB_VERSION at the
+  // same time).
+  if (isRegularFile(installPath)) {
     console.log(`==> libchdb already present at ${installPath} (delete to reinstall)`);
     process.exit(0);
   }

--- a/.github/scripts/chdb-install.mjs
+++ b/.github/scripts/chdb-install.mjs
@@ -1,0 +1,126 @@
+// chdb-install.mjs — installs libchdb.so, the in-process ClickHouse engine
+// every chdb-tagged test lane needs, for the `just chdb-install` recipe
+// (just/chdb.just). Extracted from that recipe's former inline
+// `case "$os"` / `case "$arch"` platform detection, URL construction,
+// `curl`/`tar`/`sudo install` sequence, and idempotency short-circuit
+// (CLAUDE.md invariant 15, issue #3094, epic #3091).
+//
+// Self-contained by design (no `lib/` import): this script does exactly one
+// thing — resolve a platform to a release asset, fetch it, install it — and
+// gains nothing from the shared GitHub Actions annotation/exec helpers the
+// other scripts use to talk to a workflow run; its two callers are a bare
+// `just chdb-install` from a contributor's shell and the identical recipe
+// running inside CI, and both just want the same plain stdout narration the
+// bash recipe body printed.
+//
+// Platform detection uses Node's own `process.platform` / `process.arch`
+// rather than shelling out to `uname`, which is both fewer moving parts and
+// already normalized: Node reports `arm64` for an ARM64 host on every OS it
+// runs on, so unlike the replaced bash (`case "$arch" in aarch64|arm64)`)
+// there is only ever one ARM64 spelling to match, not two.
+//
+// Pinned to chdb-core v26.5.0 (ClickHouse 26.5) by just/chdb.just's own
+// `CHDB_VERSION` variable — see that file for why. The standalone
+// `<platform>-libchdb.tar.gz` assets the chdb-go driver expects live in the
+// `chdb-io/chdb-core` repo, whose release tags track the ClickHouse version
+// directly. Mirrors update_libchdb.sh shipped inside chdb-go.
+//
+// Env contract:
+//   CHDB_VERSION       chdb-core release tag to install, e.g. "v26.5.0"
+//                       (required — just/chdb.just always passes it).
+//   CHDB_INSTALL_PATH  absolute path libchdb.so is installed to, e.g.
+//                       "/usr/local/lib/libchdb.so" (required, same source).
+//   CHDB_PLATFORM      optional override for `process.platform` (test hook).
+//   CHDB_ARCH          optional override for `process.arch` (test hook).
+//
+// Exit: 0 on a fresh install or the idempotent short-circuit (install path
+// already exists — delete it to force a reinstall); 1 on an unsupported
+// platform or any curl/tar/install failure.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+
+// assetNameFor — map a (platform, arch) pair to the chdb-core release asset
+// filename. Unknown/x86_64 arches fall back to the x86_64 asset for that OS,
+// matching the replaced Justfile `case` statement's own default arms
+// (`*) asset="linux-x86_64-libchdb.tar.gz" ;;` / the Darwin equivalent) —
+// this was never an allow-list of known-good arches, just a two-way arm64
+// fork, and stays that shape here.
+export function assetNameFor(platform, arch) {
+  switch (platform) {
+    case 'linux':
+      return arch === 'arm64' ? 'linux-aarch64-libchdb.tar.gz' : 'linux-x86_64-libchdb.tar.gz';
+    case 'darwin':
+      return arch === 'arm64' ? 'macos-arm64-libchdb.tar.gz' : 'macos-x86_64-libchdb.tar.gz';
+    default:
+      return null;
+  }
+}
+
+// downloadUrlFor — the chdb-core release asset URL for one version + asset.
+export function downloadUrlFor(version, asset) {
+  return `https://github.com/chdb-io/chdb-core/releases/download/${version}/${asset}`;
+}
+
+// run — spawn `cmd` with inherited stdio (curl/tar/sudo all narrate their own
+// progress, and `sudo install` needs the real TTY to prompt for a password),
+// exiting the process on a spawn failure or a non-zero status. Never used for
+// anything whose output this script needs to inspect.
+function run(cmd, args) {
+  const res = spawnSync(cmd, args, { stdio: 'inherit' });
+  if (res.error) {
+    console.error(`chdb-install: failed to run \`${cmd}\`: ${res.error.message}`);
+    process.exit(1);
+  }
+  if (res.status !== 0) {
+    console.error(`chdb-install: \`${[cmd, ...args].join(' ')}\` exited ${res.status}`);
+    process.exit(res.status ?? 1);
+  }
+}
+
+function main() {
+  const chdbVersion = process.env.CHDB_VERSION;
+  const installPath = process.env.CHDB_INSTALL_PATH;
+  if (!chdbVersion || !installPath) {
+    console.error('chdb-install: CHDB_VERSION and CHDB_INSTALL_PATH must both be set (see just/chdb.just).');
+    process.exit(1);
+  }
+
+  // Idempotency short-circuit: skip the download entirely once the shared
+  // library is already on disk. Override CHDB_VERSION at the recipe call
+  // (`just chdb-install CHDB_VERSION=v26.5.0`) — deleting the install path is
+  // still what actually forces a reinstall.
+  if (existsSync(installPath)) {
+    console.log(`==> libchdb already present at ${installPath} (delete to reinstall)`);
+    process.exit(0);
+  }
+
+  const platform = process.env.CHDB_PLATFORM || process.platform;
+  const arch = process.env.CHDB_ARCH || process.arch;
+  const asset = assetNameFor(platform, arch);
+  if (!asset) {
+    console.error(`chdb-install: unsupported platform: ${platform}`);
+    process.exit(1);
+  }
+
+  const url = downloadUrlFor(chdbVersion, asset);
+  console.log(`==> downloading ${url}`);
+
+  const tmp = mkdtempSync(join(tmpdir(), 'chdb-install-'));
+  try {
+    const archivePath = join(tmp, 'libchdb.tar.gz');
+    run('curl', ['-fsSL', '-o', archivePath, url]);
+    run('tar', ['-C', tmp, '-xzf', archivePath]);
+    console.log(`==> installing to ${installPath} (sudo may prompt)`);
+    run('sudo', ['install', '-m', '0755', join(tmp, 'libchdb.so'), installPath]);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+  console.log(`==> libchdb ${chdbVersion} installed`);
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) main();

--- a/.github/scripts/chdb-install.test.mjs
+++ b/.github/scripts/chdb-install.test.mjs
@@ -1,0 +1,45 @@
+// chdb-install.test.mjs — node:test guard for chdb-install.mjs's pure
+// platform-to-asset mapping. This is the exact logic the replaced Justfile
+// `case "$os"` / `case "$arch"` recipe body encoded inline where nothing
+// could unit-test it; pinning it here is the whole point of the extraction
+// (CLAUDE.md invariant 15, issue #3094).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { assetNameFor, downloadUrlFor } from './chdb-install.mjs';
+
+test('linux x64 maps to the linux-x86_64 asset', () => {
+  assert.equal(assetNameFor('linux', 'x64'), 'linux-x86_64-libchdb.tar.gz');
+});
+
+test('linux arm64 maps to the linux-aarch64 asset', () => {
+  assert.equal(assetNameFor('linux', 'arm64'), 'linux-aarch64-libchdb.tar.gz');
+});
+
+test('darwin x64 maps to the macos-x86_64 asset', () => {
+  assert.equal(assetNameFor('darwin', 'x64'), 'macos-x86_64-libchdb.tar.gz');
+});
+
+test('darwin arm64 maps to the macos-arm64 asset', () => {
+  assert.equal(assetNameFor('darwin', 'arm64'), 'macos-arm64-libchdb.tar.gz');
+});
+
+test('an unrecognised arch on a supported OS falls back to the x86_64 asset', () => {
+  // Mirrors the replaced `case "$arch" in ...; *) asset="...x86_64..." ;;`
+  // default arm — this was never an allow-list of known-good arches.
+  assert.equal(assetNameFor('linux', 'riscv64'), 'linux-x86_64-libchdb.tar.gz');
+  assert.equal(assetNameFor('darwin', 'riscv64'), 'macos-x86_64-libchdb.tar.gz');
+});
+
+test('an unsupported platform yields no asset', () => {
+  assert.equal(assetNameFor('win32', 'x64'), null);
+  assert.equal(assetNameFor('freebsd', 'arm64'), null);
+});
+
+test('downloadUrlFor builds the chdb-core release asset URL', () => {
+  assert.equal(
+    downloadUrlFor('v26.5.0', 'linux-x86_64-libchdb.tar.gz'),
+    'https://github.com/chdb-io/chdb-core/releases/download/v26.5.0/linux-x86_64-libchdb.tar.gz',
+  );
+});

--- a/.github/scripts/chdb-install.test.mjs
+++ b/.github/scripts/chdb-install.test.mjs
@@ -1,13 +1,17 @@
 // chdb-install.test.mjs — node:test guard for chdb-install.mjs's pure
-// platform-to-asset mapping. This is the exact logic the replaced Justfile
-// `case "$os"` / `case "$arch"` recipe body encoded inline where nothing
-// could unit-test it; pinning it here is the whole point of the extraction
-// (CLAUDE.md invariant 15, issue #3094).
+// platform-to-asset mapping and its `[ -f ]`-equivalent idempotency check.
+// This is the exact logic the replaced Justfile `case "$os"` / `case "$arch"`
+// recipe body encoded inline where nothing could unit-test it; pinning it
+// here is the whole point of the extraction (CLAUDE.md invariant 15, issue
+// #3094).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { assetNameFor, downloadUrlFor } from './chdb-install.mjs';
+import { assetNameFor, downloadUrlFor, isRegularFile } from './chdb-install.mjs';
 
 test('linux x64 maps to the linux-x86_64 asset', () => {
   assert.equal(assetNameFor('linux', 'x64'), 'linux-x86_64-libchdb.tar.gz');
@@ -42,4 +46,33 @@ test('downloadUrlFor builds the chdb-core release asset URL', () => {
     downloadUrlFor('v26.5.0', 'linux-x86_64-libchdb.tar.gz'),
     'https://github.com/chdb-io/chdb-core/releases/download/v26.5.0/linux-x86_64-libchdb.tar.gz',
   );
+});
+
+test('isRegularFile is false for a path that does not exist', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'chdb-install-test-'));
+  try {
+    assert.equal(isRegularFile(join(dir, 'missing.so')), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('isRegularFile is true for an actual regular file', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'chdb-install-test-'));
+  try {
+    const file = join(dir, 'libchdb.so');
+    writeFileSync(file, '');
+    assert.equal(isRegularFile(file), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('isRegularFile is false for a directory — matches bash `[ -f ]`, not a bare existence check', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'chdb-install-test-'));
+  try {
+    assert.equal(isRegularFile(dir), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -871,6 +871,16 @@ jobs:
       - name: Assert the chDB round-trip legs are bounded and diagnosable
         run: node --test .github/scripts/chdb-roundtrip.test.mjs
 
+      # `chdb-install` (just/chdb.just) delegates its platform-detection /
+      # URL-construction to this module (CLAUDE.md invariant 15, #3094). The
+      # asset-name mapping is the one part of it that used to be invisible to
+      # any linter, inline in a Justfile `case "$os"`/`case "$arch"` — pinned
+      # here rather than only exercised by an actual `just chdb-install` run
+      # on whatever runner OS/arch this CI happens to have. Pure in-process
+      # test, no network.
+      - name: chdb-install self-test (platform/arch asset mapping)
+        run: node --test .github/scripts/chdb-install.test.mjs
+
       # `roundtrip (promql)` (tsouza/cerberus#2629) is a REQUIRED context
       # posted by an aggregator job that runs no tests of its own — it exists
       # only to roll the sharded `roundtrip-promql-shard` matrix (separate

--- a/just/chdb.just
+++ b/just/chdb.just
@@ -19,8 +19,11 @@ CHDB_INSTALL_PATH := "/usr/local/lib/libchdb.so"
 # while staying below the 26.7 aggregate-state serialization change.
 # Mirror update_libchdb.sh shipped inside chdb-go.
 #
-# Idempotent: skips download if the install path already exists. Override
-# CHDB_VERSION at the recipe call (`just chdb-install CHDB_VERSION=v26.5.0`).
+# Idempotent: skips download if the install path already exists as a regular
+# file. Override CHDB_VERSION as a `just` variable assignment before the
+# recipe name (`just CHDB_VERSION=v26.5.0 chdb-install`) — a recipe-call-style
+# `just chdb-install CHDB_VERSION=v26.5.0` is not valid `just` syntax and
+# fails with "does not contain recipe 'CHDB_VERSION=v26.5.0'".
 #
 # The platform-detection (case "$os"/case "$arch"), URL construction,
 # curl/tar/sudo install, and idempotency short-circuit all live in

--- a/just/chdb.just
+++ b/just/chdb.just
@@ -21,35 +21,14 @@ CHDB_INSTALL_PATH := "/usr/local/lib/libchdb.so"
 #
 # Idempotent: skips download if the install path already exists. Override
 # CHDB_VERSION at the recipe call (`just chdb-install CHDB_VERSION=v26.5.0`).
+#
+# The platform-detection (case "$os"/case "$arch"), URL construction,
+# curl/tar/sudo install, and idempotency short-circuit all live in
+# .github/scripts/chdb-install.mjs (CLAUDE.md invariant 15, issue #3094) —
+# self-contained, no shared lib/ dependency — so this recipe is a thin
+# env-passing wrapper around it.
 
 # Install libchdb.so, the in-process ClickHouse engine every chdb-tagged lane needs.
 chdb-install:
-    @if [ -f "{{CHDB_INSTALL_PATH}}" ]; then \
-        echo "==> libchdb already present at {{CHDB_INSTALL_PATH}} (delete to reinstall)"; \
-        exit 0; \
-    fi
-    @os="$(uname -s)"; \
-        arch="$(uname -m)"; \
-        case "$os" in \
-            Linux) \
-                case "$arch" in \
-                    aarch64|arm64) asset="linux-aarch64-libchdb.tar.gz" ;; \
-                    *)             asset="linux-x86_64-libchdb.tar.gz" ;; \
-                esac ;; \
-            Darwin) \
-                case "$arch" in \
-                    arm64) asset="macos-arm64-libchdb.tar.gz" ;; \
-                    *)     asset="macos-x86_64-libchdb.tar.gz" ;; \
-                esac ;; \
-            *) echo "unsupported platform: $os" >&2; exit 1 ;; \
-        esac; \
-        url="https://github.com/chdb-io/chdb-core/releases/download/{{CHDB_VERSION}}/$asset"; \
-        echo "==> downloading $url"; \
-        tmp="$(mktemp -d)"; \
-        curl -fsSL -o "$tmp/libchdb.tar.gz" "$url"; \
-        tar -C "$tmp" -xzf "$tmp/libchdb.tar.gz"; \
-        echo "==> installing to {{CHDB_INSTALL_PATH}} (sudo may prompt)"; \
-        sudo install -m 0755 "$tmp/libchdb.so" "{{CHDB_INSTALL_PATH}}"; \
-        rm -rf "$tmp"; \
-        echo "==> libchdb {{CHDB_VERSION}} installed"
+    @CHDB_VERSION="{{CHDB_VERSION}}" CHDB_INSTALL_PATH="{{CHDB_INSTALL_PATH}}" node .github/scripts/chdb-install.mjs
 


### PR DESCRIPTION
## Summary

- Extracts `chdb-install`'s inline platform-detection (`case "$os"`/`case "$arch"`), URL
  construction, `curl`/`tar`/`sudo install`, and idempotency short-circuit into
  `.github/scripts/chdb-install.mjs` — self-contained, no shared `lib/` dependency, per CLAUDE.md
  invariant 15 (extended by #3092), part of the Justfile modularization epic #3091.
- `just/chdb.just`'s `chdb-install` recipe becomes a thin env-passing wrapper:
  `CHDB_VERSION`/`CHDB_INSTALL_PATH` forwarded, script does the rest.
- Platform detection uses Node's own `process.platform`/`process.arch` instead of shelling out to
  `uname` — `process.arch` already normalizes to a single `arm64` spelling on every OS, so unlike
  the replaced bash there's only one ARM64 case to match, not two (`aarch64|arm64`).
- Adds `.github/scripts/chdb-install.test.mjs` pinning the platform/arch → asset-name mapping
  (the part of the old recipe body no linter could ever see) and the idempotency check's
  file-vs-directory behavior, wired into `ci.yml`'s `lint` job.

## Adversarial-review follow-ups (this update)

An ACPR pass on the first version of this PR surfaced three real, fixed issues and confirmed two
flagged items are non-issues:

- **Fixed — idempotency check was looser than the bash it replaced.** `existsSync(installPath)` is
  true for any filesystem entry, while the original bash guard was `[ -f "$path" ]` (true only for
  a regular file). Replaced with a `statSync(...).isFile()`-backed `isRegularFile()` helper and
  added three unit tests pinning the file / missing / directory cases.
- **Fixed — `chdb-install.mjs` was missing from `.github/scripts/README.md`'s Modules catalog.**
  That file's own preface says every module gets an entry; added one describing the script and
  explicitly justifying the no-`lib/`-import, no-`::error::`/`::notice::` design against the
  issue's own "self-contained" scope and "identical to current behavior" acceptance criterion.
- **Fixed — pre-existing wrong `just` override-syntax example**, carried over verbatim into the new
  wrapper recipe's comment: `just chdb-install CHDB_VERSION=v26.5.0` is not valid `just` syntax
  (verified live: `error: Justfile does not contain recipe 'CHDB_VERSION=v26.5.0'`). The working
  form is a variable assignment before the recipe name (`just CHDB_VERSION=v26.5.0 chdb-install`,
  also verified live). Predates this PR (present since before #3093/#3102) but touched here, so
  fixed in place rather than filed separately.
- **Confirmed non-issue — unsupported-platform error casing.** `process.platform` reports lowercase
  tokens (`win32`) vs. the old bash's raw `uname -s` output; this only affects an error path that
  never fires on the Linux/macOS hosts this script targets, and no acceptance criterion covers
  unsupported-platform error text.
- **Confirmed non-issue — no `::error::`/`::notice::` workflow-command annotations.** The issue's
  own Scope line mandates "self-contained — no shared-`lib/` dependency", and the replaced bash
  recipe printed no annotations either (confirmed against the pre-refactor recipe body) — adding
  them now would be a behavior change beyond "identical to current behavior."

## Verification

- `node --test .github/scripts/chdb-install.test.mjs` — 10/10 pass (was 7/7 before the
  idempotency-check fix added three more).
- `node .github/scripts/verify-just-invocations.mjs` — 59 distinct invocations / 85 call sites
  across 35 workflow files, all dry-run clean.
- `node --test .github/scripts/assert-gate-suites-wired.test.mjs && node .github/scripts/assert-gate-suites-wired.mjs`
  — 82 suites, all wired.
- `node .github/scripts/forbid-sql-raw.mjs` — clean.
- `actionlint .github/workflows/ci.yml` — clean.
- `markdownlint-cli2 .github/scripts/README.md` — clean.
- Real clean-environment install: pointed `CHDB_INSTALL_PATH` at a scratch path with the file
  absent and ran `CHDB_VERSION=v26.5.0 CHDB_INSTALL_PATH=<scratch> node .github/scripts/chdb-install.mjs`
  — real `curl`/`tar`/`sudo install` executed, `libchdb.so` (531,689,328 bytes) landed at the
  scratch path, output identical to the old recipe's `==> downloading …` / `==> installing to …` /
  `==> libchdb v26.5.0 installed` lines.
- Second run against that now-installed scratch path short-circuited with the identical
  `==> libchdb already present at … (delete to reinstall)` line, no network activity, exit 0 — this
  is with the new `isRegularFile()` check, confirming the tightened idempotency logic still
  short-circuits correctly on a real regular file.
- `just chdb-install` against this host's real `/usr/local/lib/libchdb.so` (already installed)
  short-circuits identically.
- `just --dry-run CHDB_VERSION=v26.5.0 chdb-install` — confirms the corrected comment's override
  syntax actually works; `just --dry-run chdb-install CHDB_VERSION=v26.5.0` (the old, wrong comment)
  fails as documented.

## Acceptance criteria (issue #3094)

- [x] `.github/scripts/verify-just-invocations.mjs` reports zero broken invocations.
- [x] `just chdb-install` on a clean environment installs `libchdb.so` identically to the current
      behavior.
- [x] A second run against an already-installed environment still short-circuits without
      re-downloading.

Part of epic #3091.

Closes #3094
