### PR TITLE
refactor(justfile): extract migration-lane logic to .mjs

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -2564,6 +2564,56 @@ what actually runs.
     daemon happens to hold is exactly the substitution this module exists to
     prevent.
 
+- **`migration-cerberus-image.mjs`** — `just/migration.just`'s
+  `migration-cerberus-image` recipe, extracted from its inline `if [ "$img" =
+  "$local_tag" ]` body (issue #3099). The build-vs-pull decision `just
+  migration-tier1-up` / `migration-tier2-up` call as a sub-invocation before
+  every stack `up`: `CERBERUS_IMAGE` unset resolves to `MIGRATION_LOCAL_IMAGE`
+  and builds it from `Dockerfile.local` through `build-with-registry-retry.mjs`
+  (the one retry wrapper every image build in the tree goes through);
+  `CERBERUS_IMAGE` set to anything else pulls that ref through `just
+  _pull-retry`. `migration-cerberus-image.test.mjs` pins the decision,
+  including the edge case of `CERBERUS_IMAGE` set to exactly the local tag
+  (still the build path — a string-equality test, not an is-it-set check).
+  - Env: `MIGRATION_LOCAL_IMAGE` (required), `CERBERUS_IMAGE` (optional).
+  - Exit: the build or pull command's own status; `1` if `MIGRATION_LOCAL_IMAGE`
+    is unset.
+
+- **`migration-tier-seed.mjs`** — `just/migration.just`'s
+  `migration-tier1-seed` / `migration-tier2-seed` recipes, folded into one
+  tier-parameterized script (issue #3099) so Tier-2 reuses Tier-1's own
+  default-archetype-list handling instead of a near-duplicate recipe. An
+  explicit archetype argument seeds only that one; the empty default seeds
+  every archetype `DEFAULT_ARCHETYPES[tier]` lists (Tier-1: `three-signal` +
+  `kube-prometheus-stack`; Tier-2: `three-signal` alone, matching what
+  `migration-tier2-seed` always hardcoded before this extraction). Manifest
+  paths follow the existing convention every scenario reader hardcodes:
+  `three-signal` writes the unsuffixed `manifest.json`, every other archetype
+  writes `manifest-<archetype>.json`. `migration-tier-seed.test.mjs` pins the
+  tier-to-defaults mapping, the manifest-path convention, and the `go run`
+  argv construction.
+  - Usage: `node .github/scripts/migration-tier-seed.mjs [archetype]`.
+  - Env: `MIGRATION_SEED_TIER` (required; `tier1` | `tier2`).
+  - Exit: the first failing seeder's own status; `1` for an unrecognised tier.
+
+- **`migration-tier-logs.mjs`** — `just/migration.just`'s
+  `migration-tier1-logs` / `migration-tier2-logs` recipes, folded into one
+  tier-parameterized script (issue #3099) so Tier-2 reuses Tier-1's own
+  `docker compose ps` + per-service `logs --tail` loop instead of duplicating
+  its shape over a second compose file and a longer service list. Never fails
+  on its own — every `docker` invocation runs the same way the replaced
+  `|| true`-guarded bash did, since the CI job runs this on FAILURE, before
+  teardown deletes the containers it reads from, and a dump must never itself
+  turn a lane red or mask the real failure. `migration-tier-logs.test.mjs`
+  pins the tier-label mapping, the whitespace-list parsing, and the
+  `docker compose` argv construction (repeated `-f` per file, `--tail=N` per
+  service).
+  - Usage: `node .github/scripts/migration-tier-logs.mjs`.
+  - Env: `MIGRATION_LOG_TIER`, `MIGRATION_COMPOSE_FILES` (whitespace-separated
+    `-f` targets, in order), `MIGRATION_LOG_SERVICES` (whitespace-separated
+    service names, in order), `MIGRATION_LOG_TAIL` — all required.
+  - Exit: always `0`.
+
 - **`dashboard-matrix.mjs`** — `e2e.yml`, the `dashboard-setup` job. The k3d
   twin of `compose-smoke-matrix.mjs`: single source of truth for how the
   `dashboard` (k3d) lane fans its Playwright spec set across a MODEST matrix

--- a/.github/scripts/migration-cerberus-image.mjs
+++ b/.github/scripts/migration-cerberus-image.mjs
@@ -1,0 +1,95 @@
+// migration-cerberus-image.mjs — resolve and put the cerberus image the
+// migration stacks run into the local Docker daemon: the SINGLE acquisition
+// point, shared by CI and local dev. Extracted from the `migration-cerberus-image`
+// Justfile recipe body (CLAUDE.md invariant 15, issue #3099, epic #3091).
+//
+// Two paths, decided by CERBERUS_IMAGE alone: unset (every local run, every PR /
+// dispatch / push CI run) it builds MIGRATION_LOCAL_IMAGE from the repo-root
+// Dockerfile.local — whose final unnamed stage IS the cerberus image, so no
+// `--target` is needed — and the stack proves this tree. Set (release.yml's
+// artifact lane) it pulls that released tag and the stack proves the artifact.
+//
+// This exists because the compose up path deliberately cannot acquire the image
+// itself: `pull_policy: never` and no `--build` on the up recipes (migration-tier1-up
+// / migration-tier2-up in just/migration.just) are what keep a release run from
+// recompiling the source tree over the released image.
+//
+// The build path shells out to build-with-registry-retry.mjs (the one retry
+// wrapper every image-building command in the tree goes through — see that
+// module's own header); the pull path shells out to `just _pull-retry`
+// (just/common.just), the SAME recipe every other pull-then-run lane already
+// uses. Neither is re-implemented here: this script owns only the
+// build-vs-pull DECISION the replaced bash `if` made, not the two mechanisms
+// either branch already had.
+//
+// Env contract:
+//   MIGRATION_LOCAL_IMAGE  required; the locally-built tag (just/migration.just's
+//                          own MIGRATION_LOCAL_IMAGE variable, suffix included).
+//   CERBERUS_IMAGE         optional; a released image ref (release.yml's
+//                          artifact lane). Unset or empty selects the build path.
+//
+// Exit: the status of whichever command (build-with-registry-retry.mjs or
+// `just _pull-retry`) it ran; 1 if MIGRATION_LOCAL_IMAGE is missing.
+
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+import { error, log } from './lib/gh.mjs';
+
+// resolveCerberusImage — the exact `img="${CERBERUS_IMAGE:-$local_tag}"` /
+// `if [ "$img" = "$local_tag" ]` decision the replaced bash made. Pure so the
+// build-vs-pull branch is unit-testable without a Docker daemon.
+//
+// Deliberately compares the RESOLVED image to localImage, not whether
+// cerberusImageEnv was set: a caller who explicitly sets CERBERUS_IMAGE to the
+// exact local tag still gets the build path, matching the bash's own
+// string-equality test rather than an "is CERBERUS_IMAGE set" check.
+export function resolveCerberusImage(cerberusImageEnv, localImage) {
+  const image = cerberusImageEnv && cerberusImageEnv !== '' ? cerberusImageEnv : localImage;
+  return { image, source: image === localImage ? 'build' : 'pull' };
+}
+
+function isMain() {
+  const invoked = process.argv[1] || '';
+  return invoked.endsWith('migration-cerberus-image.mjs');
+}
+
+if (isMain()) {
+  const localImage = process.env.MIGRATION_LOCAL_IMAGE;
+  if (!localImage) {
+    error('migration-cerberus-image: MIGRATION_LOCAL_IMAGE must be set (see just/migration.just).');
+    process.exit(1);
+  }
+
+  const { image, source } = resolveCerberusImage(process.env.CERBERUS_IMAGE || '', localImage);
+
+  let res;
+  if (source === 'build') {
+    log(`==> migration cerberus image: build ${image} from Dockerfile.local`);
+    res = spawnSync(
+      'node',
+      [
+        '.github/scripts/build-with-registry-retry.mjs',
+        'docker',
+        'build',
+        '--build-arg',
+        'GO_IMAGE',
+        '-f',
+        'Dockerfile.local',
+        '-t',
+        image,
+        '.',
+      ],
+      { stdio: 'inherit' },
+    );
+  } else {
+    log(`==> migration cerberus image: pull ${image}`);
+    res = spawnSync('just', ['_pull-retry', image], { stdio: 'inherit' });
+  }
+
+  if (res.error) {
+    error(`migration-cerberus-image: failed to run the ${source} command: ${res.error.message}`);
+    process.exit(1);
+  }
+  process.exit(res.status ?? 1);
+}

--- a/.github/scripts/migration-cerberus-image.test.mjs
+++ b/.github/scripts/migration-cerberus-image.test.mjs
@@ -1,0 +1,37 @@
+// migration-cerberus-image.test.mjs — node:test guard for
+// migration-cerberus-image.mjs's pure build-vs-pull decision (issue #3099).
+// The real Docker build/pull is exercised live by `just migration-tier1` /
+// `migration-tier2` in the real migration-e2e.yml CI job.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveCerberusImage } from './migration-cerberus-image.mjs';
+
+test('an unset CERBERUS_IMAGE selects the build path against the local tag', () => {
+  assert.deepEqual(resolveCerberusImage('', 'cerberus:migration-tier1'), {
+    image: 'cerberus:migration-tier1',
+    source: 'build',
+  });
+});
+
+test('a CERBERUS_IMAGE set to a released tag selects the pull path', () => {
+  assert.deepEqual(resolveCerberusImage('ghcr.io/tsouza/cerberus:v1.13.0', 'cerberus:migration-tier1'), {
+    image: 'ghcr.io/tsouza/cerberus:v1.13.0',
+    source: 'pull',
+  });
+});
+
+test('CERBERUS_IMAGE set to exactly the local tag still selects build — matches the bash string-equality test, not an is-it-set check', () => {
+  assert.deepEqual(resolveCerberusImage('cerberus:migration-tier1', 'cerberus:migration-tier1'), {
+    image: 'cerberus:migration-tier1',
+    source: 'build',
+  });
+});
+
+test('a distinct local tag (COMPOSE_PROJECT_SUFFIX applied) still resolves against ITS OWN local tag', () => {
+  assert.deepEqual(resolveCerberusImage('', 'cerberus:migration-tier1-abcd1234'), {
+    image: 'cerberus:migration-tier1-abcd1234',
+    source: 'build',
+  });
+});

--- a/.github/scripts/migration-tier-logs.mjs
+++ b/.github/scripts/migration-tier-logs.mjs
@@ -1,0 +1,100 @@
+// migration-tier-logs.mjs — dump one migration tier's compose stack state and
+// per-service log tail, parameterized by tier + service list so
+// `migration-tier1-logs` and `migration-tier2-logs` (just/migration.just)
+// share ONE implementation instead of the identical loop shape duplicated
+// per tier (CLAUDE.md invariant 15, issue #3099, epic #3091).
+//
+// The CI job runs this on failure BEFORE teardown, so a red run carries the
+// evidence instead of a bare assertion message; teardown then deletes the
+// containers this reads from, which is why that ordering matters (see
+// just/migration.just's own comment on migration-tier1-logs /
+// migration-tier2-logs). Every docker command here is run the same way the
+// replaced `|| true`-guarded bash was: this script NEVER fails on its own,
+// nor lets a container that already exited mask the real failure.
+//
+// Usage:
+//   node .github/scripts/migration-tier-logs.mjs
+//
+// Env:
+//   MIGRATION_LOG_TIER      required; used only to LABEL the narration lines
+//                            ("tier1" -> "tier-1"), matching the replaced
+//                            recipes' own wording exactly.
+//   MIGRATION_COMPOSE_FILES required; whitespace-separated compose file
+//                            path(s) — one for Tier-1, Tier-1's plus the
+//                            ruler leg's for Tier-2 — passed to `docker
+//                            compose` as repeated `-f` flags, in order.
+//   MIGRATION_LOG_SERVICES  required; whitespace-separated service names to
+//                            dump, in order (just/migration.just's
+//                            MIGRATION_TIER1_SERVICES / MIGRATION_TIER2_SERVICES).
+//   MIGRATION_LOG_TAIL      required; trailing line count passed to `docker
+//                            compose logs --tail`.
+//
+// Exit: always 0 — a dump must never turn a lane red on its own.
+
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+import { error, log } from './lib/gh.mjs';
+
+// tierLabel — "tier1" -> "tier-1", matching every existing `echo "==> migration
+// tier-N ..."` line's hyphenated spelling. Identical mapping to
+// migration-tier-seed.mjs's own — kept as a single-line duplicate rather than
+// a shared import, since sharing a one-line regex across two small,
+// independently-testable scripts would trade a trivial duplication for a
+// cross-script coupling neither script otherwise needs.
+export function tierLabel(tier) {
+  return tier.replace(/^tier(\d+)$/, 'tier-$1');
+}
+
+// parseList — a whitespace-separated env value to a non-empty-token array.
+export function parseList(value) {
+  return (value || '').split(/\s+/).filter((s) => s !== '');
+}
+
+// composeFileArgs — one repeated `-f <file>` pair per compose file, in order.
+export function composeFileArgs(files) {
+  return files.flatMap((f) => ['-f', f]);
+}
+
+// psArgs — the `docker` argv that prints one tier's compose stack state.
+export function psArgs(files) {
+  return ['compose', ...composeFileArgs(files), 'ps'];
+}
+
+// logsArgsFor — the `docker` argv that dumps one service's trailing log lines.
+export function logsArgsFor(files, service, tail) {
+  return ['compose', ...composeFileArgs(files), 'logs', `--tail=${tail}`, service];
+}
+
+function isMain() {
+  const invoked = process.argv[1] || '';
+  return invoked.endsWith('migration-tier-logs.mjs');
+}
+
+if (isMain()) {
+  const tier = process.env.MIGRATION_LOG_TIER || '';
+  const files = parseList(process.env.MIGRATION_COMPOSE_FILES);
+  const services = parseList(process.env.MIGRATION_LOG_SERVICES);
+  const tail = process.env.MIGRATION_LOG_TAIL || '';
+
+  if (!tier || files.length === 0 || services.length === 0 || !tail) {
+    error(
+      'migration-tier-logs: MIGRATION_LOG_TIER, MIGRATION_COMPOSE_FILES, MIGRATION_LOG_SERVICES and ' +
+        'MIGRATION_LOG_TAIL must all be set (see just/migration.just).',
+    );
+    process.exit(1);
+  }
+
+  const label = tierLabel(tier);
+  log(`==> migration ${label} compose state`);
+  spawnSync('docker', psArgs(files), { stdio: 'inherit' });
+
+  for (const service of services) {
+    log(`==> migration ${label} logs: ${service}`);
+    spawnSync('docker', logsArgsFor(files, service, tail), { stdio: 'inherit' });
+  }
+
+  // Never fails on its own — matches the replaced recipe's `|| true` guard
+  // on every command.
+  process.exit(0);
+}

--- a/.github/scripts/migration-tier-logs.test.mjs
+++ b/.github/scripts/migration-tier-logs.test.mjs
@@ -1,0 +1,59 @@
+// migration-tier-logs.test.mjs — node:test guard for migration-tier-logs.mjs's
+// pure tier-label, list-parsing, and docker-argv-construction logic (issue
+// #3099). The real `docker compose ps` / `logs` against a live stack is
+// exercised by `just migration-tier1` / `migration-tier2` in the real
+// migration-e2e.yml CI job.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { composeFileArgs, logsArgsFor, parseList, psArgs, tierLabel } from './migration-tier-logs.mjs';
+
+test('tierLabel hyphenates the tier name', () => {
+  assert.equal(tierLabel('tier1'), 'tier-1');
+  assert.equal(tierLabel('tier2'), 'tier-2');
+});
+
+test('parseList splits on whitespace and drops empty tokens', () => {
+  assert.deepEqual(parseList('clickhouse   otel-collector\tprometheus'), ['clickhouse', 'otel-collector', 'prometheus']);
+});
+
+test('parseList on an empty/undefined value is an empty array', () => {
+  assert.deepEqual(parseList(''), []);
+  assert.deepEqual(parseList(undefined), []);
+});
+
+test('composeFileArgs emits one -f pair per file, in order', () => {
+  assert.deepEqual(composeFileArgs(['a.yml']), ['-f', 'a.yml']);
+  assert.deepEqual(composeFileArgs(['a.yml', 'b.yml']), ['-f', 'a.yml', '-f', 'b.yml']);
+});
+
+test('psArgs builds the Tier-1-shaped single-file ps command', () => {
+  assert.deepEqual(psArgs(['test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml']), [
+    'compose',
+    '-f',
+    'test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml',
+    'ps',
+  ]);
+});
+
+test('psArgs builds the Tier-2-shaped two-file ps command, files in order', () => {
+  assert.deepEqual(
+    psArgs([
+      'test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml',
+      'test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml',
+    ]),
+    [
+      'compose',
+      '-f',
+      'test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml',
+      '-f',
+      'test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml',
+      'ps',
+    ],
+  );
+});
+
+test('logsArgsFor builds a --tail=N logs command for one service', () => {
+  assert.deepEqual(logsArgsFor(['a.yml'], 'clickhouse', '200'), ['compose', '-f', 'a.yml', 'logs', '--tail=200', 'clickhouse']);
+});

--- a/.github/scripts/migration-tier-seed.mjs
+++ b/.github/scripts/migration-tier-seed.mjs
@@ -1,0 +1,117 @@
+// migration-tier-seed.mjs — seed one migration tier's archetype fixtures into
+// its running stack, parameterized by tier so `migration-tier1-seed` and
+// `migration-tier2-seed` (just/migration.just) share ONE implementation
+// instead of a near-duplicate recipe/script per tier (CLAUDE.md invariant 15,
+// issue #3099, epic #3091).
+//
+// Folds `migration-tier1-seed`'s own default-archetype-list handling: an
+// explicit archetype argument seeds ONLY that one (for iterating on a single
+// story locally once the stack is already up); the empty default seeds every
+// archetype the tier declares, into the ONE compose-stack lifecycle the
+// canonical `just migration-tier1` / `migration-tier2` composite (and the CI
+// migration-e2e.yml jobs) drive.
+//
+// Tier-1 seeds two archetypes by default (MIG-02/06/07/08's
+// kube-prometheus-stack plus every other @tier1 scenario's three-signal — see
+// just/migration.just's own comment on MIGRATION_TIER1_ARCHETYPES). Tier-2
+// runs against the same seeded window Tier-1 does — the ruler tier adds
+// Grafana-managed alerting on top of the SAME cerberus/ClickHouse pair, not a
+// second corpus — so its default list is three-signal alone; this was
+// previously `migration-tier2-seed`'s hardcoded, parameter-less command,
+// which DEFAULT_ARCHETYPES.tier2 now reproduces exactly rather than special-cases.
+//
+// Manifest path convention (test/e2e/migration/lib/live.go's LoadManifest,
+// and tier1_parity_test.go's plain-Go substrate self-check, both hardcode this):
+// three-signal writes the historical unsuffixed manifest.json; every other
+// archetype writes manifest-<archetype>.json.
+//
+// Usage:
+//   node .github/scripts/migration-tier-seed.mjs [archetype]
+//
+// Env:
+//   MIGRATION_SEED_TIER  required; "tier1" or "tier2".
+//
+// Exit: the first failing `go run` seeder's own exit status; 0 once every
+// archetype seeds cleanly; 1 for an unrecognised tier.
+
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+import { error, log } from './lib/gh.mjs';
+
+// DEFAULT_ARCHETYPES — the archetype set each tier seeds when no explicit
+// archetype argument is given. Tier-1 mirrors just/migration.just's own
+// MIGRATION_TIER1_ARCHETYPES; Tier-2 mirrors the fixture
+// `migration-tier2-seed` always seeded before this extraction.
+export const DEFAULT_ARCHETYPES = {
+  tier1: ['three-signal', 'kube-prometheus-stack'],
+  tier2: ['three-signal'],
+};
+
+// tierLabel — "tier1" -> "tier-1", matching every existing `echo "==> migration
+// tier-N ..."` line's hyphenated spelling.
+export function tierLabel(tier) {
+  return tier.replace(/^tier(\d+)$/, 'tier-$1');
+}
+
+// resolveArchetypes — the archetype list to seed for `tier`, given the
+// (possibly empty) requested archetype argument. Returns null for an
+// unrecognised tier so the caller can fail loudly rather than silently
+// seeding nothing.
+export function resolveArchetypes(tier, requested, defaults = DEFAULT_ARCHETYPES) {
+  if (!Object.prototype.hasOwnProperty.call(defaults, tier)) return null;
+  if (requested && requested.trim() !== '') return [requested.trim()];
+  return [...defaults[tier]];
+}
+
+// manifestPathFor — the manifest path one archetype's seed run publishes to.
+// three-signal keeps the historical unsuffixed path; every other archetype
+// gets its own `manifest-<archetype>.json`.
+export function manifestPathFor(archetype) {
+  return archetype === 'three-signal'
+    ? 'test/e2e/migration/.out/manifest.json'
+    : `test/e2e/migration/.out/manifest-${archetype}.json`;
+}
+
+// seedArgsFor — the full `go run` argv that seeds one archetype's fixture.
+export function seedArgsFor(archetype, manifestPath) {
+  return [
+    'run',
+    './test/e2e/migration/cmd/seed',
+    '--fixture',
+    `test/e2e/migration/archetypes/${archetype}/seed/fixture.json`,
+    '--manifest',
+    manifestPath,
+  ];
+}
+
+function isMain() {
+  const invoked = process.argv[1] || '';
+  return invoked.endsWith('migration-tier-seed.mjs');
+}
+
+if (isMain()) {
+  const tier = process.env.MIGRATION_SEED_TIER || '';
+  const requested = process.argv[2] || '';
+
+  const archetypes = resolveArchetypes(tier, requested);
+  if (archetypes === null) {
+    error(
+      `migration-tier-seed: unrecognised MIGRATION_SEED_TIER "${tier}" — expected one of: ${Object.keys(DEFAULT_ARCHETYPES).join(', ')}.`,
+    );
+    process.exit(1);
+  }
+
+  const label = tierLabel(tier);
+  for (const archetype of archetypes) {
+    const manifest = manifestPathFor(archetype);
+    log(`==> migration ${label} seed (${archetype}, manifest ${manifest})`);
+    const res = spawnSync('go', seedArgsFor(archetype, manifest), { stdio: 'inherit' });
+    if (res.error) {
+      error(`migration-tier-seed: failed to run the Go seeder for ${archetype}: ${res.error.message}`);
+      process.exit(1);
+    }
+    if (res.status !== 0) process.exit(res.status ?? 1);
+  }
+  process.exit(0);
+}

--- a/.github/scripts/migration-tier-seed.test.mjs
+++ b/.github/scripts/migration-tier-seed.test.mjs
@@ -1,0 +1,61 @@
+// migration-tier-seed.test.mjs — node:test guard for migration-tier-seed.mjs's
+// pure tier-parameterization, default-archetype-list, manifest-path, and
+// seed-argv logic (issue #3099). The real `go run` seeder against a live
+// stack is exercised by `just migration-tier1` / `migration-tier2` in the
+// real migration-e2e.yml CI job.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { DEFAULT_ARCHETYPES, manifestPathFor, resolveArchetypes, seedArgsFor, tierLabel } from './migration-tier-seed.mjs';
+
+test('tierLabel hyphenates the tier name', () => {
+  assert.equal(tierLabel('tier1'), 'tier-1');
+  assert.equal(tierLabel('tier2'), 'tier-2');
+});
+
+test('resolveArchetypes with no requested archetype returns tier1s default two-archetype list', () => {
+  assert.deepEqual(resolveArchetypes('tier1', ''), ['three-signal', 'kube-prometheus-stack']);
+});
+
+test('resolveArchetypes with no requested archetype returns tier2s default single-archetype list', () => {
+  assert.deepEqual(resolveArchetypes('tier2', ''), ['three-signal']);
+});
+
+test('resolveArchetypes with an explicit archetype seeds ONLY that one, for either tier', () => {
+  assert.deepEqual(resolveArchetypes('tier1', 'kube-prometheus-stack'), ['kube-prometheus-stack']);
+  assert.deepEqual(resolveArchetypes('tier2', 'three-signal'), ['three-signal']);
+});
+
+test('resolveArchetypes trims whitespace around an explicit archetype', () => {
+  assert.deepEqual(resolveArchetypes('tier1', '  three-signal  '), ['three-signal']);
+});
+
+test('resolveArchetypes returns null for an unrecognised tier', () => {
+  assert.equal(resolveArchetypes('tier3', ''), null);
+});
+
+test('resolveArchetypes never lets a caller mutate the shared defaults', () => {
+  const list = resolveArchetypes('tier1', '');
+  list.push('mutated');
+  assert.deepEqual(DEFAULT_ARCHETYPES.tier1, ['three-signal', 'kube-prometheus-stack']);
+});
+
+test('manifestPathFor keeps three-signal at the historical unsuffixed path', () => {
+  assert.equal(manifestPathFor('three-signal'), 'test/e2e/migration/.out/manifest.json');
+});
+
+test('manifestPathFor suffixes every other archetype', () => {
+  assert.equal(manifestPathFor('kube-prometheus-stack'), 'test/e2e/migration/.out/manifest-kube-prometheus-stack.json');
+});
+
+test('seedArgsFor builds the go run argv for one archetype', () => {
+  assert.deepEqual(seedArgsFor('three-signal', 'test/e2e/migration/.out/manifest.json'), [
+    'run',
+    './test/e2e/migration/cmd/seed',
+    '--fixture',
+    'test/e2e/migration/archetypes/three-signal/seed/fixture.json',
+    '--manifest',
+    'test/e2e/migration/.out/manifest.json',
+  ]);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,6 +674,19 @@ jobs:
           node --test .github/scripts/e2e-seed-rolling.test.mjs
           node --test .github/scripts/e2e-seed-stop.test.mjs
           node --test .github/scripts/e2e-chaos-overlay.test.mjs
+      # Migration-lane extraction (#3099, epic #3091): the pure helpers behind
+      # the .mjs replacements for migration-cerberus-image's build-vs-pull
+      # decision, migration-tier1-seed/migration-tier2-seed's shared
+      # tier-parameterized archetype loop, and migration-tier1-logs/
+      # migration-tier2-logs's shared tier-parameterized compose-log loop.
+      # Self-test only here, same rationale as the e2e-up family above — the
+      # real Docker build/pull and the real compose stack are what the real
+      # migration-e2e.yml CI job exercises these against.
+      - name: Self-test the migration-lane .mjs helpers
+        run: |
+          node --test .github/scripts/migration-cerberus-image.test.mjs
+          node --test .github/scripts/migration-tier-seed.test.mjs
+          node --test .github/scripts/migration-tier-logs.test.mjs
       # The updater itself is workflow_dispatch-only. Its controller remains
       # ordinary repository code, so its pure unit/round-trip contract belongs
       # on the existing PR policy lane without exposing the updater to PR events.

--- a/just/migration.just
+++ b/just/migration.just
@@ -33,18 +33,14 @@ MIGRATION_LOCAL_IMAGE := "cerberus:migration-tier1${COMPOSE_PROJECT_SUFFIX:-}"
 # This exists because the compose up path deliberately cannot acquire the image
 # itself: `pull_policy: never` and no `--build` on the up recipes are what keep
 # a release run from recompiling the source tree over the released image.
+#
+# The build-vs-pull decision, the build command, and the pull command all live
+# in .github/scripts/migration-cerberus-image.mjs (CLAUDE.md invariant 15,
+# issue #3099) — this recipe is a thin env-passing wrapper around it.
 
 # Put the cerberus image the migration stacks run into the local Docker daemon.
 migration-cerberus-image:
-    @local_tag="{{MIGRATION_LOCAL_IMAGE}}"; \
-    img="${CERBERUS_IMAGE:-$local_tag}"; \
-    if [ "$img" = "$local_tag" ]; then \
-        echo "==> migration cerberus image: build $img from Dockerfile.local"; \
-        node .github/scripts/build-with-registry-retry.mjs docker build --build-arg GO_IMAGE -f Dockerfile.local -t "$img" .; \
-    else \
-        echo "==> migration cerberus image: pull $img"; \
-        just _pull-retry "$img"; \
-    fi
+    @MIGRATION_LOCAL_IMAGE="{{MIGRATION_LOCAL_IMAGE}}" node .github/scripts/migration-cerberus-image.mjs
 
 # Bring the Tier-1 stack up and wait for every healthcheck to pass. The cerberus
 # image is acquired first by migration-cerberus-image; there is deliberately no
@@ -124,19 +120,15 @@ MIGRATION_LOG_TAIL := "200"
 # canonical `just migration-tier1` composite (and the CI migration-tier1 job)
 # drives — the whole `@tier1` scenario set is green off one seed pass, not
 # just whichever archetype happened to be seeded last.
+#
+# The archetype loop, the default-list fallback, and the manifest-path
+# convention all live in .github/scripts/migration-tier-seed.mjs, folded
+# behind a tier parameter (MIGRATION_SEED_TIER) so migration-tier2-seed below
+# reuses the exact same implementation (CLAUDE.md invariant 15, issue #3099).
 
 # Seed the Tier-1 archetype fixtures into the running stack (all of them by default).
 migration-tier1-seed archetype="":
-    @archetypes="{{archetype}}"; \
-    [ -n "$archetypes" ] || archetypes="{{MIGRATION_TIER1_ARCHETYPES}}"; \
-    for a in $archetypes; do \
-        manifest="test/e2e/migration/.out/manifest.json"; \
-        [ "$a" = "three-signal" ] || manifest="test/e2e/migration/.out/manifest-$a.json"; \
-        echo "==> migration tier-1 seed ($a, manifest $manifest)"; \
-        go run ./test/e2e/migration/cmd/seed \
-            --fixture test/e2e/migration/archetypes/$a/seed/fixture.json \
-            --manifest "$manifest"; \
-    done
+    @MIGRATION_SEED_TIER=tier1 node .github/scripts/migration-tier-seed.mjs {{archetype}}
 
 # Assert the Tier-1 substrate contract against the seeded stack: the collector
 # provisioned the OTel schema, cerberus serves all three heads off it, each
@@ -165,18 +157,19 @@ migration-tier1-run:
 # The CI job runs this on failure BEFORE teardown, so a red run carries the
 # evidence instead of a bare assertion message; teardown then deletes the
 # containers this reads from, which is why that ordering matters. Every command
-# is `|| true`-guarded: a dump must never turn a lane red on its own, nor mask
-# the real failure with a container that has already exited.
+# runs the same way the replaced `|| true`-guarded bash did: a dump must never
+# turn a lane red on its own, nor mask the real failure with a container that
+# has already exited.
+#
+# The `docker compose ps` / per-service `logs` loop lives in
+# .github/scripts/migration-tier-logs.mjs, parameterized by tier + compose
+# file list + service list, so migration-tier2-logs below reuses the exact
+# same implementation instead of duplicating the loop shape (CLAUDE.md
+# invariant 15, issue #3099).
 
 # Dump the Tier-1 stack's container state and per-service log tail. Never fails on its own.
 migration-tier1-logs:
-    @echo "==> migration tier-1 compose state"; \
-    docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml ps || true; \
-    for svc in {{MIGRATION_TIER1_SERVICES}}; do \
-        echo "==> migration tier-1 logs: $svc"; \
-        docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
-            logs --tail={{MIGRATION_LOG_TAIL}} "$svc" || true; \
-    done
+    @MIGRATION_LOG_TIER=tier1 MIGRATION_COMPOSE_FILES="test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml" MIGRATION_LOG_SERVICES="{{MIGRATION_TIER1_SERVICES}}" MIGRATION_LOG_TAIL="{{MIGRATION_LOG_TAIL}}" node .github/scripts/migration-tier-logs.mjs
 
 # Tear the Tier-1 stack down. `-v` is mandatory, not cosmetic: the reference
 # images declare their own VOLUMEs, and a surviving volume would carry one
@@ -224,13 +217,13 @@ migration-tier2-up:
 # Tier-2 runs against the same seeded window Tier-1 does — the ruler tier
 # adds Grafana-managed alerting on top of the SAME cerberus/ClickHouse pair,
 # not a second one — so this is the identical seed step, not a second corpus.
+# Reuses migration-tier1-seed's own .github/scripts/migration-tier-seed.mjs
+# (MIGRATION_SEED_TIER=tier2's default archetype list is three-signal alone —
+# see that script's own DEFAULT_ARCHETYPES).
 
 # Seed the Tier-2 stack — the same window Tier-1 uses, not a second corpus.
 migration-tier2-seed:
-    @echo "==> migration tier-2 seed"
-    go run ./test/e2e/migration/cmd/seed \
-        --fixture test/e2e/migration/archetypes/three-signal/seed/fixture.json \
-        --manifest test/e2e/migration/.out/manifest.json
+    @MIGRATION_SEED_TIER=tier2 node .github/scripts/migration-tier-seed.mjs
 
 # Assert the Tier-2 substrate contract: Grafana provisioned the rule fixture
 # (kube-prometheus-stack's recording rule + NodeCPUSaturation alert, plus the
@@ -261,19 +254,12 @@ migration-tier2-run:
 # Dump the Tier-2 stack's container state and per-service log tail — the ruler
 # leg included, since a Tier-2 failure is usually Grafana rejecting the rule
 # fixture or the write-back bridge dropping a sample. See
-# migration-tier1-logs' comment for the ordering-before-teardown rationale.
+# migration-tier1-logs' comment for the ordering-before-teardown rationale and
+# for where the loop itself now lives.
 
 # Dump the Tier-2 stack's container state and per-service log tail, ruler leg included.
 migration-tier2-logs:
-    @echo "==> migration tier-2 compose state"; \
-    docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
-        -f test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml ps || true; \
-    for svc in {{MIGRATION_TIER2_SERVICES}}; do \
-        echo "==> migration tier-2 logs: $svc"; \
-        docker compose -f test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
-            -f test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml \
-            logs --tail={{MIGRATION_LOG_TAIL}} "$svc" || true; \
-    done
+    @MIGRATION_LOG_TIER=tier2 MIGRATION_COMPOSE_FILES="test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml" MIGRATION_LOG_SERVICES="{{MIGRATION_TIER2_SERVICES}}" MIGRATION_LOG_TAIL="{{MIGRATION_LOG_TAIL}}" node .github/scripts/migration-tier-logs.mjs
 
 # Tear the Tier-2 stack down. `-v` is mandatory — see migration-tier1-down's
 # comment; the same reference-image VOLUME concern applies here since this

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -1588,14 +1588,20 @@ func TestMigrationTier1SeedRecipe(t *testing.T) {
 	t.Parallel()
 
 	recipe := justRecipeBody(t, "migration-tier1-seed")
+	script, err := os.ReadFile(migrationSeedScript)
+	if err != nil {
+		t.Fatalf("read %s: %v", migrationSeedScript, err)
+	}
+	combined := recipe + "\n" + string(script)
 	for _, want := range []string{
 		tier1SeedCmdPath,
 		tier1ArchetypeFixtureDir,
 		tier1ArchetypeFixtureFile,
 		tier1ManifestOutput,
 	} {
-		if !strings.Contains(recipe, want) {
-			t.Fatalf("Justfile recipe migration-tier1-seed does not reference %q; body:\n%s", want, recipe)
+		if !strings.Contains(combined, want) {
+			t.Fatalf("neither Justfile recipe migration-tier1-seed nor %s references %q; recipe body:\n%s",
+				migrationSeedScript, want, recipe)
 		}
 	}
 
@@ -1665,6 +1671,13 @@ const (
 	// migrationImageRecipe is the SINGLE point at which the image enters the
 	// Docker daemon.
 	migrationImageRecipe = "migration-cerberus-image"
+	// migrationImageScript is where migrationImageRecipe's build-or-pull
+	// decision actually lives (#3099) — the recipe body itself is just a
+	// one-line delegation to it.
+	migrationImageScript = "../../.github/scripts/migration-cerberus-image.mjs"
+	// migrationSeedScript is where migration-tier1-seed's/migration-tier2-
+	// seed's fixture-path construction actually lives (#3099).
+	migrationSeedScript = "../../.github/scripts/migration-tier-seed.mjs"
 	// dockerfileLocalPath builds the image the stacks run when no released
 	// artifact is supplied; cerberusMainPath declares the source-build stamp.
 	dockerfileLocalPath = "../../Dockerfile.local"
@@ -1754,12 +1767,21 @@ func TestMigrationImageIsAcquiredOnceNeverRebuilt(t *testing.T) {
 	// The acquisition recipe itself must be able to do BOTH halves: build the
 	// local tag from Dockerfile.local, and pull anything else — the pull going
 	// through the retry helper rather than a single-attempt `docker pull`.
-	acquire := justRecipeBody(t, migrationImageRecipe)
-	for _, want := range []string{"docker build", "Dockerfile.local", pullRetryRecipe, lib.ImageEnv} {
+	acquireRecipe := justRecipeBody(t, migrationImageRecipe)
+	acquireScript, err := os.ReadFile(migrationImageScript)
+	if err != nil {
+		t.Fatalf("read %s: %v", migrationImageScript, err)
+	}
+	acquire := acquireRecipe + "\n" + string(acquireScript)
+	// "docker build" is now two separate spawnSync argv elements rather than
+	// one literal string (#3099), so build-with-registry-retry.mjs — the
+	// script migration-cerberus-image.mjs delegates the build path to — is
+	// what actually proves a real `docker build` happens.
+	for _, want := range []string{"build-with-registry-retry.mjs", "Dockerfile.local", pullRetryRecipe, lib.ImageEnv} {
 		if !strings.Contains(acquire, want) {
-			t.Fatalf("Justfile recipe %s does not reference %q; it must build the local tag from "+
-				"Dockerfile.local and pull a released one (with retry), decided by %s alone. Body:\n%s",
-				migrationImageRecipe, want, lib.ImageEnv, acquire)
+			t.Fatalf("neither Justfile recipe %s nor %s references %q; it must build the local tag from "+
+				"Dockerfile.local and pull a released one (with retry), decided by %s alone. Recipe body:\n%s",
+				migrationImageRecipe, migrationImageScript, want, lib.ImageEnv, acquireRecipe)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Extracts `just/migration.just`'s remaining inline bash into three parameterized
`.mjs` scripts, per CLAUDE.md invariant 15 (epic #3091):

- `.github/scripts/migration-cerberus-image.mjs` — the `migration-cerberus-image`
  recipe's build-vs-pull decision (`CERBERUS_IMAGE` unset → build
  `MIGRATION_LOCAL_IMAGE` from `Dockerfile.local` via
  `build-with-registry-retry.mjs`; set → pull that ref via `just _pull-retry`).
- `.github/scripts/migration-tier-seed.mjs`, parameterized by
  `MIGRATION_SEED_TIER` (`tier1`/`tier2`) — folds `migration-tier1-seed`'s
  default-archetype-list handling (`three-signal` + `kube-prometheus-stack`)
  and `migration-tier2-seed`'s previously-hardcoded single-archetype seed
  (`three-signal` alone) into one script, so `migration-tier2-seed` now reuses
  it instead of duplicating the archetype/manifest-path logic.
- `.github/scripts/migration-tier-logs.mjs`, parameterized by tier + compose
  file list + service list — dedupes `migration-tier1-logs`/
  `migration-tier2-logs`'s identical `docker compose ps` + per-service
  `logs --tail` loop into one script.

Each new script ships a companion `.test.mjs` pinning its pure logic (the
build-vs-pull decision, the tier→default-archetype-list map, the manifest-path
convention, the `go run`/`docker compose` argv construction), wired into
`ci.yml`'s `forbid-skip` job right after the existing e2e-up-family self-test
step (same "self-test only here, the real thing runs in the real CI job"
rationale).

## The `@just` sub-invocation pattern is preserved exactly

The critical constraint from #3099: `migration-tier1-up` / `migration-tier2-up`
call `migration-tier1-down`/`migration-tier2-down`, `migration-cerberus-image`,
and `_compose-pull-retry` as **`@just <recipe>` sub-invocation lines inside
the recipe body**, never as declared Justfile prerequisites — this
deliberately avoids `just`'s dependency-graph deduplication (a recipe named
twice in one invocation chain runs once), which here would risk leaving a
stack half up or not torn down.

This PR does not touch those call sites at all. Before and after, in
`just/migration.just`:

```just
migration-tier1-up:
    @just migration-tier1-down
    @just migration-cerberus-image
    @just _compose-pull-retry test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
    ...

migration-tier2-up:
    @just migration-tier2-down
    @just migration-cerberus-image
    @just _compose-pull-retry test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml \
        test/e2e/migration/tiers/tier2-ruler/docker-compose.ruler.yml
    ...
```

Byte-identical, both before and after this diff — `git diff` on
`just/migration.just` shows zero changes to these two recipes' bodies. Only
the *inside* of the leaf recipes those lines call out to (`migration-cerberus-image`,
`migration-tier1-seed`, `migration-tier1-logs`, `migration-tier2-seed`,
`migration-tier2-logs`) changed, from inline bash to a one-line env-passing
`node .github/scripts/<name>.mjs` wrapper — the same shape `chdb-install`
(#3094) and `k3d-image-import` (#3096) already established for this repo's
prior extractions.

`just --dry-run migration-tier1` / `migration-tier2` (below) confirm the
composite recipe graphs still resolve with the sub-invocations intact.

## Design notes

- `migration-cerberus-image.mjs` shells out to `just _pull-retry <img>` for
  the pull branch and to `build-with-registry-retry.mjs` for the build
  branch — neither retry mechanism is reimplemented here; this script owns
  only the build-vs-pull *decision* the replaced bash `if` made.
- `migration-tier-seed.mjs`'s per-archetype echo line now also fires for
  Tier-2 (`==> migration tier-2 seed (three-signal, manifest ...)`) instead of
  the previous bare `==> migration tier-2 seed`. This is the one intentional
  cosmetic change: folding Tier-2 into the shared per-archetype loop makes its
  one iteration print the same detail Tier-1's loop always did. Nothing reads
  this exact string (verified: no test or doc references
  `migration tier-2 seed`).
- `migration-tier-logs.mjs` and `migration-tier-seed.mjs` each define their
  own one-line `tierLabel()` (`"tier1" -> "tier-1"`) rather than sharing an
  import — a cross-script coupling for one regex was judged not worth it for
  two otherwise-independent, independently-testable scripts.

## Verification

Cannot run a real migration-tier k3d/compose stack in this sandbox (same
carve-out prior extraction sub-issues in this epic used — verified via the
real `migration-e2e.yml` CI job on this PR). Locally:

- `node --check` on all six new files: clean.
- `node --test .github/scripts/migration-cerberus-image.test.mjs
  .github/scripts/migration-tier-seed.test.mjs
  .github/scripts/migration-tier-logs.test.mjs`: 21/21 passing.
- `node .github/scripts/verify-just-invocations.mjs`: **0 broken invocations**
  (59 distinct invocations, 85 call sites across 35 workflow files).
- `node .github/scripts/assert-gate-suites-wired.mjs`: 93/93 suites wired
  (includes the 3 new ones).
- `just --dry-run migration-tier1` / `just --dry-run migration-tier2`: both
  resolve cleanly, `@just` sub-invocation lines unchanged (see above).
- `just --dry-run migration-cerberus-image` / `migration-tier1-seed[
  kube-prometheus-stack]` / `migration-tier2-seed` / `migration-tier1-logs` /
  `migration-tier2-logs`: all resolve with correct variable interpolation.
- Manual smoke test of each script with a fake `go`/`docker`/`just` on `PATH`
  confirms the exact argv each branch constructs matches the replaced bash
  byte-for-byte (build-vs-pull decision, per-archetype seed loop incl. the
  explicit-archetype override, per-service compose-log loop incl. the
  two-compose-file Tier-2 case).
- `node .github/scripts/doc-refs.mjs`: clean; `node .github/scripts/markdownlint-run.mjs`:
  0 issues; `actionlint .github/workflows/ci.yml`: clean.
- `git diff origin/main -- just/migration.just`: confirmed the
  `migration-tier1-up` / `migration-tier2-up` recipe bodies have **zero**
  diff hunks touching them — every hunk lands in a comment block or in one
  of the five leaf recipes whose bodies were replaced.

Not verifiable locally: the real Docker build/pull of the cerberus image, and
the real `docker compose` stack + Gherkin scenario run — these are exactly
what `just migration-tier1` / `just migration-tier2` exercise in the real
`migration-e2e.yml` CI job, per the issue's own carve-out.

Closes #3099
