### PR TITLE
refactor(justfile,e2e): dedupe e2e-bwc-up against the e2e-up extraction

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -2062,20 +2062,20 @@ what actually runs.
     `POLL_SECONDS` (default `180`), `POLL_INTERVAL_SECONDS` (default `5`),
     `MIN_HISTORY_SECONDS` (default `60`).
   - Exit: `0` once every signal clears the floor; `1` on timeout.
-- **`k3d-image-import.mjs`** — the Justfile (`e2e-up`), extracted from its
-  image-import-and-verify retry loop (cerberus issue #3096). k3d bundles
-  every image into one tarball and runs `ctr image import` inside a
-  transient tools node — the bundled tarball intermittently vanishes
-  mid-import (importing one image at a time shrinks the race), and `k3d
-  image import` reports success even on a silent node-level failure (so
+- **`k3d-image-import.mjs`** — the Justfile (`e2e-up` and `e2e-bwc-up`),
+  extracted from `e2e-up`'s image-import-and-verify retry loop (cerberus
+  issue #3096). k3d bundles every image into one tarball and runs `ctr image
+  import` inside a transient tools node — the bundled tarball intermittently
+  vanishes mid-import (importing one image at a time shrinks the race), and
+  `k3d image import` reports success even on a silent node-level failure (so
   landing is VERIFIED against the node's own containerd, never trusted from
   k3d's exit code). Designed from day one for reuse by `e2e-bwc-up`
-  (sub-issue #3097, not wired to this script by #3096) and the
-  multi-data-shard `e2e-datashard-up` (issue #3107): an arbitrary argv image
-  list plus an `IMAGE_IMPORT_EXCLUDE` glob-pattern parameter (`e2e-bwc-up`
-  needs to skip the standalone `clickhouse/clickhouse-server:*-alpine` image
-  its kustomization never applies) are first-class from the start, not a
-  retrofit.
+  (sub-issue #3097, wired up in that issue): an arbitrary argv image list
+  plus an `IMAGE_IMPORT_EXCLUDE` glob-pattern parameter let `e2e-bwc-up`
+  reuse this script unchanged, skipping the standalone
+  `clickhouse/clickhouse-server:*-alpine` image its kustomization never
+  applies. The multi-data-shard `e2e-datashard-up` (issue #3107) still
+  duplicates this loop rather than reusing this script.
   - Usage: `node .github/scripts/k3d-image-import.mjs <image>...`.
   - Env: `K3D_CLUSTER` (required), `IMAGE_IMPORT_EXCLUDE` (optional,
     whitespace-separated globs), `IMAGE_IMPORT_ATTEMPTS` (default `5`),

--- a/.github/scripts/k3d-image-import.mjs
+++ b/.github/scripts/k3d-image-import.mjs
@@ -18,15 +18,15 @@
 //      k3d's own exit code.
 //
 // Designed for reuse from day one (cerberus issue #3096's own scope note):
-// the `e2e-bwc-up` lane (sub-issue #3097, NOT wired to this script by this
-// PR) needs to import an EXTENDED image list while EXCLUDING the standalone
-// ClickHouse image (`clickhouse/clickhouse-server:*-alpine`) its
-// kustomization never applies — both an arbitrary image list and an
-// exclusion-filter are therefore first-class parameters here, not a
-// retrofit: `e2e-bwc-up` (and the multi-data-shard `e2e-datashard-up`,
-// which duplicates this exact loop today — tracked separately, see
-// cerberus issue #3107) will be able to reuse this script by changing only
-// their own image list + exclude patterns, never this script's interface.
+// the `e2e-bwc-up` lane (sub-issue #3097) imports an EXTENDED image list
+// while EXCLUDING the standalone ClickHouse image
+// (`clickhouse/clickhouse-server:*-alpine`) its kustomization never
+// applies — both an arbitrary image list and an exclusion-filter were
+// therefore first-class parameters here from the start, not a retrofit:
+// `e2e-bwc-up` reuses this script by changing only its own image list +
+// exclude pattern at the call site, never this script's interface. The
+// multi-data-shard `e2e-datashard-up` still duplicates this exact loop
+// today — tracked separately, see cerberus issue #3107.
 //
 // Usage:
 //   node .github/scripts/k3d-image-import.mjs <image>...

--- a/just/e2e-bwc.just
+++ b/just/e2e-bwc.just
@@ -40,7 +40,7 @@ e2e-bwc-up scenario="object-storage": e2e-down
     @echo "==> [bwc] pre-pulling external + bwc images on host docker"
     @# The standalone-CH image (the *-alpine tag in E2E_EXTERNAL_IMAGES) backs
     @# test/e2e/k3s/clickhouse.yaml, which the bwc kustomization EXCLUDES — this
-    @# lane runs the chart's BUNDLED ClickHouse (the non-alpine tag in
+    @# lane runs the chart-bundled ClickHouse (the non-alpine tag in
     @# E2E_BWC_IMAGES) instead, so skip pulling the unused standalone image (it
     @# is filtered from the k3d import step below via IMAGE_IMPORT_EXCLUDE too).
     @for img in {{E2E_EXTERNAL_IMAGES}} {{E2E_BWC_IMAGES}}; do \

--- a/just/e2e-bwc.just
+++ b/just/e2e-bwc.just
@@ -33,17 +33,7 @@
 
 # Boot the k3d stack with the chart's bundled ClickHouse for the given scenario.
 e2e-bwc-up scenario="object-storage": e2e-down
-    @echo "==> [bwc] pre-pulling k3s node image (retry — Docker Hub flaky from CI)"
-    @just _pull-retry {{K3S_IMAGE}}
-    @echo "==> [bwc] creating k3d cluster {{K3D_CLUSTER}}"
-    k3d cluster create {{K3D_CLUSTER}} \
-        --image {{K3S_IMAGE}} \
-        --port "3000:30030@loadbalancer" \
-        --port "8080:30080@loadbalancer" \
-        --no-lb=false \
-        --k3s-arg "--disable=traefik@server:0" \
-        {{K3D_EXTRA_ARGS}} \
-        --wait
+    @just _e2e-k3d-cluster-create
     @echo "==> [bwc] building cerberus image (build tags: '{{CERBERUS_BUILD_TAGS}}')"
     node .github/scripts/build-with-registry-retry.mjs \
         docker build -t {{CERBERUS_IMAGE}} --build-arg GO_BUILD_TAGS="{{CERBERUS_BUILD_TAGS}}" --build-arg GO_IMAGE -f Dockerfile.local .
@@ -51,37 +41,20 @@ e2e-bwc-up scenario="object-storage": e2e-down
     @# The standalone-CH image (the *-alpine tag in E2E_EXTERNAL_IMAGES) backs
     @# test/e2e/k3s/clickhouse.yaml, which the bwc kustomization EXCLUDES — this
     @# lane runs the chart's BUNDLED ClickHouse (the non-alpine tag in
-    @# E2E_BWC_IMAGES) instead, so skip importing the unused standalone image.
+    @# E2E_BWC_IMAGES) instead, so skip pulling the unused standalone image (it
+    @# is filtered from the k3d import step below via IMAGE_IMPORT_EXCLUDE too).
     @for img in {{E2E_EXTERNAL_IMAGES}} {{E2E_BWC_IMAGES}}; do \
         case "$img" in clickhouse/clickhouse-server:*-alpine) continue ;; esac; \
         just _pull-retry "$img"; \
     done
-    @# Import each image individually + VERIFY it landed in the node's
-    @# containerd (k3d image import can print success while the node import
-    @# silently failed -> ImagePullBackOff with pullPolicy:Never). Same robust
-    @# loop as `e2e-up`, extended with the bwc image set.
-    @for img in {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} {{E2E_BWC_IMAGES}}; do \
-        case "$img" in clickhouse/clickhouse-server:*-alpine) continue ;; esac; \
-        ref="$img"; \
-        case "$ref" in \
-            *.*/*|*:*/*) ;; \
-            */*) ref="docker.io/$ref" ;; \
-            *) ref="docker.io/library/$ref" ;; \
-        esac; \
-        landed=0; \
-        for attempt in 1 2 3 4 5; do \
-            k3d image import "$img" -c {{K3D_CLUSTER}} || true; \
-            if docker exec k3d-{{K3D_CLUSTER}}-server-0 ctr -n k8s.io images ls -q | grep -qF "$ref"; then \
-                landed=1; break; \
-            fi; \
-            echo "  import attempt $attempt: $ref not in containerd yet, retrying with backoff" >&2; \
-            sleep $((attempt * 2)); \
-        done; \
-        if [ "$landed" != "1" ]; then \
-            echo "ERROR: $ref missing from k3d node containerd after 5 import attempts" >&2; \
-            exit 1; \
-        fi; \
-    done
+    @echo "==> [bwc] importing images into k3d ({{K3D_CLUSTER}}) — one at a time, with retry+verify"
+    @# Same retry+verify loop `e2e-up` runs (cerberus issue #3096), reused
+    @# unchanged via .github/scripts/k3d-image-import.mjs — only the image list
+    @# (extended with E2E_BWC_IMAGES) and the exclusion filter (the standalone
+    @# *-alpine ClickHouse image the bwc kustomization never applies) differ.
+    @IMAGE_IMPORT_EXCLUDE="clickhouse/clickhouse-server:*-alpine" \
+    K3D_CLUSTER={{K3D_CLUSTER}} node .github/scripts/k3d-image-import.mjs \
+        {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} {{E2E_BWC_IMAGES}}
     @echo "==> [bwc] phase 1: namespace + MinIO + bucket-create Job (before ClickHouse)"
     kubectl apply -f test/e2e/k3s/namespace.yaml
     kubectl apply -f test/e2e/k3s-bwc/minio.yaml -f test/e2e/k3s-bwc/bucket-job.yaml

--- a/just/e2e.just
+++ b/just/e2e.just
@@ -92,8 +92,7 @@ K3D_EXTRA_ARGS := env_var_or_default("K3D_EXTRA_ARGS", "")
 # run verbatim (`e2e-datashard-up` too — see issue #3107, filed to bring it
 # onto this same shared recipe). Pulled out on its own so a future flag
 # change (a port, a k3s arg) never has to land in more than one place.
-# `e2e-up` calls this now; `e2e-bwc-up` moves onto it in sub-issue #3097,
-# never touched by this PR.
+# `e2e-up` and `e2e-bwc-up` (sub-issue #3097) both call this now.
 _e2e-k3d-cluster-create:
     @echo "==> pre-pulling k3s node image (retry — Docker Hub flaky from CI)"
     @just _pull-retry {{K3S_IMAGE}}
@@ -132,8 +131,8 @@ e2e-up: e2e-down
     @# spent. Logic lives in .github/scripts/k3d-image-import.mjs (cerberus
     @# issue #3096) — designed from day one with an IMAGE_IMPORT_EXCLUDE
     @# glob-pattern parameter and an arbitrary argv image list, so
-    @# `e2e-bwc-up` (sub-issue #3097) can reuse it unchanged by only
-    @# varying its own call site.
+    @# `e2e-bwc-up` (sub-issue #3097) reuses it unchanged, only varying its
+    @# own image list and exclusion filter at the call site.
     @K3D_CLUSTER={{K3D_CLUSTER}} node .github/scripts/k3d-image-import.mjs {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}}
     @echo "==> applying fixture manifests (CH, Grafana, collector, sample apps)"
     kubectl apply -k test/e2e/k3s/


### PR DESCRIPTION
## Summary

`e2e-bwc-up` (in `just/e2e-bwc.just`) carried its own copy of `e2e-up`'s k3d
cluster-create step and its image-import-and-verify retry loop, duplicated
verbatim before the #3096 extraction (merged as #3108) pulled both pieces
out into a shared `_e2e-k3d-cluster-create` recipe and
`.github/scripts/k3d-image-import.mjs` — both of which were designed from
day one (see that script's own header) to be reused unchanged by this lane
via an `IMAGE_IMPORT_EXCLUDE` glob parameter and an arbitrary argv image
list. This PR does the rewiring:

- `e2e-bwc-up` now calls `just _e2e-k3d-cluster-create` instead of running
  its own `k3d cluster create` invocation.
- `e2e-bwc-up`'s image-import-and-verify loop (the 5-attempt, backoff,
  containerd-verify shape) is replaced by a call to
  `.github/scripts/k3d-image-import.mjs`, with
  `IMAGE_IMPORT_EXCLUDE="clickhouse/clickhouse-server:*-alpine"` (the
  standalone ClickHouse image the bwc kustomization never applies — this
  lane runs the chart's *bundled* ClickHouse instead) and an image list
  extended with `E2E_BWC_IMAGES` on top of `CERBERUS_IMAGE` +
  `E2E_EXTERNAL_IMAGES`.
- The host-side pre-pull loop (`just _pull-retry` per image, skipping the
  alpine tag) is left as-is — that loop isn't the duplicated *retry* logic
  this issue targets (`_pull-retry` already dedupes the actual retry
  mechanism via `pull-images.mjs`); only the k3d-import-and-verify loop was
  reduplicated bash.
- Updated the cross-referencing comments in `just/e2e.just`,
  `.github/scripts/k3d-image-import.mjs`, and `.github/scripts/README.md`
  that described this wiring as still pending sub-issue #3097 work.

### `e2e-bwc-verify-placement.mjs` / `lib/k8s.mjs`

Checked the second scope item — refactoring `e2e-bwc-verify-placement.mjs`
to import `lib/k8s.mjs` instead of inlining `kubectl()`/`clickhousePod()`/
`chQuery()` — and found it was **already done** as part of the #3096
extraction (landed in #3108, which promoted `lib/bwc-k8s.mjs` to
`lib/k8s.mjs`). The script already imports `makeKubectl`,
`clickhousePodName`, and `chQuery` from `lib/k8s.mjs`; its own local
`chQuery(pod, sql)` is a thin 3-line wrapper binding the database/user/
password defaults, not a duplicated implementation. No further change was
needed there.

### Companion `.test.mjs`

Checked whether `e2e-bwc-verify-placement.mjs` should get a companion
`.test.mjs`. Its two closest siblings and fellow `lib/k8s.mjs` consumers —
`e2e-bwc-verify-mode-toggle.mjs` and `e2e-datashard-verify.mjs` — have no
test file either: all three scripts shell straight out to `kubectl`/
`clickhouse-client` against real cluster state with no injectable pure
logic worth isolating (unlike `lib/k8s.mjs` and `k3d-image-import.mjs`,
which do have `.test.mjs` files backing their pure helper functions). Per
that established convention, no `.test.mjs` was added for this file.

## Local verification

- `node --check` on every touched `.mjs` file — clean.
- `node --test .github/scripts/k3d-image-import.test.mjs` — 11/11 passing
  (untouched logic, re-run to confirm nothing regressed).
- `node --test .github/scripts/lib/k8s.test.mjs` — 5/5 passing (untouched).
- `just --list` — `e2e-bwc-up`'s one-line summary is unchanged.
- `just --dry-run e2e-bwc-up object-storage` — renders the expected shell,
  confirms the shared cluster-create step and the `k3d-image-import.mjs`
  invocation interpolate correctly with the extended image list.
- `node .github/scripts/verify-just-invocations.mjs` — `59 distinct
  invocation(s) (85 call site(s) across 35 workflow file(s)) all dry-run
  clean`.
- `markdownlint-cli2 .github/scripts/README.md` — 0 issues.
- Pre-push hooks (`forbid-skip`, `repo-hygiene`, `forbid-sql-raw`,
  `actionlint`, etc.) all passed on push.

**Not verifiable locally** (no k3d/Docker cluster in this sandbox, per this
issue's own carve-out): the real BWC e2e CI lane —
`just e2e-bwc-up && just e2e-bwc-verify && just e2e-bwc-down` — must be
confirmed green via the actual CI job on this PR, the same pattern used for
prior e2e-family sub-issues in this epic (#3091).

Closes #3097
