### PR TITLE
fix(ci): match FQDN hostnames in datashard replica-affinity verify

### DIFF
--- a/.github/scripts/e2e-datashard-replica-affinity-verify.mjs
+++ b/.github/scripts/e2e-datashard-replica-affinity-verify.mjs
@@ -122,8 +122,15 @@ async function fireOne(url) {
 // hostname `<sts-name>-<ordinal>`) into { shard, replica }, or null for a
 // hostname that does not match (never expected on this lane's own cluster,
 // but never silently misclassified as shard "0" either).
+//
+// `system.query_log.hostname` reports the pod's FULLY QUALIFIED domain name
+// on this cluster (e.g.
+// `cerberus-clickhouse-datashard-1-0.cerberus-clickhouse-headless-datashard-1
+// .cerberus.svc.cluster.local`), so the `-datashard-<shard>-<ordinal>`
+// segment is followed by the FQDN's own `.` domain separator, not
+// necessarily end-of-string — issue #3131.
 function hostnameShardReplica(hostname) {
-  const m = /-datashard-(\d+)-(\d+)$/.exec(hostname);
+  const m = /-datashard-(\d+)-(\d+)(?:\.|$)/.exec(hostname);
   if (!m) return null;
   return { shard: Number(m[1]), replica: Number(m[2]) };
 }


### PR DESCRIPTION
## Problem

`hostnameShardReplica` in `.github/scripts/e2e-datashard-replica-affinity-verify.mjs`
parsed `system.query_log.hostname` with a regex anchored to end-of-string:

```js
const m = /-datashard-(\d+)-(\d+)$/.exec(hostname);
```

The real value ClickHouse reports on this cluster is the pod's fully qualified
domain name, e.g.:

```
cerberus-clickhouse-datashard-1-0.cerberus-clickhouse-headless-datashard-1.cerberus.svc.cluster.local
```

The `-datashard-1-0` segment is followed by `.cerberus-clickhouse-headless-...`,
not end-of-string, so the anchored regex never matched — every child statement
in a real burst was rejected with "cannot classify".

This was invisible until now because this lane's seeding always failed before
reaching this code path (fixed by #3124, already merged).

## Fix

Widened the regex to accept either end-of-string or the FQDN's own `.` domain
separator as the terminator: `/-datashard-(\d+)-(\d+)(?:\.|$)/`. This still
matches the bare pod name form (`cerberus-clickhouse-datashard-1-0`) as well
as the FQDN form, and still rejects a non-matching hostname.

## Test coverage

Checked `.github/scripts/README.md` for this repo's own testing convention.
The "verify" family of real-cluster e2e scripts
(`e2e-bwc-verify-mode-toggle.mjs`, `e2e-bwc-verify-placement.mjs`,
`e2e-cerberus-restart-gate.mjs`, `e2e-datashard-verify.mjs`, and this file)
has no `.test.mjs` siblings in this repo, even where they contain
comparably pure, unit-testable logic (e.g. `e2e-datashard-verify.mjs`'s own
`maxConcurrent()`) — they're validated against real cluster data by CI runs
instead (both `datashard` and `datashard-replica-affinity` jobs are marked
INFORMATIONAL, never a PR gate, in the README). Scripts that DO get
`.test.mjs` siblings are the ones extracted from inline bash/awk with a
self-contained transform (`e2e-seed*.mjs`, `e2e-datasource-sync.mjs`,
`e2e-chaos-overlay.mjs`, `e2e-wait-otel.mjs`). Following that existing
convention rather than inventing a new one, this PR does not add a
`.test.mjs` file for this script.

## Verification

- `node --check .github/scripts/e2e-datashard-replica-affinity-verify.mjs` — OK.
- Confirmed locally against the real FQDN shape from the issue body and the
  bare pod-name shape; both match, non-matching hostnames still return
  `null`.
- Dispatched a real `e2e.yml` run against this branch:
  [run 34031008278](https://github.com/tsouza/cerberus/actions/runs/34031008278),
  job `datashard-replica-affinity`
  ([job 101480375088](https://github.com/tsouza/cerberus/actions/runs/34031008278/job/101480375088)) —
  **completed, conclusion `success`**. Its real log shows:

  ```
  replica-affinity verify: namespace=cerberus db=otel cluster=bwc_cluster dataShardCount=2 replicas=2 pod=cerberus-clickhouse-datashard-0-0
  topology confirmed: 2 shard(s), 2 replica(s) each
  fired 3 request(s): statuses=200,200,200
  observed 104 initiator trace(s); 3 genuinely solver-split (kEff>1)
  checked 3 (trace, data-shard) group(s) across 3 split trace(s)
  ##[notice]e2e-datashard-replica-affinity-verify: all assertions passed (dataShardCount=2, replicas=2, splitTraces=3, groupsChecked=3)
  ```

  Zero `##[error]` annotations anywhere in the job log — no "cannot classify"
  errors, and `hostnameShardReplica` correctly classified every remote-shard
  child statement across all 3 genuinely solver-split traces. #3131's
  acceptance criteria are genuinely met by this run.

  (Note: on a normal PR-triggered run this job shows `skipping` — it's
  informational and only runs via `workflow_dispatch`/schedule, per the
  README, which is why a real-cluster dispatch was needed to verify this fix
  rather than relying on this PR's own required checks.)

Closes #3131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016H8AVBwHzAYcMi4kuYub9F
