### PR TITLE
refactor(justfile): extract coverage family + baseline diff-stat helper to .mjs

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -196,6 +196,25 @@ caps from `crawlShardTimeoutMinutes(depth)` here, and
 `parseSpecBudgetsFromSource()` lets the guard test read the real spec file so
 the pinned numbers cannot drift away from what the crawl actually asks for.
 
+`lib/coverage-fold.mjs` (issue #3095, epic #3091) holds the `mode: set`
+union fold every coverage-lane profile merge needs: `foldProfile()` keeps one
+row per coverage block, the widest execution count seen for it anywhere,
+sorted — exactly what `-coverpkg`'s multiply-instrumented raw profiles
+require, since every linked test binary emits a row for every block it
+links. `just/test.just`'s `_coverage-fold` recipe (a single-file, in-place
+fold) and `coverage-merge.mjs`'s two folds (the ratchet-shard fold and the
+cover.out+cover-chdb.out merge) all call `writeFoldedProfile()` here instead
+of each hand-copying the same three-line awk pipeline.
+
+`lib/regen-diff.mjs` (issue #3095, epic #3091) is `printDiffStat(paths,
+label)` — the "review this diff before committing" banner every
+`update-*-baseline` recipe (plus `gen-config-docs`, `bench-report`, and
+`migration-golden`) prints after regenerating a committed artefact. Replaces
+twelve copies of `@echo` / `@echo "Diff of regenerated <thing>:"` /
+`@git --no-pager diff --stat <path...> || true` with one call each; an
+absent `label` prints the bare diff-stat with no banner, matching
+`update-parity-enrolment-baseline`'s one exception to the pattern.
+
 ## CI lane registry
 
 `.github/ci-lanes.json` is the machine-readable inventory of Cerberus's test
@@ -1155,6 +1174,28 @@ what actually runs.
     mode only), `GO` (default `go`, test seam).
   - Exit: `0` when every shard this invocation is responsible for passes,
     `1` on a failed shard, an out-of-range `LEG_INDEX`, or missing env.
+- **`coverage-merge.mjs`** — `just/test.just`'s `coverage-merge` recipe
+  (issue #3095, epic #3091). Merges cover.out (default-tag lane, required)
+  with cover-chdb.out (chdb-tagged lane, optional) into cover-merged.out and
+  hands off to `coverage-summary.mjs`'s floor gate. Folds any
+  `cover-chdb-ratchet-*.out` sibling shard profiles (tsouza/cerberus#2645)
+  into cover-chdb.out first — erroring if shards exist with no cover-chdb.out
+  to fold into — then folds cover.out + cover-chdb.out together, or copies
+  cover.out alone when no chdb-tagged profile was produced, deciding the
+  `COVERAGE_LANES` value (`default+chdb` or `default`) it passes to
+  `coverage-summary.mjs`. Both folds go through `lib/coverage-fold.mjs`'s
+  `foldProfile()`/`writeFoldedProfile()`. Deliberately does NOT touch
+  `coverage-chdb`'s own recipe body: `test/regression/tagged_test_enrollment_test.go`
+  statically parses that exact bash as chdb-tagged test execution evidence,
+  and extracting it too needs enrollment-scanner changes tracked separately
+  as tsouza/cerberus#3113. `coverage-merge.test.mjs` is the `node --test`
+  guard, exercising the merge/fold mechanics with synthetic profiles (no
+  chDB needed).
+  - Env: none of its own; forwards the caller's environment plus a computed
+    `COVERAGE_LANES` to the `coverage-summary.mjs` subprocess it spawns.
+  - Exit: `1` if cover.out is missing/empty or a ratchet shard has no
+    cover-chdb.out to fold into; otherwise `coverage-summary.mjs`'s own exit
+    status.
 - **`coverage-summary.mjs`** — `coverage.yml`, invoked at the end of the `just
   coverage` recipe rather than as its own workflow step (so a local run gets the
   same verdict CI does). Renders the per-package coverage table into the step

--- a/.github/scripts/coverage-merge.mjs
+++ b/.github/scripts/coverage-merge.mjs
@@ -1,0 +1,121 @@
+// coverage-merge.mjs — merges cover.out (default-tag lane, required) with
+// cover-chdb.out (chdb-tagged lane, optional) into cover-merged.out and runs
+// the floor gate. Extracted from the `coverage-merge` Justfile recipe body
+// (CLAUDE.md invariant 15, issue #3095, epic #3091) — the recipe now reads
+// `coverage-merge:\n    @node .github/scripts/coverage-merge.mjs`, and every
+// awk `mode: set` fold this used to hand-copy now goes through the single
+// `foldProfile()`/`writeFoldedProfile()` implementation in
+// `lib/coverage-fold.mjs`.
+//
+// Reads whatever cover.out / cover-chdb.out already sit in `cwd`, so it
+// works equally after running `coverage-default` + `coverage-chdb` locally
+// in the same tree, or after a CI job downloads each lane's profile
+// artifact into one directory (tsouza/cerberus#2634) — either way the merge
+// is a fact about the files, not about how they got there.
+//
+// Two folds happen before the coverage-summary.mjs gate runs:
+//   1. cover-chdb-ratchet-*.out sibling shard profiles (tsouza/cerberus#2645
+//      moved TestCardinalityRatchet's extra shards out of `coverage-chdb`
+//      itself into their own CI matrix job) are folded INTO cover-chdb.out
+//      first, if any are present. A ratchet shard with no cover-chdb.out to
+//      fold into is an error, not a silent no-op — that combination can only
+//      mean the main sweep never ran at all.
+//   2. cover.out and cover-chdb.out (now including any folded-in ratchet
+//      shards) are folded together into cover-merged.out. Absent
+//      cover-chdb.out, cover-merged.out is just a copy of cover.out and the
+//      lane record says so (`default`, not `default+chdb`).
+//
+// The lane set decided here is handed to coverage-summary.mjs via
+// COVERAGE_LANES, which records it beside the profile as
+// cover-merged.out.lanes.json, bound to the profile's own SHA-256 — the ONLY
+// thing `update-coverage-floor` accepts as proof a profile carries both
+// lanes. This script is the one step that legitimately knows, because it is
+// the step that decided.
+//
+// Deliberately UNCHANGED by this extraction: `coverage-chdb`'s own
+// conditional `go test`/COVERAGE_REQUIRE_LANES gate stays literal Justfile
+// bash — test/regression/tagged_test_enrollment_test.go statically parses
+// that exact recipe body as execution evidence for the chdb-tagged test
+// tail, and test/regression/coverage_recipe_fail_closed_test.go counts its
+// `go test -timeout` invocations via `just --dump`. Moving that recipe's
+// control flow into a script would require rewriting both scanners — real,
+// separate work tracked as tsouza/cerberus#3113.
+//
+// Usage: node .github/scripts/coverage-merge.mjs
+// Exit: 1 if cover.out is missing/empty, or if ratchet shard files exist
+// with no cover-chdb.out to fold them into; otherwise the exit status of the
+// coverage-summary.mjs floor gate it hands off to.
+
+import { copyFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import process from 'node:process';
+
+import { error, log } from './lib/gh.mjs';
+import { writeFoldedProfile } from './lib/coverage-fold.mjs';
+
+const COVERAGE_SUMMARY_MJS = new URL('./coverage-summary.mjs', import.meta.url);
+const RATCHET_SHARD_PATTERN = /^cover-chdb-ratchet-.*\.out$/;
+
+function isNonEmptyFile(path) {
+  try {
+    return existsSync(path) && statSync(path).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+// ratchetShardFiles — the cover-chdb-ratchet-*.out sibling shard profiles
+// among `names` (a directory listing), sorted. Mirrors the replaced bash's
+// `shopt -s nullglob; RATCHET_FILES=(cover-chdb-ratchet-*.out)`: an empty
+// result when none are present, never the literal unmatched pattern.
+export function ratchetShardFiles(names) {
+  return names.filter((name) => RATCHET_SHARD_PATTERN.test(name)).sort();
+}
+
+// main — the recipe body. Every path is resolved against `cwd` (default
+// process.cwd()); `env` seeds the coverage-summary.mjs subprocess's
+// environment on top of process.env (a test-only hook — the CLI entry point
+// below always uses process.env). Returns the exit status the CLI should
+// use; never throws.
+export function main({ cwd = process.cwd(), env = process.env } = {}) {
+  const p = (name) => join(cwd, name);
+
+  if (!isNonEmptyFile(p('cover.out'))) {
+    error("cover.out not found — run 'just coverage-default' first");
+    return 1;
+  }
+
+  const ratchetFiles = ratchetShardFiles(readdirSync(cwd));
+  if (ratchetFiles.length > 0) {
+    if (!isNonEmptyFile(p('cover-chdb.out'))) {
+      error(`found ratchet shard profile(s) (${ratchetFiles.join(' ')}) but no cover-chdb.out to fold them into`);
+      return 1;
+    }
+    log(`==> folding cover-chdb.out with the ratchet shard profile(s): ${ratchetFiles.join(' ')}`);
+    writeFoldedProfile(p('cover-chdb.out'), [p('cover-chdb.out'), ...ratchetFiles.map(p)]);
+  }
+
+  let lanes;
+  if (isNonEmptyFile(p('cover-chdb.out'))) {
+    log('==> merging profiles');
+    writeFoldedProfile(p('cover-merged.out'), [p('cover.out'), p('cover-chdb.out')]);
+    lanes = 'default+chdb';
+  } else {
+    log('==> no chdb-tagged profile found, merged profile is default-tag only');
+    copyFileSync(p('cover.out'), p('cover-merged.out'));
+    lanes = 'default';
+  }
+
+  log('');
+  const res = spawnSync(process.execPath, [fileURLToPath(COVERAGE_SUMMARY_MJS)], {
+    stdio: 'inherit',
+    cwd,
+    env: { ...env, COVERAGE_LANES: lanes },
+  });
+  return res.status ?? 1;
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) process.exit(main());

--- a/.github/scripts/coverage-merge.test.mjs
+++ b/.github/scripts/coverage-merge.test.mjs
@@ -1,0 +1,133 @@
+// coverage-merge.test.mjs — node:test guard for the `coverage-merge`
+// recipe's extracted logic (CLAUDE.md invariant 15, issue #3095, epic
+// #3091): the cover.out precondition, the ratchet-shard fold and its own
+// precondition, the merge-vs-copy lane decision, and the handoff to the real
+// (already independently tested) coverage-summary.mjs gate — no chDB or
+// libchdb.so needed, since every fixture here is a synthetic profile.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { main, ratchetShardFiles } from './coverage-merge.mjs';
+
+test('ratchetShardFiles matches the cover-chdb-ratchet-*.out shape and ignores everything else, sorted', () => {
+  const names = ['cover.out', 'cover-chdb.out', 'cover-chdb-ratchet-3.out', 'cover-chdb-ratchet-2.out', 'notes.txt'];
+  assert.deepEqual(ratchetShardFiles(names), ['cover-chdb-ratchet-2.out', 'cover-chdb-ratchet-3.out']);
+});
+
+test('ratchetShardFiles is empty when no shard files are present (the nullglob shape)', () => {
+  assert.deepEqual(ratchetShardFiles(['cover.out', 'cover-chdb.out']), []);
+});
+
+function tmpDir() {
+  return mkdtempSync(join(tmpdir(), 'coverage-merge-test-'));
+}
+
+// An empty COVERAGE_FLOORS directory: the coverage-summary.mjs gate this
+// hands off to will report "no floor" problems for every package in the
+// profile and exit 1 — irrelevant here, since these tests only assert on
+// the MERGE mechanics (which files got written, and what lane record was
+// stamped), never on the floor-gate verdict itself.
+function floorlessEnv(dir) {
+  return { ...process.env, COVERAGE_FLOORS: join(dir, 'empty-floors') };
+}
+
+test('missing cover.out fails closed and writes nothing', () => {
+  const dir = tmpDir();
+  try {
+    const status = main({ cwd: dir, env: floorlessEnv(dir) });
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('empty cover.out is treated the same as missing (mirrors the replaced `test -s`)', () => {
+  const dir = tmpDir();
+  try {
+    writeFileSync(join(dir, 'cover.out'), '');
+    const status = main({ cwd: dir, env: floorlessEnv(dir) });
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a ratchet shard file with no cover-chdb.out to fold into fails closed', () => {
+  const dir = tmpDir();
+  try {
+    writeFileSync(join(dir, 'cover.out'), 'mode: set\nfoo.go:1.1,2.2 1 1\n');
+    writeFileSync(join(dir, 'cover-chdb-ratchet-2.out'), 'mode: set\nfoo.go:1.1,2.2 1 1\n');
+    const status = main({ cwd: dir, env: floorlessEnv(dir) });
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('no cover-chdb.out at all: cover-merged.out is a copy of cover.out, lane record says "default"', () => {
+  const dir = tmpDir();
+  try {
+    writeFileSync(join(dir, 'cover.out'), 'mode: set\nfoo.go:1.1,2.2 1 1\n');
+    main({ cwd: dir, env: floorlessEnv(dir) });
+    assert.equal(readFileSync(join(dir, 'cover-merged.out'), 'utf8'), 'mode: set\nfoo.go:1.1,2.2 1 1\n');
+    const record = JSON.parse(readFileSync(join(dir, 'cover-merged.out.lanes.json'), 'utf8'));
+    assert.equal(record.lanes, 'default');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cover.out + cover-chdb.out fold into cover-merged.out, lane record says "default+chdb"', () => {
+  const dir = tmpDir();
+  try {
+    writeFileSync(join(dir, 'cover.out'), 'mode: set\nfoo.go:1.1,2.2 1 1\nfoo.go:3.1,4.2 1 0\n');
+    writeFileSync(join(dir, 'cover-chdb.out'), 'mode: set\nfoo.go:1.1,2.2 1 0\nfoo.go:3.1,4.2 1 9\n');
+    main({ cwd: dir, env: floorlessEnv(dir) });
+    // Widest count per block, across both files.
+    assert.equal(
+      readFileSync(join(dir, 'cover-merged.out'), 'utf8'),
+      'mode: set\nfoo.go:1.1,2.2 1 1\nfoo.go:3.1,4.2 1 9\n',
+    );
+    const record = JSON.parse(readFileSync(join(dir, 'cover-merged.out.lanes.json'), 'utf8'));
+    assert.equal(record.lanes, 'default+chdb');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a ratchet shard is folded into cover-chdb.out BEFORE the cover.out merge', () => {
+  const dir = tmpDir();
+  try {
+    writeFileSync(join(dir, 'cover.out'), 'mode: set\nfoo.go:1.1,2.2 1 0\n');
+    writeFileSync(join(dir, 'cover-chdb.out'), 'mode: set\nfoo.go:1.1,2.2 1 0\n');
+    writeFileSync(join(dir, 'cover-chdb-ratchet-2.out'), 'mode: set\nfoo.go:1.1,2.2 1 5\n');
+    main({ cwd: dir, env: floorlessEnv(dir) });
+    assert.equal(readFileSync(join(dir, 'cover-chdb.out'), 'utf8'), 'mode: set\nfoo.go:1.1,2.2 1 5\n');
+    assert.equal(readFileSync(join(dir, 'cover-merged.out'), 'utf8'), 'mode: set\nfoo.go:1.1,2.2 1 5\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the coverage-summary.mjs handoff is genuinely reached: on a both-lane profile, an unfloored package fails the gate, not silently', () => {
+  // Proves main() does not swallow or bypass the downstream gate. A
+  // default-only profile's floor comparison is deliberately SKIPPED (with a
+  // notice) by coverage-summary.mjs itself — see its own module comment —
+  // so this needs a cover-chdb.out present too (lanes=default+chdb) for the
+  // comparison to actually run: an unfloored package is then its "unfloored
+  // package" failure mode (see its test suite), which can only fire if the
+  // subprocess actually ran against the file this wrote.
+  const dir = tmpDir();
+  try {
+    writeFileSync(join(dir, 'cover.out'), 'mode: set\nfoo.go:1.1,2.2 10 1\n');
+    writeFileSync(join(dir, 'cover-chdb.out'), 'mode: set\nfoo.go:1.1,2.2 10 1\n');
+    const status = main({ cwd: dir, env: floorlessEnv(dir) });
+    assert.equal(status, 1, 'an unfloored package on a both-lane profile must fail the gate, proving the handoff ran for real');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/lib/coverage-fold.mjs
+++ b/.github/scripts/lib/coverage-fold.mjs
@@ -1,0 +1,92 @@
+// coverage-fold.mjs — the `mode: set` union fold every coverage-lane profile
+// merge in the Justfile used to repeat as its own three-line awk pipeline.
+//
+// -coverpkg (see just/test.just's own comment on COVERAGE_RAPID_SEED and the
+// coverage lanes) makes every linked test binary emit a row for every block
+// it links, so a raw profile carries the same block many times over. The
+// fold keeps ONE row per block — the WIDEST execution count seen for it
+// anywhere — which is exactly `mode: set`'s definition and loses nothing a
+// floor gate cares about.
+//
+// Before this module, that fold was hand-copied three times in
+// just/test.just:
+//   - `_coverage-fold FILE` (a single-file, in-place fold `coverage-default`
+//     runs on cover.out right after writing it);
+//   - `coverage-merge`'s ratchet-shard fold (cover-chdb.out plus any
+//     cover-chdb-ratchet-*.out sibling shards, folded back into
+//     cover-chdb.out — tsouza/cerberus#2645);
+//   - `coverage-merge`'s own closing fold (cover.out + cover-chdb.out into
+//     cover-merged.out).
+// All three ran the identical awk one-liner over a different file list.
+// `foldProfile()` is that awk, written once (issue #3095, epic #3091);
+// `writeFoldedProfile()` is the read-fold-write-atomically wrapper both the
+// CLI below and coverage-merge.mjs call.
+//
+// CLI: node .github/scripts/lib/coverage-fold.mjs <out-file> <in-file...>
+// (an in-place fold, matching the replaced `_coverage-fold FILE` recipe,
+// simply repeats <out-file> as the sole <in-file>.)
+
+import { readFileSync, renameSync, writeFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const PROFILE_HEADER = 'mode: set';
+
+// parseProfileBody — yield [blockKey, count] pairs from one profile's raw
+// text, skipping its first line unconditionally (the "mode: set" header),
+// matching the replaced awk's `FNR==1{next}` — which skips a file's first
+// line by POSITION, not by checking its content.
+function parseProfileBody(text) {
+  const lines = text.split('\n');
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === '') continue;
+    const fields = line.trim().split(/\s+/);
+    if (fields.length < 3) continue;
+    const [block, numStmt, count] = fields;
+    rows.push([`${block} ${numStmt}`, Number(count)]);
+  }
+  return rows;
+}
+
+// foldProfile — fold N raw profile texts (each carrying its own "mode: set"
+// header) into one: one row per distinct block, the widest count kept, rows
+// sorted (matching the replaced pipeline's trailing `| sort`). Pure — no I/O.
+export function foldProfile(texts) {
+  const widest = new Map();
+  for (const text of texts) {
+    for (const [key, count] of parseProfileBody(text)) {
+      const current = widest.get(key);
+      if (current === undefined || count > current) widest.set(key, count);
+    }
+  }
+  const rows = [...widest.entries()].map(([key, count]) => `${key} ${count}`).sort();
+  return [PROFILE_HEADER, ...rows].join('\n') + '\n';
+}
+
+// writeFoldedProfile — read every path in `inPaths` fully into memory, fold
+// them, and write the result to `outPath`. `outPath` may be one of the
+// inputs (the in-place case): every input is read before anything is
+// written, and the write itself lands via a rename from a sibling temp file,
+// so a reader never observes a partially-written profile — the same
+// guarantee the replaced `... > FILE.folded && mv FILE.folded FILE` gave.
+export function writeFoldedProfile(outPath, inPaths) {
+  const texts = inPaths.map((p) => readFileSync(p, 'utf8'));
+  const folded = foldProfile(texts);
+  const tmpPath = `${outPath}.folding-${process.pid}`;
+  writeFileSync(tmpPath, folded);
+  renameSync(tmpPath, outPath);
+}
+
+function main() {
+  const [outPath, ...inPaths] = process.argv.slice(2);
+  if (!outPath || inPaths.length === 0) {
+    console.error('coverage-fold: usage: node coverage-fold.mjs <out-file> <in-file...>');
+    process.exit(1);
+  }
+  writeFoldedProfile(outPath, inPaths);
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) main();

--- a/.github/scripts/lib/coverage-fold.test.mjs
+++ b/.github/scripts/lib/coverage-fold.test.mjs
@@ -1,0 +1,96 @@
+// coverage-fold.test.mjs — node:test guard for the `mode: set` union fold
+// (CLAUDE.md invariant 15, issue #3095, epic #3091): the widest-count
+// dedup, the header-skip-by-position (not by content), the sorted output,
+// and the CLI's in-place / multi-file-merge shapes.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { foldProfile, writeFoldedProfile } from './coverage-fold.mjs';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const CLI = join(here, 'coverage-fold.mjs');
+
+test('foldProfile keeps the widest count per block across every input', () => {
+  const a = 'mode: set\nfoo.go:1.1,2.2 3 1\nfoo.go:3.1,4.2 1 5\n';
+  const b = 'mode: set\nfoo.go:1.1,2.2 3 7\nfoo.go:3.1,4.2 1 2\n';
+  const out = foldProfile([a, b]);
+  assert.equal(out, 'mode: set\nfoo.go:1.1,2.2 3 7\nfoo.go:3.1,4.2 1 5\n');
+});
+
+test('foldProfile sorts rows lexically, matching the replaced `| sort`', () => {
+  const text = 'mode: set\nzzz.go:1.1,2.2 1 1\naaa.go:1.1,2.2 1 1\n';
+  const out = foldProfile([text]);
+  assert.equal(out, 'mode: set\naaa.go:1.1,2.2 1 1\nzzz.go:1.1,2.2 1 1\n');
+});
+
+test('foldProfile skips the first line of EVERY input by position, whatever its content', () => {
+  // Mirrors awk's `FNR==1{next}`: the first line of a file is dropped even
+  // when — unlike a real profile — it happens to look like a data row.
+  const text = 'foo.go:1.1,2.2 3 9\nfoo.go:3.1,4.2 1 5\n';
+  const out = foldProfile([text]);
+  assert.equal(out, 'mode: set\nfoo.go:3.1,4.2 1 5\n');
+});
+
+test('foldProfile on a single-line (header-only) input yields no rows', () => {
+  assert.equal(foldProfile(['mode: set\n']), 'mode: set\n');
+});
+
+test('foldProfile de-duplicates a block repeated within the SAME input (the -coverpkg fan-out shape)', () => {
+  const text = 'mode: set\nfoo.go:1.1,2.2 3 0\nfoo.go:1.1,2.2 3 4\nfoo.go:1.1,2.2 3 2\n';
+  assert.equal(foldProfile([text]), 'mode: set\nfoo.go:1.1,2.2 3 4\n');
+});
+
+test('writeFoldedProfile folds two distinct files into a third', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'coverage-fold-test-'));
+  try {
+    const a = join(dir, 'a.out');
+    const b = join(dir, 'b.out');
+    const out = join(dir, 'merged.out');
+    writeFileSync(a, 'mode: set\nfoo.go:1.1,2.2 1 1\n');
+    writeFileSync(b, 'mode: set\nfoo.go:1.1,2.2 1 9\n');
+    writeFoldedProfile(out, [a, b]);
+    assert.equal(readFileSync(out, 'utf8'), 'mode: set\nfoo.go:1.1,2.2 1 9\n');
+    // Inputs are untouched.
+    assert.equal(readFileSync(a, 'utf8'), 'mode: set\nfoo.go:1.1,2.2 1 1\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeFoldedProfile folds a file IN PLACE (out path repeated as the sole input)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'coverage-fold-test-'));
+  try {
+    const file = join(dir, 'cover.out');
+    writeFileSync(file, 'mode: set\nfoo.go:1.1,2.2 1 3\nfoo.go:1.1,2.2 1 1\n');
+    writeFoldedProfile(file, [file]);
+    assert.equal(readFileSync(file, 'utf8'), 'mode: set\nfoo.go:1.1,2.2 1 3\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: node coverage-fold.mjs <out> <in...> folds and writes', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'coverage-fold-cli-test-'));
+  try {
+    const a = join(dir, 'a.out');
+    const b = join(dir, 'b.out');
+    const out = join(dir, 'merged.out');
+    writeFileSync(a, 'mode: set\nfoo.go:1.1,2.2 1 2\n');
+    writeFileSync(b, 'mode: set\nfoo.go:1.1,2.2 1 8\n');
+    execFileSync(process.execPath, [CLI, out, a, b]);
+    assert.equal(readFileSync(out, 'utf8'), 'mode: set\nfoo.go:1.1,2.2 1 8\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: missing arguments exits non-zero', () => {
+  assert.throws(() => execFileSync(process.execPath, [CLI], { stdio: 'pipe' }));
+  assert.throws(() => execFileSync(process.execPath, [CLI, '/tmp/out.out'], { stdio: 'pipe' }));
+});

--- a/.github/scripts/lib/regen-diff.mjs
+++ b/.github/scripts/lib/regen-diff.mjs
@@ -1,0 +1,63 @@
+// regen-diff.mjs — the closing "review this diff before committing" step
+// every `update-*-baseline` recipe (plus `gen-config-docs`, `bench-report`
+// and `migration-golden`) repeated as:
+//
+//     @echo
+//     @echo "Diff of regenerated <thing>:"
+//     @git --no-pager diff --stat <path...> || true
+//
+// twelve times over (`update-nightly-perf-baseline`, `update-coverage-floor`,
+// `update-parity-enrolment-baseline`, `update-parity-ledgers`,
+// `update-cardinality-baseline`, `update-solver-decision-baseline`,
+// `update-scale-wall-baseline`, `update-perf-smoke-baseline`,
+// `update-metadata-query-size-baseline`, `bench-report`, `gen-config-docs`,
+// `migration-golden`). `update-parity-enrolment-baseline` is the one
+// exception in that set: it prints the bare diff-stat with no banner at all
+// — `printDiffStat` matches that by treating an absent `label` as "no
+// banner", rather than forcing a thirteenth recipe to carry a label nothing
+// else needed. Issue #3095, epic #3091, CLAUDE.md invariant 15.
+//
+// `|| true` in the replaced idiom is deliberate and preserved here: the
+// diff-stat is purely informational, never a gate. Each recipe's own
+// regeneration step already exits before reaching this one on a real
+// failure, so `printDiffStat` never reflects git's own exit status and this
+// module's CLI always exits 0.
+//
+// CLI: node .github/scripts/lib/regen-diff.mjs [--label <label>] <path...>
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { git, log } from './gh.mjs';
+
+// printDiffStat — print `git --no-pager diff --stat <paths>`, optionally
+// preceded by a blank line and a "Diff of regenerated <label>:" banner.
+// `paths` is a path string or an array of them (`update-parity-ledgers`
+// diffs two directories at once). Never throws.
+export function printDiffStat(paths, label) {
+  const pathList = Array.isArray(paths) ? paths : [paths];
+  if (label) {
+    log('');
+    log(`Diff of regenerated ${label}:`);
+  }
+  const res = git(['--no-pager', 'diff', '--stat', ...pathList]);
+  const out = res.stdout.replace(/\n$/, '');
+  if (out) log(out);
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  let label;
+  let paths = argv;
+  if (argv[0] === '--label') {
+    label = argv[1];
+    paths = argv.slice(2);
+  }
+  if (paths.length === 0) {
+    console.error('regen-diff: usage: node regen-diff.mjs [--label <label>] <path...>');
+    process.exit(1);
+  }
+  printDiffStat(paths, label);
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) main();

--- a/.github/scripts/lib/regen-diff.test.mjs
+++ b/.github/scripts/lib/regen-diff.test.mjs
@@ -1,0 +1,117 @@
+// regen-diff.test.mjs — node:test guard for the shared "diff of regenerated
+// X" idiom (CLAUDE.md invariant 15, issue #3095, epic #3091). Runs the real
+// `git` binary against a throwaway repo so the assertions cover the actual
+// `git --no-pager diff --stat` behaviour the replaced Justfile lines relied
+// on, not a stubbed approximation of it.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const CLI = join(here, 'regen-diff.mjs');
+
+// gitRepoFixture — a throwaway repo with one committed file, so a caller can
+// modify it and get a real, non-empty `git diff --stat`.
+function gitRepoFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'regen-diff-test-'));
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir });
+  writeFileSync(join(dir, 'baseline.json'), 'one\ntwo\nthree\n');
+  execFileSync('git', ['add', 'baseline.json'], { cwd: dir });
+  execFileSync('git', ['commit', '-q', '-m', 'baseline'], { cwd: dir });
+  return dir;
+}
+
+function runCli(dir, args) {
+  return execFileSync(process.execPath, [CLI, ...args], { cwd: dir, encoding: 'utf8' });
+}
+
+test('with a label: prints a blank line, a "Diff of regenerated <label>:" banner, then the stat', () => {
+  const dir = gitRepoFixture();
+  try {
+    writeFileSync(join(dir, 'baseline.json'), 'one\ntwo\nthree\nfour\n');
+    const out = runCli(dir, ['--label', 'baseline', 'baseline.json']);
+    const lines = out.split('\n');
+    assert.equal(lines[0], '');
+    assert.equal(lines[1], 'Diff of regenerated baseline:');
+    assert.match(out, /baseline\.json\s*\|\s*1 \+/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a multi-word label is printed verbatim', () => {
+  const dir = gitRepoFixture();
+  try {
+    writeFileSync(join(dir, 'baseline.json'), 'one\ntwo\nthree\nfour\n');
+    const out = runCli(dir, ['--label', 'parity ledgers', 'baseline.json']);
+    assert.match(out, /^Diff of regenerated parity ledgers:$/m);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('without --label: prints the bare diff-stat, no banner at all (the update-parity-enrolment-baseline shape)', () => {
+  const dir = gitRepoFixture();
+  try {
+    writeFileSync(join(dir, 'baseline.json'), 'one\ntwo\nthree\nfour\n');
+    const out = runCli(dir, ['baseline.json']);
+    assert.doesNotMatch(out, /Diff of regenerated/);
+    assert.match(out, /baseline\.json\s*\|\s*1 \+/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a no-op regeneration (no diff) prints nothing beyond the banner', () => {
+  const dir = gitRepoFixture();
+  try {
+    const out = runCli(dir, ['--label', 'baseline', 'baseline.json']);
+    assert.equal(out, '\nDiff of regenerated baseline:\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('multiple paths are diffed together, matching update-parity-ledgers\' two-directory call', () => {
+  const dir = gitRepoFixture();
+  try {
+    writeFileSync(join(dir, 'a.json'), 'x\n');
+    writeFileSync(join(dir, 'b.json'), 'y\n');
+    execFileSync('git', ['add', 'a.json', 'b.json'], { cwd: dir });
+    execFileSync('git', ['commit', '-q', '-m', 'seed'], { cwd: dir });
+    writeFileSync(join(dir, 'a.json'), 'x\nx2\n');
+    writeFileSync(join(dir, 'b.json'), 'y\ny2\n');
+    const out = runCli(dir, ['--label', 'parity ledgers', 'a.json', 'b.json']);
+    assert.match(out, /a\.json/);
+    assert.match(out, /b\.json/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('exits 0 even though `git diff --stat` on an unmodified path prints nothing — matches `|| true`', () => {
+  const dir = gitRepoFixture();
+  try {
+    // No modification at all: exercises the never-throws, always-0-exit path.
+    execFileSync(process.execPath, [CLI, '--label', 'baseline', 'baseline.json'], { cwd: dir });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI: no path arguments exits non-zero', () => {
+  const dir = gitRepoFixture();
+  try {
+    assert.throws(() => execFileSync(process.execPath, [CLI], { cwd: dir, stdio: 'pipe' }));
+    assert.throws(() => execFileSync(process.execPath, [CLI, '--label', 'x'], { cwd: dir, stdio: 'pipe' }));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/perf-coverage-fanout.test.mjs
+++ b/.github/scripts/perf-coverage-fanout.test.mjs
@@ -26,6 +26,10 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 // split) — reading that one file directly, rather than the root file,
 // keeps this scan's plain-text recipe-boundary slicing working without
 // pulling in a `just --dump` dependency for this cheap check-lane script.
+// coverage-merge's OWN logic moved out of that recipe body entirely (issue
+// #3095, epic #3091, coverage-merge.mjs) — the assertions that used to slice
+// its Justfile text now read that module's source instead; see
+// coverageMergeScriptSource() below.
 const justfile = readFileSync(path.join(here, '..', '..', 'just', 'test.just'), 'utf8');
 const coverageWorkflow = readFileSync(path.join(here, '..', 'workflows', 'coverage.yml'), 'utf8');
 const TAGS = 'chdb,agpl_oracle,chdb_agpl_oracle';
@@ -39,12 +43,16 @@ function coverageChdbRecipeBody() {
   return justfile.slice(start, end);
 }
 
-/** The coverage-merge recipe body — where the ratchet shard fold now lives (tsouza/cerberus#2645). */
-function coverageMergeRecipeBody() {
-  const start = justfile.indexOf('\ncoverage-merge:\n');
-  const end = justfile.indexOf('\ncoverage:', start + 1);
-  assert.ok(start >= 0 && end >= 0 && end > start, 'Justfile: cannot isolate the coverage-merge recipe');
-  return justfile.slice(start, end);
+/**
+ * coverage-merge's own logic — where the ratchet shard fold now lives
+ * (tsouza/cerberus#2645). Issue #3095 (epic #3091) extracted the
+ * `coverage-merge` Justfile recipe body into coverage-merge.mjs, so this
+ * now reads that module's source directly rather than slicing just/test.just
+ * (whose `coverage-merge:` recipe is a one-line `node coverage-merge.mjs`
+ * call and carries none of this logic itself any more).
+ */
+function coverageMergeScriptSource() {
+  return readFileSync(path.join(here, 'coverage-merge.mjs'), 'utf8');
 }
 
 /** The `timeout-minutes:` of a named coverage.yml job. */
@@ -173,13 +181,18 @@ test('the coverage-chdb recipe main sweep never carries -skip — it is the sole
   );
 });
 
-test('the coverage-merge recipe folds cover-chdb.out together with every extra shard profile before merging with cover.out', () => {
-  const body = coverageMergeRecipeBody();
-  assert.match(body, /cover-chdb\.out "\$\{RATCHET_FILES\[@\]\}"/);
+test('coverage-merge.mjs folds cover-chdb.out together with every extra shard profile before merging with cover.out', () => {
+  const src = coverageMergeScriptSource();
   assert.match(
-    body,
-    /RATCHET_FILES=\(cover-chdb-ratchet-\*\.out\)/,
-    'coverage-merge must look for the ratchet shard profiles wherever they landed — coverage-chdb no longer ' +
+    src,
+    /writeFoldedProfile\(p\('cover-chdb\.out'\), \[p\('cover-chdb\.out'\), \.\.\.ratchetFiles\.map\(p\)\]\)/,
+    'coverage-merge.mjs must fold cover-chdb.out together with the ratchet shard files it found, in place, ' +
+      'before the cover.out+cover-chdb.out merge below it',
+  );
+  assert.match(
+    src,
+    /RATCHET_SHARD_PATTERN = \/\^cover-chdb-ratchet-\.\*\\\.out\$\//,
+    'coverage-merge.mjs must look for the ratchet shard profiles wherever they landed — coverage-chdb no longer ' +
       'always shares a directory with them (tsouza/cerberus#2645)',
   );
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,6 +674,13 @@ jobs:
           node --test .github/scripts/e2e-seed-rolling.test.mjs
           node --test .github/scripts/e2e-seed-stop.test.mjs
           node --test .github/scripts/e2e-chaos-overlay.test.mjs
+      # Baseline diff-stat helper extraction (#3095, epic #3091): the
+      # shared `git --no-pager diff --stat` banner every update-*-baseline /
+      # gen-config-docs / bench-report / migration-golden recipe now calls
+      # instead of repeating it. Self-test only here — the 12 recipes
+      # themselves are what a real regeneration run exercises this against.
+      - name: Self-test the regen-diff helper
+        run: node --test .github/scripts/lib/regen-diff.test.mjs
       # The updater itself is workflow_dispatch-only. Its controller remains
       # ordinary repository code, so its pure unit/round-trip contract belongs
       # on the existing PR policy lane without exposing the updater to PR events.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -267,6 +267,8 @@ jobs:
           node --test .github/scripts/coverage-aggregate.test.mjs
           node --test .github/scripts/coverage-verdict.test.mjs
           node --test .github/scripts/perf-coverage-fanout.test.mjs
+          node --test .github/scripts/lib/coverage-fold.test.mjs
+          node --test .github/scripts/coverage-merge.test.mjs
 
       # Computed as a step output rather than a static job-level `env:` GHA
       # expression: a `push` event needs a network call (resolve the source PR

--- a/just/e2e.just
+++ b/just/e2e.just
@@ -359,9 +359,7 @@ migration-scenarios out="build/migration-scenarios.json":
 migration-golden:
     @echo "==> regenerating the tier-0 migration goldens"
     MIGRATION_UPDATE_GOLDENS=1 go test -tags=migration ./test/e2e/migration/tiers/tier0-offline/... -count=1
-    @echo
-    @echo "Diff of regenerated goldens:"
-    @git --no-pager diff --stat test/e2e/migration/archetypes/ || true
+    @node .github/scripts/lib/regen-diff.mjs --label goldens test/e2e/migration/archetypes/
 
 # Run the startup-speed benchmark: spawn cerberus and measure wall-clock
 # time from process-start to first 200 OK on /healthz. Asserts < 2.5 s.

--- a/just/test.just
+++ b/just/test.just
@@ -387,9 +387,7 @@ ts-grid-instant-memory-integration:
 update-nightly-perf-baseline:
     @just _pull-retry {{CH_TEST_IMAGE}}
     UPDATE_NIGHTLY_PERF_BASELINE=1 go test -timeout 15m -tags=integration -count=1 -run TestPerfNightlyRealCH ./test/perf/nightly/...
-    @echo
-    @echo "Diff of regenerated baseline:"
-    @git --no-pager diff --stat test/perf/nightly-baseline.json || true
+    @node .github/scripts/lib/regen-diff.mjs --label baseline test/perf/nightly-baseline.json
 
 # Run #2437's periodic self-check: deliberately breaks two real
 # memory-bounding mechanisms (the #2429 fanout resource bound, the spill
@@ -651,9 +649,12 @@ COVERAGE_RAPID_SEED := "20260903"
 # repeats where the useful content is ~2 MB. One row per block, keeping the
 # widest count, is `mode: set`'s union and loses nothing — it is the same
 # fold `coverage-merge` does, just applied a step earlier, so the on-disk
-# file and the uploaded artifact stay the size they were.
+# file and the uploaded artifact stay the size they were. The fold itself is
+# `foldProfile()` in `.github/scripts/lib/coverage-fold.mjs` (issue #3095) —
+# the one implementation this recipe and `coverage-merge`'s own two folds
+# all share, rather than three hand-copies of the same awk.
 _coverage-fold FILE:
-    @{ echo "mode: set"; awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' {{FILE}} | sort; } > {{FILE}}.folded && mv {{FILE}}.folded {{FILE}}
+    @node .github/scripts/lib/coverage-fold.mjs {{FILE}} {{FILE}}
 
 # Default-tag coverage lane: writes cover.out. Split out of the chdb-tagged
 # lane (below) and the merge/gate step (`coverage-merge`) so CI can shard the
@@ -783,45 +784,17 @@ coverage-chdb:
 # own SHA-256. That record is the ONLY thing `update-coverage-floor` will accept
 # as proof that a profile carries both lanes — this recipe is the one step that
 # legitimately knows, because it is the step that decided.
+#
+# Extracted to .github/scripts/coverage-merge.mjs (issue #3095, epic #3091) —
+# see that module's header for the ratchet-shard fold and the merge-vs-copy
+# lane decision. `coverage-chdb`'s own recipe body stays untouched bash:
+# test/regression/tagged_test_enrollment_test.go statically parses its exact
+# shell text as chdb-tagged test execution evidence. Extracting it too is
+# tracked separately as tsouza/cerberus#3113.
 
 # Merge the two lane profiles into cover-merged.out and run the floor gate.
 coverage-merge:
-    @test -s cover.out || { echo "error: cover.out not found — run 'just coverage-default' first" >&2; exit 1; }
-    # Fold TestCardinalityRatchet's extra shard profiles (cover-chdb-ratchet-
-    # *.out) into cover-chdb.out first, BEFORE the cover.out+cover-chdb.out
-    # merge below. tsouza/cerberus#2645 moved these files' origin out of
-    # `coverage-chdb` itself (where this fold used to run immediately after
-    # writing them) into their own `coverage-chdb-ratchet` CI matrix job, so
-    # they no longer always share a directory with cover-chdb.out at the
-    # moment it is produced — a local `just coverage` still leaves them
-    # sitting right here, but in CI they only converge here, in the
-    # `coverage` aggregator job, after it downloads every lane's artifact
-    # into one directory. `shopt -s nullglob` (rather than a bare `-e` test)
-    # is what makes an unmatched `cover-chdb-ratchet-*.out` glob expand to
-    # NOTHING instead of the literal pattern string, which would otherwise
-    # hand awk a "file" it can never open.
-    @shopt -s nullglob; \
-    RATCHET_FILES=(cover-chdb-ratchet-*.out); \
-    if [ ${#RATCHET_FILES[@]} -gt 0 ]; then \
-        test -s cover-chdb.out || { echo "error: found ratchet shard profile(s) (${RATCHET_FILES[*]}) but no cover-chdb.out to fold them into" >&2; exit 1; }; \
-        echo "==> folding cover-chdb.out with the ratchet shard profile(s): ${RATCHET_FILES[*]}"; \
-        { echo "mode: set"; \
-          awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' cover-chdb.out "${RATCHET_FILES[@]}" | sort; \
-        } > cover-chdb.out.folded && mv cover-chdb.out.folded cover-chdb.out; \
-    fi
-    @if [ -s cover-chdb.out ]; then \
-        echo "==> merging profiles"; \
-        { echo "mode: set"; \
-          awk 'FNR==1{next} { k=$1" "$2; if (!(k in m) || $3>m[k]) m[k]=$3 } END { for (k in m) print k, m[k] }' cover.out cover-chdb.out | sort; \
-        } > cover-merged.out; \
-        LANES=default+chdb; \
-    else \
-        echo "==> no chdb-tagged profile found, merged profile is default-tag only"; \
-        cp cover.out cover-merged.out; \
-        LANES=default; \
-    fi; \
-    echo; \
-    COVERAGE_LANES="$LANES" node .github/scripts/coverage-summary.mjs
+    @node .github/scripts/coverage-merge.mjs
 
 # Generate the coverage profile and hold it to the committed per-package
 # floors, chaining the three recipes above: `coverage-default` writes
@@ -873,9 +846,7 @@ coverage: coverage-default coverage-chdb coverage-merge
 update-coverage-floor:
     @test -s cover-merged.out || { echo "error: cover-merged.out not found — run 'just coverage' first; the floors are derived from the profile it writes" >&2; exit 1; }
     @COVERAGE_UPDATE_FLOORS=1 node .github/scripts/coverage-summary.mjs
-    @echo
-    @echo "Diff of regenerated floors:"
-    @git --no-pager diff --stat test/coverage-floor/ || true
+    @node .github/scripts/lib/regen-diff.mjs --label floors test/coverage-floor/
 
 # Regenerate the exact per-head roster of TXTAR fixtures carrying a live
 # reference parity contract. The assertion mode never writes; this recipe is
@@ -884,7 +855,7 @@ update-coverage-floor:
 # Regenerate the per-head roster of fixtures carrying a live parity contract.
 update-parity-enrolment-baseline:
     UPDATE_PARITY_ENROLMENT_BASELINE=1 go test -count=1 -run '^TestParityEnrolmentBaseline$' ./test/regression
-    @git --no-pager diff --stat test/regression/parity-enrolment-baselines/ || true
+    @node .github/scripts/lib/regen-diff.mjs test/regression/parity-enrolment-baselines/
 
 # Regenerate the fixture-derived artefacts named by SHARD, one or more of:
 #
@@ -1016,9 +987,7 @@ update-golden *shards:
 # Regenerate the parser-surface and rejection parity ledgers.
 update-parity-ledgers: update-parity-enrolment-baseline
     CERBERUS_UPDATE_INVENTORY=1 go test -count=1 ./test/surface-parity/ ./test/rejection-parity/
-    @echo
-    @echo "Diff of regenerated parity ledgers:"
-    @git --no-pager diff --stat test/surface-parity/ test/rejection-parity/ || true
+    @node .github/scripts/lib/regen-diff.mjs --label "parity ledgers" test/surface-parity/ test/rejection-parity/
 
 CARDINALITY_BASELINE_TIMEOUT := "60m"
 
@@ -1043,9 +1012,7 @@ CARDINALITY_BASELINE_TIMEOUT := "60m"
 # Regenerate the cardinality / fan-factor ratchet baseline. Slow; needs libchdb.so.
 update-cardinality-baseline:
     @CHDB_INSTALL_PATH="{{CHDB_INSTALL_PATH}}" CARDINALITY_BASELINE_TIMEOUT="{{CARDINALITY_BASELINE_TIMEOUT}}" node .github/scripts/cardinality-baseline-update.mjs
-    @echo
-    @echo "Diff of regenerated baseline:"
-    @git --no-pager diff --stat test/perf/cardinality-baseline/ || true
+    @node .github/scripts/lib/regen-diff.mjs --label baseline test/perf/cardinality-baseline/
 
 # Regenerate the routing-DECISION ratchet baseline (perf-assessment
 # Component D) from the current PromQL corpus. Parses every `-- query.promql --`
@@ -1066,9 +1033,7 @@ update-cardinality-baseline:
 # Regenerate the routing-decision ratchet baseline. Pure Go; review the diff.
 update-solver-decision-baseline:
     UPDATE_SOLVER_DECISION_BASELINE=1 go test -count=1 -run TestSolverDecisionRatchet ./test/perf/
-    @echo
-    @echo "Diff of regenerated baseline:"
-    @git --no-pager diff --stat test/perf/solver-decision-baseline/ || true
+    @node .github/scripts/lib/regen-diff.mjs --label baseline test/perf/solver-decision-baseline/
 
 # Regenerate the SCALE-WALL pin baseline — the perf guard for the wall /
 # scan-amplification regression classes the cardinality ratchet is blind to
@@ -1089,9 +1054,7 @@ update-solver-decision-baseline:
 update-scale-wall-baseline:
     @test -f "{{CHDB_INSTALL_PATH}}" || { echo "error: {{CHDB_INSTALL_PATH}} not found — run 'just chdb-install' first; the scale-wall bounds are measured by an in-process chDB run" >&2; exit 1; }
     UPDATE_SCALE_WALL_BASELINE=1 go test -tags chdb -count=1 -run TestScaleWallPin ./test/perf/
-    @echo
-    @echo "Diff of regenerated baseline:"
-    @git --no-pager diff --stat test/perf/scale-wall-baseline.json || true
+    @node .github/scripts/lib/regen-diff.mjs --label baseline test/perf/scale-wall-baseline.json
 
 # Regenerate the PERF-SMOKE baseline (#2370 PR 1) — the committed per-sentinel
 # memory ceilings the real-ClickHouse sentinel differential asserts against.
@@ -1111,9 +1074,7 @@ update-perf-smoke-baseline:
     @# Second tier — see the perf-smoke-integration recipe for why.
     @just _pull-retry {{CH_STRICT_SCAN_IMAGE}}
     UPDATE_PERF_SMOKE_BASELINE=1 go test -timeout 20m -tags=integration -count=1 -run TestPerfSmokeRealCH ./test/perf/smoke/...
-    @echo
-    @echo "Diff of regenerated baseline:"
-    @git --no-pager diff --stat test/perf/perf-smoke-baseline.json || true
+    @node .github/scripts/lib/regen-diff.mjs --label baseline test/perf/perf-smoke-baseline.json
 
 # Regenerate the METADATA QUERY-SIZE budget — the perf guard for the rendered
 # SIZE of the combined /api/v1/series query, the axis the cardinality and
@@ -1133,9 +1094,7 @@ update-perf-smoke-baseline:
 # Regenerate the metadata query-size budget. Pure Go; review the diff.
 update-metadata-query-size-baseline:
     UPDATE_METADATA_QUERY_SIZE_BASELINE=1 go test -count=1 -run TestMetadataQuerySizeRatchet ./test/perf/
-    @echo
-    @echo "Diff of regenerated baseline:"
-    @git --no-pager diff --stat test/perf/metadata-query-size-baseline.json || true
+    @node .github/scripts/lib/regen-diff.mjs --label baseline test/perf/metadata-query-size-baseline.json
 
 # Regenerate the publishable benchmark document (docs/benchmarks.md) from
 # LIVE measurements: optimizer before/after wins, per-construct scaling
@@ -1157,9 +1116,7 @@ update-metadata-query-size-baseline:
 bench-report:
     @test -f "{{CHDB_INSTALL_PATH}}" || { echo "error: {{CHDB_INSTALL_PATH}} not found — run 'just chdb-install' first; the benchmark document is generated by an in-process chDB measurement pass" >&2; exit 1; }
     go run -tags chdb ./cmd/bench-report -out docs/benchmarks.md
-    @echo
-    @echo "Diff of regenerated benchmark document:"
-    @git --no-pager diff --stat docs/benchmarks.md || true
+    @node .github/scripts/lib/regen-diff.mjs --label "benchmark document" docs/benchmarks.md
 
 # Regenerate docs/configuration.md from the single source of truth in
 # internal/config: the CERBERUS_* env-key metadata (config.EnvDocs) and the
@@ -1172,7 +1129,5 @@ bench-report:
 # Regenerate docs/configuration.md from the internal/config env metadata and defaults.
 gen-config-docs:
     go run ./cmd/cerberus config-docs -out docs/configuration.md
-    @echo
-    @echo "Diff of regenerated configuration document:"
-    @git --no-pager diff --stat docs/configuration.md || true
+    @node .github/scripts/lib/regen-diff.mjs --label "configuration document" docs/configuration.md
 


### PR DESCRIPTION
### What

Extracts the coverage family's duplicated Justfile logic into `.github/scripts/*.mjs`,
per invariant 15 (epic #3091):

- **`.github/scripts/lib/coverage-fold.mjs`** (`foldProfile()` / `writeFoldedProfile()`) —
  the `mode: set` union fold (widest execution count per coverage block, sorted) that used
  to be hand-copied three times: the private `_coverage-fold` recipe's single-file
  in-place fold, `coverage-merge`'s ratchet-shard fold, and `coverage-merge`'s own
  cover.out+cover-chdb.out merge fold. All three now call this one implementation.
- **`.github/scripts/coverage-merge.mjs`** — the full `coverage-merge` recipe body: the
  `cover.out` precondition, the ratchet-shard fold and its own precondition, the
  merge-vs-copy lane decision (`default+chdb` vs `default`), and the handoff to
  `coverage-summary.mjs`'s floor gate.
- **`.github/scripts/lib/regen-diff.mjs`** (`printDiffStat(paths, label)`) — the
  `@echo` / `@echo "Diff of regenerated <thing>:"` / `@git --no-pager diff --stat
  <path...> || true` idiom, duplicated across all 12 named recipes:
  `update-nightly-perf-baseline`, `update-coverage-floor`,
  `update-parity-enrolment-baseline`, `update-parity-ledgers`,
  `update-cardinality-baseline`, `update-solver-decision-baseline`,
  `update-scale-wall-baseline`, `update-perf-smoke-baseline`,
  `update-metadata-query-size-baseline`, `bench-report`, `gen-config-docs`,
  `migration-golden`. An absent `label` reproduces
  `update-parity-enrolment-baseline`'s one exception — the bare diff-stat with no
  banner at all.

### Deliberate scope decision: `coverage-chdb.mjs` not extracted

The issue's scope also named `coverage-chdb.mjs`. Investigation found this unsafe to do
as a mechanical extraction: `coverage-chdb`'s recipe body (the `if [ -e libchdb.so ]`
conditional, the `go test -tags chdb,agpl_oracle,chdb_agpl_oracle ...` invocation, and the
closing `COVERAGE_REQUIRE_LANES` gate) is not just executed by `just` — its **literal
shell text** is statically parsed as chdb-tagged test execution evidence by three
regression tests:

- `test/regression/tagged_test_enrollment_test.go`'s `taggedCoverageChdbLaneIsFailClosed`
  parses the exact conditional/gate text, and this recipe is the **sole CI evidence** for
  a long tail of other chdb-tagged packages.
- `test/regression/coverage_recipe_fail_closed_test.go`'s
  `TestCoverageRecipeFailsClosedOnGoTestFailure` counts `go test -timeout` occurrences
  across `coverage-default` + `coverage-chdb` + `coverage-merge` via `just --dump` and
  asserts none carry `|| true`.
- `test/regression/rapid_seed_pin_test.go` asserts both `coverage-default` and
  `coverage-chdb`'s bodies literally carry `CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}}`.

Moving the `go test` invocation into a `.mjs` script drops that text from `just --dump`
entirely, breaking all three. The enrollment scanner does support a "script" entrypoint
kind (used today for `migration-e2e.mjs`), but it's hand-wired per script across ~100
lines of that test file, not a generic mechanism — wiring `coverage-chdb.mjs` into it is
real, separate work. Filed as **#3113** and cited from both `coverage-merge.mjs`'s header
and the `coverage-merge` recipe's comment.

`coverage-merge.mjs` itself carries none of this risk: its recipe body has zero `go test`
invocations and is referenced by name in none of those three scanners (verified by
grep), so extracting it in full is safe.

### Verified locally

- `node --check` on every new/touched `.mjs` file.
- `node --test` on all three new suites (`lib/coverage-fold.test.mjs`,
  `lib/regen-diff.test.mjs`, `coverage-merge.test.mjs`) — 24 cases, all passing, using
  synthetic profile/git fixtures (no chDB needed for the pure fold/diff-stat logic).
- `node --test .github/scripts/perf-coverage-fanout.test.mjs` — updated to read
  `coverage-merge.mjs`'s source instead of slicing the now-trivial Justfile recipe body;
  all 13 cases pass.
- `node .github/scripts/verify-just-invocations.mjs` — zero broken invocations.
- `node .github/scripts/assert-gate-suites-wired.mjs` — all three new suites wired
  (`coverage.yml`'s `coverage-plan` job for the two coverage-specific ones,
  `ci.yml`'s `forbid-skip` job for the general-purpose `regen-diff.test.mjs`).
- `go test ./test/regression/...` — full package green, including
  `TestCoverageRecipeFailsClosedOnGoTestFailure`, `TestRapidSeedPin*`,
  `TestEveryTaggedTestHasAnExecutingLane`, and `TestJustfileRecipeDescriptionsAreSummaries`
  (caught and fixed a `just --list` description-block regression on `coverage-merge`
  during review).
- `just _coverage-fold` and `just coverage-merge` end to end against synthetic
  `cover.out`/`cover-chdb.out` fixtures at the repo root: correct widest-count fold,
  correct `default+chdb` vs `default` lane record, correct fail-closed behavior on a
  missing `cover.out` and on an orphaned ratchet-shard file.
- Each of the 12 diff-stat recipes' new one-line tail, spot-checked directly
  (`node .github/scripts/lib/regen-diff.mjs [--label ...] <path...>`) against a real
  modified file and against a real no-op: output byte-identical to the replaced bash.
- `actionlint` and `markdownlint-cli2` on the touched workflow/README files.
- `forbid-deferral.mjs`'s `DEFERRAL_MARKERS` regexes run against every added line by
  hand (the gate itself needs PR/API context this worktree doesn't have) — no marker
  fires.

### Not verified locally (legitimate chDB/CI-only carve-out)

- `just coverage` end to end with a **real** chDB-tagged profile (needs `libchdb.so` +
  the full test corpus) — the merge/fold *mechanics* are covered by the synthetic-fixture
  tests above and the manual end-to-end run against hand-written profiles; a real chdb
  lane run is what `coverage.yml`'s CI job exercises this against.
- `golangci-lint` — per this repo's own documented unreliability in an agent worktree
  (reports clean without analyzing); only CI's `lint` job is evidence, and no Go source
  changed in this PR regardless.

Closes #3095
