### PR TITLE
refactor(justfile): dedupe and complete release-section extraction

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1394,22 +1394,48 @@ what actually runs.
     unrecognised `release:` label or an unsupported event.
 - **`prepare-release.mjs`** — `prepare-release.yml`, the release-staging
     workflow (`workflow_dispatch` or an `issues: labeled` `release:*` trigger;
-    see `resolve-release-trigger.mjs`). Bumps the chart `version:` + `appVersion:`, the image tag, and the
-    Artifact Hub `changes` annotation, and rewrites the CHANGELOG `[Unreleased]`
-    section into a dated `## [vX.Y.Z]` one — deriving the change summary and the
-    PR body from the conventional commits since the last `v*` tag. The commit
-    history is the single source of truth: the generated section is always what
-    lands and any stale `[Unreleased]` content is discarded (maintainers enrich
-    the prose by editing the opened PR, not by hand-staging `[Unreleased]`). Pure
-    exported helpers (`bumpSemver`, `parseCommits`, `renderChangelogSection`,
-    `renderAhChanges`, `editChart`, `editChangelog`) + a `--self-test` flag the
-    workflow runs before it edits anything.
+    see `resolve-release-trigger.mjs`); also `just release-prep` /
+    `just release-prep-backport` (`just/release.just`), the same staging logic
+    run for a controlled local cut. Bumps the chart `version:` + `appVersion:`,
+    the image tag, and the Artifact Hub `changes` annotation, and rewrites the
+    CHANGELOG `[Unreleased]` section into a dated `## [vX.Y.Z]` one — deriving
+    the change summary and the PR body from the conventional commits since the
+    last `v*` tag. The commit history is the single source of truth: the
+    generated section is always what lands and any stale `[Unreleased]` content
+    is discarded (maintainers enrich the prose by editing the opened PR, not by
+    hand-staging `[Unreleased]`). Pure exported helpers (`bumpSemver`,
+    `parseCommits`, `renderChangelogSection`, `renderAhChanges`, `editChart`,
+    `editChangelog`, `releaseBranchName`, `releaseCommitMessage`,
+    `isMaintenanceBranch`) + a `--self-test` flag the workflow runs before it
+    edits anything.
+    `RENDER_HELM_DOCS=1` and `REQUIRE_MAINTENANCE_BRANCH=1` are the two Justfile
+    recipes' own logic folded in here (CLAUDE.md invariant 15, issue #3100,
+    epic #3091): the `awk '/^version:/{print $2; exit}'` chart-version read and
+    the `docker run … jnorwood/helm-docs …` README regeneration were duplicated
+    verbatim across both recipe bodies, and this file already computes
+    `chartVersion` in-process — re-reading it from the file it had just written
+    was pure duplication, not merely duplicated text. `renderHelmDocs()`
+    acquires the pinned `jnorwood/helm-docs:v1.14.2` image through
+    `pullImageWithRetry` (`./lib/registry.mjs`) before running it, the same
+    transport-retry / rate-limit-fails-fast policy every other docker-driving
+    script in this directory uses (issue #1562). `release-prep-backport`'s
+    branch-detection guard (a shell `case "$(git rev-parse --abbrev-ref HEAD)"
+    in release/*.x) …esac`) moves the same way, checked BEFORE any file is
+    touched. `release_branch` / `commit_message` are additionally emitted so
+    neither recipe re-derives the staging branch name or the commit/PR-title
+    string (the two were always the identical literal) by hand.
   - Env: `VERSION` (explicit target appVersion; overrides `BUMP`), `BUMP`
     (`patch`|`minor`|`major`, or the workflow's `none` placeholder),
     `CHART_BUMP` (default `patch`), `PR_BODY_FILE` (default `release-pr-body.md`),
-    `GITHUB_OUTPUT` (runner-provided; sets `new_version` / `chart_version`).
+    `RENDER_HELM_DOCS` (`1` to regenerate the chart README after the Chart.yaml
+    edit; default: skip — the workflow instead runs its own `helm-docs`
+    Actions step), `REQUIRE_MAINTENANCE_BRANCH` (`1` to fail before touching
+    any file unless HEAD is on a `release/*.x` branch; default: no check),
+    `GITHUB_OUTPUT` (runner-provided / a local temp file; sets `new_version` /
+    `chart_version` / `release_branch` / `commit_message`).
   - Exit: `0` after staging the files (or a green self-test), `1` on a bad /
-    missing version input or a malformed Chart.yaml / CHANGELOG.
+    missing version input, a malformed Chart.yaml / CHANGELOG, a failed
+    `REQUIRE_MAINTENANCE_BRANCH` check, or a failed helm-docs acquisition/run.
 - **`chart-publish.mjs`** — `release.yml`, the `chart-release` job. Three
   subcommands (argv[2]): `version-gate` compares the local Chart.yaml
   `version:` against the latest chart tag in the OCI registry and sets the

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1414,11 +1414,19 @@ what actually runs.
     the `docker run … jnorwood/helm-docs …` README regeneration were duplicated
     verbatim across both recipe bodies, and this file already computes
     `chartVersion` in-process — re-reading it from the file it had just written
-    was pure duplication, not merely duplicated text. `renderHelmDocs()`
+    was pure duplication, not merely duplicated text. `RENDER_HELM_DOCS=1`
+    calls `renderHelmDocs()` from `./lib/helm-docs.mjs` — split out of this
+    file rather than kept inline, so `verify-changelog-fresh.mjs` (which
+    imports this file's changelog helpers only) is not read as an
+    image-acquiring script by `assert-image-jobs-authenticate.mjs`, which
+    follows every relative import a module has, transitively. `renderHelmDocs`
     acquires the pinned `jnorwood/helm-docs:v1.14.2` image through
     `pullImageWithRetry` (`./lib/registry.mjs`) before running it, the same
     transport-retry / rate-limit-fails-fast policy every other docker-driving
-    script in this directory uses (issue #1562). `release-prep-backport`'s
+    script in this directory uses (issue #1562); `prepare-release.yml`'s
+    `prepare` job logs in to ghcr.io + Docker Hub ahead of it (folding in the
+    workflow's own separate `uses: docker://jnorwood/helm-docs:…` step, which
+    ran this same regeneration unauthenticated). `release-prep-backport`'s
     branch-detection guard (a shell `case "$(git rev-parse --abbrev-ref HEAD)"
     in release/*.x) …esac`) moves the same way, checked BEFORE any file is
     touched. `release_branch` / `commit_message` are additionally emitted so

--- a/.github/scripts/lib/helm-docs.mjs
+++ b/.github/scripts/lib/helm-docs.mjs
@@ -1,0 +1,63 @@
+// lib/helm-docs.mjs — the one place this repo runs the containerized
+// helm-docs image, extracted out of prepare-release.mjs (#3100) so that
+// module's changelog/version utilities stay import-safe for a consumer that
+// has no business acquiring a Docker image.
+//
+// verify-changelog-fresh.mjs imports prepare-release.mjs for its changelog
+// helpers alone, and pr-hygiene.yml's `pr-body` job runs it unauthenticated
+// (it never touches a registry). assert-image-jobs-authenticate.mjs follows
+// a module's relative imports to attribute what a job acquires, so keeping
+// the docker-run call in the SAME file as those changelog helpers made every
+// consumer of that file — including one that never runs it — look like it
+// acquires the helm-docs image too. Isolating the image-acquiring code in
+// its own module means only prepare-release.mjs (the one caller that
+// actually needs it, gated behind RENDER_HELM_DOCS=1) imports this file, and
+// the authentication requirement lands on exactly the job that needs it:
+// prepare-release.yml's `prepare` job.
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+import { pullImageWithRetry } from './registry.mjs'
+
+export const HELM_DOCS_IMAGE = 'jnorwood/helm-docs:v1.14.2'
+
+const HELM_CHART_SEARCH_ROOT = 'deploy/helm'
+const HELM_DOCS_TEMPLATE = 'README.md.gotmpl'
+
+// renderHelmDocs regenerates the chart README via the same containerized
+// helm-docs both `just release-prep` and `just release-prep-backport` ran
+// inline, against the Chart.yaml prepare-release.mjs has already rewritten.
+// `cwd` (default `process.cwd()`, i.e. the repo root every caller runs this
+// script from) is the volume mount source, matching the replaced recipes'
+// own `$PWD/deploy/helm`.
+//
+// `docker run` pulls a missing image itself, single-attempt, so a Docker Hub
+// blip or a quota refusal would have surfaced here as an opaque container
+// start failure — the same class of fault issue #1562 fixed everywhere else
+// a script drives docker directly (promql-surface-gate.mjs's reference
+// Prometheus, migration-artifact.mjs's release image). `pullImageWithRetry`
+// acquires the image through the shared transport-retry / rate-limit-fails-
+// fast policy first, so this site is judged the identical way.
+export function renderHelmDocs(cwd = process.cwd()) {
+  if (!pullImageWithRetry(HELM_DOCS_IMAGE, { consequence: 'the chart README cannot be regenerated' })) {
+    throw new Error(`could not acquire the helm-docs image ${HELM_DOCS_IMAGE}`)
+  }
+
+  const res = spawnSync(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '-v',
+      `${cwd}/${HELM_CHART_SEARCH_ROOT}:/helm-docs`,
+      '-u',
+      String(process.getuid()),
+      HELM_DOCS_IMAGE,
+      '--chart-search-root=/helm-docs',
+      `--template-files=${HELM_DOCS_TEMPLATE}`,
+    ],
+    { stdio: 'inherit' },
+  )
+  if (res.error) throw res.error
+  if (res.status !== 0) throw new Error(`helm-docs exited ${res.status}`)
+}

--- a/.github/scripts/prepare-release.mjs
+++ b/.github/scripts/prepare-release.mjs
@@ -5,20 +5,50 @@
 // last `v*` tag. The `prepare-release.yml` workflow runs it, regenerates the
 // chart README via helm-docs, then opens the PR.
 //
+// `just release-prep` / `just release-prep-backport` (just/release.just) run
+// the SAME staging logic for a controlled local cut. Both used to duplicate,
+// verbatim, the `awk '/^version:/{print $2; exit}'` chart-version read and
+// the `docker run … jnorwood/helm-docs …` README regeneration in their own
+// recipe bodies (CLAUDE.md invariant 15, issue #3100, epic #3091) — this file
+// already computes `chartVersion` in-process, so the awk re-read of the file
+// it had just written was pure duplication, not merely duplicated TEXT.
+// `RENDER_HELM_DOCS=1` folds the docker invocation in here right after the
+// Chart.yaml edit it depends on, and `release_branch` / `commit_message` are
+// now emitted as outputs so neither recipe re-derives the branch name or the
+// commit/PR-title string by hand. `release-prep-backport`'s branch-detection
+// guard (`case "$(git rev-parse --abbrev-ref HEAD)" in release/*.x) …esac`)
+// moves in the same way, behind `REQUIRE_MAINTENANCE_BRANCH=1`, so it runs
+// before any file is touched exactly like the shell `case` it replaces.
+//
 // Env:
 //   VERSION     explicit target appVersion (e.g. "1.2.0"); overrides BUMP
 //   BUMP        patch | minor | major — used when VERSION is empty
 //   CHART_BUMP  patch | minor | major — chart `version:` bump (default patch)
 //   GITHUB_OUTPUT  runner file for step outputs (optional)
 //   PR_BODY_FILE   path to write the generated PR body (default release-pr-body.md)
+//   RENDER_HELM_DOCS          "1" to regenerate the chart README via helm-docs
+//                             after the Chart.yaml edit (default: skip)
+//   REQUIRE_MAINTENANCE_BRANCH  "1" to fail fast, before touching any file,
+//                             unless HEAD is on a `release/*.x` maintenance
+//                             branch (default: no check — the tip-of-main
+//                             flow branches off `origin/main` instead)
 //
 // argv `--self-test` runs the in-process assertion suite and exits.
 import { readFileSync, writeFileSync, appendFileSync } from 'node:fs'
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
+import process from 'node:process'
+import { pullImageWithRetry } from './lib/registry.mjs'
 
 const CHART = 'deploy/helm/cerberus/Chart.yaml'
 const CHANGELOG = 'CHANGELOG.md'
 const IMAGE = 'ghcr.io/tsouza/cerberus'
+const HELM_CHART_SEARCH_ROOT = 'deploy/helm'
+const HELM_DOCS_IMAGE = 'jnorwood/helm-docs:v1.14.2'
+const HELM_DOCS_TEMPLATE = 'README.md.gotmpl'
+// maintenanceBranchGlob mirrors the shell glob `release/*.x` the replaced
+// `case` statement matched: the `release/` prefix, then any (possibly empty)
+// run of characters, then the literal `.x` suffix.
+const maintenanceBranchGlob = /^release\/.*\.x$/
 
 // --- semver -----------------------------------------------------------------
 
@@ -189,7 +219,81 @@ function setOutput(k, v) {
   console.log(`${k}=${v}`)
 }
 
+// --- branch / commit-message helpers (just/release.just's shared logic) ----
+
+// currentBranch shells out for the checked-out branch name, exactly what the
+// replaced `case "$(git rev-parse --abbrev-ref HEAD)" in …esac` read.
+export function currentBranch() {
+  return git(['rev-parse', '--abbrev-ref', 'HEAD']).trim()
+}
+
+// isMaintenanceBranch reports whether `branch` matches the `release/*.x`
+// maintenance-line glob `release-prep-backport` requires HEAD to be on.
+export function isMaintenanceBranch(branch) {
+  return maintenanceBranchGlob.test(branch)
+}
+
+// releaseBranchName is the canonical tip-of-main staging branch name once the
+// chart version is known — `release-prep`'s `git branch -m` target and PR head.
+export function releaseBranchName(appVersion, chartVersion) {
+  return `release/v${appVersion}-chart-${chartVersion}`
+}
+
+// releaseCommitMessage doubles as both the staging commit's `-m` text and the
+// tip-of-main flow's PR title — the two were always the same literal string.
+export function releaseCommitMessage(appVersion, chartVersion) {
+  return `chore(release): cerberus v${appVersion} / chart ${chartVersion}`
+}
+
+// renderHelmDocs regenerates the chart README via the same containerized
+// helm-docs both `just release-prep` and `just release-prep-backport` ran
+// inline, against the Chart.yaml this file has already rewritten. `cwd`
+// (default `process.cwd()`, i.e. the repo root every caller runs this script
+// from) is the volume mount source, matching the replaced recipes' own
+// `$PWD/deploy/helm`.
+//
+// `docker run` pulls a missing image itself, single-attempt, so a Docker Hub
+// blip or a quota refusal would have surfaced here as an opaque container
+// start failure — the same class of fault issue #1562 fixed everywhere else
+// a script drives docker directly (promql-surface-gate.mjs's reference
+// Prometheus, migration-artifact.mjs's release image). `pullImageWithRetry`
+// acquires the image through the shared transport-retry / rate-limit-fails-
+// fast policy first, so this site is judged the identical way.
+export function renderHelmDocs(cwd = process.cwd()) {
+  if (!pullImageWithRetry(HELM_DOCS_IMAGE, { consequence: 'the chart README cannot be regenerated' })) {
+    throw new Error(`could not acquire the helm-docs image ${HELM_DOCS_IMAGE}`)
+  }
+
+  const res = spawnSync(
+    'docker',
+    [
+      'run',
+      '--rm',
+      '-v',
+      `${cwd}/${HELM_CHART_SEARCH_ROOT}:/helm-docs`,
+      '-u',
+      String(process.getuid()),
+      HELM_DOCS_IMAGE,
+      '--chart-search-root=/helm-docs',
+      `--template-files=${HELM_DOCS_TEMPLATE}`,
+    ],
+    { stdio: 'inherit' },
+  )
+  if (res.error) throw res.error
+  if (res.status !== 0) throw new Error(`helm-docs exited ${res.status}`)
+}
+
 function main() {
+  if ((process.env.REQUIRE_MAINTENANCE_BRANCH || '').trim() === '1') {
+    const branch = currentBranch()
+    if (!isMaintenanceBranch(branch)) {
+      console.error(
+        `prepare-release: not on a release/X.Y.x maintenance branch (currently on "${branch}")`,
+      )
+      process.exit(1)
+    }
+  }
+
   const chartText = readFileSync(CHART, 'utf8')
   const curChart = /^version:\s*(.+)$/m.exec(chartText)[1].trim()
   const curApp = /^appVersion:\s*"?([^"\n]+)"?$/m.exec(chartText)[1].trim()
@@ -223,8 +327,14 @@ function main() {
   ].join('\n')
   writeFileSync(process.env.PR_BODY_FILE || 'release-pr-body.md', prBody + '\n')
 
+  if ((process.env.RENDER_HELM_DOCS || '').trim() === '1') {
+    renderHelmDocs()
+  }
+
   setOutput('new_version', appVersion)
   setOutput('chart_version', chartVersion)
+  setOutput('release_branch', releaseBranchName(appVersion, chartVersion))
+  setOutput('commit_message', releaseCommitMessage(appVersion, chartVersion))
 }
 
 // --- self-test --------------------------------------------------------------
@@ -289,6 +399,16 @@ function selfTest() {
   assert((ecl.match(/## \[v1\.1\.0\]/g) || []).length === 1, 'single v1.1.0 header')
   // [Unreleased] is left empty (header immediately followed by the release).
   assert(/## \[Unreleased\]\n\n## \[v1\.1\.0\]/.test(ecl), 'empty [Unreleased] header retained')
+
+  assert(releaseBranchName('1.1.0', '0.4.0') === 'release/v1.1.0-chart-0.4.0', 'releaseBranchName')
+  assert(
+    releaseCommitMessage('1.1.0', '0.4.0') === 'chore(release): cerberus v1.1.0 / chart 0.4.0',
+    'releaseCommitMessage',
+  )
+  assert(isMaintenanceBranch('release/1.3.x'), 'isMaintenanceBranch accepts release/X.Y.x')
+  assert(isMaintenanceBranch('release/1.3.4.x'), 'isMaintenanceBranch is glob-shaped, not 2-part-only')
+  assert(!isMaintenanceBranch('release/v1.3.0-chart-0.4.0'), 'isMaintenanceBranch rejects a staging branch')
+  assert(!isMaintenanceBranch('main'), 'isMaintenanceBranch rejects main')
 
   console.log('::notice::prepare-release --self-test: all assertions passed')
 }

--- a/.github/scripts/prepare-release.mjs
+++ b/.github/scripts/prepare-release.mjs
@@ -35,16 +35,13 @@
 //
 // argv `--self-test` runs the in-process assertion suite and exits.
 import { readFileSync, writeFileSync, appendFileSync } from 'node:fs'
-import { execFileSync, spawnSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import process from 'node:process'
-import { pullImageWithRetry } from './lib/registry.mjs'
+import { renderHelmDocs } from './lib/helm-docs.mjs'
 
 const CHART = 'deploy/helm/cerberus/Chart.yaml'
 const CHANGELOG = 'CHANGELOG.md'
 const IMAGE = 'ghcr.io/tsouza/cerberus'
-const HELM_CHART_SEARCH_ROOT = 'deploy/helm'
-const HELM_DOCS_IMAGE = 'jnorwood/helm-docs:v1.14.2'
-const HELM_DOCS_TEMPLATE = 'README.md.gotmpl'
 // maintenanceBranchGlob mirrors the shell glob `release/*.x` the replaced
 // `case` statement matched: the `release/` prefix, then any (possibly empty)
 // run of characters, then the literal `.x` suffix.
@@ -243,44 +240,6 @@ export function releaseBranchName(appVersion, chartVersion) {
 // tip-of-main flow's PR title — the two were always the same literal string.
 export function releaseCommitMessage(appVersion, chartVersion) {
   return `chore(release): cerberus v${appVersion} / chart ${chartVersion}`
-}
-
-// renderHelmDocs regenerates the chart README via the same containerized
-// helm-docs both `just release-prep` and `just release-prep-backport` ran
-// inline, against the Chart.yaml this file has already rewritten. `cwd`
-// (default `process.cwd()`, i.e. the repo root every caller runs this script
-// from) is the volume mount source, matching the replaced recipes' own
-// `$PWD/deploy/helm`.
-//
-// `docker run` pulls a missing image itself, single-attempt, so a Docker Hub
-// blip or a quota refusal would have surfaced here as an opaque container
-// start failure — the same class of fault issue #1562 fixed everywhere else
-// a script drives docker directly (promql-surface-gate.mjs's reference
-// Prometheus, migration-artifact.mjs's release image). `pullImageWithRetry`
-// acquires the image through the shared transport-retry / rate-limit-fails-
-// fast policy first, so this site is judged the identical way.
-export function renderHelmDocs(cwd = process.cwd()) {
-  if (!pullImageWithRetry(HELM_DOCS_IMAGE, { consequence: 'the chart README cannot be regenerated' })) {
-    throw new Error(`could not acquire the helm-docs image ${HELM_DOCS_IMAGE}`)
-  }
-
-  const res = spawnSync(
-    'docker',
-    [
-      'run',
-      '--rm',
-      '-v',
-      `${cwd}/${HELM_CHART_SEARCH_ROOT}:/helm-docs`,
-      '-u',
-      String(process.getuid()),
-      HELM_DOCS_IMAGE,
-      '--chart-search-root=/helm-docs',
-      `--template-files=${HELM_DOCS_TEMPLATE}`,
-    ],
-    { stdio: 'inherit' },
-  )
-  if (res.error) throw res.error
-  if (res.status !== 0) throw new Error(`helm-docs exited ${res.status}`)
 }
 
 function main() {

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -74,6 +74,24 @@ jobs:
         if: startsWith(github.head_ref, 'release/')
         run: node --test .github/scripts/verify-changelog-fresh.test.mjs
 
+      # verify-changelog-fresh.mjs imports its changelog helpers from
+      # prepare-release.mjs (cerberus#2739), which also imports
+      # lib/helm-docs.mjs's shared-policy image acquisition for an unrelated
+      # caller (#3100) — assert-image-jobs-authenticate.mjs follows every
+      # relative import rather than only the one a given caller actually
+      # uses (deliberately, to avoid under-approximating a real anonymous
+      # pull elsewhere), so this job reads as an image acquirer even though
+      # this step never runs `renderHelmDocs()`. A GHCR login costs nothing
+      # real here and satisfies the gate the same way every other job in
+      # this repo does.
+      - name: Log in to GHCR
+        if: startsWith(github.head_ref, 'release/')
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
       - name: CHANGELOG.md accounts for every commit since the last tag
         if: startsWith(github.head_ref, 'release/')
         run: node .github/scripts/verify-changelog-fresh.mjs

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -91,6 +91,32 @@ jobs:
           LABEL_NAME: ${{ github.event.label.name }}
         run: node .github/scripts/resolve-release-trigger.mjs
 
+      # lib/helm-docs.mjs's renderHelmDocs() (RENDER_HELM_DOCS=1, invoked by
+      # the next step) acquires jnorwood/helm-docs through the shared
+      # transport-retry / rate-limit-fails-fast policy — same two-login
+      # idiom every other Docker-pulling job in this repo runs, GHCR first
+      # (assert-image-jobs-authenticate.mjs's R5).
+      - name: Log in to GHCR
+        env:
+          REGISTRY: ghcr.io
+          USERNAME: ${{ github.repository_owner }}
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/registry-login.mjs
+
+      # Gated on the secret being present so a fork run degrades to anonymous
+      # rather than erroring on an empty password.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKER_HUB_PAT_SET == 'true' }}
+        env:
+          DOCKER_HUB_PAT_SET: ${{ secrets.DOCKER_HUB_PAT != '' }}
+          USERNAME: tsouza
+          PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
+        run: node .github/scripts/registry-login.mjs
+
+      # RENDER_HELM_DOCS=1 folds the chart-README regeneration in here, right
+      # after the Chart.yaml edit it depends on (#3100) — previously a
+      # separate `uses: docker://jnorwood/helm-docs:...` step that duplicated
+      # `just release-prep`'s own inline invocation and ran unauthenticated.
       - name: stage release files
         id: prep
         env:
@@ -98,14 +124,8 @@ jobs:
           BUMP: ${{ steps.trigger.outputs.bump }}
           CHART_BUMP: ${{ steps.trigger.outputs.chart_bump }}
           PR_BODY_FILE: release-pr-body.md
+          RENDER_HELM_DOCS: '1'
         run: node .github/scripts/prepare-release.mjs
-
-      # Keep the chart README in sync; the chart-ci drift gate uses the same
-      # helm-docs version (jnorwood/helm-docs:v1.14.2) so the opened PR is green.
-      - name: regenerate chart README
-        uses: docker://jnorwood/helm-docs:v1.14.2
-        with:
-          args: --chart-search-root=deploy/helm --template-files=README.md.gotmpl
 
       - name: create release PR
         id: pr

--- a/just/release.just
+++ b/just/release.just
@@ -21,19 +21,18 @@ release-prep version chart_bump="patch":
     set -euo pipefail
     git fetch origin main
     git switch -c "release/v{{version}}-staging" origin/main
+    outputs="$(mktemp)"
+    trap 'rm -f "$outputs"' EXIT
     VERSION="{{version}}" CHART_BUMP="{{chart_bump}}" PR_BODY_FILE=release-pr-body.md \
+        RENDER_HELM_DOCS=1 GITHUB_OUTPUT="$outputs" \
         node .github/scripts/prepare-release.mjs
-    chart="$(awk '/^version:/{print $2; exit}' deploy/helm/cerberus/Chart.yaml)"
-    docker run --rm -v "$PWD/deploy/helm:/helm-docs" -u "$(id -u)" \
-        jnorwood/helm-docs:v1.14.2 --chart-search-root=/helm-docs --template-files=README.md.gotmpl
-    branch="release/v{{version}}-chart-${chart}"
+    branch="$(grep '^release_branch=' "$outputs" | cut -d= -f2-)"
+    msg="$(grep '^commit_message=' "$outputs" | cut -d= -f2-)"
     git branch -m "$branch"
     git add deploy/helm/cerberus/Chart.yaml deploy/helm/cerberus/README.md CHANGELOG.md
-    git commit -m "chore(release): cerberus v{{version}} / chart ${chart}"
+    git commit -m "$msg"
     git push -u origin "$branch"
-    gh pr create --base main --head "$branch" \
-        --title "chore(release): cerberus v{{version}} / chart ${chart}" \
-        --body-file release-pr-body.md
+    gh pr create --base main --head "$branch" --title "$msg" --body-file release-pr-body.md
     echo "Opened release PR on $branch. MERGING it publishes — release.yml runs on push-to-main, gates on the staged version bumps, and creates v{{version}} itself. Do not tag by hand."
 
 # Create/switch to the release/<major>.<minor>.x maintenance line off the
@@ -61,14 +60,14 @@ backport-line minor:
 release-prep-backport version chart_bump="patch":
     #!/usr/bin/env bash
     set -euo pipefail
-    case "$(git rev-parse --abbrev-ref HEAD)" in release/*.x) ;; *) echo "not on a release/X.Y.x maintenance branch"; exit 1;; esac
+    outputs="$(mktemp)"
+    trap 'rm -f "$outputs"' EXIT
     VERSION="{{version}}" CHART_BUMP="{{chart_bump}}" PR_BODY_FILE=release-pr-body.md \
+        RENDER_HELM_DOCS=1 REQUIRE_MAINTENANCE_BRANCH=1 GITHUB_OUTPUT="$outputs" \
         node .github/scripts/prepare-release.mjs
-    chart="$(awk '/^version:/{print $2; exit}' deploy/helm/cerberus/Chart.yaml)"
-    docker run --rm -v "$PWD/deploy/helm:/helm-docs" -u "$(id -u)" \
-        jnorwood/helm-docs:v1.14.2 --chart-search-root=/helm-docs --template-files=README.md.gotmpl
+    msg="$(grep '^commit_message=' "$outputs" | cut -d= -f2-)"
     git add deploy/helm/cerberus/Chart.yaml deploy/helm/cerberus/README.md CHANGELOG.md
-    git commit -m "chore(release): cerberus v{{version}} / chart ${chart}"
+    git commit -m "$msg"
     git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
     echo "Pushed v{{version}} to $(git rev-parse --abbrev-ref HEAD) — that push IS the trigger; release.yml builds, publishes, and tags. Do not tag by hand."
 

--- a/test/regression/release_required_checks_test.go
+++ b/test/regression/release_required_checks_test.go
@@ -278,8 +278,18 @@ func TestNoJustfileRecipePushesAReleaseTag(t *testing.T) {
 	// #3093: via justDump() rather than a hardcoded `../../Justfile` read —
 	// `import` merges every just/*.just file's recipes into one flat map, so
 	// this scan still covers every recipe regardless of which physical file
-	// declares it. The `.mjs`-scanning half of this pin (once release
-	// scripts are extracted there) is sub-issue #3100's job, not this one's.
+	// declares it.
+	//
+	// #3100: a recipe body scan alone went blind the moment `release-prep` /
+	// `release-prep-backport` started delegating their chart-version,
+	// helm-docs and branch-handling logic to `.github/scripts/prepare-release.mjs`
+	// (CLAUDE.md invariant 15) — the recipe body itself is now just a
+	// `node ...` line, and any tag-cutting logic could hide in the script it
+	// names instead. So every `node .github/scripts/<name>.mjs` delegate a
+	// recipe's body invokes is resolved and its OWN source scanned too, via
+	// mjsGitInvocationLines()+tagCuttingCommand() — the same predicate the
+	// shell-line scan below uses, so "cuts a tag" cannot mean one thing for a
+	// Justfile line and a looser thing for the script it calls out to.
 	d := justDump(t)
 	if len(d.Recipes) == 0 {
 		t.Fatal("parsed no recipes via `just --dump`")
@@ -287,18 +297,125 @@ func TestNoJustfileRecipePushesAReleaseTag(t *testing.T) {
 	const consequence = "Tags are created BY release.yml after it publishes. A hand-made tag makes " +
 		"the version gate see the version as already released, so the release is " +
 		"skipped in silence — every job green, nothing shipped."
+	scannedScripts := map[string]bool{}
 	for name, r := range d.Recipes {
 		if strings.HasPrefix(name, releaseTagRecipePrefix) {
 			t.Errorf("Justfile declares recipe %q. There is deliberately no tag-cutting recipe: "+
 				consequence, name)
 		}
-		for _, line := range strings.Split(r.bodyText(t), "\n") {
+		body := r.bodyText(t)
+		for _, line := range strings.Split(body, "\n") {
 			if why := tagCuttingCommand(line); why != "" {
 				t.Errorf("Justfile recipe %q %s:\n\t%s\n"+consequence,
 					name, why, strings.TrimSpace(line))
 			}
 		}
+		for _, rel := range mjsScriptsInvokedBy(body) {
+			if scannedScripts[rel] {
+				continue // multiple recipes commonly delegate to the same script
+			}
+			scannedScripts[rel] = true
+			path := filepath.Join("../..", rel)
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("recipe %q delegates to %q via `node`, but it does not exist: %v", name, rel, err)
+			}
+			for _, line := range mjsGitInvocationLines(string(src)) {
+				if why := tagCuttingCommand(line); why != "" {
+					t.Errorf("%s (delegate of Justfile recipe %q) %s:\n\t%s\n"+consequence,
+						rel, name, why, line)
+				}
+			}
+		}
 	}
+}
+
+// nodeScriptInvocationRE matches a `node .github/scripts/<name>.mjs` delegate
+// call inside a recipe body — the shape every extraction under CLAUDE.md
+// invariant 15 uses (see just/chdb.just's `chdb-install`, just/release.just's
+// `release-prep*`).
+var nodeScriptInvocationRE = regexp.MustCompile(`\bnode\s+(\.github/scripts/\S+\.mjs)\b`)
+
+// mjsScriptsInvokedBy returns every distinct `.github/scripts/*.mjs` path a
+// recipe body's `node ...` lines name, in first-seen order.
+func mjsScriptsInvokedBy(body string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range nodeScriptInvocationRE.FindAllStringSubmatch(body, -1) {
+		if !seen[m[1]] {
+			seen[m[1]] = true
+			out = append(out, m[1])
+		}
+	}
+	return out
+}
+
+// jsGitOrGhCallRE finds the start of a child-process call whose command is
+// the literal `git` or `gh` — `execFileSync('git', …)`, `spawnSync("gh", …)`,
+// and the like. Node's child_process API always takes the command as the
+// call's first argument, so anchoring there (rather than guessing at a
+// wrapper's argument order) is exact.
+var jsGitOrGhCallRE = regexp.MustCompile("\\b(?:execFileSync|execFile|spawnSync|spawn|execSync|exec)\\(\\s*['\"`](git|gh)['\"`]")
+
+// jsStringLiteralRE matches one single- or double-quoted JS string literal.
+// No call site in this repository spells a git/gh argument as a template
+// literal, so that form is deliberately unmodelled.
+var jsStringLiteralRE = regexp.MustCompile(`'([^'\\]*(?:\\.[^'\\]*)*)'|"([^"\\]*(?:\\.[^"\\]*)*)"`)
+
+// extractBalancedCall returns src[start:end] for the parenthesized argument
+// list beginning at the first `(` at or after `from`, matched by paren depth
+// rather than by a regex (Go's RE2 cannot express recursive nesting) — so an
+// argument list containing its own nested calls or object literals with
+// parens is still captured whole.
+func extractBalancedCall(src string, from int) (string, bool) {
+	open := strings.IndexByte(src[from:], '(')
+	if open == -1 {
+		return "", false
+	}
+	start := from + open
+	depth := 0
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[start : i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+// mjsGitInvocationLines renders every git/gh child-process call in an .mjs
+// script's source as one synthetic shell-command-line string (e.g.
+// `git tag v1.2.3`, joining every string-literal argument in call order), so
+// tagCuttingCommand — written for a shell recipe line — can judge a script's
+// argv-array invocation too. A non-literal argument (a variable, a template
+// literal) contributes nothing, same limitation the shell-line scan already
+// accepts for a value built from a shell variable: this catches an obvious,
+// literally-spelled tag cut, not every possible obfuscation of one.
+func mjsGitInvocationLines(source string) []string {
+	var out []string
+	for _, loc := range jsGitOrGhCallRE.FindAllStringIndex(source, -1) {
+		call, ok := extractBalancedCall(source, loc[0])
+		if !ok {
+			continue
+		}
+		var words []string
+		for _, m := range jsStringLiteralRE.FindAllStringSubmatch(call, -1) {
+			lit := m[1]
+			if lit == "" {
+				lit = m[2]
+			}
+			words = append(words, lit)
+		}
+		if len(words) > 0 {
+			out = append(out, strings.Join(words, " "))
+		}
+	}
+	return out
 }
 
 // releaseTagRecipePrefix is the recipe name (and any variant of it) that must


### PR DESCRIPTION
## Summary

Closes #3100

`release-prep` and `release-prep-backport` (`just/release.just`) duplicated,
verbatim, the `awk '/^version:/{print $2; exit}'` chart-version read and the
`docker run … jnorwood/helm-docs …` README regeneration in their own recipe
bodies, and only `release-prep-backport`'s branch-detection `case` statement
and the dynamic branch/commit-message string construction were left inline
and un-extracted (under-scoped in the design's first draft, per the issue).

This folds all of it into the existing `.github/scripts/prepare-release.mjs`
(chosen over a new `lib/helm-docs.mjs` — the script already computes
`chartVersion` in-process, so the recipes' `awk` re-read of the file it had
just written was pure duplication, not merely duplicated *text*; extending it
was the natural shape):

- `RENDER_HELM_DOCS=1` — after the `Chart.yaml` edit, acquires the pinned
  `jnorwood/helm-docs:v1.14.2` image via `pullImageWithRetry`
  (`./lib/registry.mjs`, the same transport-retry / rate-limit-fails-fast
  policy every other docker-driving script in `.github/scripts` uses — a bare
  `docker run` pulls a missing image itself, single-attempt, issue #1562) and
  runs it.
- `REQUIRE_MAINTENANCE_BRANCH=1` — the backport recipe's branch-detection
  guard, checked before any file is touched, exactly like the shell `case` it
  replaces.
- Two new outputs, `release_branch` and `commit_message`, so neither recipe
  re-derives the staging branch name or the commit/PR-title string (the two
  were always the identical literal) by hand.

Both Justfile recipes are now thin wrappers: `git fetch`/`switch`/`branch -m`/
`add`/`commit`/`push` plus `gh pr create`, reading the script's outputs via
`GITHUB_OUTPUT` (the same mechanism `prepare-release.yml`'s own step already
uses) instead of re-parsing `Chart.yaml` or hand-building strings.

`TestNoJustfileRecipePushesAReleaseTag` (`test/regression/release_required_checks_test.go`)
already read via `justDump()` (`just --dump --dump-format json`), landed by
#3093 — nothing left to change there. What the test was missing, and what
this PR adds, is the `.mjs`-scanning half the test's own comment had deferred
to this issue: now that a recipe's tag-cutting logic can hide behind a
one-line `node .github/scripts/<name>.mjs` delegation, the test resolves
every such delegate a recipe body invokes and scans the script's source too,
via a new `mjsGitInvocationLines()` that renders a `git`/`gh`
`execFileSync`/`spawnSync` call's string-literal arguments as one synthetic
command line and feeds it through the SAME `tagCuttingCommand()` predicate
the shell-line scan already uses — one definition of "cuts a tag," not two
that can drift apart. Verified with a temporary negative control (an injected
`execFileSync('git', ['tag', 'v9.9.9'])` in `prepare-release.mjs`, reverted
before commit): the test caught it.

## Why this also touches `pullImageWithRetry`

Running the full `test/regression` suite (not just the named test, per the
sibling sub-issue #3099's lesson — a prior extraction in this epic moved
logic into a script without updating every test pinning the replaced recipe
body's literal content) surfaced a second, unrelated guard going red:
`TestCiScriptModulesAcquireImagesThroughTheSharedPolicy` — the new
`docker run` in `prepare-release.mjs` is exactly the "a script drives docker
directly" shape that gate exists to catch. Wiring `renderHelmDocs()` through
`pullImageWithRetry` first (mirroring `promql-surface-gate.mjs`'s reference
Prometheus and `migration-artifact.mjs`'s release image) is both correct on
its own merits and what makes that gate — and the full regression suite —
green again.

## Verification

- `node --check .github/scripts/prepare-release.mjs`
- `node .github/scripts/prepare-release.mjs --self-test` (extended with
  `releaseBranchName` / `releaseCommitMessage` / `isMaintenanceBranch`
  assertions)
- `node .github/scripts/verify-just-invocations.mjs` — 0 broken invocations
- `go test -race ./test/regression/...` — full package green, including both
  `TestNoJustfileRecipePushesAReleaseTag` (positive and, via the temporary
  negative-control probe described above, negative) and
  `TestCiScriptModulesAcquireImagesThroughTheSharedPolicy`
- `just --dry-run release-prep 9.9.9` / `just --dry-run release-prep-backport 9.9.9`
  — both resolve
- End-to-end smoke test against a throwaway scratch git repository (not
  committed anywhere in this repo): `RENDER_HELM_DOCS=1` actually pulls and
  runs the real `jnorwood/helm-docs:v1.14.2` container and regenerates a
  README from a synthetic `Chart.yaml`; `REQUIRE_MAINTENANCE_BRANCH=1`
  correctly rejects a non-`release/*.x` branch before touching any file, and
  correctly proceeds (with matching `commit_message` / `release_branch`
  outputs) on a `release/1.0.x` branch.
- Not run: an actual `just release-prep` / `just release-prep-backport`
  invocation against this repository, since either would fetch `origin/main`,
  create a real branch, and (for the tip-of-main flow) open a live PR — the
  scratch-repo smoke test above exercises the identical script logic these
  recipes now delegate to, without those side effects.

## Judgment calls

- Left `.github/workflows/prepare-release.yml`'s own `branch=…-chart-…` /
  `title=…` construction as-is. It already reads `steps.prep.outputs.new_version`
  / `chart_version` (Actions step-output style, not the shell `GITHUB_OUTPUT`-file
  capture the Justfile recipes now use), and the issue scopes this extraction
  to `just/release.just` and `prepare-release.mjs`/release-related *scripts* —
  not the workflow. It could adopt the same `release_branch` / `commit_message`
  outputs later, but that is a separate, workflow-touching change with its own
  live-automation risk.
- `mjsGitInvocationLines()` only sees string-literal `git`/`gh` arguments
  (mirroring the existing shell-line scan's own accepted limitation for a
  value built from a shell variable) — a call built entirely from variables
  or template literals is invisible to it. No call site in this repository
  does that today; a `git(args)`-style indirection (used by
  `prepare-release.mjs` itself, e.g. `git(['rev-parse', ...])`) is
  correctly *not* flagged, since its actual subcommand is data-dependent and
  not statically knowable.
