### PR TITLE
refactor(justfile): extract compose-grafana-smoke to .mjs

### DIFF
--- a/.github/scripts/compose-grafana-smoke.mjs
+++ b/.github/scripts/compose-grafana-smoke.mjs
@@ -1,0 +1,137 @@
+// compose-grafana-smoke.mjs — run the compose-stack Grafana catch-net
+// Playwright spec against an already-running `docker compose up --wait`
+// stack, extracted from `just compose-grafana-smoke`'s former inline bash
+// (CLAUDE.md invariant 15, issue #3098, epic #3091).
+//
+// BUG FIXED BY THIS EXTRACTION. The replaced recipe body installed the
+// Playwright suite's npm deps with:
+//
+//   ( [ -f package-lock.json ] && npm ci || npm install --no-audit --no-fund )
+//
+// A bash `&&`/`||` chain treats ANY non-zero `npm ci` exit as "the left side
+// failed", not just the ENOENT case the idiom was written for — so a
+// corrupted lockfile, an out-of-sync lockfile, or a real dependency-integrity
+// error all fell through to `npm install`, which silently re-resolves the
+// lockfile and (almost always) exits 0. The recipe reported success on top of
+// a genuine install failure. `decideInstallCommand` / `installDeps` below
+// replace the whole idiom with an explicit branch on lockfile PRESENCE only:
+// `npm ci` failing is now a hard, fatal error with no fallback, full stop;
+// `npm install --no-audit --no-fund` runs on exactly one branch — lockfile
+// absent — never as a rescue from a failed `npm ci`.
+//
+// Env contract:
+//   PLAYWRIGHT_DIR      the Playwright suite's directory, relative to the
+//                       repo root or absolute (default test/e2e/playwright)
+//   PLAYWRIGHT_SPEC     spec file to run                (default compose_grafana_smoke.spec.ts)
+//   GRAFANA_BASE_URL    forwarded to the spec            (default http://localhost:3000)
+//   GRAFANA_URL         forwarded to the spec            (default http://localhost:3000)
+//   CERBERUS_URL        forwarded to the spec            (default http://localhost:8080)
+//
+// Exit: 0 when the spec run passes; 1 on any install, browser-install, or
+// spec failure (the failing subprocess's own exit status where non-zero).
+
+import { spawnSync } from 'node:child_process';
+import { statSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { error, log, notice } from './lib/gh.mjs';
+
+// isRegularFile — true only when `path` exists and is a regular file, never a
+// directory or other entry. Matches the replaced bash's `[ -f "$path" ]`
+// exactly. Self-contained rather than shared (see chdb-install.mjs's own
+// copy) — this is one predicate, not worth a lib/ module for two callers.
+export function isRegularFile(path) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+const PLAYWRIGHT_DIR = process.env.PLAYWRIGHT_DIR || 'test/e2e/playwright';
+const PLAYWRIGHT_SPEC = process.env.PLAYWRIGHT_SPEC || 'compose_grafana_smoke.spec.ts';
+const GRAFANA_BASE_URL = process.env.GRAFANA_BASE_URL || 'http://localhost:3000';
+const GRAFANA_URL = process.env.GRAFANA_URL || 'http://localhost:3000';
+const CERBERUS_URL = process.env.CERBERUS_URL || 'http://localhost:8080';
+
+// decideInstallCommand — pure: which npm command a lockfile's presence calls
+// for. Mirrors the replaced idiom's SUCCESS-path branching only — lockfile
+// present -> `npm ci`, lockfile absent -> `npm install --no-audit --no-fund`
+// — and nothing else, since the failure-path fallback that made the two
+// branches indistinguishable on error is exactly what this extraction
+// removes. Exported so the npm-ci-failure regression test can pin the branch
+// choice without spawning npm.
+export function decideInstallCommand(lockfileExists) {
+  return lockfileExists
+    ? { cmd: 'npm', args: ['ci'] }
+    : { cmd: 'npm', args: ['install', '--no-audit', '--no-fund'] };
+}
+
+// runStep — spawn `cmd` with inherited stdio (npm/playwright both narrate
+// their own progress) and report a structured result instead of exiting
+// directly, so callers decide what "fatal" means for their own step.
+function runStep(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (res.error) {
+    return { ok: false, status: 1, spawnError: res.error };
+  }
+  return { ok: res.status === 0, status: res.status === null ? 1 : res.status };
+}
+
+// installDeps — install the Playwright suite's npm deps in `dir`, using
+// `runFn` (defaults to runStep) so the regression test can stub the actual
+// subprocess call. Returns the decided command plus the outcome; never
+// attempts a second command regardless of the first one's result — that
+// absence of a second call IS the bug fix, and the test below asserts it by
+// counting invocations.
+export function installDeps(dir, { lockfileExists, runFn = runStep } = {}) {
+  const { cmd, args } = decideInstallCommand(lockfileExists);
+  const result = runFn(cmd, args, { cwd: dir });
+  return { cmd, args, lockfileExists, ...result };
+}
+
+function main() {
+  log(`==> compose-grafana-smoke: installing deps in ${PLAYWRIGHT_DIR}`);
+  const lockfileExists = isRegularFile(`${PLAYWRIGHT_DIR}/package-lock.json`);
+  const install = installDeps(PLAYWRIGHT_DIR, { lockfileExists });
+  if (!install.ok) {
+    error(
+      install.lockfileExists
+        ? `\`npm ci\` failed (exit ${install.status}) against an existing package-lock.json in ${PLAYWRIGHT_DIR} — ` +
+            'this is fatal, with no `npm install` fallback: a corrupted or out-of-sync lockfile is a real bug to fix, ' +
+            'not to paper over (cerberus#3098).'
+        : `\`npm install\` failed (exit ${install.status}) in ${PLAYWRIGHT_DIR}.`,
+    );
+    process.exit(install.status);
+  }
+
+  log('==> compose-grafana-smoke: installing Playwright browsers (chromium)');
+  const browsers = runStep('npx', ['playwright', 'install', '--with-deps', 'chromium'], { cwd: PLAYWRIGHT_DIR });
+  if (!browsers.ok) {
+    error(`\`npx playwright install --with-deps chromium\` failed (exit ${browsers.status}) in ${PLAYWRIGHT_DIR}.`);
+    process.exit(browsers.status);
+  }
+
+  log(`==> compose-grafana-smoke: running ${PLAYWRIGHT_SPEC} against ${CERBERUS_URL} / ${GRAFANA_URL}`);
+  const spec = runStep('npx', ['playwright', 'test', PLAYWRIGHT_SPEC, '--reporter=list'], {
+    cwd: PLAYWRIGHT_DIR,
+    env: {
+      ...process.env,
+      GRAFANA_BASE_URL,
+      GRAFANA_URL,
+      CERBERUS_URL,
+    },
+  });
+  if (!spec.ok) {
+    error(`playwright spec ${PLAYWRIGHT_SPEC} failed (exit ${spec.status}).`);
+    process.exit(spec.status);
+  }
+
+  notice(`compose-grafana-smoke: ${PLAYWRIGHT_SPEC} passed.`);
+  process.exit(0);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/.github/scripts/compose-grafana-smoke.test.mjs
+++ b/.github/scripts/compose-grafana-smoke.test.mjs
@@ -1,0 +1,106 @@
+// compose-grafana-smoke.test.mjs — node:test guard for
+// compose-grafana-smoke.mjs's install-decision logic, in particular the
+// npm-ci-failure regression this extraction exists to fix (CLAUDE.md
+// invariant 15, issue #3098, epic #3091).
+//
+// The regression under test: the replaced Justfile idiom
+// `( [ -f package-lock.json ] && npm ci || npm install ... )` silently fell
+// back to `npm install` on ANY `npm ci` failure, not just a missing
+// lockfile. `runNpmCiFailureStub` below simulates exactly that failure (a
+// non-zero `npm ci` exit with a lockfile present) and asserts two things the
+// old bash could not guarantee: (1) `installDeps` reports failure rather
+// than swallowing it, and (2) the install step is invoked exactly once —
+// proving no second, fallback command ever runs. A test written against the
+// OLD masking behavior would see `ok: true` here; this one would fail
+// against that behavior, which is the point.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { decideInstallCommand, installDeps, isRegularFile } from './compose-grafana-smoke.mjs';
+
+test('a present lockfile decides npm ci', () => {
+  assert.deepEqual(decideInstallCommand(true), { cmd: 'npm', args: ['ci'] });
+});
+
+test('a missing lockfile decides npm install --no-audit --no-fund', () => {
+  assert.deepEqual(decideInstallCommand(false), { cmd: 'npm', args: ['install', '--no-audit', '--no-fund'] });
+});
+
+test('a failed npm ci is reported as a hard failure, never falls back to npm install', () => {
+  const calls = [];
+  const runFn = (cmd, args) => {
+    calls.push({ cmd, args });
+    // Simulate exactly the bug scenario: package-lock.json exists, but `npm
+    // ci` itself fails (corrupted/out-of-sync lockfile, integrity error) —
+    // NOT the ENOENT/missing-lockfile case the fallback was meant for.
+    return { ok: false, status: 1 };
+  };
+
+  const result = installDeps('test/e2e/playwright', { lockfileExists: true, runFn });
+
+  assert.equal(result.ok, false, 'a failed npm ci must be reported as a failure');
+  assert.equal(result.status, 1);
+  assert.equal(calls.length, 1, 'npm ci failing must never trigger a second, fallback install command');
+  assert.deepEqual(calls[0], { cmd: 'npm', args: ['ci'] });
+});
+
+test('a successful npm ci is reported as success with no install fallback attempted', () => {
+  const calls = [];
+  const runFn = (cmd, args) => {
+    calls.push({ cmd, args });
+    return { ok: true, status: 0 };
+  };
+
+  const result = installDeps('test/e2e/playwright', { lockfileExists: true, runFn });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { cmd: 'npm', args: ['ci'] });
+});
+
+test('a missing lockfile runs npm install, never npm ci', () => {
+  const calls = [];
+  const runFn = (cmd, args) => {
+    calls.push({ cmd, args });
+    return { ok: true, status: 0 };
+  };
+
+  const result = installDeps('test/e2e/playwright', { lockfileExists: false, runFn });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { cmd: 'npm', args: ['install', '--no-audit', '--no-fund'] });
+});
+
+test('isRegularFile is false for a path that does not exist', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'compose-grafana-smoke-test-'));
+  try {
+    assert.equal(isRegularFile(join(dir, 'missing-lock.json')), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('isRegularFile is true for an actual regular file', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'compose-grafana-smoke-test-'));
+  try {
+    const file = join(dir, 'package-lock.json');
+    writeFileSync(file, '{}');
+    assert.equal(isRegularFile(file), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('isRegularFile is false for a directory — matches bash `[ -f ]`, not a bare existence check', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'compose-grafana-smoke-test-'));
+  try {
+    assert.equal(isRegularFile(dir), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,15 @@ jobs:
       # branch, not a standing gate on every unrelated PR.
       - name: Self-test the verify-just-invocations CLI
         run: node --test .github/scripts/verify-just-invocations.test.mjs
+      # compose-grafana-smoke extraction (#3098, epic #3091): pure unit
+      # coverage for the install-command decision, in particular the
+      # regression fix — a failed `npm ci` against an existing lockfile is
+      # now fatal with no `npm install` fallback, unlike the replaced bash
+      # idiom's `&&`/`||` chain. Self-test only here, same rationale as
+      # verify-just-invocations — a real compose + Grafana stack is what the
+      # real e2e CI job exercises the full script against.
+      - name: Self-test the compose-grafana-smoke .mjs helper
+        run: node --test .github/scripts/compose-grafana-smoke.test.mjs
       # e2e-up family extraction (#3096, epic #3091 phase 5): the pure
       # helpers behind the .mjs replacements for e2e-up's inline
       # bash/awk — kubectl/ClickHouse lookups, image-ref filtering, the

--- a/just/e2e-bwc.just
+++ b/just/e2e-bwc.just
@@ -307,18 +307,16 @@ e2e-datashard-verify count="2":
 # Tear the multi-data-shard lane down.
 e2e-datashard-down: e2e-down
 
-# Run the compose-stack Grafana catch-net spec locally. Assumes the
-# quickstart compose stack is already up (`docker compose up --wait`).
-# Drives Grafana through every provisioned dashboard and asserts every
-# /api/ds/query + /api/dashboards/* response is 2xx with no tunneled
-# per-target error. Mirrors the Playwright step the compose-smoke CI
-# job runs.
-
-# Run the compose-stack Grafana catch-net spec. Assumes the compose stack is
-# already up. Logic lives in compose-grafana-smoke.mjs (CLAUDE.md invariant
-# 15, issue #3098) — in particular the npm-install decision, which treats a
+# Assumes the quickstart compose stack is already up (`docker compose up
+# --wait`). Drives Grafana through every provisioned dashboard and asserts
+# every /api/ds/query + /api/dashboards/* response is 2xx with no tunneled
+# per-target error. Mirrors the Playwright step the compose-smoke CI job
+# runs. Logic lives in compose-grafana-smoke.mjs (CLAUDE.md invariant 15,
+# issue #3098) — in particular the npm-install decision, which treats a
 # `npm ci` failure against an existing lockfile as fatal rather than falling
 # back to `npm install` (the bug the old inline `&&`/`||` idiom had).
+
+# Run the compose-stack Grafana catch-net spec.
 compose-grafana-smoke:
     @echo "==> compose-grafana-smoke playwright catch-net"
     node .github/scripts/compose-grafana-smoke.mjs

--- a/just/e2e-bwc.just
+++ b/just/e2e-bwc.just
@@ -314,14 +314,12 @@ e2e-datashard-down: e2e-down
 # per-target error. Mirrors the Playwright step the compose-smoke CI
 # job runs.
 
-# Run the compose-stack Grafana catch-net spec. Assumes the compose stack is already up.
+# Run the compose-stack Grafana catch-net spec. Assumes the compose stack is
+# already up. Logic lives in compose-grafana-smoke.mjs (CLAUDE.md invariant
+# 15, issue #3098) — in particular the npm-install decision, which treats a
+# `npm ci` failure against an existing lockfile as fatal rather than falling
+# back to `npm install` (the bug the old inline `&&`/`||` idiom had).
 compose-grafana-smoke:
     @echo "==> compose-grafana-smoke playwright catch-net"
-    cd test/e2e/playwright && \
-        ( [ -f package-lock.json ] && npm ci || npm install --no-audit --no-fund ) && \
-        npx playwright install --with-deps chromium && \
-        GRAFANA_BASE_URL=http://localhost:3000 \
-        GRAFANA_URL=http://localhost:3000 \
-        CERBERUS_URL=http://localhost:8080 \
-        npx playwright test compose_grafana_smoke.spec.ts --reporter=list
+    node .github/scripts/compose-grafana-smoke.mjs
 


### PR DESCRIPTION
## Summary

Extracts the `compose-grafana-smoke` Justfile recipe's Playwright-runner logic into
`.github/scripts/compose-grafana-smoke.mjs`, per CLAUDE.md invariant 15 (dependency-light
Node ESM, `node:` builtins only, env-driven inputs, `::error::`/`::notice::` workflow
commands, `process.exit(1)` on failure). `just/e2e-bwc.just`'s `compose-grafana-smoke` recipe
now just calls the script — same recipe name, same local-dev contract ("assumes the compose
stack is already up").

### Bug fix

The replaced recipe body ran:

```sh
( [ -f package-lock.json ] && npm ci || npm install --no-audit --no-fund )
```

A bash `&&`/`||` chain treats **any** non-zero exit from the left side as "failed", so a
corrupted or out-of-sync lockfile, or a real dependency-integrity error from `npm ci`, fell
through to `npm install` — which silently re-resolves the lockfile and (almost always) exits
0. The recipe reported success on top of a genuine install failure.

The extracted script replaces this with an explicit branch on lockfile *presence* only:

- `decideInstallCommand(lockfileExists)` — pure function, `lockfileExists ? npm ci : npm
  install --no-audit --no-fund`.
- `installDeps(dir, { lockfileExists, runFn })` — runs the decided command exactly once via
  `runFn` (defaults to a `spawnSync`-based `runStep`) and returns a structured result; it
  never attempts a second command regardless of the outcome of the first.
- `main()` treats a failed `npm ci` as fatal: it prints the failure and calls
  `process.exit(install.status)` with no `npm install` fallback path in the code at all (not
  just "unreached in this run" — there is no such branch to reach).

### Regression test

`.github/scripts/compose-grafana-smoke.test.mjs` stubs `runFn` to simulate the exact bug
scenario — lockfile present, `npm ci` itself fails — and asserts:

1. `installDeps(...).ok === false` (the failure is reported, not swallowed).
2. `runFn` was called **exactly once**, with `{ cmd: 'npm', args: ['ci'] }` — proving no
   second, fallback `npm install` call is ever attempted.

A test written against the *old* masking idiom would see `ok: true` here (or a second
`npm install` call); this test fails against that behavior, which is the point per the issue's
acceptance criteria. Companion cases pin the missing-lockfile branch (`npm install
--no-audit --no-fund`, never `npm ci`) and the `isRegularFile` helper (file / missing / a
directory, matching bash's `[ -f ]` exactly, mirroring `chdb-install.mjs`'s own version of
this predicate).

### CI wiring

- Added a `node --test .github/scripts/compose-grafana-smoke.test.mjs` self-test step to
  `.github/workflows/ci.yml`, right after the sibling `verify-just-invocations` self-test step
  — `.github/scripts/assert-gate-suites-wired.mjs` requires every `*.test.mjs` to be invoked
  by some workflow, and this is the same "self-test only, the real e2e job exercises the
  full thing" rationale used for `verify-just-invocations.test.mjs` and the e2e-up family
  tests right next to it.
- `.github/ci-lanes.json`'s two `compose-grafana-smoke`-recipe lane entries reference the
  recipe by its (unchanged) name, so no update was needed there.

## Verification

- `node --check .github/scripts/compose-grafana-smoke.mjs` and `...test.mjs` — clean.
- `node --test .github/scripts/compose-grafana-smoke.test.mjs` — 8/8 pass.
- `node .github/scripts/verify-just-invocations.mjs` — 0 broken invocations (59 distinct
  invocations, 85 call sites, 35 workflow files).
- `node .github/scripts/assert-gate-suites-wired.mjs` — 91/91 suites wired (was 90/91 before
  the CI wiring above).
- `just --dry-run compose-grafana-smoke` — resolves cleanly to the new `node
  .github/scripts/compose-grafana-smoke.mjs` invocation.
- `actionlint .github/workflows/ci.yml` — clean.
- `just --unstable --fmt --check` — identical output before/after this change (the diff it
  reports is pre-existing drift elsewhere in the Justfile, unrelated to this PR).

**Could not verify locally** (per the issue's own carve-out, same pattern as #3091's prior
extraction sub-issues): `just compose-grafana-smoke` end-to-end against a real
Docker-Compose + Grafana stack, since bringing that stack up is out of scope for this
sandbox. This needs the real `e2e.yml` compose-smoke CI job on this PR.

Closes #3098
