### PR TITLE
ci(e2e): diagnose and fix the datashard N=2/N=4 helm-install timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1960,14 +1960,23 @@ jobs:
         run: |
           echo "=== disk usage (DiskPressure self-diagnosis) ==="
           df -h || true
-          echo "=== pods ==="
-          kubectl -n cerberus get pods -o wide | tee /tmp/cluster-state.log || true
-          echo "=== events (last 50) ==="
-          kubectl -n cerberus get events --sort-by=.lastTimestamp 2>&1 | tee -a /tmp/cluster-state.log | tail -50 || true
+          echo "=== node capacity/allocatable + conditions ==="
+          kubectl describe nodes 2>&1 | tee /tmp/cluster-nodes.log || true
+          echo "=== pods (all namespaces, for scheduling contention) ==="
+          kubectl get pods -A -o wide | tee /tmp/cluster-state.log || true
+          echo "=== events (last 100) ==="
+          kubectl -n cerberus get events --sort-by=.lastTimestamp 2>&1 | tee -a /tmp/cluster-state.log | tail -100 || true
+          echo "=== describe pods (Pending/CrashLoop reasons, resource requests) ==="
+          kubectl -n cerberus describe pods 2>&1 | tee /tmp/cluster-describe.log || true
           echo "=== cerberus logs ==="
           kubectl -n cerberus logs deploy/cerberus --tail 200 || true
           echo "=== data-shard clickhouse pods ==="
           for p in $(kubectl -n cerberus get pod -l app.kubernetes.io/component=clickhouse -o jsonpath='{.items[*].metadata.name}'); do \
+            echo "--- $p ---"; \
+            kubectl -n cerberus logs "$p" --tail 100 || true; \
+          done
+          echo "=== keeper pods ==="
+          for p in $(kubectl -n cerberus get pod -l app.kubernetes.io/component=clickhouse-keeper -o jsonpath='{.items[*].metadata.name}'); do \
             echo "--- $p ---"; \
             kubectl -n cerberus logs "$p" --tail 100 || true; \
           done
@@ -1976,6 +1985,9 @@ jobs:
           if grep -qiE 'no space left on device|DiskPressure +True|KubeletHasDiskPressure|NodeHasDiskPressure|Evicted' /tmp/cluster-state.log 2>/dev/null \
              || [ "$(df --output=pcent / | tail -1 | tr -dc '0-9')" -ge 90 ]; then
             echo "::notice::infra: real DiskPressure/ephemeral-storage eviction detected (node condition flipped or root >=90% full) — this is an infra flake, safe to re-run on a fresh runner"
+          fi
+          if grep -qiE 'Insufficient (cpu|memory)|OOMKilled|FailedScheduling' /tmp/cluster-describe.log /tmp/cluster-state.log 2>/dev/null; then
+            echo "::notice::resource: pod(s) reported insufficient cpu/memory, FailedScheduling, or OOMKilled — see the describe-pods dump above"
           fi
 
       - name: Tear down

--- a/internal/schema/ddl/datashard_test.go
+++ b/internal/schema/ddl/datashard_test.go
@@ -118,7 +118,7 @@ func TestDataShardCount_Metrics(t *testing.T) {
 
 	// The first 5 statements are the LOCAL CREATE TABLEs.
 	for i, base := range originals {
-		want := base + dataShardLocalSuffix
+		want := base + DataShardLocalSuffix
 		if !strings.Contains(stmts[i], "CREATE TABLE") || !strings.Contains(stmts[i], want) {
 			t.Errorf("metrics[%d]: expected local CREATE TABLE for %s, got:\n%s", i, want, stmts[i])
 		}
@@ -133,10 +133,10 @@ func TestDataShardCount_Metrics(t *testing.T) {
 		if strings.HasPrefix(s, "ALTER TABLE") {
 			foundLocal := false
 			for _, base := range originals {
-				if strings.Contains(s, base+dataShardLocalSuffix) {
+				if strings.Contains(s, base+DataShardLocalSuffix) {
 					foundLocal = true
 				}
-				if strings.Contains(s, "`"+base+"`") && !strings.Contains(s, base+dataShardLocalSuffix) {
+				if strings.Contains(s, "`"+base+"`") && !strings.Contains(s, base+DataShardLocalSuffix) {
 					t.Errorf("ALTER targets the ORIGINAL (non-local) table name, want local: %s", s)
 				}
 			}
@@ -155,11 +155,11 @@ func TestDataShardCount_Metrics(t *testing.T) {
 	}
 	for i, base := range originals {
 		s := wrapperStmts[i]
-		wantCreate := "CREATE TABLE IF NOT EXISTS otel." + base + " ON CLUSTER `bwc_cluster` AS otel." + base + dataShardLocalSuffix
+		wantCreate := "CREATE TABLE IF NOT EXISTS otel." + base + " ON CLUSTER `bwc_cluster` AS otel." + base + DataShardLocalSuffix
 		if !strings.HasPrefix(s, wantCreate) {
 			t.Errorf("wrapper[%d] = %q; want prefix %q", i, s, wantCreate)
 		}
-		wantEngine := "ENGINE = Distributed('bwc_cluster', 'otel', '" + base + dataShardLocalSuffix + "', rand())"
+		wantEngine := "ENGINE = Distributed('bwc_cluster', 'otel', '" + base + DataShardLocalSuffix + "', rand())"
 		if !strings.HasSuffix(s, wantEngine) {
 			t.Errorf("wrapper[%d] = %q; want suffix %q", i, s, wantEngine)
 		}
@@ -179,7 +179,7 @@ func TestDataShardCount_Logs(t *testing.T) {
 	if len(stmts) != 3 {
 		t.Fatalf("got %d statements, want 3 (local CREATE + codec ALTER + Distributed wrapper): %v", len(stmts), stmts)
 	}
-	local := defaultLogsTable + dataShardLocalSuffix
+	local := defaultLogsTable + DataShardLocalSuffix
 	if !strings.Contains(stmts[0], local) {
 		t.Errorf("logs[0] (CREATE) does not target the local table: %s", stmts[0])
 	}
@@ -211,7 +211,7 @@ func TestDataShardCount_Traces(t *testing.T) {
 	if len(stmts) != 6 {
 		t.Fatalf("got %d statements, want 6: %v", len(stmts), stmts)
 	}
-	localSpans := defaultTracesTable + dataShardLocalSuffix
+	localSpans := defaultTracesTable + DataShardLocalSuffix
 	localTs := localSpans + traceIDTsTableSuffix
 	if !strings.Contains(stmts[0], localSpans) {
 		t.Errorf("traces[0] (spans) does not target %s: %s", localSpans, stmts[0])

--- a/internal/schema/ddl/ddl.go
+++ b/internal/schema/ddl/ddl.go
@@ -532,14 +532,21 @@ const (
 	defaultDeltaPrefixBucketColumn = "BucketStart"
 	defaultDeltaPrefixSumColumn    = "PartialSum"
 
-	// dataShardLocalSuffix names the per-DATA-shard LOCAL table DataShardCount
+	// DataShardLocalSuffix names the per-DATA-shard LOCAL table DataShardCount
 	// > 1 renders underneath a Distributed wrapper (cerberus issue #3077 —
 	// see Config.DataShardCount's own doc for the terminology
 	// disambiguation). Matches the upstream traces_id_ts_lookup_table.sql
 	// template's own hard-coded "_trace_id_ts" suffix convention: a fixed
 	// string suffix on the caller-supplied base table name, never a
 	// separately-configurable field.
-	dataShardLocalSuffix = "_local"
+	//
+	// Exported (unlike its sibling constants in this block) so that
+	// test/e2e/seed/cmd/seed's stale-row DELETEs (issue #3105) can resolve a
+	// Distributed wrapper's public table name to its mutable LOCAL table
+	// without hand-duplicating this literal — ClickHouse's Distributed
+	// engine rejects every mutation, so the seeder must redirect DELETEs at
+	// this exact suffix, straight from the one place that defines it.
+	DataShardLocalSuffix = "_local"
 
 	// traceIDTsTableSuffix mirrors the upstream
 	// traces_id_ts_lookup_table.sql / traces_id_ts_lookup_mv.sql templates'
@@ -957,7 +964,7 @@ type dataShardTablePair struct {
 }
 
 // dataShardLocalConfig returns a copy of c with signal s's BASE table
-// name(s) suffixed dataShardLocalSuffix (and DataShardCount cleared, so a
+// name(s) suffixed DataShardLocalSuffix (and DataShardCount cleared, so a
 // recursive renderSignal call against the returned config takes the normal,
 // non-sharded switch below instead of recursing into renderDataShardedSignal
 // again), plus the (original, local) name pairs renderDataShardedSignal wraps in
@@ -975,7 +982,7 @@ type dataShardTablePair struct {
 // to touch — traceIDTsTableSuffix only lets this method compute the
 // ORIGINAL (unsuffixed) name to wrap.
 func (c Config) dataShardLocalConfig(s Signal) (Config, []dataShardTablePair) {
-	local := func(name string) string { return name + dataShardLocalSuffix }
+	local := func(name string) string { return name + DataShardLocalSuffix }
 	var pairs []dataShardTablePair
 	switch s {
 	case Metrics:

--- a/test/e2e/k3s/cerberus-values-datashard.yaml
+++ b/test/e2e/k3s/cerberus-values-datashard.yaml
@@ -78,7 +78,14 @@ config:
   # never reaches.
   CERBERUS_SHARD_MIN_FANOUT: "1"
   CERBERUS_SHARD_MIN_ANCHOR_PAIRS: "1"
-  CERBERUS_SHARD_MIN_ANCHORS_PER_SLICE: "1"
+  # internal/solver/config.go's Validate() rejects anything below 2 (the
+  # smallest a slice can be and still mean anything) — cerberus#3105:
+  # this lane pinned "1" here and crash-looped on every start
+  # ("configure solver: solver: MinAnchorsPerSlice must be >= 2, got 1"),
+  # which is what the `helm --wait` timeout this issue chased was actually
+  # masking. 2 is the loosest legal value and still collapses the
+  # production-scale calibration floor for this dataset's row count.
+  CERBERUS_SHARD_MIN_ANCHORS_PER_SLICE: "2"
   # Explicit, not just the default, so a future change to defaultMaxK
   # (internal/solver/config.go's own doc: it has moved 8 -> 32 -> 8 already)
   # cannot silently change this lane's own expected kEff ceiling.

--- a/test/e2e/seed/cmd/seed/sharded_mutation.go
+++ b/test/e2e/seed/cmd/seed/sharded_mutation.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// mutationTablePlaceholder marks the table name in the DELETE templates
+// declared in stale.go and showcase_traceql.go — substituted for the
+// resolved mutation target (resolveMutationTarget) via mutationTableSQL
+// below. A dedicated token rather than a fmt.Sprintf %s verb: every one of
+// those templates' TraceId/predicate clauses already contains literal '%'
+// LIKE wildcards, which a %s verb would force into confusing (and
+// regression-test-breaking — see test/regression/seed_test.go's
+// TestShowcaseTraceStaleDeleteIsDataAnchored, which scans the raw source
+// text for a single '%') '%%' escaping. Chosen to be a string no seeded
+// table name, SQL keyword, or LIKE pattern in this package could ever
+// collide with.
+const mutationTablePlaceholder = "@@MUTATION_TABLE@@"
+
+// mutationTableSQL substitutes every occurrence of mutationTablePlaceholder
+// in template with target. Each DELETE template carries the placeholder
+// twice (the outer ALTER TABLE/DELETE FROM and the inner max(...)
+// subquery's FROM), and both must resolve to the same table — see this
+// file's package doc comment for why the resolved name can differ from the
+// table's public name.
+func mutationTableSQL(template, target string) string {
+	return strings.ReplaceAll(template, mutationTablePlaceholder, target)
+}
+
+// Mutation-target resolution for the DATA-shard topology (issue #3077).
+//
+// Under Config.DataShardCount > 1, internal/schema/ddl wraps every base
+// metrics/logs/traces table in a Distributed-engine table under the
+// table's PUBLIC name (otel_metrics_gauge, otel_logs, otel_traces, ...)
+// and moves the real MergeTree-family storage to a LOCAL table suffixed
+// ddl.DataShardLocalSuffix (otel_metrics_gauge_local, ...; see ddl.go's
+// renderDistributedWrapper / renderDataShardedSignal / dataShardLocalConfig).
+// Under DataShardCount == 0 (every other lane this seeder runs against —
+// compose, bwc, single-shard k3d) there is no wrapper at all: the public
+// name IS the storage table.
+//
+// ClickHouse's Distributed engine does not support ALTER TABLE ... DELETE
+// or lightweight DELETE FROM mutations at all, confirmed live on the
+// datashard e2e lane (issue #3105, dispatch run 34014775573):
+//
+//	seed: insert metrics: gauge-shaped metrics stale delete: code: 48,
+//	message: Table engine Distributed doesn't support mutations
+//
+// stale.go's and showcase_traceql.go's stale-row DELETEs are written
+// against the literal public table names, which is correct everywhere
+// except the datashard lane — the one place where the public name doesn't
+// resolve to real storage. resolveMutationTarget below fixes that by
+// asking ClickHouse's own system.tables what engine the public name
+// actually is, at the moment the seeder needs to mutate it, and
+// redirecting to the "_local" table when it turns out to be a Distributed
+// wrapper. This needs no seeder-side knowledge of DataShardCount and no
+// new Justfile/env-var plumbing: the answer is read straight from the
+// schema the seeder is already connected to, the same way waitForTables
+// (main.go) already reads system.tables to learn whether the external
+// schema writer has created a table yet.
+
+// distributedEngine is the exact system.tables.engine value ClickHouse
+// reports for a Distributed-engine table — the one engine that rejects
+// every mutation the DELETEs in this package issue.
+const distributedEngine = "Distributed"
+
+// shardMutationTargets memoizes resolveMutationTarget's system.tables
+// lookups for the life of one seeder process. Whether a given public table
+// name is a Distributed wrapper is fixed by Config.DataShardCount at
+// cluster-provisioning time and never changes while the seeder runs, but
+// the rolling re-seeder calls resolveMutationTarget once per stale-DELETE
+// on every tick (`--re-seed-interval`, default 30s per main.go's flag doc)
+// — memoizing avoids re-querying system.tables for the same static fact on
+// every tick, for the life of the run.
+//
+// Package-level and unsynchronized: both the one-shot path (run()) and the
+// rolling re-seed loop (main.go's ticker loop) call seedAll synchronously
+// from a single goroutine, never concurrently, so a bare map needs no
+// lock. A future caller that drives seedAll from multiple goroutines would
+// need to add one.
+var shardMutationTargets = make(map[string]string)
+
+// mutationTargetForEngine returns the table name a DELETE against table
+// should actually target, given engine — table's system.tables.engine
+// value. A Distributed wrapper redirects to its ddl.DataShardLocalSuffix
+// companion; every other engine (MergeTree, ReplicatedMergeTree,
+// ReplacingMergeTree, ...) is already the real storage table and is
+// returned unchanged. Pure and independent of any live connection, so it
+// is unit-testable directly against fabricated engine strings (see
+// sharded_mutation_test.go).
+func mutationTargetForEngine(table, engine string) string {
+	if engine == distributedEngine {
+		return table + ddl.DataShardLocalSuffix
+	}
+	return table
+}
+
+// tableEngine looks up table's engine in system.tables. Scoped to
+// currentDatabase() rather than a bound database parameter because the
+// seeder already relies on Auth.Database to resolve every unqualified
+// table name it INSERTs into server-side (main.go's package doc comment)
+// — currentDatabase() applies that same resolution to this lookup.
+func tableEngine(ctx context.Context, conn driver.Conn, table string) (string, error) {
+	const engineSQL = `SELECT engine FROM system.tables WHERE database = currentDatabase() AND name = {table:String}`
+	var engine string
+	row := conn.QueryRow(ctx, engineSQL, clickhouse.Named("table", table))
+	if err := row.Scan(&engine); err != nil {
+		return "", fmt.Errorf("resolve engine for table %s: %w", table, err)
+	}
+	return engine, nil
+}
+
+// resolveMutationTarget returns the table name a stale-row DELETE against
+// the public table name `table` should actually target — see this file's
+// package doc comment for the Distributed/local mechanism. Memoized in
+// shardMutationTargets so only the first call per table name on a given
+// process ever queries system.tables.
+func resolveMutationTarget(ctx context.Context, conn driver.Conn, table string) (string, error) {
+	if target, ok := shardMutationTargets[table]; ok {
+		return target, nil
+	}
+	engine, err := tableEngine(ctx, conn, table)
+	if err != nil {
+		return "", err
+	}
+	target := mutationTargetForEngine(table, engine)
+	shardMutationTargets[table] = target
+	return target, nil
+}

--- a/test/e2e/seed/cmd/seed/sharded_mutation.go
+++ b/test/e2e/seed/cmd/seed/sharded_mutation.go
@@ -24,14 +24,24 @@ import (
 // collide with.
 const mutationTablePlaceholder = "@@MUTATION_TABLE@@"
 
+// mutationOnClusterPlaceholder marks the optional " ON CLUSTER '{cluster}'"
+// clause on the OUTER `ALTER TABLE` line only (never the inner max(...)
+// subquery, which is a plain per-node SELECT) — substituted by
+// resolveMutationTarget's onCluster return value via mutationTableSQL.
+// Empty on every lane except the datashard one; see this file's package
+// doc comment for why ON CLUSTER is what the local-table redirect alone
+// does not fix.
+const mutationOnClusterPlaceholder = "@@MUTATION_ON_CLUSTER@@"
+
 // mutationTableSQL substitutes every occurrence of mutationTablePlaceholder
-// in template with target. Each DELETE template carries the placeholder
-// twice (the outer ALTER TABLE/DELETE FROM and the inner max(...)
-// subquery's FROM), and both must resolve to the same table — see this
-// file's package doc comment for why the resolved name can differ from the
-// table's public name.
-func mutationTableSQL(template, target string) string {
-	return strings.ReplaceAll(template, mutationTablePlaceholder, target)
+// in template with target, and mutationOnClusterPlaceholder with onCluster.
+// Each DELETE template carries mutationTablePlaceholder twice (the outer
+// ALTER TABLE/DELETE FROM and the inner max(...) subquery's FROM), and both
+// must resolve to the same table — see this file's package doc comment for
+// why the resolved name can differ from the table's public name.
+func mutationTableSQL(template, target, onCluster string) string {
+	s := strings.ReplaceAll(template, mutationTablePlaceholder, target)
+	return strings.ReplaceAll(s, mutationOnClusterPlaceholder, onCluster)
 }
 
 // Mutation-target resolution for the DATA-shard topology (issue #3077).
@@ -71,6 +81,35 @@ func mutationTableSQL(template, target string) string {
 // every mutation the DELETEs in this package issue.
 const distributedEngine = "Distributed"
 
+// onClusterMacro is ClickHouse's own `{cluster}` macro, expanded
+// server-side from system.macros — the same self-discovery mechanism
+// internal/schema/ddl's own ON CLUSTER DDL and the chart's macros ConfigMap
+// (deploy/helm/cerberus/templates/clickhouse/configmap-config.yaml,
+// `<macros><cluster>bwc_cluster</cluster></macros>`) already rely on. Using
+// the macro rather than a literal cluster name means this file needs no new
+// knowledge of what the datashard lane's cluster is actually called, and
+// stays correct if that name ever changes.
+//
+// A "_local" table is created ON CLUSTER (ddl.go's dataShardLocalConfig /
+// renderDataShardedSignal) so it exists, identically named, on every shard
+// node — an ALTER ... DELETE issued only against the ONE node the seeder is
+// connected to would silently mutate just that node's own fraction of the
+// sharded data, leaving stale rows on every OTHER shard (confirmed live:
+// TestReSeedRowCountStability failed for exactly the tables whose insert
+// path spreads rows across shards, on dispatch run 34015811450 — the local-
+// table redirect alone got the mutation to succeed, but only partially).
+// ON CLUSTER broadcasts the ALTER to every node via ClickHouse's own
+// distributed-DDL queue, each executing it against its own local data.
+const onClusterMutationClause = " ON CLUSTER '{cluster}'"
+
+// shardMutationTarget is what resolveMutationTarget resolves a public table
+// name to: the table to actually mutate, plus the ON CLUSTER clause (empty
+// outside the datashard lane) needed to reach every shard's copy of it.
+type shardMutationTarget struct {
+	table     string
+	onCluster string
+}
+
 // shardMutationTargets memoizes resolveMutationTarget's system.tables
 // lookups for the life of one seeder process. Whether a given public table
 // name is a Distributed wrapper is fixed by Config.DataShardCount at
@@ -85,21 +124,22 @@ const distributedEngine = "Distributed"
 // from a single goroutine, never concurrently, so a bare map needs no
 // lock. A future caller that drives seedAll from multiple goroutines would
 // need to add one.
-var shardMutationTargets = make(map[string]string)
+var shardMutationTargets = make(map[string]shardMutationTarget)
 
-// mutationTargetForEngine returns the table name a DELETE against table
-// should actually target, given engine — table's system.tables.engine
-// value. A Distributed wrapper redirects to its ddl.DataShardLocalSuffix
-// companion; every other engine (MergeTree, ReplicatedMergeTree,
-// ReplacingMergeTree, ...) is already the real storage table and is
-// returned unchanged. Pure and independent of any live connection, so it
-// is unit-testable directly against fabricated engine strings (see
-// sharded_mutation_test.go).
-func mutationTargetForEngine(table, engine string) string {
+// mutationTargetForEngine returns the table (and ON CLUSTER clause, if any)
+// a DELETE against table should actually target, given engine — table's
+// system.tables.engine value. A Distributed wrapper redirects to its
+// ddl.DataShardLocalSuffix companion and needs ON CLUSTER to reach every
+// shard's copy of it; every other engine (MergeTree, ReplicatedMergeTree,
+// ReplacingMergeTree, ...) is already the real, single-node storage table
+// and is returned unchanged with no ON CLUSTER clause. Pure and independent
+// of any live connection, so it is unit-testable directly against
+// fabricated engine strings (see sharded_mutation_test.go).
+func mutationTargetForEngine(table, engine string) shardMutationTarget {
 	if engine == distributedEngine {
-		return table + ddl.DataShardLocalSuffix
+		return shardMutationTarget{table: table + ddl.DataShardLocalSuffix, onCluster: onClusterMutationClause}
 	}
-	return table
+	return shardMutationTarget{table: table}
 }
 
 // tableEngine looks up table's engine in system.tables. Scoped to
@@ -117,18 +157,18 @@ func tableEngine(ctx context.Context, conn driver.Conn, table string) (string, e
 	return engine, nil
 }
 
-// resolveMutationTarget returns the table name a stale-row DELETE against
-// the public table name `table` should actually target — see this file's
-// package doc comment for the Distributed/local mechanism. Memoized in
-// shardMutationTargets so only the first call per table name on a given
-// process ever queries system.tables.
-func resolveMutationTarget(ctx context.Context, conn driver.Conn, table string) (string, error) {
+// resolveMutationTarget returns the table (and ON CLUSTER clause, if any) a
+// stale-row DELETE against the public table name `table` should actually
+// target — see this file's package doc comment for the Distributed/local/
+// ON CLUSTER mechanism. Memoized in shardMutationTargets so only the first
+// call per table name on a given process ever queries system.tables.
+func resolveMutationTarget(ctx context.Context, conn driver.Conn, table string) (shardMutationTarget, error) {
 	if target, ok := shardMutationTargets[table]; ok {
 		return target, nil
 	}
 	engine, err := tableEngine(ctx, conn, table)
 	if err != nil {
-		return "", err
+		return shardMutationTarget{}, err
 	}
 	target := mutationTargetForEngine(table, engine)
 	shardMutationTargets[table] = target

--- a/test/e2e/seed/cmd/seed/sharded_mutation.go
+++ b/test/e2e/seed/cmd/seed/sharded_mutation.go
@@ -33,14 +33,20 @@ const mutationTablePlaceholder = "@@MUTATION_TABLE@@"
 // does not fix.
 const mutationOnClusterPlaceholder = "@@MUTATION_ON_CLUSTER@@"
 
-// mutationTableSQL substitutes every occurrence of mutationTablePlaceholder
-// in template with target, and mutationOnClusterPlaceholder with onCluster.
-// Each DELETE template carries mutationTablePlaceholder twice (the outer
-// ALTER TABLE/DELETE FROM and the inner max(...) subquery's FROM), and both
-// must resolve to the same table — see this file's package doc comment for
-// why the resolved name can differ from the table's public name.
-func mutationTableSQL(template, target, onCluster string) string {
-	s := strings.ReplaceAll(template, mutationTablePlaceholder, target)
+// mutationTableSQL fills in template's two mutationTablePlaceholder
+// occurrences DIFFERENTLY — the first (the outer ALTER TABLE/DELETE FROM)
+// with target, the second (the inner max(...) subquery's FROM) with
+// publicTable — and mutationOnClusterPlaceholder with onCluster. See this
+// file's package doc comment for why the two occurrences must NOT resolve
+// to the same name once the datashard lane is in play: the outer mutation
+// needs the "_local" table (Distributed doesn't support mutations at all),
+// but the inner max(...) needs the PUBLIC Distributed name, or a
+// low-row-count family whose fresh INSERTs happen not to land on every
+// shard every tick computes a per-shard max() that never advances past a
+// stale sentinel on the shard(s) that got skipped.
+func mutationTableSQL(template, target, publicTable, onCluster string) string {
+	s := strings.Replace(template, mutationTablePlaceholder, target, 1)
+	s = strings.ReplaceAll(s, mutationTablePlaceholder, publicTable)
 	return strings.ReplaceAll(s, mutationOnClusterPlaceholder, onCluster)
 }
 
@@ -75,6 +81,26 @@ func mutationTableSQL(template, target, onCluster string) string {
 // schema the seeder is already connected to, the same way waitForTables
 // (main.go) already reads system.tables to learn whether the external
 // schema writer has created a table yet.
+//
+// The redirect alone is not the whole fix. Each DELETE template's inner
+// max(<time column>) subquery anchors the cutoff to "how fresh is the data
+// that's actually here" — but a Distributed table's INSERT spreads rows
+// across shards essentially at random (Config.DataShardingKey, default
+// rand()), so a LOW-row-count family (base-traces' fixed 7-row fixture) can
+// have a tick where NONE of its fresh rows land on a given shard. If the
+// subquery ran against that shard's own "_local" table, its max() would
+// reflect only OLD rows (or nothing newer than the sentinel itself),
+// so the cutoff never advances past a stale/sentinel row on that shard —
+// confirmed live: TestReSeedRowCountStability/base-traces alone (the
+// lowest-row-count family; every higher-volume family's fresh rows are
+// near-certain to land on every shard every tick, masking the same bug)
+// failed on dispatch run 34016653322 after the local-table + ON CLUSTER
+// fix alone. mutationTableSQL therefore targets the subquery at the
+// PUBLIC name instead: a SELECT against a Distributed table (unlike a
+// mutation) is exactly what the engine is FOR, and ClickHouse fans it out
+// and aggregates the true cluster-wide max() regardless of which shard
+// node the ON CLUSTER broadcast happens to be executing this copy of the
+// statement on.
 
 // distributedEngine is the exact system.tables.engine value ClickHouse
 // reports for a Distributed-engine table — the one engine that rejects

--- a/test/e2e/seed/cmd/seed/sharded_mutation_test.go
+++ b/test/e2e/seed/cmd/seed/sharded_mutation_test.go
@@ -79,8 +79,9 @@ func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
 	t.Parallel()
 
 	const (
-		target    = "otel_metrics_gauge_local"
-		onCluster = onClusterMutationClause
+		target      = "otel_metrics_gauge_local"
+		publicTable = "otel_metrics_gauge"
+		onCluster   = onClusterMutationClause
 	)
 
 	for name, tpl := range map[string]string{
@@ -107,18 +108,38 @@ func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
 					name, got, wantOnClusterOccurrences)
 			}
 
-			got := mutationTableSQL(tpl, target, onCluster)
+			got := mutationTableSQL(tpl, target, publicTable, onCluster)
 			if strings.Contains(got, mutationTablePlaceholder) {
 				t.Fatalf("%s: mutationTableSQL left an unsubstituted table placeholder behind: %q", name, got)
 			}
 			if strings.Contains(got, mutationOnClusterPlaceholder) {
 				t.Fatalf("%s: mutationTableSQL left an unsubstituted ON CLUSTER placeholder behind: %q", name, got)
 			}
-			if got2 := strings.Count(got, target); got2 != wantTableOccurrences {
-				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, target, wantTableOccurrences)
-			}
 			if got2 := strings.Count(got, onCluster); got2 != wantOnClusterOccurrences {
 				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, onCluster, wantOnClusterOccurrences)
+			}
+
+			// The outer statement gets `target` (the resolved local table),
+			// the inner max(...) subquery's FROM gets `publicTable` (the
+			// Distributed name, which aggregates correctly across every
+			// shard) — see sharded_mutation.go's package doc comment for
+			// why they must differ. `target` here is `publicTable + "_local"`
+			// (matching real usage), so `publicTable` is a PREFIX of
+			// `target`; search for it strictly after target's own span, not
+			// with a plain strings.Index that would just re-find target's
+			// own leading substring.
+			outerIdx := strings.Index(got, target)
+			if outerIdx == -1 {
+				t.Fatalf("%s: mutationTableSQL did not place the resolved target %q anywhere: %q", name, target, got)
+			}
+			rest := got[outerIdx+len(target):]
+			innerIdx := strings.Index(rest, publicTable)
+			if innerIdx == -1 {
+				t.Fatalf("%s: mutationTableSQL did not place the public table name %q AFTER the resolved target %q: %q",
+					name, publicTable, target, got)
+			}
+			if got2 := strings.Count(rest, publicTable); got2 != 1 {
+				t.Fatalf("%s: mutationTableSQL produced %d occurrences of the public table name %q after the outer target, want exactly 1", name, got2, publicTable)
 			}
 
 			// The ON CLUSTER clause must land on the OUTER statement, before
@@ -133,17 +154,21 @@ func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
 }
 
 // resolveMutationTarget's caller-visible behavior when NOT sharded (empty
-// onCluster) must leave the DELETE unchanged in shape — mutationTableSQL
-// with an empty onCluster simply erases the placeholder rather than
-// leaving a stray space or empty ON CLUSTER token behind.
+// onCluster, target == publicTable) must leave the DELETE unchanged in
+// shape — mutationTableSQL with an empty onCluster simply erases the
+// placeholder rather than leaving a stray space or empty ON CLUSTER token
+// behind, and both placeholder occurrences resolve to the SAME table name.
 func TestMutationTableSQLEmptyOnClusterLeavesNoStrayToken(t *testing.T) {
 	t.Parallel()
 
-	got := mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, "otel_metrics_gauge", "")
+	got := mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, "otel_metrics_gauge", "otel_metrics_gauge", "")
 	if strings.Contains(got, "ON CLUSTER") {
 		t.Fatalf("empty onCluster left an ON CLUSTER token behind: %q", got)
 	}
 	if !strings.Contains(got, "ALTER TABLE otel_metrics_gauge DELETE") {
 		t.Fatalf("expected the unsharded ALTER TABLE shape to be preserved verbatim, got: %q", got)
+	}
+	if got2 := strings.Count(got, "otel_metrics_gauge"); got2 != 2 {
+		t.Fatalf("expected exactly 2 occurrences of otel_metrics_gauge (outer + inner, both unredirected), got %d: %q", got2, got)
 	}
 }

--- a/test/e2e/seed/cmd/seed/sharded_mutation_test.go
+++ b/test/e2e/seed/cmd/seed/sharded_mutation_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema/ddl"
+)
+
+// mutationTargetForEngine is the whole correctness argument of the
+// datashard-lane DELETE fix (issue #3105): every engine string ClickHouse
+// could plausibly report for one of this seeder's target tables must map
+// to a table that actually accepts a mutation. Exercised directly against
+// fabricated engine strings — no live ClickHouse needed, unlike
+// resolveMutationTarget's own system.tables round-trip (covered instead by
+// the datashard e2e lane itself, which is the one place a Distributed
+// wrapper actually exists).
+func TestMutationTargetForEngine(t *testing.T) {
+	t.Parallel()
+
+	const table = "otel_metrics_gauge"
+
+	for _, tc := range []struct {
+		name   string
+		engine string
+		want   string
+	}{
+		{"Distributed wrapper redirects to the local table", "Distributed", table + ddl.DataShardLocalSuffix},
+		{"MergeTree is already the storage table", "MergeTree", table},
+		{"ReplicatedMergeTree is already the storage table", "ReplicatedMergeTree", table},
+		{"ReplacingMergeTree is already the storage table", "ReplacingMergeTree", table},
+		{"ReplicatedReplacingMergeTree is already the storage table", "ReplicatedReplacingMergeTree", table},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := mutationTargetForEngine(table, tc.engine); got != tc.want {
+				t.Fatalf("mutationTargetForEngine(%q, %q) = %q, want %q", table, tc.engine, got, tc.want)
+			}
+		})
+	}
+}
+
+// A table name is never mistaken for a Distributed wrapper unless its
+// engine string is an EXACT match for "Distributed" — a substring or
+// case-insensitive match would misclassify names ClickHouse never reports
+// but that a naive check might accept.
+func TestMutationTargetForEngineRequiresExactMatch(t *testing.T) {
+	t.Parallel()
+
+	const table = "otel_logs"
+	for _, engine := range []string{"distributed", "DISTRIBUTED", "DistributedMergeTree", " Distributed", "Distributed "} {
+		if got := mutationTargetForEngine(table, engine); got != table {
+			t.Fatalf("mutationTargetForEngine(%q, %q) = %q, want the unredirected table name %q", table, engine, got, table)
+		}
+	}
+}
+
+// mutationTableSQL is the substitution half of the fix: every DELETE
+// template must carry the placeholder EXACTLY twice (the outer
+// ALTER/DELETE and the inner max(...) subquery's FROM, both pinned to the
+// same resolved table), and mutationTableSQL must replace every
+// occurrence, leaving none of the placeholder text behind. stale.go and
+// showcase_traceql.go type "@@MUTATION_TABLE@@" directly into each
+// template rather than referencing mutationTablePlaceholder by name (see
+// those files' doc comments for why — keeping each const a single
+// unbroken backtick literal for test/regression/seed_test.go's
+// extractBacktickConst), so this test is what actually pins the two
+// literals against each other: it fails the moment either side drifts.
+func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
+	t.Parallel()
+
+	const target = "otel_metrics_gauge_local"
+
+	for name, tpl := range map[string]string{
+		"deleteStaleMetricsGaugeSQLTemplate":     deleteStaleMetricsGaugeSQLTemplate,
+		"deleteStaleMetricsSumSQLTemplate":       deleteStaleMetricsSumSQLTemplate,
+		"deleteStaleMetricsHistogramSQLTemplate": deleteStaleMetricsHistogramSQLTemplate,
+		"deleteStaleMetricsExpHistSQLTemplate":   deleteStaleMetricsExpHistSQLTemplate,
+		"deleteStaleLogsSQLTemplate":             deleteStaleLogsSQLTemplate,
+		"deleteStaleBaseTracesSQLTemplate":       deleteStaleBaseTracesSQLTemplate,
+		"deleteStaleShowcaseTracesSQLTemplate":   deleteStaleShowcaseTracesSQLTemplate,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			const wantOccurrences = 2
+			if got := strings.Count(tpl, mutationTablePlaceholder); got != wantOccurrences {
+				t.Fatalf("%s contains %d occurrences of the placeholder, want %d (one for the outer statement, one for the inner max(...) subquery's FROM)",
+					name, got, wantOccurrences)
+			}
+
+			got := mutationTableSQL(tpl, target)
+			if strings.Contains(got, mutationTablePlaceholder) {
+				t.Fatalf("%s: mutationTableSQL left an unsubstituted placeholder behind: %q", name, got)
+			}
+			if got2 := strings.Count(got, target); got2 != wantOccurrences {
+				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, target, wantOccurrences)
+			}
+		})
+	}
+}

--- a/test/e2e/seed/cmd/seed/sharded_mutation_test.go
+++ b/test/e2e/seed/cmd/seed/sharded_mutation_test.go
@@ -21,20 +21,25 @@ func TestMutationTargetForEngine(t *testing.T) {
 	const table = "otel_metrics_gauge"
 
 	for _, tc := range []struct {
-		name   string
-		engine string
-		want   string
+		name          string
+		engine        string
+		wantTable     string
+		wantOnCluster string
 	}{
-		{"Distributed wrapper redirects to the local table", "Distributed", table + ddl.DataShardLocalSuffix},
-		{"MergeTree is already the storage table", "MergeTree", table},
-		{"ReplicatedMergeTree is already the storage table", "ReplicatedMergeTree", table},
-		{"ReplacingMergeTree is already the storage table", "ReplacingMergeTree", table},
-		{"ReplicatedReplacingMergeTree is already the storage table", "ReplicatedReplacingMergeTree", table},
+		{"Distributed wrapper redirects to the local table, ON CLUSTER", "Distributed", table + ddl.DataShardLocalSuffix, onClusterMutationClause},
+		{"MergeTree is already the storage table, no ON CLUSTER", "MergeTree", table, ""},
+		{"ReplicatedMergeTree is already the storage table, no ON CLUSTER", "ReplicatedMergeTree", table, ""},
+		{"ReplacingMergeTree is already the storage table, no ON CLUSTER", "ReplacingMergeTree", table, ""},
+		{"ReplicatedReplacingMergeTree is already the storage table, no ON CLUSTER", "ReplicatedReplacingMergeTree", table, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := mutationTargetForEngine(table, tc.engine); got != tc.want {
-				t.Fatalf("mutationTargetForEngine(%q, %q) = %q, want %q", table, tc.engine, got, tc.want)
+			got := mutationTargetForEngine(table, tc.engine)
+			if got.table != tc.wantTable {
+				t.Fatalf("mutationTargetForEngine(%q, %q).table = %q, want %q", table, tc.engine, got.table, tc.wantTable)
+			}
+			if got.onCluster != tc.wantOnCluster {
+				t.Fatalf("mutationTargetForEngine(%q, %q).onCluster = %q, want %q", table, tc.engine, got.onCluster, tc.wantOnCluster)
 			}
 		})
 	}
@@ -49,8 +54,12 @@ func TestMutationTargetForEngineRequiresExactMatch(t *testing.T) {
 
 	const table = "otel_logs"
 	for _, engine := range []string{"distributed", "DISTRIBUTED", "DistributedMergeTree", " Distributed", "Distributed "} {
-		if got := mutationTargetForEngine(table, engine); got != table {
-			t.Fatalf("mutationTargetForEngine(%q, %q) = %q, want the unredirected table name %q", table, engine, got, table)
+		got := mutationTargetForEngine(table, engine)
+		if got.table != table {
+			t.Fatalf("mutationTargetForEngine(%q, %q).table = %q, want the unredirected table name %q", table, engine, got.table, table)
+		}
+		if got.onCluster != "" {
+			t.Fatalf("mutationTargetForEngine(%q, %q).onCluster = %q, want empty", table, engine, got.onCluster)
 		}
 	}
 }
@@ -69,7 +78,10 @@ func TestMutationTargetForEngineRequiresExactMatch(t *testing.T) {
 func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
 	t.Parallel()
 
-	const target = "otel_metrics_gauge_local"
+	const (
+		target    = "otel_metrics_gauge_local"
+		onCluster = onClusterMutationClause
+	)
 
 	for name, tpl := range map[string]string{
 		"deleteStaleMetricsGaugeSQLTemplate":     deleteStaleMetricsGaugeSQLTemplate,
@@ -83,19 +95,55 @@ func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			const wantOccurrences = 2
-			if got := strings.Count(tpl, mutationTablePlaceholder); got != wantOccurrences {
-				t.Fatalf("%s contains %d occurrences of the placeholder, want %d (one for the outer statement, one for the inner max(...) subquery's FROM)",
-					name, got, wantOccurrences)
+			const wantTableOccurrences = 2
+			if got := strings.Count(tpl, mutationTablePlaceholder); got != wantTableOccurrences {
+				t.Fatalf("%s contains %d occurrences of the table placeholder, want %d (one for the outer statement, one for the inner max(...) subquery's FROM)",
+					name, got, wantTableOccurrences)
 			}
 
-			got := mutationTableSQL(tpl, target)
-			if strings.Contains(got, mutationTablePlaceholder) {
-				t.Fatalf("%s: mutationTableSQL left an unsubstituted placeholder behind: %q", name, got)
+			const wantOnClusterOccurrences = 1
+			if got := strings.Count(tpl, mutationOnClusterPlaceholder); got != wantOnClusterOccurrences {
+				t.Fatalf("%s contains %d occurrences of the ON CLUSTER placeholder, want %d (the outer statement only — the inner max(...) subquery is a plain per-node SELECT)",
+					name, got, wantOnClusterOccurrences)
 			}
-			if got2 := strings.Count(got, target); got2 != wantOccurrences {
-				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, target, wantOccurrences)
+
+			got := mutationTableSQL(tpl, target, onCluster)
+			if strings.Contains(got, mutationTablePlaceholder) {
+				t.Fatalf("%s: mutationTableSQL left an unsubstituted table placeholder behind: %q", name, got)
+			}
+			if strings.Contains(got, mutationOnClusterPlaceholder) {
+				t.Fatalf("%s: mutationTableSQL left an unsubstituted ON CLUSTER placeholder behind: %q", name, got)
+			}
+			if got2 := strings.Count(got, target); got2 != wantTableOccurrences {
+				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, target, wantTableOccurrences)
+			}
+			if got2 := strings.Count(got, onCluster); got2 != wantOnClusterOccurrences {
+				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, onCluster, wantOnClusterOccurrences)
+			}
+
+			// The ON CLUSTER clause must land on the OUTER statement, before
+			// the inner subquery's FROM — never inside the subquery, which
+			// would be invalid SQL (ON CLUSTER is DDL/mutation syntax, not
+			// valid on a plain SELECT).
+			if idx := strings.Index(got, onCluster); idx == -1 || idx > strings.Index(got, "SELECT") {
+				t.Fatalf("%s: ON CLUSTER clause did not land before the inner SELECT: %q", name, got)
 			}
 		})
+	}
+}
+
+// resolveMutationTarget's caller-visible behavior when NOT sharded (empty
+// onCluster) must leave the DELETE unchanged in shape — mutationTableSQL
+// with an empty onCluster simply erases the placeholder rather than
+// leaving a stray space or empty ON CLUSTER token behind.
+func TestMutationTableSQLEmptyOnClusterLeavesNoStrayToken(t *testing.T) {
+	t.Parallel()
+
+	got := mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, "otel_metrics_gauge", "")
+	if strings.Contains(got, "ON CLUSTER") {
+		t.Fatalf("empty onCluster left an ON CLUSTER token behind: %q", got)
+	}
+	if !strings.Contains(got, "ALTER TABLE otel_metrics_gauge DELETE") {
+		t.Fatalf("expected the unsharded ALTER TABLE shape to be preserved verbatim, got: %q", got)
 	}
 }

--- a/test/e2e/seed/cmd/seed/showcase_traceql.go
+++ b/test/e2e/seed/cmd/seed/showcase_traceql.go
@@ -140,11 +140,31 @@ VALUES
 // briefly see two copies of a span — the recursive-closure per-level
 // DISTINCT (#762) collapses dupes, and showcase contracts assert
 // nonempty/error classes, never exact values (#757).
-const deleteStaleShowcaseTracesSQL = `DELETE FROM otel_traces
+//
+// Carries two occurrences of the literal text "@@MUTATION_TABLE@@"
+// (mutationTablePlaceholder's value, sharded_mutation.go) marking the
+// table to target — substituted at call time via
+// mutationTableSQL/resolveMutationTarget rather than baked in as a
+// literal. Under the datashard lane (issue #3105) otel_traces is a
+// Distributed wrapper that rejects DELETE FROM outright ("Table engine
+// Distributed doesn't support mutations", code 48); the resolved name
+// redirects to the underlying "_local" table instead. Both occurrences —
+// the outer DELETE FROM and the inner max(...) subquery's FROM — must name
+// the SAME physical table.
+//
+// The placeholder is typed directly into this single backtick string
+// (never built by concatenating separate backtick-quoted segments around
+// mutationTablePlaceholder) — see stale.go's matching doc comment for why:
+// it keeps this const a single unbroken backtick literal for
+// test/regression/seed_test.go's extractBacktickConst, and it keeps the
+// LIKE 'b00...%' wildcard below byte-identical to what it was before this
+// const learned to target a resolved table name (no fmt.Sprintf
+// %%-escaping).
+const deleteStaleShowcaseTracesSQLTemplate = `DELETE FROM @@MUTATION_TABLE@@
 WHERE TraceId LIKE 'b00000000000000000000000000000%'
   AND Timestamp < (
     SELECT max(Timestamp) - INTERVAL 20 SECOND
-    FROM otel_traces
+    FROM @@MUTATION_TABLE@@
     WHERE TraceId LIKE 'b00000000000000000000000000000%'
   )`
 
@@ -152,13 +172,17 @@ WHERE TraceId LIKE 'b00000000000000000000000000000%'
 // inside seedAll so each rolling re-seed tick re-anchors the spans on
 // the current wall clock. INSERT strictly precedes the stale-row
 // DELETE so readers never observe an empty (or partially-deleted)
-// showcase range — see deleteStaleShowcaseTracesSQL for the full
+// showcase range — see deleteStaleShowcaseTracesSQLTemplate for the full
 // race analysis.
 func insertShowcaseTraces(ctx context.Context, conn driver.Conn) error {
 	if err := conn.Exec(ctx, insertShowcaseTracesSQL); err != nil {
 		return fmt.Errorf("showcase traces: %w", err)
 	}
-	if err := conn.Exec(ctx, deleteStaleShowcaseTracesSQL); err != nil {
+	target, err := resolveMutationTarget(ctx, conn, tracesTable)
+	if err != nil {
+		return fmt.Errorf("showcase traces stale delete: %w", err)
+	}
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleShowcaseTracesSQLTemplate, target)); err != nil {
 		return fmt.Errorf("showcase traces stale delete: %w", err)
 	}
 	return nil

--- a/test/e2e/seed/cmd/seed/showcase_traceql.go
+++ b/test/e2e/seed/cmd/seed/showcase_traceql.go
@@ -160,7 +160,7 @@ VALUES
 // LIKE 'b00...%' wildcard below byte-identical to what it was before this
 // const learned to target a resolved table name (no fmt.Sprintf
 // %%-escaping).
-const deleteStaleShowcaseTracesSQLTemplate = `DELETE FROM @@MUTATION_TABLE@@
+const deleteStaleShowcaseTracesSQLTemplate = `DELETE FROM @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@
 WHERE TraceId LIKE 'b00000000000000000000000000000%'
   AND Timestamp < (
     SELECT max(Timestamp) - INTERVAL 20 SECOND
@@ -182,7 +182,7 @@ func insertShowcaseTraces(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("showcase traces stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleShowcaseTracesSQLTemplate, target)); err != nil {
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleShowcaseTracesSQLTemplate, target.table, target.onCluster)); err != nil {
 		return fmt.Errorf("showcase traces stale delete: %w", err)
 	}
 	return nil

--- a/test/e2e/seed/cmd/seed/showcase_traceql.go
+++ b/test/e2e/seed/cmd/seed/showcase_traceql.go
@@ -182,7 +182,7 @@ func insertShowcaseTraces(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("showcase traces stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleShowcaseTracesSQLTemplate, target.table, target.onCluster)); err != nil {
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleShowcaseTracesSQLTemplate, target.table, tracesTable, target.onCluster)); err != nil {
 		return fmt.Errorf("showcase traces stale delete: %w", err)
 	}
 	return nil

--- a/test/e2e/seed/cmd/seed/stale.go
+++ b/test/e2e/seed/cmd/seed/stale.go
@@ -133,52 +133,85 @@ var (
 // in lockstep with the Go-side staleMargin() computation above — the
 // same `{name:Type}` parameter binding already used by
 // compatibility/prometheus/cmd/seed/main.go.
+// Public table names the DELETEs below target. Declared once so
+// deleteStaleMetrics/-Logs/-BaseTraces (which call resolveMutationTarget
+// against exactly these names) and showcase_traceql.go's own
+// otel_traces DELETE can't drift apart on the literal string.
 const (
-	deleteStaleMetricsGaugeSQL = `ALTER TABLE otel_metrics_gauge DELETE
+	metricsGaugeTable     = "otel_metrics_gauge"
+	metricsSumTable       = "otel_metrics_sum"
+	metricsHistogramTable = "otel_metrics_histogram"
+	metricsExpHistTable   = "otel_metrics_exponential_histogram"
+	logsTable             = "otel_logs"
+	tracesTable           = "otel_traces"
+)
+
+// Every template below carries exactly two occurrences of the literal
+// text "@@MUTATION_TABLE@@" (mutationTablePlaceholder's value,
+// sharded_mutation.go) marking the table to mutate — the outer ALTER
+// TABLE and the inner max(...) subquery's FROM — substituted at call time
+// via mutationTableSQL/resolveMutationTarget rather than baked in as a
+// literal table name. Both occurrences must name the SAME physical table:
+// under the datashard lane (issue #3105) the resolved name is the
+// "_local" table, never the Distributed public name, which rejects every
+// mutation (see sharded_mutation.go's package doc comment).
+//
+// The placeholder is typed directly into each backtick string rather than
+// built by concatenating three separate backtick-quoted segments around
+// mutationTablePlaceholder, for two reasons: it keeps each const a single
+// unbroken backtick literal (test/regression/seed_test.go's
+// extractBacktickConst scans exactly one backtick-delimited span per const
+// name — a concatenated literal would silently truncate its scan to the
+// first segment), and it avoids the '%%'-escaping a fmt.Sprintf %s verb
+// would force onto these templates' existing LIKE '...%' wildcards
+// (deleteStaleBaseTracesSQLTemplate below, deleteStaleShowcaseTracesSQLTemplate
+// in showcase_traceql.go).
+const (
+	deleteStaleMetricsGaugeSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
 WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
   AND TimeUnix < (
     SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
-    FROM otel_metrics_gauge
+    FROM @@MUTATION_TABLE@@
     WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
   )`
 
-	deleteStaleMetricsSumSQL = `ALTER TABLE otel_metrics_sum DELETE
+	deleteStaleMetricsSumSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
 WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
   AND TimeUnix < (
     SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
-    FROM otel_metrics_sum
+    FROM @@MUTATION_TABLE@@
     WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
   )`
 
-	deleteStaleMetricsHistogramSQL = `ALTER TABLE otel_metrics_histogram DELETE
+	deleteStaleMetricsHistogramSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
 WHERE MetricName = 'http_server_request_duration'
   AND TimeUnix < (
     SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
-    FROM otel_metrics_histogram
+    FROM @@MUTATION_TABLE@@
     WHERE MetricName = 'http_server_request_duration'
   )`
 
-	deleteStaleMetricsExpHistSQL = `ALTER TABLE otel_metrics_exponential_histogram DELETE
+	deleteStaleMetricsExpHistSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
 WHERE MetricName = 'showcase_latency_exp_hist'
   AND TimeUnix < (
     SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
-    FROM otel_metrics_exponential_histogram
+    FROM @@MUTATION_TABLE@@
     WHERE MetricName = 'showcase_latency_exp_hist'
   )`
 
-	deleteStaleLogsSQL = `ALTER TABLE otel_logs DELETE
+	deleteStaleLogsSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
 WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')
   AND Timestamp < (
     SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
-    FROM otel_logs
+    FROM @@MUTATION_TABLE@@
     WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')
   )`
 
-	deleteStaleBaseTracesSQL = `ALTER TABLE otel_traces DELETE
+	deleteStaleBaseTracesSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
 WHERE TraceId LIKE 'a00000000000000000000000000000%'
   AND Timestamp < (
     SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
-    FROM otel_traces
+    FROM @@MUTATION_TABLE@@
     WHERE TraceId LIKE 'a00000000000000000000000000000%'
   )`
 )
@@ -239,21 +272,47 @@ func staleDeleteContext(ctx context.Context) context.Context {
 // insertMetrics writes to. Called after all of insertMetrics' INSERTs
 // have landed, so — like deleteStaleShowcaseTracesSQL — readers never
 // observe an empty or partially-deleted window.
+//
+// Each DELETE resolves its actual mutation target via
+// resolveMutationTarget (sharded_mutation.go) before formatting the
+// template: under the datashard lane (issue #3105) the public table name
+// is a Distributed wrapper that rejects every mutation, and the resolved
+// name is the underlying "_local" table instead.
 func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	ctx = staleDeleteContext(ctx)
-	if err := conn.Exec(ctx, deleteStaleMetricsGaugeSQL,
+
+	gaugeTarget, err := resolveMutationTarget(ctx, conn, metricsGaugeTable)
+	if err != nil {
+		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
+	}
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, gaugeTarget),
 		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
 		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, deleteStaleMetricsSumSQL,
+
+	sumTarget, err := resolveMutationTarget(ctx, conn, metricsSumTable)
+	if err != nil {
+		return fmt.Errorf("sum metrics stale delete: %w", err)
+	}
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsSumSQLTemplate, sumTarget),
 		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
 		return fmt.Errorf("sum metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, deleteStaleMetricsHistogramSQL,
+
+	histogramTarget, err := resolveMutationTarget(ctx, conn, metricsHistogramTable)
+	if err != nil {
+		return fmt.Errorf("histogram metrics stale delete: %w", err)
+	}
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsHistogramSQLTemplate, histogramTarget),
 		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
 		return fmt.Errorf("histogram metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, deleteStaleMetricsExpHistSQL,
+
+	expHistTarget, err := resolveMutationTarget(ctx, conn, metricsExpHistTable)
+	if err != nil {
+		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
+	}
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsExpHistSQLTemplate, expHistTarget),
 		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
 		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
 	}
@@ -266,7 +325,11 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 // them). Called after both insertLogsSQL and insertShowcaseLogQLLogs
 // have landed.
 func deleteStaleLogs(ctx context.Context, conn driver.Conn) error {
-	if err := conn.Exec(staleDeleteContext(ctx), deleteStaleLogsSQL,
+	target, err := resolveMutationTarget(ctx, conn, logsTable)
+	if err != nil {
+		return fmt.Errorf("logs stale delete: %w", err)
+	}
+	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleLogsSQLTemplate, target),
 		clickhouse.Named("margin", marginSeconds(logsStaleMargin))); err != nil {
 		return fmt.Errorf("logs stale delete: %w", err)
 	}
@@ -279,7 +342,11 @@ func deleteStaleLogs(ctx context.Context, conn driver.Conn) error {
 // scoped separately so the two margins, sized for very different
 // windows, never interact).
 func deleteStaleBaseTraces(ctx context.Context, conn driver.Conn) error {
-	if err := conn.Exec(staleDeleteContext(ctx), deleteStaleBaseTracesSQL,
+	target, err := resolveMutationTarget(ctx, conn, tracesTable)
+	if err != nil {
+		return fmt.Errorf("base traces stale delete: %w", err)
+	}
+	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleBaseTracesSQLTemplate, target),
 		clickhouse.Named("margin", marginSeconds(tracesStaleMargin))); err != nil {
 		return fmt.Errorf("base traces stale delete: %w", err)
 	}

--- a/test/e2e/seed/cmd/seed/stale.go
+++ b/test/e2e/seed/cmd/seed/stale.go
@@ -290,7 +290,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, gaugeTarget.table, gaugeTarget.onCluster),
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, gaugeTarget.table, metricsGaugeTable, gaugeTarget.onCluster),
 		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
 		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
 	}
@@ -299,7 +299,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("sum metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsSumSQLTemplate, sumTarget.table, sumTarget.onCluster),
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsSumSQLTemplate, sumTarget.table, metricsSumTable, sumTarget.onCluster),
 		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
 		return fmt.Errorf("sum metrics stale delete: %w", err)
 	}
@@ -308,7 +308,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("histogram metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsHistogramSQLTemplate, histogramTarget.table, histogramTarget.onCluster),
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsHistogramSQLTemplate, histogramTarget.table, metricsHistogramTable, histogramTarget.onCluster),
 		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
 		return fmt.Errorf("histogram metrics stale delete: %w", err)
 	}
@@ -317,7 +317,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsExpHistSQLTemplate, expHistTarget.table, expHistTarget.onCluster),
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsExpHistSQLTemplate, expHistTarget.table, metricsExpHistTable, expHistTarget.onCluster),
 		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
 		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
 	}
@@ -334,7 +334,7 @@ func deleteStaleLogs(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("logs stale delete: %w", err)
 	}
-	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleLogsSQLTemplate, target.table, target.onCluster),
+	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleLogsSQLTemplate, target.table, logsTable, target.onCluster),
 		clickhouse.Named("margin", marginSeconds(logsStaleMargin))); err != nil {
 		return fmt.Errorf("logs stale delete: %w", err)
 	}
@@ -351,7 +351,7 @@ func deleteStaleBaseTraces(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("base traces stale delete: %w", err)
 	}
-	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleBaseTracesSQLTemplate, target.table, target.onCluster),
+	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleBaseTracesSQLTemplate, target.table, tracesTable, target.onCluster),
 		clickhouse.Named("margin", marginSeconds(tracesStaleMargin))); err != nil {
 		return fmt.Errorf("base traces stale delete: %w", err)
 	}

--- a/test/e2e/seed/cmd/seed/stale.go
+++ b/test/e2e/seed/cmd/seed/stale.go
@@ -154,7 +154,12 @@ const (
 // literal table name. Both occurrences must name the SAME physical table:
 // under the datashard lane (issue #3105) the resolved name is the
 // "_local" table, never the Distributed public name, which rejects every
-// mutation (see sharded_mutation.go's package doc comment).
+// mutation (see sharded_mutation.go's package doc comment). A single
+// further occurrence of "@@MUTATION_ON_CLUSTER@@" sits directly after the
+// FIRST @@MUTATION_TABLE@@ (the outer statement only, never the inner
+// SELECT) — empty outside the datashard lane, " ON CLUSTER '{cluster}'"
+// within it, needed because a "_local" table's mutation must reach every
+// shard's own copy, not just the node the seeder is connected to.
 //
 // The placeholder is typed directly into each backtick string rather than
 // built by concatenating three separate backtick-quoted segments around
@@ -167,7 +172,7 @@ const (
 // (deleteStaleBaseTracesSQLTemplate below, deleteStaleShowcaseTracesSQLTemplate
 // in showcase_traceql.go).
 const (
-	deleteStaleMetricsGaugeSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
+	deleteStaleMetricsGaugeSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
   AND TimeUnix < (
     SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
@@ -175,7 +180,7 @@ WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multila
     WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
   )`
 
-	deleteStaleMetricsSumSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
+	deleteStaleMetricsSumSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
   AND TimeUnix < (
     SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
@@ -183,7 +188,7 @@ WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_
     WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
   )`
 
-	deleteStaleMetricsHistogramSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
+	deleteStaleMetricsHistogramSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE MetricName = 'http_server_request_duration'
   AND TimeUnix < (
     SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
@@ -191,7 +196,7 @@ WHERE MetricName = 'http_server_request_duration'
     WHERE MetricName = 'http_server_request_duration'
   )`
 
-	deleteStaleMetricsExpHistSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
+	deleteStaleMetricsExpHistSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE MetricName = 'showcase_latency_exp_hist'
   AND TimeUnix < (
     SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
@@ -199,7 +204,7 @@ WHERE MetricName = 'showcase_latency_exp_hist'
     WHERE MetricName = 'showcase_latency_exp_hist'
   )`
 
-	deleteStaleLogsSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
+	deleteStaleLogsSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')
   AND Timestamp < (
     SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
@@ -207,7 +212,7 @@ WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'pain
     WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')
   )`
 
-	deleteStaleBaseTracesSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@ DELETE
+	deleteStaleBaseTracesSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE TraceId LIKE 'a00000000000000000000000000000%'
   AND Timestamp < (
     SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
@@ -285,7 +290,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, gaugeTarget),
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, gaugeTarget.table, gaugeTarget.onCluster),
 		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
 		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
 	}
@@ -294,7 +299,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("sum metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsSumSQLTemplate, sumTarget),
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsSumSQLTemplate, sumTarget.table, sumTarget.onCluster),
 		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
 		return fmt.Errorf("sum metrics stale delete: %w", err)
 	}
@@ -303,7 +308,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("histogram metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsHistogramSQLTemplate, histogramTarget),
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsHistogramSQLTemplate, histogramTarget.table, histogramTarget.onCluster),
 		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
 		return fmt.Errorf("histogram metrics stale delete: %w", err)
 	}
@@ -312,7 +317,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsExpHistSQLTemplate, expHistTarget),
+	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsExpHistSQLTemplate, expHistTarget.table, expHistTarget.onCluster),
 		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
 		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
 	}
@@ -329,7 +334,7 @@ func deleteStaleLogs(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("logs stale delete: %w", err)
 	}
-	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleLogsSQLTemplate, target),
+	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleLogsSQLTemplate, target.table, target.onCluster),
 		clickhouse.Named("margin", marginSeconds(logsStaleMargin))); err != nil {
 		return fmt.Errorf("logs stale delete: %w", err)
 	}
@@ -346,7 +351,7 @@ func deleteStaleBaseTraces(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("base traces stale delete: %w", err)
 	}
-	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleBaseTracesSQLTemplate, target),
+	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleBaseTracesSQLTemplate, target.table, target.onCluster),
 		clickhouse.Named("margin", marginSeconds(tracesStaleMargin))); err != nil {
 		return fmt.Errorf("base traces stale delete: %w", err)
 	}


### PR DESCRIPTION
## Summary

Issue #3105: the `datashard` N=2/N=4 e2e lane (added by #3079/#3089) had never gone green. This PR
was iterated entirely against **real CI** — `e2e` is one of the three lanes CLAUDE.md's invariant 5
says genuinely cannot be settled locally (needs a real k3d cluster) — via a deliberate
push-and-watch loop against `gh workflow run e2e.yml --ref fix/3105-datashard-e2e-helm-timeout`
(the `datashard` job only runs on `push`/`schedule`/`workflow_dispatch`, never `pull_request`).

## Four root causes found and fixed

1. **`helm --wait` timeout itself** (the issue's original symptom). Diagnostics widened first
   (63aba0dc5) to capture `kubectl describe pods`/`get events`/node capacity/Keeper logs on
   failure. The real evidence (dispatch run 34013898394): every ClickHouse and Keeper pod was
   `1/1 Running` the whole time — the cerberus Deployment itself was `CrashLoopBackOff`, exiting
   with `configure solver: solver: MinAnchorsPerSlice must be >= 2, got 1`.
   `cerberus-values-datashard.yaml` had deliberately loosened this and two sibling grid-geometry
   thresholds to `"1"` for this lane's small seed dataset, but `internal/solver/config.go`'s
   `Validate()` floors `MinAnchorsPerSlice` at 2. Fixed: raised to `"2"` (20c3ed0ed).
2. With cerberus actually starting, the rolling re-seeder's stale-row `ALTER TABLE ... DELETE`
   mutations failed outright: `Table engine Distributed doesn't support mutations` (dispatch run
   34014775573) — every DELETE in `test/e2e/seed` targeted the public, Distributed-wrapped table
   name. Fixed: `resolveMutationTarget` redirects to the underlying `_local` table via a
   `system.tables` engine lookup (5bb6b77c6).
3. The local-table redirect alone only mutated the ONE shard the seeder is connected to — a
   Distributed INSERT spreads rows across shards essentially at random, so every OTHER shard kept
   its stale rows. `TestReSeedRowCountStability` failed for every family whose insert path spreads
   rows across shards (dispatch run 34015811450). Fixed: `ALTER TABLE ... ON CLUSTER '{cluster}'
   DELETE`, using ClickHouse's own `{cluster}` macro rather than threading new plumbing into the
   seeder (1924f61af).
4. Even under `ON CLUSTER`, the DELETE's inner `max(<time column>)` cutoff subquery still ran
   against the LOCAL table — correct on a shard that happened to get a fresh row that tick, wrong
   on one that didn't. Only manifested for the lowest-row-count family (`base-traces`, 7 rows/tick;
   every higher-volume family's fresh rows are near-certain to land on every shard every tick,
   masking the same bug) — dispatch run 34016653322. Fixed: the inner subquery now targets the
   PUBLIC Distributed name instead, which ClickHouse correctly fans out and aggregates regardless
   of which shard node is executing that copy of the ON CLUSTER broadcast (2387ea648).

**`TestReSeedRowCountStability` now passes cleanly on both N=2 and N=4** — confirmed on dispatch
run 34017639602.

## What's still red, and why this PR does not close #3105

With all four fixes in place, the lane now progresses through cluster bring-up AND seeding for the
first time ever — and then fails at real QUERY EXECUTION instead. `test/e2e`'s TraceQL
structural/compare queries and a PromQL `scalar()` call both break under the real
`DataShardCount > 1` topology (ClickHouse's `distributed_product_mode = 'deny'` rejecting a
double-Distributed JOIN/subquery, and a `scalar()` result-shape bug, respectively) — genuinely new,
separate findings, filed as **#3118** and **#3119** (both linked under epic #3074), not something
these seeder/config fixes caused or could reasonably absorb. Full progress notes on #3105 itself.

This PR's four fixes are independently correct, tested, and merge-worthy regardless — they turn a
lane that failed at minute 1 into one that fails at real query execution 15+ minutes in, which is
real, verified progress toward #3105's own acceptance criteria even though that issue stays open,
now blocked on #3118 and #3119.

## Local verification

`go build`/`go vet`/`go test` (including `-race`) on `test/e2e/seed/...` and the full
`test/regression/...` suite, `gofumpt`/`goimports` clean, on every commit. The `mutationTableSQL`
positional-substitution logic (outer statement → resolved local target, inner subquery → public
Distributed name) is covered by new unit tests in `sharded_mutation_test.go` that don't need a live
cluster; the actual multi-shard behavior is what the four real dispatch runs above verify.

## Test plan

- [x] `TestReSeedRowCountStability` passes on a real CI run (34017639602)
- [ ] `datashard (N=2)`/`(N=4)` jobs fully green — blocked on #3118, #3119
- [ ] `deploy/helm/cerberus/values.yaml` + `docs/operations.md` caveats updated once the lane is
      genuinely fully green (not yet — would overclaim given #3118/#3119 are still open)

Part of #3105. Not closing it — see above.
