### PR TITLE
fix(test): recognize @# as a comment start in tagged-test-enrollment lexer

### DIFF
--- a/test/regression/tagged_test_enrollment_test.go
+++ b/test/regression/tagged_test_enrollment_test.go
@@ -752,6 +752,14 @@ func taggedShellSegments(script string) ([]taggedShellSegment, error) {
 			comment = true
 			continue
 		}
+		// A `just` recipe's leading "@" is a quiet-execution marker, not a shell
+		// token, so "@#" at a command-start position is a comment start exactly
+		// like a bare "#" would be there.
+		if char == '@' && index+1 < len(script) && script[index+1] == '#' &&
+			(index == 0 || unicode.IsSpace(rune(script[index-1])) || strings.ContainsRune(";|&", rune(script[index-1]))) {
+			comment = true
+			continue
+		}
 		switch char {
 		case '\n':
 			flush("\n")
@@ -1920,6 +1928,28 @@ func TestTaggedTestEnrollmentNegativeControls(t *testing.T) {
 			if command.Executable == "go" || command.Executable == "just" {
 				t.Fatalf("prose counted as execution: %#v", command)
 			}
+		}
+	})
+
+	t.Run("@# quiet-recipe comment with an apostrophe is not an unterminated quote", func(t *testing.T) {
+		commands, err := taggedStaticCommands(strings.Join([]string{
+			"@# e2e-up's kubelet's pod's cache needs a moment to settle",
+			"go test -tags tagged ./internal/example/...",
+		}, "\n"))
+		if err != nil {
+			t.Fatalf("static command parse = %v, %v", commands, err)
+		}
+		found := false
+		for _, command := range commands {
+			if command.Executable == "@#" || command.Executable == "@" {
+				t.Fatalf("@#-comment counted as execution: %#v", command)
+			}
+			if command.Executable == "go" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("command following the @#-comment was not recognized: %#v", commands)
 		}
 	})
 	t.Run("dynamic Go subcommand fails closed", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`test/regression/tagged_test_enrollment_test.go`'s hand-rolled shell-segment lexer
(`taggedShellSegments`'s comment-detection guard) only recognized `#` as starting a comment when
it was preceded by start-of-script, whitespace, or one of `;|&`. A `just` recipe comment line
written as `@#...` (the `@`-quiet-execution prefix immediately followed by `#`) was not
recognized, because `@` matched none of those conditions — so an apostrophe inside such a comment
(e.g. a contraction like "e2e-up's") was counted as a real shell quote character, throwing off the
lexer's quote-balance tracking and producing a false "unterminated shell quote" parse failure for
the rest of the script.

## Fix

Extended the comment-detection guard in `taggedShellSegments` so that `@` immediately followed by
`#` at a command-start position (start of script, after whitespace, or after `;`/`|`/`&`) is also
recognized as a comment start — a recipe's leading `@` is a quiet-execution marker, not a shell
token.

I verified the comment-detection logic exists only once in this file (`taggedShellSegments`,
around line 751 on this branch). The `next == '#'` reference near line 940 that the issue
mentioned is `taggedDollarExpands`, which handles `$#` (shell parameter-count expansion) — unrelated
logic, not a duplicate of the comment guard — so only one fix site was needed.

Bare `#` and `#` following `;`/`|`/`&` are untouched; `@` used elsewhere (not immediately followed
by `#`, or not at a command-start position) is untouched too, so a plain `@go test ...`
quiet-execution prefix still lexes exactly as before.

## Testing

- Added a regression case to `TestTaggedTestEnrollmentNegativeControls` with a synthetic `@#`
  comment containing several apostrophes, followed by a real command, asserting the comment isn't
  counted as an execution and the following command is still recognized.
- Verified locally that the new test fails with the pre-fix "unterminated shell quote" error when
  the fix is reverted, and passes with the fix applied.
- `go build ./test/regression/...`, `go vet ./test/regression/...`, and
  `go test -race ./test/regression/...` all clean.
- `gofumpt -l` / `goimports -local github.com/tsouza/cerberus -l` clean on the changed file.

Closes #3103
