### PR TITLE
fix(e2e/seed): resolve stale-row DELETE cutoff client-side to avoid nondeterminism

### DIFF
--- a/test/e2e/seed/cmd/seed/sharded_mutation.go
+++ b/test/e2e/seed/cmd/seed/sharded_mutation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -11,42 +12,51 @@ import (
 	"github.com/tsouza/cerberus/internal/schema/ddl"
 )
 
-// mutationTablePlaceholder marks the table name in the DELETE templates
-// declared in stale.go and showcase_traceql.go — substituted for the
-// resolved mutation target (resolveMutationTarget) via mutationTableSQL
-// below. A dedicated token rather than a fmt.Sprintf %s verb: every one of
-// those templates' TraceId/predicate clauses already contains literal '%'
-// LIKE wildcards, which a %s verb would force into confusing (and
-// regression-test-breaking — see test/regression/seed_test.go's
-// TestShowcaseTraceStaleDeleteIsDataAnchored, which scans the raw source
-// text for a single '%') '%%' escaping. Chosen to be a string no seeded
-// table name, SQL keyword, or LIKE pattern in this package could ever
-// collide with.
+// mutationTablePlaceholder marks the table name in a mutation-family SQL
+// template declared in stale.go/showcase_traceql.go — substituted for the
+// resolved table name via mutationTableSQL below. A dedicated token rather
+// than a fmt.Sprintf %s verb: every one of those templates' TraceId/
+// predicate clauses already contains literal '%' LIKE wildcards, which a
+// %s verb would force into confusing (and regression-test-breaking — see
+// test/regression/seed_test.go's TestShowcaseTraceStaleDeleteIsDataAnchored,
+// which scans the raw source text for a single '%') '%%' escaping. Chosen
+// to be a string no seeded table name, SQL keyword, or LIKE pattern in this
+// package could ever collide with.
+//
+// Each template — the step-A cutoff SELECT and the step-B literal-cutoff
+// ALTER/DELETE alike (see this file's package doc comment for the two-step
+// design, issue #3124) — carries exactly ONE occurrence of this token: a
+// step-A template substitutes it for the PUBLIC table name, a step-B
+// template substitutes it for the resolved mutation target (the "_local"
+// table under the datashard lane). The two statements are substituted
+// independently by two separate mutationTableSQL calls; nothing here ties
+// one template's substitution to the other's the way the old single-
+// statement subquery design once did.
 const mutationTablePlaceholder = "@@MUTATION_TABLE@@"
 
 // mutationOnClusterPlaceholder marks the optional " ON CLUSTER '{cluster}'"
-// clause on the OUTER `ALTER TABLE` line only (never the inner max(...)
-// subquery, which is a plain per-node SELECT) — substituted by
-// resolveMutationTarget's onCluster return value via mutationTableSQL.
-// Empty on every lane except the datashard one; see this file's package
-// doc comment for why ON CLUSTER is what the local-table redirect alone
-// does not fix.
+// clause on a step-B ALTER TABLE/DELETE FROM template — substituted by
+// resolveMutationTarget's onCluster return value via mutationTableSQL. Empty
+// on every lane except the datashard one; see this file's package doc
+// comment for why ON CLUSTER is what the local-table redirect alone does not
+// fix. Never appears in a step-A cutoff SELECT template: that statement is a
+// plain per-node SELECT (mutationTableSQL still erases the token if a
+// template doesn't carry it, so passing onCluster="" for a step-A
+// substitution is always safe).
 const mutationOnClusterPlaceholder = "@@MUTATION_ON_CLUSTER@@"
 
-// mutationTableSQL fills in template's two mutationTablePlaceholder
-// occurrences DIFFERENTLY — the first (the outer ALTER TABLE/DELETE FROM)
-// with target, the second (the inner max(...) subquery's FROM) with
-// publicTable — and mutationOnClusterPlaceholder with onCluster. See this
-// file's package doc comment for why the two occurrences must NOT resolve
-// to the same name once the datashard lane is in play: the outer mutation
-// needs the "_local" table (Distributed doesn't support mutations at all),
-// but the inner max(...) needs the PUBLIC Distributed name, or a
-// low-row-count family whose fresh INSERTs happen not to land on every
-// shard every tick computes a per-shard max() that never advances past a
-// stale sentinel on the shard(s) that got skipped.
-func mutationTableSQL(template, target, publicTable, onCluster string) string {
-	s := strings.Replace(template, mutationTablePlaceholder, target, 1)
-	s = strings.ReplaceAll(s, mutationTablePlaceholder, publicTable)
+// mutationTableSQL fills in template's mutationTablePlaceholder occurrence
+// with table and its mutationOnClusterPlaceholder occurrence (if any) with
+// onCluster. Used for BOTH halves of the two-step literal-cutoff design
+// (issue #3124): once per family for the step-A cutoff SELECT (table =
+// the PUBLIC name, onCluster = "" — a SELECT needs no cluster broadcast),
+// and once per family for the step-B ALTER/DELETE (table = the resolved
+// mutation target, onCluster = resolveMutationTarget's own return value).
+// Earlier revisions of this function filled the (then two-occurrence)
+// placeholder differently for the outer statement vs. the inner max(...)
+// subquery it now replaces; that split is gone along with the subquery.
+func mutationTableSQL(template, table, onCluster string) string {
+	s := strings.ReplaceAll(template, mutationTablePlaceholder, table)
 	return strings.ReplaceAll(s, mutationOnClusterPlaceholder, onCluster)
 }
 
@@ -82,25 +92,47 @@ func mutationTableSQL(template, target, publicTable, onCluster string) string {
 // (main.go) already reads system.tables to learn whether the external
 // schema writer has created a table yet.
 //
-// The redirect alone is not the whole fix. Each DELETE template's inner
-// max(<time column>) subquery anchors the cutoff to "how fresh is the data
-// that's actually here" — but a Distributed table's INSERT spreads rows
-// across shards essentially at random (Config.DataShardingKey, default
-// rand()), so a LOW-row-count family (base-traces' fixed 7-row fixture) can
-// have a tick where NONE of its fresh rows land on a given shard. If the
-// subquery ran against that shard's own "_local" table, its max() would
-// reflect only OLD rows (or nothing newer than the sentinel itself),
-// so the cutoff never advances past a stale/sentinel row on that shard —
-// confirmed live: TestReSeedRowCountStability/base-traces alone (the
-// lowest-row-count family; every higher-volume family's fresh rows are
-// near-certain to land on every shard every tick, masking the same bug)
-// failed on dispatch run 34016653322 after the local-table + ON CLUSTER
-// fix alone. mutationTableSQL therefore targets the subquery at the
-// PUBLIC name instead: a SELECT against a Distributed table (unlike a
-// mutation) is exactly what the engine is FOR, and ClickHouse fans it out
-// and aggregates the true cluster-wide max() regardless of which shard
-// node the ON CLUSTER broadcast happens to be executing this copy of the
-// statement on.
+// The redirect alone is not the whole fix. Every stale-row cutoff — "how
+// fresh is the data that's actually here" — is computed by a
+// max(<time column>) SELECT (resolveStaleCutoff below), and that SELECT
+// must run against the PUBLIC name, never a shard's own "_local" table: a
+// SELECT against a Distributed table (unlike a mutation) is exactly what
+// the engine is FOR, and ClickHouse fans it out and aggregates the true
+// cluster-wide max() regardless of which shard node happens to run it.
+// Anchoring the read at a shard's own "_local" table instead breaks on a
+// LOW-row-count family (base-traces' fixed 7-row fixture): a Distributed
+// table's INSERT spreads rows across shards essentially at random
+// (Config.DataShardingKey, default rand()), so a tick can land NONE of its
+// fresh rows on a given shard, and that shard's own max() would reflect
+// only OLD rows (or nothing newer than the sentinel itself) — confirmed
+// live: TestReSeedRowCountStability/base-traces alone (the lowest-row-count
+// family; every higher-volume family's fresh rows are near-certain to land
+// on every shard every tick, masking the same bug) failed on dispatch run
+// 34016653322 after the local-table + ON CLUSTER fix alone. resolveStaleCutoff
+// therefore always reads the PUBLIC name.
+//
+// Reading the cutoff is now (issue #3124) a SEPARATE statement from the
+// DELETE that consumes it, not a subquery nested inside the mutation.
+// Issue #3105's original design — a live `max(...)` subquery embedded
+// directly in the `ALTER ... DELETE`/`DELETE FROM` — worked against a
+// single, non-replicated "_local" table per shard, but the
+// `datashard-replica-affinity` lane (issue #3086) runs MULTIPLE REPLICAS per
+// data shard, whose "_local" tables are ReplicatedMergeTree-family; ClickHouse
+// rejects a subquery-bearing mutation against a replicated table outright
+// ("ALTER UPDATE/ALTER DELETE statement with subquery may be nondeterministic",
+// code 36) because an `ON CLUSTER` broadcast has every replica of every shard
+// independently re-evaluate the subquery, and two replicas evaluating
+// `max(...)` at slightly different wall-clock moments could disagree on which
+// rows to delete and silently diverge their data. resolveStaleCutoff
+// (this file) runs the `max(...)` SELECT once, client-side, and its caller
+// binds the resulting time.Time as a literal `{cutoff:DateTime64(9)}`
+// parameter on the DELETE — every replica's own copy of the mutation then
+// compares against the exact same fixed value, so no subquery (and no
+// per-replica re-evaluation) survives inside the mutation at all. This
+// removes the nondeterminism ClickHouse's guard rejects by construction,
+// rather than by disabling the guard via allow_nondeterministic_mutations —
+// the guard's own reasoning (real, not a false positive) is left intact for
+// any future mutation that still needs it.
 
 // distributedEngine is the exact system.tables.engine value ClickHouse
 // reports for a Distributed-engine table — the one engine that rejects
@@ -199,4 +231,27 @@ func resolveMutationTarget(ctx context.Context, conn driver.Conn, table string) 
 	target := mutationTargetForEngine(table, engine)
 	shardMutationTargets[table] = target
 	return target, nil
+}
+
+// resolveStaleCutoff runs selectTemplate — a step-A "SELECT max(<time
+// column>) - INTERVAL ... FROM @@MUTATION_TABLE@@ WHERE ..." query, with
+// exactly one mutationTablePlaceholder occurrence and no
+// mutationOnClusterPlaceholder — against publicTable and scans the single
+// resulting value into a time.Time. That value is the literal cutoff every
+// replica of the caller's own step-B ALTER/DELETE compares against (see
+// this file's package doc comment for why resolving it client-side, once,
+// before the mutation is issued removes issue #3124's nondeterminism
+// hazard by construction). Always queries the PUBLIC Distributed name,
+// never the resolved mutation target — see the package doc comment for why
+// a Distributed SELECT is what correctly aggregates the cluster-wide
+// max() regardless of which shard node runs it. selectArgs are forwarded
+// to conn.QueryRow verbatim (most callers bind a {margin:UInt64} parameter
+// alongside the query text).
+func resolveStaleCutoff(ctx context.Context, conn driver.Conn, selectTemplate, publicTable string, selectArgs ...any) (time.Time, error) {
+	sql := mutationTableSQL(selectTemplate, publicTable, "")
+	var cutoff time.Time
+	if err := conn.QueryRow(ctx, sql, selectArgs...).Scan(&cutoff); err != nil {
+		return time.Time{}, fmt.Errorf("resolve stale cutoff: %w", err)
+	}
+	return cutoff, nil
 }

--- a/test/e2e/seed/cmd/seed/sharded_mutation_test.go
+++ b/test/e2e/seed/cmd/seed/sharded_mutation_test.go
@@ -64,17 +64,19 @@ func TestMutationTargetForEngineRequiresExactMatch(t *testing.T) {
 	}
 }
 
-// mutationTableSQL is the substitution half of the fix: every DELETE
-// template must carry the placeholder EXACTLY twice (the outer
-// ALTER/DELETE and the inner max(...) subquery's FROM, both pinned to the
-// same resolved table), and mutationTableSQL must replace every
-// occurrence, leaving none of the placeholder text behind. stale.go and
-// showcase_traceql.go type "@@MUTATION_TABLE@@" directly into each
-// template rather than referencing mutationTablePlaceholder by name (see
+// mutationTableSQL is the substitution half of the fix: every step-A
+// cutoff SELECT template must carry the table placeholder EXACTLY once and
+// carry NO ON CLUSTER placeholder (a plain SELECT is never DDL/mutation
+// syntax), and every step-B ALTER/DELETE template must carry the table
+// placeholder EXACTLY once plus the ON CLUSTER placeholder EXACTLY once —
+// mutationTableSQL must replace every occurrence, leaving none of the
+// placeholder text behind. stale.go and showcase_traceql.go type
+// "@@MUTATION_TABLE@@"/"@@MUTATION_ON_CLUSTER@@" directly into each
+// template rather than referencing the placeholder consts by name (see
 // those files' doc comments for why — keeping each const a single
 // unbroken backtick literal for test/regression/seed_test.go's
-// extractBacktickConst), so this test is what actually pins the two
-// literals against each other: it fails the moment either side drifts.
+// extractBacktickConst), so this test is what actually pins the literals
+// against each other: it fails the moment either side drifts.
 func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
 	t.Parallel()
 
@@ -84,7 +86,39 @@ func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
 		onCluster   = onClusterMutationClause
 	)
 
-	for name, tpl := range map[string]string{
+	selectTemplates := map[string]string{
+		"selectStaleMetricsGaugeCutoffSQLTemplate":     selectStaleMetricsGaugeCutoffSQLTemplate,
+		"selectStaleMetricsSumCutoffSQLTemplate":       selectStaleMetricsSumCutoffSQLTemplate,
+		"selectStaleMetricsHistogramCutoffSQLTemplate": selectStaleMetricsHistogramCutoffSQLTemplate,
+		"selectStaleMetricsExpHistCutoffSQLTemplate":   selectStaleMetricsExpHistCutoffSQLTemplate,
+		"selectStaleLogsCutoffSQLTemplate":             selectStaleLogsCutoffSQLTemplate,
+		"selectStaleBaseTracesCutoffSQLTemplate":       selectStaleBaseTracesCutoffSQLTemplate,
+		"selectStaleShowcaseTracesCutoffSQLTemplate":   selectStaleShowcaseTracesCutoffSQLTemplate,
+	}
+	for name, tpl := range selectTemplates {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			const wantTableOccurrences = 1
+			if got := strings.Count(tpl, mutationTablePlaceholder); got != wantTableOccurrences {
+				t.Fatalf("%s contains %d occurrences of the table placeholder, want %d (a step-A cutoff SELECT substitutes it once, for the PUBLIC table)",
+					name, got, wantTableOccurrences)
+			}
+			if strings.Contains(tpl, mutationOnClusterPlaceholder) {
+				t.Fatalf("%s contains the ON CLUSTER placeholder, want none — a step-A cutoff SELECT is a plain per-node query, never DDL/mutation syntax", name)
+			}
+
+			got := mutationTableSQL(tpl, publicTable, "")
+			if strings.Contains(got, mutationTablePlaceholder) {
+				t.Fatalf("%s: mutationTableSQL left an unsubstituted table placeholder behind: %q", name, got)
+			}
+			if got2 := strings.Count(got, publicTable); got2 != wantTableOccurrences {
+				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, publicTable, wantTableOccurrences)
+			}
+		})
+	}
+
+	deleteTemplates := map[string]string{
 		"deleteStaleMetricsGaugeSQLTemplate":     deleteStaleMetricsGaugeSQLTemplate,
 		"deleteStaleMetricsSumSQLTemplate":       deleteStaleMetricsSumSQLTemplate,
 		"deleteStaleMetricsHistogramSQLTemplate": deleteStaleMetricsHistogramSQLTemplate,
@@ -92,83 +126,65 @@ func TestMutationTableSQLReplacesEveryTemplatePlaceholder(t *testing.T) {
 		"deleteStaleLogsSQLTemplate":             deleteStaleLogsSQLTemplate,
 		"deleteStaleBaseTracesSQLTemplate":       deleteStaleBaseTracesSQLTemplate,
 		"deleteStaleShowcaseTracesSQLTemplate":   deleteStaleShowcaseTracesSQLTemplate,
-	} {
+	}
+	for name, tpl := range deleteTemplates {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			const wantTableOccurrences = 2
+			const wantTableOccurrences = 1
 			if got := strings.Count(tpl, mutationTablePlaceholder); got != wantTableOccurrences {
-				t.Fatalf("%s contains %d occurrences of the table placeholder, want %d (one for the outer statement, one for the inner max(...) subquery's FROM)",
+				t.Fatalf("%s contains %d occurrences of the table placeholder, want %d (a step-B ALTER/DELETE substitutes it once, for the resolved mutation target)",
 					name, got, wantTableOccurrences)
 			}
 
 			const wantOnClusterOccurrences = 1
 			if got := strings.Count(tpl, mutationOnClusterPlaceholder); got != wantOnClusterOccurrences {
-				t.Fatalf("%s contains %d occurrences of the ON CLUSTER placeholder, want %d (the outer statement only — the inner max(...) subquery is a plain per-node SELECT)",
-					name, got, wantOnClusterOccurrences)
+				t.Fatalf("%s contains %d occurrences of the ON CLUSTER placeholder, want %d", name, got, wantOnClusterOccurrences)
 			}
 
-			got := mutationTableSQL(tpl, target, publicTable, onCluster)
+			const cutoffBind = "{cutoff:DateTime64(9)}"
+			if !strings.Contains(tpl, cutoffBind) {
+				t.Fatalf("%s: step-B template must bind the literal cutoff as %s — no subquery may survive inside the mutation (issue #3124)", name, cutoffBind)
+			}
+			if strings.Contains(tpl, "SELECT") {
+				t.Fatalf("%s: step-B template must carry no SELECT of its own — the cutoff is resolved by a separate step-A query, never a subquery nested in the mutation (issue #3124)", name)
+			}
+
+			got := mutationTableSQL(tpl, target, onCluster)
 			if strings.Contains(got, mutationTablePlaceholder) {
 				t.Fatalf("%s: mutationTableSQL left an unsubstituted table placeholder behind: %q", name, got)
 			}
 			if strings.Contains(got, mutationOnClusterPlaceholder) {
 				t.Fatalf("%s: mutationTableSQL left an unsubstituted ON CLUSTER placeholder behind: %q", name, got)
 			}
+			if got2 := strings.Count(got, target); got2 != wantTableOccurrences {
+				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, target, wantTableOccurrences)
+			}
 			if got2 := strings.Count(got, onCluster); got2 != wantOnClusterOccurrences {
 				t.Fatalf("%s: mutationTableSQL produced %d occurrences of %q, want %d", name, got2, onCluster, wantOnClusterOccurrences)
-			}
-
-			// The outer statement gets `target` (the resolved local table),
-			// the inner max(...) subquery's FROM gets `publicTable` (the
-			// Distributed name, which aggregates correctly across every
-			// shard) — see sharded_mutation.go's package doc comment for
-			// why they must differ. `target` here is `publicTable + "_local"`
-			// (matching real usage), so `publicTable` is a PREFIX of
-			// `target`; search for it strictly after target's own span, not
-			// with a plain strings.Index that would just re-find target's
-			// own leading substring.
-			outerIdx := strings.Index(got, target)
-			if outerIdx == -1 {
-				t.Fatalf("%s: mutationTableSQL did not place the resolved target %q anywhere: %q", name, target, got)
-			}
-			rest := got[outerIdx+len(target):]
-			innerIdx := strings.Index(rest, publicTable)
-			if innerIdx == -1 {
-				t.Fatalf("%s: mutationTableSQL did not place the public table name %q AFTER the resolved target %q: %q",
-					name, publicTable, target, got)
-			}
-			if got2 := strings.Count(rest, publicTable); got2 != 1 {
-				t.Fatalf("%s: mutationTableSQL produced %d occurrences of the public table name %q after the outer target, want exactly 1", name, got2, publicTable)
-			}
-
-			// The ON CLUSTER clause must land on the OUTER statement, before
-			// the inner subquery's FROM — never inside the subquery, which
-			// would be invalid SQL (ON CLUSTER is DDL/mutation syntax, not
-			// valid on a plain SELECT).
-			if idx := strings.Index(got, onCluster); idx == -1 || idx > strings.Index(got, "SELECT") {
-				t.Fatalf("%s: ON CLUSTER clause did not land before the inner SELECT: %q", name, got)
 			}
 		})
 	}
 }
 
 // resolveMutationTarget's caller-visible behavior when NOT sharded (empty
-// onCluster, target == publicTable) must leave the DELETE unchanged in
-// shape — mutationTableSQL with an empty onCluster simply erases the
-// placeholder rather than leaving a stray space or empty ON CLUSTER token
-// behind, and both placeholder occurrences resolve to the SAME table name.
+// onCluster) must leave the DELETE unchanged in shape — mutationTableSQL
+// with an empty onCluster simply erases the placeholder rather than
+// leaving a stray space or empty ON CLUSTER token behind.
 func TestMutationTableSQLEmptyOnClusterLeavesNoStrayToken(t *testing.T) {
 	t.Parallel()
 
-	got := mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, "otel_metrics_gauge", "otel_metrics_gauge", "")
+	got := mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, "otel_metrics_gauge", "")
 	if strings.Contains(got, "ON CLUSTER") {
 		t.Fatalf("empty onCluster left an ON CLUSTER token behind: %q", got)
 	}
 	if !strings.Contains(got, "ALTER TABLE otel_metrics_gauge DELETE") {
 		t.Fatalf("expected the unsharded ALTER TABLE shape to be preserved verbatim, got: %q", got)
 	}
-	if got2 := strings.Count(got, "otel_metrics_gauge"); got2 != 2 {
-		t.Fatalf("expected exactly 2 occurrences of otel_metrics_gauge (outer + inner, both unredirected), got %d: %q", got2, got)
+	if got2 := strings.Count(got, "otel_metrics_gauge"); got2 != 1 {
+		t.Fatalf("expected exactly 1 occurrence of otel_metrics_gauge (the outer target; no inner subquery survives post-#3124), got %d: %q", got2, got)
+	}
+	if !strings.Contains(got, "{cutoff:DateTime64(9)}") {
+		t.Fatalf("expected the literal cutoff bind parameter to survive mutationTableSQL untouched: %q", got)
 	}
 }

--- a/test/e2e/seed/cmd/seed/showcase_traceql.go
+++ b/test/e2e/seed/cmd/seed/showcase_traceql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
@@ -108,6 +109,33 @@ VALUES
    map('db.system', 'postgres', 'db.system.name', 'postgres', 'payload_bytes', '96'),
    40000000, 'Ok', '', [], [], [], [], [], [], [])`
 
+// selectStaleShowcaseTracesCutoffSQLTemplate resolves the stale-row cutoff
+// for the b0... showcase TraceId range (issue #3124's step A) — run once
+// against the PUBLIC otel_traces name (see sharded_mutation.go's package
+// doc comment for why a Distributed SELECT, unlike a mutation, correctly
+// aggregates cluster-wide regardless of which node runs it) and scanned
+// into a time.Time by resolveStaleCutoff. deleteStaleShowcaseTracesSQLTemplate
+// (step B) then binds that literal back as {cutoff:DateTime64(9)} — see its
+// own doc comment for the full margin/ordering analysis this split
+// preserves unchanged, and for why the cutoff must live in a separate
+// statement from the DELETE at all.
+//
+// Carries exactly ONE occurrence of the literal text "@@MUTATION_TABLE@@"
+// (mutationTablePlaceholder's value, sharded_mutation.go), substituted for
+// the PUBLIC table name via mutationTableSQL — never the resolved mutation
+// target, which under the datashard lane (issue #3105) is the "_local"
+// table a plain SELECT never needs to redirect to. Typed directly into this
+// single backtick string (never built by concatenating separate
+// backtick-quoted segments around mutationTablePlaceholder) — see
+// deleteStaleShowcaseTracesSQLTemplate's own doc comment for why: it keeps
+// this const a single unbroken backtick literal for
+// test/regression/seed_test.go's extractBacktickConst, and it keeps the
+// LIKE 'b00...%' wildcard byte-identical rather than forcing fmt.Sprintf
+// %%-escaping.
+const selectStaleShowcaseTracesCutoffSQLTemplate = `SELECT max(Timestamp) - INTERVAL 20 SECOND
+FROM @@MUTATION_TABLE@@
+WHERE TraceId LIKE 'b00000000000000000000000000000%'`
+
 // deleteStaleShowcaseTracesSQL drops the *previous* ticks' showcase
 // spans (the b0... TraceId range is exclusively this seeder's) AFTER
 // the re-anchored INSERT has landed. Without any delete every 30 s
@@ -141,16 +169,34 @@ VALUES
 // DISTINCT (#762) collapses dupes, and showcase contracts assert
 // nonempty/error classes, never exact values (#757).
 //
-// Carries two occurrences of the literal text "@@MUTATION_TABLE@@"
+// The cutoff (`max(showcase Timestamp) - 20s`) is resolved to a literal
+// time.Time BEFORE this statement runs — selectStaleShowcaseTracesCutoffSQLTemplate
+// above, via resolveStaleCutoff — rather than living as a subquery nested
+// inside this DELETE. issue #3105's original design nested it directly, and
+// that worked against a single non-replicated "_local" table per shard, but
+// the datashard-replica-affinity lane (issue #3086) runs multiple REPLICAS
+// per shard, and ClickHouse rejects a subquery-bearing mutation against a
+// replicated table outright ("...statement with subquery may be
+// nondeterministic", code 36): every replica of every shard would otherwise
+// re-evaluate the subquery independently, and two replicas evaluating
+// max(...) at slightly different wall-clock moments could disagree on which
+// rows to delete and silently diverge their data. Binding the literal
+// {cutoff:DateTime64(9)} instead means every replica's own copy of this
+// DELETE compares against the exact same fixed value — no subquery, and no
+// per-replica re-evaluation, survives inside the mutation at all.
+//
+// Carries exactly ONE occurrence of the literal text "@@MUTATION_TABLE@@"
 // (mutationTablePlaceholder's value, sharded_mutation.go) marking the
 // table to target — substituted at call time via
 // mutationTableSQL/resolveMutationTarget rather than baked in as a
 // literal. Under the datashard lane (issue #3105) otel_traces is a
 // Distributed wrapper that rejects DELETE FROM outright ("Table engine
 // Distributed doesn't support mutations", code 48); the resolved name
-// redirects to the underlying "_local" table instead. Both occurrences —
-// the outer DELETE FROM and the inner max(...) subquery's FROM — must name
-// the SAME physical table.
+// redirects to the underlying "_local" table instead. One occurrence of
+// "@@MUTATION_ON_CLUSTER@@" follows it — empty outside the datashard lane,
+// " ON CLUSTER '{cluster}'" within it, needed because a "_local" table's
+// mutation must reach every shard's own copy, not just the node the
+// seeder is connected to.
 //
 // The placeholder is typed directly into this single backtick string
 // (never built by concatenating separate backtick-quoted segments around
@@ -162,11 +208,7 @@ VALUES
 // %%-escaping).
 const deleteStaleShowcaseTracesSQLTemplate = `DELETE FROM @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@
 WHERE TraceId LIKE 'b00000000000000000000000000000%'
-  AND Timestamp < (
-    SELECT max(Timestamp) - INTERVAL 20 SECOND
-    FROM @@MUTATION_TABLE@@
-    WHERE TraceId LIKE 'b00000000000000000000000000000%'
-  )`
+  AND Timestamp < {cutoff:DateTime64(9)}`
 
 // insertShowcaseTraces re-seeds the two showcase trace topologies. Runs
 // inside seedAll so each rolling re-seed tick re-anchors the spans on
@@ -182,7 +224,12 @@ func insertShowcaseTraces(ctx context.Context, conn driver.Conn) error {
 	if err != nil {
 		return fmt.Errorf("showcase traces stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleShowcaseTracesSQLTemplate, target.table, tracesTable, target.onCluster)); err != nil {
+	cutoff, err := resolveStaleCutoff(ctx, conn, selectStaleShowcaseTracesCutoffSQLTemplate, tracesTable)
+	if err != nil {
+		return fmt.Errorf("showcase traces stale delete: %w", err)
+	}
+	sql := mutationTableSQL(deleteStaleShowcaseTracesSQLTemplate, target.table, target.onCluster)
+	if err := conn.Exec(ctx, sql, clickhouse.Named("cutoff", cutoff)); err != nil {
 		return fmt.Errorf("showcase traces stale delete: %w", err)
 	}
 	return nil

--- a/test/e2e/seed/cmd/seed/stale.go
+++ b/test/e2e/seed/cmd/seed/stale.go
@@ -117,7 +117,7 @@ var (
 )
 
 // Stale-row DELETEs, one per table these fixtures write to. Each scopes
-// both the outer DELETE and the max(<time column>) subquery to the
+// both the step-A cutoff SELECT and the step-B DELETE to the
 // MetricName/ServiceName/TraceId set this seeder owns in that table —
 // the time column itself is NOT uniform across tables: the OTel-CH
 // exporter's schema names it `TimeUnix` on every otel_metrics_* table
@@ -128,11 +128,15 @@ var (
 // use TimeUnix; the logs/base-traces DELETEs after them use Timestamp —
 // unscoped would either eat rows the dogfood self-telemetry pipeline
 // wrote into the same table (see showcase_traceql.go / showcase_logql.go
-// doc comments) or anchor the cutoff on foreign rows. The margin is a
-// bound query parameter (`{margin:UInt64}`), not a literal, so it stays
-// in lockstep with the Go-side staleMargin() computation above — the
-// same `{name:Type}` parameter binding already used by
-// compatibility/prometheus/cmd/seed/main.go.
+// doc comments) or anchor the cutoff on foreign rows. Both DateTime64(9)
+// columns (see internal/schema/ddl/ddl.go's column-codec comments) accept
+// a Go time.Time directly via clickhouse-go v2's native driver — the type
+// resolveStaleCutoff (sharded_mutation.go) scans the SELECT's result into,
+// and every step-B template below binds back as {cutoff:DateTime64(9)}.
+// The margin is a bound query parameter on the step-A SELECT
+// (`{margin:UInt64}`), not a literal, so it stays in lockstep with the
+// Go-side staleMargin() computation above — the same `{name:Type}`
+// parameter binding already used by compatibility/prometheus/cmd/seed/main.go.
 // Public table names the DELETEs below target. Declared once so
 // deleteStaleMetrics/-Logs/-BaseTraces (which call resolveMutationTarget
 // against exactly these names) and showcase_traceql.go's own
@@ -146,23 +150,32 @@ const (
 	tracesTable           = "otel_traces"
 )
 
-// Every template below carries exactly two occurrences of the literal
-// text "@@MUTATION_TABLE@@" (mutationTablePlaceholder's value,
-// sharded_mutation.go) marking the table to mutate — the outer ALTER
-// TABLE and the inner max(...) subquery's FROM — substituted at call time
-// via mutationTableSQL/resolveMutationTarget rather than baked in as a
-// literal table name. Both occurrences must name the SAME physical table:
-// under the datashard lane (issue #3105) the resolved name is the
-// "_local" table, never the Distributed public name, which rejects every
-// mutation (see sharded_mutation.go's package doc comment). A single
-// further occurrence of "@@MUTATION_ON_CLUSTER@@" sits directly after the
-// FIRST @@MUTATION_TABLE@@ (the outer statement only, never the inner
-// SELECT) — empty outside the datashard lane, " ON CLUSTER '{cluster}'"
-// within it, needed because a "_local" table's mutation must reach every
-// shard's own copy, not just the node the seeder is connected to.
+// Every family below is two separate templates (issue #3124's two-step
+// literal-cutoff split — see sharded_mutation.go's package doc comment for
+// the full replica-divergence hazard this avoids): a step-A cutoff SELECT
+// run once against the PUBLIC table to resolve `max(<time column>) -
+// margin` to a literal time.Time (resolveStaleCutoff, sharded_mutation.go),
+// and a step-B ALTER TABLE ... DELETE that binds that literal as
+// `{cutoff:DateTime64(9)}` — no subquery survives inside the mutation, so
+// every replica's own copy of the ALTER compares against the exact same
+// fixed value.
+//
+// Each template carries exactly ONE occurrence of the literal text
+// "@@MUTATION_TABLE@@" (mutationTablePlaceholder's value,
+// sharded_mutation.go): a step-A template substitutes it for the PUBLIC
+// table name (a SELECT against a Distributed table aggregates cluster-wide
+// regardless of which node runs it — see sharded_mutation.go), a step-B
+// template substitutes it for the resolved mutation target (the "_local"
+// table under the datashard lane, since a Distributed table rejects every
+// mutation outright). A step-B template also carries one occurrence of
+// "@@MUTATION_ON_CLUSTER@@" — empty outside the datashard lane, "
+// ON CLUSTER '{cluster}'" within it, needed because a "_local" table's
+// mutation must reach every shard's own copy, not just the node the seeder
+// is connected to; a step-A template carries no such placeholder, since a
+// plain SELECT needs no cluster broadcast.
 //
 // The placeholder is typed directly into each backtick string rather than
-// built by concatenating three separate backtick-quoted segments around
+// built by concatenating separate backtick-quoted segments around
 // mutationTablePlaceholder, for two reasons: it keeps each const a single
 // unbroken backtick literal (test/regression/seed_test.go's
 // extractBacktickConst scans exactly one backtick-delimited span per const
@@ -172,53 +185,53 @@ const (
 // (deleteStaleBaseTracesSQLTemplate below, deleteStaleShowcaseTracesSQLTemplate
 // in showcase_traceql.go).
 const (
+	selectStaleMetricsGaugeCutoffSQLTemplate = `SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
+FROM @@MUTATION_TABLE@@
+WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')`
+
 	deleteStaleMetricsGaugeSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
-  AND TimeUnix < (
-    SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
-    FROM @@MUTATION_TABLE@@
-    WHERE MetricName IN ('up', 'target_info', 'showcase_flapping', 'showcase_multilabel')
-  )`
+  AND TimeUnix < {cutoff:DateTime64(9)}`
+
+	selectStaleMetricsSumCutoffSQLTemplate = `SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
+FROM @@MUTATION_TABLE@@
+WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')`
 
 	deleteStaleMetricsSumSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
-  AND TimeUnix < (
-    SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
-    FROM @@MUTATION_TABLE@@
-    WHERE MetricName IN ('http_server_request_duration_count', 'showcase_restarting_total')
-  )`
+  AND TimeUnix < {cutoff:DateTime64(9)}`
+
+	selectStaleMetricsHistogramCutoffSQLTemplate = `SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
+FROM @@MUTATION_TABLE@@
+WHERE MetricName = 'http_server_request_duration'`
 
 	deleteStaleMetricsHistogramSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE MetricName = 'http_server_request_duration'
-  AND TimeUnix < (
-    SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
-    FROM @@MUTATION_TABLE@@
-    WHERE MetricName = 'http_server_request_duration'
-  )`
+  AND TimeUnix < {cutoff:DateTime64(9)}`
+
+	selectStaleMetricsExpHistCutoffSQLTemplate = `SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
+FROM @@MUTATION_TABLE@@
+WHERE MetricName = 'showcase_latency_exp_hist'`
 
 	deleteStaleMetricsExpHistSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE MetricName = 'showcase_latency_exp_hist'
-  AND TimeUnix < (
-    SELECT max(TimeUnix) - INTERVAL {margin:UInt64} SECOND
-    FROM @@MUTATION_TABLE@@
-    WHERE MetricName = 'showcase_latency_exp_hist'
-  )`
+  AND TimeUnix < {cutoff:DateTime64(9)}`
+
+	selectStaleLogsCutoffSQLTemplate = `SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+FROM @@MUTATION_TABLE@@
+WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')`
 
 	deleteStaleLogsSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')
-  AND Timestamp < (
-    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
-    FROM @@MUTATION_TABLE@@
-    WHERE ServiceName IN ('api', 'frontend', 'db', 'gateway', 'shop', 'proxy', 'painter', 'packer')
-  )`
+  AND Timestamp < {cutoff:DateTime64(9)}`
+
+	selectStaleBaseTracesCutoffSQLTemplate = `SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
+FROM @@MUTATION_TABLE@@
+WHERE TraceId LIKE 'a00000000000000000000000000000%'`
 
 	deleteStaleBaseTracesSQLTemplate = `ALTER TABLE @@MUTATION_TABLE@@@@MUTATION_ON_CLUSTER@@ DELETE
 WHERE TraceId LIKE 'a00000000000000000000000000000%'
-  AND Timestamp < (
-    SELECT max(Timestamp) - INTERVAL {margin:UInt64} SECOND
-    FROM @@MUTATION_TABLE@@
-    WHERE TraceId LIKE 'a00000000000000000000000000000%'
-  )`
+  AND Timestamp < {cutoff:DateTime64(9)}`
 )
 
 // Every DELETE below is written as `ALTER TABLE ... DELETE WHERE ...` (a
@@ -273,52 +286,44 @@ func staleDeleteContext(ctx context.Context) context.Context {
 	}))
 }
 
+// deleteStaleFamily runs one fixture family's two-step literal-cutoff
+// stale-row DELETE (issue #3124): step A calls resolveStaleCutoff
+// (sharded_mutation.go) with selectTemplate against publicTable, binding
+// margin as selectTemplate's {margin:UInt64} parameter, to resolve the
+// cutoff to a literal time.Time; step B execs deleteTemplate — with that
+// time.Time bound as {cutoff:DateTime64(9)} — against the resolved
+// mutation target (resolveMutationTarget), wrapped in staleDeleteContext
+// so the DELETE stays synchronous. Under the datashard lane (issue #3105)
+// publicTable's resolved mutation target is the underlying "_local" table,
+// since the Distributed public name itself rejects every mutation.
+func deleteStaleFamily(ctx context.Context, conn driver.Conn, publicTable, selectTemplate, deleteTemplate string, margin time.Duration) error {
+	target, err := resolveMutationTarget(ctx, conn, publicTable)
+	if err != nil {
+		return err
+	}
+	cutoff, err := resolveStaleCutoff(ctx, conn, selectTemplate, publicTable, clickhouse.Named("margin", marginSeconds(margin)))
+	if err != nil {
+		return err
+	}
+	sql := mutationTableSQL(deleteTemplate, target.table, target.onCluster)
+	return conn.Exec(staleDeleteContext(ctx), sql, clickhouse.Named("cutoff", cutoff))
+}
+
 // deleteStaleMetrics prunes previous-tick rows from every metrics table
 // insertMetrics writes to. Called after all of insertMetrics' INSERTs
 // have landed, so — like deleteStaleShowcaseTracesSQL — readers never
 // observe an empty or partially-deleted window.
-//
-// Each DELETE resolves its actual mutation target via
-// resolveMutationTarget (sharded_mutation.go) before formatting the
-// template: under the datashard lane (issue #3105) the public table name
-// is a Distributed wrapper that rejects every mutation, and the resolved
-// name is the underlying "_local" table instead.
 func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
-	ctx = staleDeleteContext(ctx)
-
-	gaugeTarget, err := resolveMutationTarget(ctx, conn, metricsGaugeTable)
-	if err != nil {
+	if err := deleteStaleFamily(ctx, conn, metricsGaugeTable, selectStaleMetricsGaugeCutoffSQLTemplate, deleteStaleMetricsGaugeSQLTemplate, metricsNarrowStaleMargin); err != nil {
 		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsGaugeSQLTemplate, gaugeTarget.table, metricsGaugeTable, gaugeTarget.onCluster),
-		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
-		return fmt.Errorf("gauge-shaped metrics stale delete: %w", err)
-	}
-
-	sumTarget, err := resolveMutationTarget(ctx, conn, metricsSumTable)
-	if err != nil {
+	if err := deleteStaleFamily(ctx, conn, metricsSumTable, selectStaleMetricsSumCutoffSQLTemplate, deleteStaleMetricsSumSQLTemplate, metricsWideStaleMargin); err != nil {
 		return fmt.Errorf("sum metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsSumSQLTemplate, sumTarget.table, metricsSumTable, sumTarget.onCluster),
-		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
-		return fmt.Errorf("sum metrics stale delete: %w", err)
-	}
-
-	histogramTarget, err := resolveMutationTarget(ctx, conn, metricsHistogramTable)
-	if err != nil {
+	if err := deleteStaleFamily(ctx, conn, metricsHistogramTable, selectStaleMetricsHistogramCutoffSQLTemplate, deleteStaleMetricsHistogramSQLTemplate, metricsWideStaleMargin); err != nil {
 		return fmt.Errorf("histogram metrics stale delete: %w", err)
 	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsHistogramSQLTemplate, histogramTarget.table, metricsHistogramTable, histogramTarget.onCluster),
-		clickhouse.Named("margin", marginSeconds(metricsWideStaleMargin))); err != nil {
-		return fmt.Errorf("histogram metrics stale delete: %w", err)
-	}
-
-	expHistTarget, err := resolveMutationTarget(ctx, conn, metricsExpHistTable)
-	if err != nil {
-		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
-	}
-	if err := conn.Exec(ctx, mutationTableSQL(deleteStaleMetricsExpHistSQLTemplate, expHistTarget.table, metricsExpHistTable, expHistTarget.onCluster),
-		clickhouse.Named("margin", marginSeconds(metricsNarrowStaleMargin))); err != nil {
+	if err := deleteStaleFamily(ctx, conn, metricsExpHistTable, selectStaleMetricsExpHistCutoffSQLTemplate, deleteStaleMetricsExpHistSQLTemplate, metricsNarrowStaleMargin); err != nil {
 		return fmt.Errorf("exponential histogram metrics stale delete: %w", err)
 	}
 	return nil
@@ -330,12 +335,7 @@ func deleteStaleMetrics(ctx context.Context, conn driver.Conn) error {
 // them). Called after both insertLogsSQL and insertShowcaseLogQLLogs
 // have landed.
 func deleteStaleLogs(ctx context.Context, conn driver.Conn) error {
-	target, err := resolveMutationTarget(ctx, conn, logsTable)
-	if err != nil {
-		return fmt.Errorf("logs stale delete: %w", err)
-	}
-	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleLogsSQLTemplate, target.table, logsTable, target.onCluster),
-		clickhouse.Named("margin", marginSeconds(logsStaleMargin))); err != nil {
+	if err := deleteStaleFamily(ctx, conn, logsTable, selectStaleLogsCutoffSQLTemplate, deleteStaleLogsSQLTemplate, logsStaleMargin); err != nil {
 		return fmt.Errorf("logs stale delete: %w", err)
 	}
 	return nil
@@ -347,12 +347,7 @@ func deleteStaleLogs(ctx context.Context, conn driver.Conn) error {
 // scoped separately so the two margins, sized for very different
 // windows, never interact).
 func deleteStaleBaseTraces(ctx context.Context, conn driver.Conn) error {
-	target, err := resolveMutationTarget(ctx, conn, tracesTable)
-	if err != nil {
-		return fmt.Errorf("base traces stale delete: %w", err)
-	}
-	if err := conn.Exec(staleDeleteContext(ctx), mutationTableSQL(deleteStaleBaseTracesSQLTemplate, target.table, tracesTable, target.onCluster),
-		clickhouse.Named("margin", marginSeconds(tracesStaleMargin))); err != nil {
+	if err := deleteStaleFamily(ctx, conn, tracesTable, selectStaleBaseTracesCutoffSQLTemplate, deleteStaleBaseTracesSQLTemplate, tracesStaleMargin); err != nil {
 		return fmt.Errorf("base traces stale delete: %w", err)
 	}
 	return nil

--- a/test/regression/seed_test.go
+++ b/test/regression/seed_test.go
@@ -283,7 +283,14 @@ func TestShowcaseTraceReseedInsertsBeforeDelete(t *testing.T) {
 //  2. the margin must exceed the INSERT's own timestamp spread (so the
 //     freshest tick's oldest row is always spared) and stay below the
 //     30 s re-seed interval (so the previous tick is always collected
-//     and duplication stays bounded at ≤2 copies).
+//     and duplication stays bounded at ≤2 copies);
+//  3. the DELETE itself must compare against a literal {cutoff:DateTime64(9)}
+//     resolved by a separate step-A SELECT, never a max(...) subquery nested
+//     inside the mutation — ClickHouse rejects a subquery-bearing mutation
+//     against a replicated table as nondeterministic under the
+//     datashard-replica-affinity lane's multi-replica-per-shard topology
+//     (issue #3124); resolving the cutoff client-side, once, before the
+//     mutation is issued removes that hazard by construction.
 //
 // The offsets are parsed from the SQL constants rather than hardcoded,
 // so editing the seed topology without rebalancing the margin fails
@@ -297,22 +304,33 @@ func TestShowcaseTraceStaleDeleteIsDataAnchored(t *testing.T) {
 	}
 	content := string(buf)
 
+	selectSQL := extractBacktickConst(t, content, "selectStaleShowcaseTracesCutoffSQL")
 	deleteSQL := extractBacktickConst(t, content, "deleteStaleShowcaseTracesSQL")
-	if !strings.Contains(deleteSQL, "max(Timestamp)") {
-		t.Errorf("%s: deleteStaleShowcaseTracesSQL must anchor its cutoff on max(Timestamp) over the showcase range (data-anchored), not the server clock", showcaseTraceSeedSource)
+
+	if !strings.Contains(selectSQL, "max(Timestamp)") {
+		t.Errorf("%s: selectStaleShowcaseTracesCutoffSQLTemplate must anchor its cutoff on max(Timestamp) over the showcase range (data-anchored), not the server clock", showcaseTraceSeedSource)
 	}
-	if got := strings.Count(deleteSQL, "TraceId LIKE 'b00000000000000000000000000000%'"); got != 2 {
-		t.Errorf("%s: deleteStaleShowcaseTracesSQL must scope BOTH the outer DELETE and the max(Timestamp) subquery to the b0... showcase range (got %d scoped predicates, want 2) — an unscoped subquery anchors the cutoff on foreign rows, an unscoped delete eats the base fixture", showcaseTraceSeedSource, got)
+	if got := strings.Count(selectSQL, "TraceId LIKE 'b00000000000000000000000000000%'"); got != 1 {
+		t.Errorf("%s: selectStaleShowcaseTracesCutoffSQLTemplate must scope its max(Timestamp) read to the b0... showcase range (got %d scoped predicates, want 1) — an unscoped read anchors the cutoff on foreign rows", showcaseTraceSeedSource, got)
+	}
+	if got := strings.Count(deleteSQL, "TraceId LIKE 'b00000000000000000000000000000%'"); got != 1 {
+		t.Errorf("%s: deleteStaleShowcaseTracesSQLTemplate must scope its DELETE to the b0... showcase range (got %d scoped predicates, want 1) — an unscoped delete eats the base fixture", showcaseTraceSeedSource, got)
+	}
+	if !strings.Contains(deleteSQL, "{cutoff:DateTime64(9)}") {
+		t.Errorf("%s: deleteStaleShowcaseTracesSQLTemplate must compare against the literal {cutoff:DateTime64(9)} resolved by selectStaleShowcaseTracesCutoffSQLTemplate, not a subquery nested in the mutation (issue #3124)", showcaseTraceSeedSource)
+	}
+	if strings.Contains(deleteSQL, "SELECT") {
+		t.Errorf("%s: deleteStaleShowcaseTracesSQLTemplate must carry no SELECT of its own — a subquery nested in the mutation is rejected as nondeterministic under the datashard-replica-affinity lane (issue #3124); the cutoff must come from a separate step-A query instead", showcaseTraceSeedSource)
 	}
 
 	intervalRE := regexp.MustCompile(`INTERVAL (\d+) SECOND`)
 
-	// Margin: the single INTERVAL in the DELETE's cutoff expression.
-	deleteIntervals := intervalRE.FindAllStringSubmatch(deleteSQL, -1)
-	if len(deleteIntervals) != 1 {
-		t.Fatalf("%s: expected exactly one `INTERVAL <n> SECOND` margin in deleteStaleShowcaseTracesSQL, got %d", showcaseTraceSeedSource, len(deleteIntervals))
+	// Margin: the single INTERVAL in the step-A cutoff SELECT.
+	selectIntervals := intervalRE.FindAllStringSubmatch(selectSQL, -1)
+	if len(selectIntervals) != 1 {
+		t.Fatalf("%s: expected exactly one `INTERVAL <n> SECOND` margin in selectStaleShowcaseTracesCutoffSQLTemplate, got %d", showcaseTraceSeedSource, len(selectIntervals))
 	}
-	margin, err := strconv.Atoi(deleteIntervals[0][1])
+	margin, err := strconv.Atoi(selectIntervals[0][1])
 	if err != nil {
 		t.Fatalf("parse margin: %v", err)
 	}


### PR DESCRIPTION
## Summary

Issue #3124: the `datashard-replica-affinity` e2e lane (added by #3086/#3117) has never gotten past
seeding. Its multi-REPLICA-per-shard topology rejects every one of the seeder's stale-row
`ALTER TABLE ... DELETE`/`DELETE FROM` mutations outright:

```text
Code: 36. DB::Exception: ALTER UPDATE/ALTER DELETE statement with subquery may be nondeterministic,
see allow_nondeterministic_mutations setting.
```

## Root cause

Issue #3105 fixed the single-replica-per-shard `datashard (N=2)`/`(N=4)` lanes by redirecting each
mutation to the shard's own `_local` table (`ON CLUSTER`), with the DELETE's cutoff computed by a
`SELECT max(<time column>) - margin ...` subquery nested inside the mutation itself, scoped to the
PUBLIC Distributed table name (so it aggregates correctly cluster-wide). That design assumed a
single, non-replicated `_local` table per shard. `datashard-replica-affinity` (issue #3086) runs
MULTIPLE REPLICAS per data shard, so `_local` is `ReplicatedMergeTree`-family — and ClickHouse
refuses a subquery-bearing mutation against a replicated table by default: an `ON CLUSTER`
broadcast has every replica of every shard independently re-evaluate the subquery, and two
replicas evaluating `max(...)` at slightly different wall-clock moments could disagree on which
rows to delete and silently diverge the replicas' data. This is a real correctness guard, not a
false positive.

## Fix: literal cutoff, not a flipped setting

The issue's own acceptance criteria flagged `allow_nondeterministic_mutations=1` as unproven-safe
and preferred the architecturally cleaner alternative: resolve the cutoff to a literal value
client-side, BEFORE issuing the mutation, so every replica compares against the exact same fixed
value — removing the nondeterminism by construction rather than by disabling the guard.

Each of the 7 stale-row DELETEs (4 in `stale.go`'s `deleteStaleMetrics`, 1 each in `deleteStaleLogs`
/ `deleteStaleBaseTraces`, plus `showcase_traceql.go`'s `insertShowcaseTraces`) is now split into
two statements:

- **Step A** — `SELECT max(<time column>) - margin FROM <public-distributed-table> WHERE <predicate>`,
  run once against the PUBLIC table name (unchanged from #3105's reasoning: a Distributed SELECT
  fans out and aggregates cluster-wide correctly regardless of which node runs it). The single
  resulting `DateTime64(9)` value is scanned directly into a Go `time.Time`
  (`resolveStaleCutoff`, `sharded_mutation.go`).
- **Step B** — `ALTER TABLE <resolved-local-or-public-target>[ ON CLUSTER '{cluster}'] DELETE WHERE
  <predicate> AND <time column> < {cutoff:DateTime64(9)}`, binding that `time.Time` as a named
  parameter. No subquery survives inside the mutation at all, so every replica of every shard
  compares against the identical fixed value.

`sharded_mutation.go`'s `mutationTableSQL` substitution machinery was simplified to match: each
template now carries exactly ONE occurrence of the `@@MUTATION_TABLE@@` placeholder (substituted
against the public name for step A, the resolved mutation target for step B) instead of the old
two-occurrence "outer statement vs. inner subquery" split, which no longer applies now that no
subquery lives inside the mutation.

## Local verification

- `go build ./test/e2e/...` / `go vet ./test/e2e/...` clean.
- `go test -race ./test/e2e/seed/...` and `go test -race ./test/regression/...` — all pass,
  including the rewritten `TestMutationTableSQLReplacesEveryTemplatePlaceholder` (now split into
  step-A/step-B placeholder-shape assertions) and `TestShowcaseTraceStaleDeleteIsDataAnchored`
  (now asserts the literal `{cutoff:DateTime64(9)}` bind and the absence of a nested `SELECT` in
  the step-B template).
- `gofumpt -l` / `goimports -local github.com/tsouza/cerberus -l` clean.
- Confirmed `TimeUnix` (metrics) and `Timestamp` (logs/traces) are `DateTime64(9)` columns
  (`test/e2e/migration/expected/schema/default.sql`), matching the new `{cutoff:DateTime64(9)}`
  bind type, and that `time.Time` binds/scans directly against `DateTime64` via clickhouse-go v2
  (`lib/column/datetime64.go`'s `ScanRow`/`AppendRow`).

## CI verification

Dispatched `gh workflow run e2e.yml --ref fix/3124-mutation-nondeterministic-delete` (run
**34027281555**) and polled `datashard-replica-affinity` (job 101470398347) to a terminal state.

- Zero `Code: 36`/nondeterministic-mutation errors anywhere in the job log — the actual bug this PR
  targets is gone.
- `##[notice]initial seed landed` — `e2e-seed-rolling`'s initial seed completes for the first time
  ever on this lane (previously always timed out after 30s, blocked on the seeder's stale-row
  DELETE failing outright).
- The lane goes on to fire real burst requests (125 initiator traces observed, 3 genuinely
  solver-split) and reach `e2e-datashard-replica-affinity-verify.mjs`'s own real assertions for the
  first time ever.
- It does not pass cleanly: the verify script's own hostname-classification regex
  (`hostnameShardReplica`, anchored `$`-end-of-string) rejects the real FQDN shape ClickHouse's
  `system.query_log.hostname` reports on this cluster (e.g.
  `cerberus-clickhouse-datashard-1-0.cerberus-clickhouse-headless-datashard-1.cerberus.svc.cluster.local`)
  — a genuinely new, separate bug in the verify script itself, only exposed now that seeding no
  longer blocks the lane. Filed as **#3131** (linked under epic #3074), out of scope for this PR.
- The sibling `datashard (N=2)`/`(N=4)` jobs in the same run show only the already-tracked #3128
  `DataShardFanoutGate` overshoot (peak 10/16 vs cap 8) and #3128's own N=4 point-1-vacuous
  finding — no new failure type, confirming this change introduces no regression there.

This satisfies #3124's own stated acceptance criterion ("the lane reaches — and ideally passes —
its own real assertions"): it reaches them. It does not yet pass, but the remaining gap (#3131) is
unrelated to mutation determinism.

Closes #3124

