### PR TITLE
fix(e2e): gate mode-toggle readiness check on the pod actually rolling

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1985,6 +1985,11 @@ what actually runs.
   478) — never merely a non-ready/crash-looping pod, a plain non-zero `helm`
   exit, a timeout, or a silent success — by polling `kubectl logs` (both the
   current and `--previous` container instance) for that exact signature.
+  Pins the pod's `metadata.uid` before polling and only trusts a "still
+  Ready" reading once a pod with a DIFFERENT uid has appeared (cerberus issue
+  #3109) — `helm upgrade` returns long before the StatefulSet controller
+  actually replaces the pod, so an immediate readiness read would otherwise
+  just observe the pre-toggle pod and falsely call the hazard unreproduced.
   Requires `clickhouse.bundled.configOverrides` to have turned on
   `<logger><console>1</console></logger>`
   (`cerberus-values-bwc-mode-toggle.yaml`), the only reason the exception

--- a/.github/scripts/e2e-bwc-verify-mode-toggle.mjs
+++ b/.github/scripts/e2e-bwc-verify-mode-toggle.mjs
@@ -45,6 +45,31 @@
 //
 // Exit 0 = the exact UNKNOWN_POLICY failure was observed and the pod never
 // became Ready; 1 = anything else (with ::error:: annotation).
+//
+// THE RACE THIS SCRIPT MUST NOT LOSE (cerberus issue #3109's second symptom):
+// `just e2e-bwc-toggle-mode`'s `helm upgrade` call returns as soon as the API
+// server has accepted the new manifests — it does NOT wait for the
+// StatefulSet controller to notice the changed `checksum/config` pod-template
+// annotation and actually replace `cerberus-clickhouse-0` (that replacement
+// alone — graceful shutdown of the OLD (still-healthy) process, pod
+// termination, a brand-new Pod object, container start — reliably takes
+// several seconds on a real cluster). This script starts polling within
+// milliseconds of that `helm upgrade` returning, so its very first
+// `podReady` read is virtually guaranteed to observe the PRE-upgrade pod —
+// which has been happily Ready since the object-storage install — long
+// before the controller has even begun rolling it. Reading readiness before
+// the rollout has started is not evidence of anything: it was true before
+// the toggle and says nothing about the toggle's outcome. So this script
+// pins the pod's `metadata.uid` at the moment polling begins and treats
+// `podReady` as meaningful ONLY once a pod with a DIFFERENT uid — i.e. one
+// the controller actually created IN RESPONSE to the mode-toggling upgrade —
+// exists. Confirmed live: this exact race is why the leg has failed on
+// EVERY run since it first reached CI (dispatch run 33983571851, the very
+// first execution right after cerberus issue #3082/#3085 merged) — it is
+// not a regression in the storage-policy naming mechanism itself, which
+// `helm template` against both scenarios' rendered storage.xml (and a
+// bare-ClickHouse-26.3 repro of the same policy-rename shape) both confirm
+// still throws UNKNOWN_POLICY exactly as designed.
 
 import process from 'node:process';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -103,17 +128,45 @@ function restartCount(pod) {
   return Number(containerStatusField(pod, 'restartCount') || '0');
 }
 
+// The Pod object's own `metadata.uid` — stable for the lifetime of ONE Pod
+// object, and guaranteed different on any replacement Pod the StatefulSet
+// controller creates under the same name. Empty during the brief gap between
+// the old Pod being deleted and the new one being admitted; callers treat
+// that as "no pod to read yet" rather than a new/old determination.
+function podUID(pod) {
+  const res = kubectl(['get', 'pod', pod, '-o', 'jsonpath={.metadata.uid}']);
+  return res.stdout.trim();
+}
+
 async function main() {
   const pod = clickhousePodName(kubectl, NS);
+  const preToggleUID = podUID(pod);
   log(
-    `mode-toggle verify: namespace=${NS} pod=${pod} expected-rejected-policy=${EXPECTED_POLICY} ` +
-      `poll-budget=${POLL_SECONDS}s`,
+    `mode-toggle verify: namespace=${NS} pod=${pod} pre-toggle-uid=${preToggleUID || '<none>'} ` +
+      `expected-rejected-policy=${EXPECTED_POLICY} poll-budget=${POLL_SECONDS}s`,
   );
 
   const deadline = Date.now() + POLL_SECONDS * 1000;
   let match = null;
+  let rolled = false; // has a pod DISTINCT from the pre-toggle one appeared yet?
   while (Date.now() < deadline) {
-    if (podReady(pod)) {
+    const currentUID = podUID(pod);
+    // Until the StatefulSet controller has actually replaced the pod, its
+    // readiness describes the PRE-toggle install, not the toggle's outcome —
+    // see the module doc's "THE RACE THIS SCRIPT MUST NOT LOSE" section.
+    // currentUID is empty during the brief delete/recreate gap; that is
+    // itself evidence a replacement is underway, so it also counts as
+    // "rolled" once preToggleUID was non-empty.
+    if (!rolled) {
+      if (currentUID && currentUID === preToggleUID) {
+        await sleep(pollIntervalMs);
+        continue;
+      }
+      rolled = true;
+      log(`mode-toggle verify: rollout detected (pod uid changed from ${preToggleUID || '<none>'} to ` +
+        `${currentUID || '<none> (mid-recreate)'}) — readiness now proves something`);
+    }
+    if (currentUID && podReady(pod)) {
       error(
         `bundled ClickHouse pod ${pod} became Ready after the mode-toggling upgrade — the hazard did NOT ` +
           `reproduce (this would mean cerberus issue #3075/#3076's per-mode storage-policy names silently ` +
@@ -124,6 +177,15 @@ async function main() {
     match = scanLogsForFailure(pod);
     if (match) break;
     await sleep(pollIntervalMs);
+  }
+
+  if (!rolled) {
+    error(
+      `bundled ClickHouse pod ${pod} was NEVER replaced within ${POLL_SECONDS}s (uid stayed ${preToggleUID}) — ` +
+        'the mode-toggling helm upgrade apparently never changed the pod template (checksum/config annotation), ' +
+        'so this run proves nothing about the storage-policy hazard either way',
+    );
+    process.exit(1);
   }
 
   if (!match) {


### PR DESCRIPTION
## Summary

Fixes the second symptom named in #3109: `bwc-minio (mode-toggle)` reporting
`bundled ClickHouse pod cerberus-clickhouse-0 became Ready after the
mode-toggling upgrade` instead of reproducing the intended UNKNOWN_POLICY
startup failure (cerberus issues #3075/#3076's per-mode storage-policy-name
migration-safety mechanism).

## Root cause

`e2e-bwc-verify-mode-toggle.mjs` began polling the bundled ClickHouse pod's
readiness *immediately* after `just e2e-bwc-toggle-mode`'s `helm upgrade
--install` call returned. That call returns as soon as the Kubernetes API
server has accepted the new manifests — it does **not** wait for the
StatefulSet controller to notice the changed `checksum/config` pod-template
annotation and actually replace `cerberus-clickhouse-0` (graceful shutdown of
the still-healthy old process, pod termination, a brand-new Pod object,
container start — several seconds on a real cluster at minimum).

The verify script's very first readiness read landed ~0.3s after the `helm
upgrade` call returned (confirmed from the raw CI log timestamps below), so
it was reading the **pre-toggle pod**, which had been Ready since the
object-storage install completed minutes earlier — long before the
controller had even begun rolling it. That stale "still Ready" read was
immediately (and wrongly) reported as "the hazard did NOT reproduce."

Evidence this was never a regression in the storage-policy mechanism itself:

- `gh run view` on the very first CI execution of this leg, right after the
  mode-toggle test merged (#3085 → dispatch run `33983571851`, job
  `bwc-minio (mode-toggle)`), shows the **exact same** failure — `helm
  upgrade` returns at `18:22:41.27`, the verify script's very first readiness
  check fails at `18:22:41.58`, ~0.3s later. Every subsequent run through
  tonight's nightly (`34020360145`) fails identically, 100% reproducible —
  not a flake.
- `helm template` against the object-storage baseline vs.
  hot-cold+mode-toggle overlay confirms the rendered `storage.xml` still
  swaps `<bwc_object_store>` for `<bwc_hot_cold>` with **zero** name/config
  overlap (`deploy/helm/cerberus/templates/clickhouse/_helpers.tpl`'s
  `cerberus.clickhouse.effectivePolicyName` and `storageXML` templates are
  unchanged in behavior since #3076).
- A bare `clickhouse/clickhouse-server:26.3` container (the exact pinned
  e2e image, resolving today to `26.3.30.9`) reproduces the intended
  `UNKNOWN_POLICY` (error 478) exception and a full process exit when a
  table's persisted `storage_policy` is dropped from `storage_configuration`
  — ClickHouse's own startup-validation behavior is unchanged; no version
  drift.
- `chart-notes-assert.mjs` (the step immediately preceding the toggle in the
  job) uses fully distinct release names/namespace, ruling out any
  cross-install interference.

So this was a bug in the *verify script's timing assumption*, present since
the mode-toggle leg's very first CI run — not a regression introduced by a
later change to the chart, the values files, or ClickHouse's own version.

## Fix

`e2e-bwc-verify-mode-toggle.mjs` now pins the ClickHouse pod's
`metadata.uid` before polling begins, and only treats a "still Ready" read as
proof the hazard failed to reproduce once a pod with a **different** uid —
one the StatefulSet controller actually created in response to the
mode-toggling upgrade — has appeared. Until that rollout is observed, a
"Ready" read describes the pre-toggle pod and is skipped rather than treated
as a verdict. A poll budget that expires without ever observing the uid
change now reports its own distinct diagnostic ("the pod was never replaced —
this run proves nothing about the storage-policy hazard either way") instead
of being folded into the "hazard did not reproduce" verdict, so a future
unrelated failure (e.g. the `helm upgrade` not actually changing the pod
template) is diagnosed correctly rather than misattributed.

## Verification

- `helm lint` and `helm template` (object-storage baseline vs.
  hot-cold+mode-toggle overlay) locally — rendered `storage.xml` unaffected
  by this change (this PR only touches the Node verify script).
- `node --check .github/scripts/e2e-bwc-verify-mode-toggle.mjs` — syntax OK.
- Local Docker repro against the exact pinned `clickhouse/clickhouse-server:26.3`
  image, independent of the chart/k3d: create a table under one storage
  policy, restart the container with a config that only defines a
  differently-named policy — confirms ClickHouse still throws
  `Unknown storage policy ... (UNKNOWN_POLICY)` and exits, exactly as the
  chart's mechanism assumes.
- `markdownlint-cli2` on the touched `README.md` section — 0 issues.
- Real cluster verification: pending a `workflow_dispatch` of `e2e.yml` on
  this branch — this PR will be updated with the run result once it
  completes.

## Notes for the coordinator

This PR intentionally does **not** include a standalone `Closes #3109` line.
#3109 has two independent symptoms: the first (a PromQL `scalar()` bug) is
already fixed and merged (#3118/#3119/#3120/#3121). Once this PR's fix is
confirmed green on a real `bwc-minio (mode-toggle)` CI run, both of #3109's
symptoms will be resolved and it will be safe to close #3109 manually — please
do that after this merges rather than relying on an automatic linkage, to
avoid the auto-close race a prior PR's stale `Closes #N` caused.

Out of scope (unrelated bugs in the same epic/nightly, tracked/fixed
separately): #3105, #3118, #3119, #3122.
