### PR TITLE
refactor(justfile): dedupe e2e-datashard-up's image-import loop onto k3d-image-import.mjs

### DIFF
--- a/.github/scripts/k3d-image-import.mjs
+++ b/.github/scripts/k3d-image-import.mjs
@@ -25,8 +25,8 @@
 // therefore first-class parameters here from the start, not a retrofit:
 // `e2e-bwc-up` reuses this script by changing only its own image list +
 // exclude pattern at the call site, never this script's interface. The
-// multi-data-shard `e2e-datashard-up` still duplicates this exact loop
-// today — tracked separately, see cerberus issue #3107.
+// multi-data-shard `e2e-datashard-up` reuses it the same way (cerberus
+// issue #3107).
 //
 // Usage:
 //   node .github/scripts/k3d-image-import.mjs <image>...

--- a/just/e2e-bwc.just
+++ b/just/e2e-bwc.just
@@ -204,30 +204,15 @@ e2e-datashard-up count="2" replicas="1": e2e-down
         case "$img" in clickhouse/clickhouse-server:*-alpine) continue ;; esac; \
         just _pull-retry "$img"; \
     done
-    @# Import each image individually + VERIFY it landed (same robust loop as
-    @# e2e-up / e2e-bwc-up — see the comment on e2e-up for why).
-    @for img in {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} {{E2E_DATASHARD_IMAGES}}; do \
-        case "$img" in clickhouse/clickhouse-server:*-alpine) continue ;; esac; \
-        ref="$img"; \
-        case "$ref" in \
-            *.*/*|*:*/*) ;; \
-            */*) ref="docker.io/$ref" ;; \
-            *) ref="docker.io/library/$ref" ;; \
-        esac; \
-        landed=0; \
-        for attempt in 1 2 3 4 5; do \
-            k3d image import "$img" -c {{K3D_CLUSTER}} || true; \
-            if docker exec k3d-{{K3D_CLUSTER}}-server-0 ctr -n k8s.io images ls -q | grep -qF "$ref"; then \
-                landed=1; break; \
-            fi; \
-            echo "  import attempt $attempt: $ref not in containerd yet, retrying with backoff" >&2; \
-            sleep $((attempt * 2)); \
-        done; \
-        if [ "$landed" != "1" ]; then \
-            echo "ERROR: $ref missing from k3d node containerd after 5 import attempts" >&2; \
-            exit 1; \
-        fi; \
-    done
+    @echo "==> [datashard] importing images into k3d ({{K3D_CLUSTER}}) — one at a time, with retry+verify"
+    @# Same retry+verify loop `e2e-up` runs (cerberus issue #3096), reused
+    @# unchanged via .github/scripts/k3d-image-import.mjs — only the image list
+    @# and the exclusion filter (the standalone *-alpine ClickHouse image the
+    @# datashard kustomization never applies) differ, same as `e2e-bwc-up`
+    @# (cerberus issue #3107).
+    @IMAGE_IMPORT_EXCLUDE="clickhouse/clickhouse-server:*-alpine" \
+    K3D_CLUSTER={{K3D_CLUSTER}} node .github/scripts/k3d-image-import.mjs \
+        {{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} {{E2E_DATASHARD_IMAGES}}
     @echo "==> [datashard] phase 1: namespace"
     kubectl apply -f test/e2e/k3s/namespace.yaml
     @echo "==> [datashard] phase 2: installing cerberus + bundled ClickHouse (dataShards.count={{count}}, replicas={{replicas}}) via Helm"


### PR DESCRIPTION
## Summary

- `e2e-datashard-up`'s Justfile body carried a byte-for-byte copy of the image-import-and-verify
  retry loop that `.github/scripts/k3d-image-import.mjs` already extracts and that `e2e-bwc-up`
  already reuses (via `IMAGE_IMPORT_EXCLUDE`, landed by #3097). This replaces the inline
  `case`/retry/verify loop with the same script call.
- Call site mirrors `e2e-bwc-up` exactly: `IMAGE_IMPORT_EXCLUDE='clickhouse/clickhouse-server:*-alpine'`
  and the recipe's own `{{CERBERUS_IMAGE}} {{E2E_EXTERNAL_IMAGES}} {{E2E_DATASHARD_IMAGES}}` image
  list. No change to the script's interface.
- Updated `k3d-image-import.mjs`'s own header comment (which named `e2e-datashard-up` as the one
  remaining duplicate, tracked under #3107) so it no longer describes a now-stale state.

## Verification

- `node .github/scripts/verify-just-invocations.mjs` → `61 distinct invocation(s) (89 call site(s)
  across 35 workflow file(s)) all dry-run clean`.
- `node --test .github/scripts/verify-just-invocations.test.mjs` → 17/17 passing.
- `node --check .github/scripts/k3d-image-import.mjs` → clean.
- `just --dry-run e2e-datashard-up` → resolves cleanly, image list correctly includes both
  `clickhouse/clickhouse-server:26.6-alpine` (excluded at runtime by the script's
  `IMAGE_IMPORT_EXCLUDE`) and `clickhouse/clickhouse-server:26.3` (imported).
- `just --unstable --fmt --check` → the only diff reported is a pre-existing, unrelated blank-line
  formatting difference in the top-level `Justfile`; `just/e2e-bwc.just` itself is fmt-clean.
- Real `e2e` CI run dispatched from this branch: https://github.com/tsouza/cerberus/actions/runs/34031072501
  (run id `34031072501`). Fetched `datashard (N=2)` (job 101480560516), `datashard (N=4)`
  (job 101480560576), and `datashard-replica-affinity` (job 101480560645) logs directly via the
  Actions API. In every one, the image-import step ran via the new `k3d-image-import.mjs` call and
  logged:

  ```
  ==> excluding 1 image(s) matching IMAGE_IMPORT_EXCLUDE: clickhouse/clickhouse-server:26.6-alpine
      ok docker.io/library/cerberus:e2e
      ok ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.116.0
      ok docker.io/grafana/grafana:12.2.9
      ok docker.io/otel/opentelemetry-collector-contrib:0.152.1
      ok docker.io/library/busybox:1.37
      ok docker.io/clickhouse/clickhouse-server:26.3
  ##[notice]k3d-image-import: 6 image(s) imported and verified into cluster cerberus-e2e
  ```

  i.e. the standalone alpine ClickHouse image is correctly excluded (matching the old inline
  loop's `case … continue` behavior) and every other image lands and verifies, then the cluster
  build proceeds — confirming this refactor's image-import step works correctly with no
  regression.

All three jobs still went red overall, but on pre-existing, already-tracked failures unrelated to
this change and to image import:
- `datashard (N=2)` and `datashard (N=4)` both failed on `e2e-datashard-verify`: `peak concurrent
  per-shard ClickHouse statement count 13 exceeded DataShardFanoutCap=8 — the admission-control
  ceiling did not hold under real load` — this is #3128's `DataShardFanoutGate` admission-control
  overshoot, currently being fixed in a separate, in-flight PR.
- `datashard-replica-affinity` failed on a hostname-classification error (`child statement
  hostname "…" does not match this chart's <fullname>-datashard-<shard>-<ordinal> convention`) —
  this is #3131's tracked regex mismatch, also being fixed in a separate, concurrent PR.

Per this issue's acceptance criteria, the whole `datashard` job passing end-to-end is **not**
required here — only that the recipe body is clean, `verify-just-invocations.mjs` is clean, and the
image-import step itself works under real CI, all of which are confirmed above.

Closes #3107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016H8AVBwHzAYcMi4kuYub9F
