### PR TITLE
refactor(justfile): extract coverage-chdb recipe to .mjs (needs enrollment-scanner support)

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1158,9 +1158,33 @@ what actually runs.
     floor and for any claim/evidence disagreement. `NOT MEASURED` is a GREEN
     outcome on purpose — the verdict makes the skip legible, it does not turn
     every ordinary pull request into a blocked merge.
-- **`perf-coverage-fanout.mjs`** — `just coverage-chdb`'s
+- **`coverage-chdb.mjs`** — `just/test.just`'s `coverage-chdb` recipe
+  (tsouza/cerberus#3113, following `coverage-merge`'s own #3095/#3091
+  extraction). The chdb-tagged coverage lane: the `CHDB_INSTALL_PATH`/
+  libchdb.so existence check (graceful skip, not a failure, when absent),
+  the `go list`-derived `-coverpkg`, the composite-tag `go test` invocation
+  with its streamed `-coverpkg`-echo line filter, the local
+  `SKIP_RATCHET_FANOUT` branch into `perf-coverage-fanout.mjs`, and the
+  unconditional `COVERAGE_REQUIRE_LANES=default+chdb` fail-closed tail
+  (reached whether or not the libchdb.so branch ran). Moving this out of the
+  Justfile recipe body required teaching the scanners that used to parse its
+  exact bash text to read this file's source instead:
+  `test/regression/tagged_test_enrollment_test.go`'s `readCoverageChdbTaggedRun`/
+  `taggedCoverageChdbLaneIsFailClosed`, `coverage_recipe_fail_closed_test.go`,
+  and `perf-coverage-fanout.test.mjs` (its `mainSweepArgv()`/`CHDB_TAGS`
+  imports). `coverage-chdb.test.mjs` is the `node --test` guard, exercising
+  the full flow (skip, fail-closed tail, the main sweep, and the real
+  fan-out call) against a fake `go` executable — no chDB needed.
+  - Env: `CHDB_INSTALL_PATH` (required — the recipe always passes it),
+    `CERBERUS_RAPID_SEED` (required once the libchdb.so branch runs),
+    `SKIP_RATCHET_FANOUT`, `COVERAGE_REQUIRE_LANES`, `GO` (default `go`,
+    test seam).
+  - Exit: `0` on a graceful skip or a successful run; `1` on a failed
+    `go test`, a failed fan-out, or `COVERAGE_REQUIRE_LANES=default+chdb`
+    with no `cover-chdb.out` produced.
+- **`perf-coverage-fanout.mjs`** — `coverage-chdb.mjs`'s
   `TestCardinalityRatchet` fan-out (shards 2..`RATCHET_FANOUT` of the corpus
-  walk; shard 1 is the Justfile's own main sweep). Two modes: local (no
+  walk; shard 1 is that script's own main sweep). Two modes: local (no
   `LEG_INDEX`) runs every remaining shard CONCURRENTLY as sibling processes
   on one machine, the same technique `property-fanout.mjs` established for
   the identical timeout shape in `test/property`; CI matrix mode
@@ -1184,13 +1208,10 @@ what actually runs.
   cover.out alone when no chdb-tagged profile was produced, deciding the
   `COVERAGE_LANES` value (`default+chdb` or `default`) it passes to
   `coverage-summary.mjs`. Both folds go through `lib/coverage-fold.mjs`'s
-  `foldProfile()`/`writeFoldedProfile()`. Deliberately does NOT touch
-  `coverage-chdb`'s own recipe body: `test/regression/tagged_test_enrollment_test.go`
-  statically parses that exact bash as chdb-tagged test execution evidence,
-  and extracting it too needs enrollment-scanner changes tracked separately
-  as tsouza/cerberus#3113. `coverage-merge.test.mjs` is the `node --test`
-  guard, exercising the merge/fold mechanics with synthetic profiles (no
-  chDB needed).
+  `foldProfile()`/`writeFoldedProfile()`. Shares `isNonEmptyFile()` (the
+  `test -s <file>` check) with `coverage-chdb.mjs` via `lib/gh.mjs`.
+  `coverage-merge.test.mjs` is the `node --test` guard, exercising the
+  merge/fold mechanics with synthetic profiles (no chDB needed).
   - Env: none of its own; forwards the caller's environment plus a computed
     `COVERAGE_LANES` to the `coverage-summary.mjs` subprocess it spawns.
   - Exit: `1` if cover.out is missing/empty or a ratchet shard has no

--- a/.github/scripts/coverage-chdb.mjs
+++ b/.github/scripts/coverage-chdb.mjs
@@ -1,0 +1,223 @@
+// coverage-chdb.mjs — the chdb-tagged coverage lane: writes cover-chdb.out.
+// Requires libchdb.so (`just chdb-install`); skips itself gracefully (rather
+// than failing) when the library is absent, so a bare local `just
+// coverage-chdb` without chDB installed still leaves the default-tag lane
+// usable on its own. CI's caller sets COVERAGE_REQUIRE_LANES=default+chdb,
+// which turns that same skip into a hard failure — see the tail of main()
+// below.
+//
+// Extracted from the `coverage-chdb` Justfile recipe body (CLAUDE.md
+// invariant 15, tsouza/cerberus#3113). #3095/#3091 already extracted the
+// sibling `coverage-merge` recipe into coverage-merge.mjs the same way, but
+// THIS half stayed literal bash at the time because its exact shell text was
+// (and, for the recipe wrapper that now just calls this script, still
+// partly is) parsed as chdb-tagged test EXECUTION EVIDENCE by four
+// scanners:
+//   - test/regression/tagged_test_enrollment_test.go's readCoverageChdbTaggedRun
+//     and taggedCoverageChdbLaneIsFailClosed now read THIS file's source for
+//     the composite tag set, the go-test argv shape, and the
+//     COVERAGE_REQUIRE_LANES fail-closed tail.
+//   - test/regression/coverage_recipe_fail_closed_test.go counts this file's
+//     `go test -timeout` invocation instead of the old recipe-body one.
+//   - test/regression/rapid_seed_pin_test.go still finds
+//     CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} in the RECIPE body — the
+//     Justfile call site passes it through as an env var, unchanged from
+//     before this extraction — so that scanner needed no update.
+//   - .github/scripts/perf-coverage-fanout.test.mjs reads mainSweepArgv()
+//     structurally instead of slicing the old recipe body's "main sweep"
+//     line as text.
+// See tsouza/cerberus#3113 for the full account of what moved where and why.
+//
+// Env:
+//   CHDB_INSTALL_PATH      (required) libchdb.so path. The Justfile recipe
+//                          always passes CHDB_INSTALL_PATH from
+//                          just/chdb.just; missing it here is a caller bug,
+//                          not a legitimate "libchdb.so absent" skip.
+//   CERBERUS_RAPID_SEED    (required, only once the libchdb.so branch below
+//                          actually runs) forwarded verbatim to `go test`
+//                          and to perf-coverage-fanout.mjs — see
+//                          just/test.just's own COVERAGE_RAPID_SEED doc
+//                          comment for why the pin has to be identical
+//                          across both coverage lanes.
+//   SKIP_RATCHET_FANOUT    (optional) `1` skips the local
+//                          perf-coverage-fanout.mjs call (CI's coverage-chdb
+//                          job sets this; its own coverage-chdb-ratchet
+//                          matrix runs those shards instead, on their own
+//                          runners).
+//   COVERAGE_REQUIRE_LANES (optional) `default+chdb` hard-fails (exit 1)
+//                          unless cover-chdb.out was actually produced.
+//   GO                     go executable; default `go`. Test seam.
+//
+// Exit: 0 on a graceful skip or a successful run; 1 on a failed `go test`, a
+// failed fan-out, or COVERAGE_REQUIRE_LANES=default+chdb with no
+// cover-chdb.out produced.
+
+import { existsSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import process from 'node:process';
+
+import { capture, error, isNonEmptyFile, log } from './lib/gh.mjs';
+import { RATCHET_FANOUT } from './perf-coverage-fanout.mjs';
+
+/** The composite build-tag set every chdb-tagged package in this lane needs. */
+export const CHDB_TAGS = 'chdb,agpl_oracle,chdb_agpl_oracle';
+
+/**
+ * Shard 1 of RATCHET_FANOUT: the main sweep below carries TestCardinalityRatchet's
+ * first shard itself; perf-coverage-fanout.mjs runs the remaining
+ * RATCHET_FANOUT-1 shards (see that module's header for the full story of
+ * why the corpus is sharded at all). Importing RATCHET_FANOUT directly here
+ * — rather than restating the shard count as a literal, the way the old
+ * Justfile recipe had to (`just` recipes cannot import a JS constant) —
+ * removes the drift risk perf-coverage-fanout.test.mjs used to have to pin
+ * across the language boundary.
+ */
+const PERF_SHARD_INDEX = 1;
+
+/** Per CLAUDE.md invariant 13: named rather than a bare `60`. */
+const MAIN_SWEEP_TIMEOUT_MINUTES = 60;
+
+const COVERAGE_PROFILE = 'cover-chdb.out';
+const FANOUT_SCRIPT = new URL('./perf-coverage-fanout.mjs', import.meta.url);
+
+/**
+ * argv for the main sweep's `go test` invocation. Exported so
+ * coverage-chdb.test.mjs (and test/regression/tagged_test_enrollment_test.go's
+ * readCoverageChdbTaggedRun) can verify its shape directly, the same pattern
+ * perf-coverage-fanout.mjs's own legCommands() already established, instead
+ * of parsing this file's source as unstructured text.
+ */
+export function mainSweepArgv(coverpkg) {
+  return [
+    'test',
+    '-timeout', `${MAIN_SWEEP_TIMEOUT_MINUTES}m`,
+    '-tags', CHDB_TAGS,
+    '-coverpkg', coverpkg,
+    '-coverprofile', COVERAGE_PROFILE,
+    './...',
+  ];
+}
+
+/**
+ * Rewrites the tail of go test's -coverpkg echo, the same one-line trim
+ * `just coverage-default`'s own awk filter still applies directly in bash:
+ * -coverpkg makes go test echo the FULL package list back on every "of
+ * statements in ..." summary line, which is ~5 KiB repeated per package
+ * result — this rewrites only that sentence's tail; everything else
+ * (results, failures) passes through unchanged.
+ */
+export function filterCoverpkgLine(line) {
+  return line.replace(/of statements in github\.com\/.*/, 'of statements');
+}
+
+/**
+ * Streams `child`'s stdout to `sink` (default process.stdout), filtered
+ * line-by-line through filterCoverpkgLine — mirrors the bash pipeline's
+ * `go test ... | awk '{ ...; print; fflush() }'`. Only stdout is piped, the
+ * same as the bash version: `cmd1 | cmd2` never touches cmd1's stderr, which
+ * the caller leaves on `inherit` instead. A trailing partial line (no final
+ * newline) still gets flushed once the stream ends. `sink` is a test seam —
+ * coverage-chdb.test.mjs injects a collecting stream instead of monkey-
+ * patching the real process.stdout, which would race other tests' own
+ * output under the test runner's default concurrency.
+ */
+export function pipeFilteredStdout(child, sink = process.stdout) {
+  let carry = '';
+  child.stdout.on('data', (chunk) => {
+    carry += chunk.toString();
+    const lines = carry.split('\n');
+    carry = lines.pop();
+    for (const l of lines) sink.write(`${filterCoverpkgLine(l)}\n`);
+  });
+  child.stdout.on('end', () => {
+    if (carry) sink.write(`${filterCoverpkgLine(carry)}\n`);
+  });
+}
+
+/** Runs the main `go test` sweep, resolving to its exit code. */
+function runMainSweep(argv, env, cwd, go, stdout) {
+  return new Promise((resolve) => {
+    const child = spawn(go, argv, {
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    pipeFilteredStdout(child, stdout);
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+/**
+ * main — the recipe body. `cwd`/`env`/`go`/`stdout` are test seams (default
+ * process.cwd() / process.env / env.GO ?? 'go' / process.stdout); the CLI
+ * entry point below always uses the real ones. Returns the exit status the
+ * CLI should use; never throws.
+ */
+export async function main({ cwd = process.cwd(), env = process.env, go = env.GO || 'go', stdout = process.stdout } = {}) {
+  const p = (name) => join(cwd, name);
+
+  const chdbPath = env.CHDB_INSTALL_PATH;
+  if (!chdbPath) {
+    error('CHDB_INSTALL_PATH is required — the coverage-chdb recipe always passes it from just/chdb.just');
+    return 1;
+  }
+
+  if (!existsSync(chdbPath)) {
+    log('==> libchdb.so not found, skipping chdb lane');
+  } else {
+    log('==> chdb-tagged coverage');
+
+    const rapidSeed = env.CERBERUS_RAPID_SEED;
+    if (!rapidSeed) {
+      error('CERBERUS_RAPID_SEED is required — an unpinned rapid draw would move this lane\'s coverage run to run');
+      return 1;
+    }
+
+    const listResult = capture(go, ['list', '-tags', CHDB_TAGS, './...'], { cwd, env: { ...process.env, ...env } });
+    if (listResult.status !== 0) {
+      error(`${go} list -tags ${CHDB_TAGS} ./...: ${listResult.stderr.trim()}`);
+      return 1;
+    }
+    const coverpkg = listResult.stdout.split('\n').filter(Boolean).join(',');
+
+    const testEnv = {
+      ...env,
+      CERBERUS_RAPID_SEED: rapidSeed,
+      PERF_SHARD_INDEX: String(PERF_SHARD_INDEX),
+      PERF_SHARD_COUNT: String(RATCHET_FANOUT),
+    };
+    const code = await runMainSweep(mainSweepArgv(coverpkg), testEnv, cwd, go, stdout);
+    if (code !== 0) return code;
+
+    if (env.SKIP_RATCHET_FANOUT === '1') {
+      log('==> SKIP_RATCHET_FANOUT=1: shards 2..PERF_SHARD_COUNT run on their own coverage-chdb-ratchet CI matrix legs, not here');
+    } else {
+      const fanout = spawnSync(process.execPath, [fileURLToPath(FANOUT_SCRIPT)], {
+        cwd,
+        stdio: 'inherit',
+        env: { ...process.env, ...env, CERBERUS_RAPID_SEED: rapidSeed, TAGS: CHDB_TAGS, COVERPKG: coverpkg },
+      });
+      const fanoutCode = fanout.status ?? 1;
+      if (fanoutCode !== 0) return fanoutCode;
+    }
+  }
+
+  // Unconditional (reached whether or not the libchdb.so branch above ran):
+  // a bare local `just coverage-chdb` stays a graceful skip, but a caller
+  // that opts in via COVERAGE_REQUIRE_LANES=default+chdb is asserting the
+  // chdb lane MUST have produced real evidence — CI sets this so an install
+  // that silently no-ops fails here instead of only surfacing three steps
+  // later as a narrower merged profile.
+  if (env.COVERAGE_REQUIRE_LANES === 'default+chdb' && !isNonEmptyFile(p(COVERAGE_PROFILE))) {
+    error(`COVERAGE_REQUIRE_LANES=default+chdb but ${COVERAGE_PROFILE} was not produced (libchdb.so missing?)`);
+    return 1;
+  }
+  return 0;
+}
+
+// Import-safe: coverage-chdb.test.mjs and perf-coverage-fanout.test.mjs both
+// import mainSweepArgv()/CHDB_TAGS without triggering a real run.
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) process.exit(await main());

--- a/.github/scripts/coverage-chdb.test.mjs
+++ b/.github/scripts/coverage-chdb.test.mjs
@@ -1,0 +1,230 @@
+// coverage-chdb.test.mjs — node:test guard for the `coverage-chdb` recipe's
+// extracted logic (CLAUDE.md invariant 15, tsouza/cerberus#3113): the
+// CHDB_INSTALL_PATH/libchdb.so branch (missing env, graceful skip, and the
+// COVERAGE_REQUIRE_LANES fail-closed tail reached either way), the
+// `go list`-derived -coverpkg join, the main sweep's argv shape and its
+// stdout line filter, and exit-code propagation on a failed `go test` — all
+// against a fake `go` executable, so no real chDB or libchdb.so is needed.
+//
+// mainSweepArgv()'s shape (composite tags, no -skip, PERF_SHARD_COUNT tied
+// to RATCHET_FANOUT) is pinned by perf-coverage-fanout.test.mjs instead —
+// see that file's own header — to keep the two coverage-lane scripts' cross
+// checks together with the fan-out they both touch.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { main, filterCoverpkgLine } from './coverage-chdb.mjs';
+
+test('filterCoverpkgLine rewrites only the -coverpkg echo tail, leaving everything else untouched', () => {
+  assert.equal(
+    filterCoverpkgLine(
+      'ok  \tgithub.com/tsouza/cerberus/internal/foo\t0.5s\tcoverage: 42.0% of statements in github.com/tsouza/cerberus/internal/foo,github.com/tsouza/cerberus/internal/bar',
+    ),
+    'ok  \tgithub.com/tsouza/cerberus/internal/foo\t0.5s\tcoverage: 42.0% of statements',
+  );
+  assert.equal(filterCoverpkgLine('--- FAIL: TestSomething (0.01s)'), '--- FAIL: TestSomething (0.01s)');
+  assert.equal(filterCoverpkgLine(''), '');
+});
+
+function tmpDir() {
+  return mkdtempSync(join(tmpdir(), 'coverage-chdb-test-'));
+}
+
+function floorlessEnv(overrides = {}) {
+  return { ...process.env, ...overrides };
+}
+
+test('missing CHDB_INSTALL_PATH fails closed without touching the filesystem', async () => {
+  const dir = tmpDir();
+  try {
+    const status = await main({ cwd: dir, env: floorlessEnv() });
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('libchdb.so absent: graceful skip, exit 0, no COVERAGE_REQUIRE_LANES set', async () => {
+  const dir = tmpDir();
+  try {
+    const status = await main({ cwd: dir, env: floorlessEnv({ CHDB_INSTALL_PATH: join(dir, 'no-such-libchdb.so') }) });
+    assert.equal(status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('libchdb.so absent + COVERAGE_REQUIRE_LANES=default+chdb + no cover-chdb.out: fails closed', async () => {
+  const dir = tmpDir();
+  try {
+    const status = await main({
+      cwd: dir,
+      env: floorlessEnv({ CHDB_INSTALL_PATH: join(dir, 'no-such-libchdb.so'), COVERAGE_REQUIRE_LANES: 'default+chdb' }),
+    });
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('libchdb.so absent + COVERAGE_REQUIRE_LANES=default+chdb + a cover-chdb.out already present: the tail only checks the file, not why it is there', async () => {
+  const dir = tmpDir();
+  try {
+    writeFileSync(join(dir, 'cover-chdb.out'), 'mode: set\n');
+    const status = await main({
+      cwd: dir,
+      env: floorlessEnv({ CHDB_INSTALL_PATH: join(dir, 'no-such-libchdb.so'), COVERAGE_REQUIRE_LANES: 'default+chdb' }),
+    });
+    assert.equal(status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('libchdb.so present but CERBERUS_RAPID_SEED unset: fails closed before running go at all', async () => {
+  const dir = tmpDir();
+  const libchdb = join(dir, 'libchdb.so');
+  writeFileSync(libchdb, '');
+  try {
+    const status = await main({ cwd: dir, env: floorlessEnv({ CHDB_INSTALL_PATH: libchdb }), go: '/nonexistent/should-not-run' });
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// fakeGo emulates the two `go` subcommands this script actually calls:
+//   list -tags <tags> ./...      -> prints two fake package names
+//   test ... -coverprofile <f>   -> writes a fake profile at <f> and exits
+//                                   with $FAKE_GO_TEST_EXIT (default 0),
+//                                   echoing a -coverpkg-shaped summary line
+//                                   so the streaming filter has something
+//                                   real to rewrite.
+// perf-coverage-fanout.mjs's own legs reach this SAME fake go when GO is
+// forwarded into the fan-out's env (see the "runs the real fan-out" test
+// below) — its legs also invoke `go test ... -coverprofile <f>`, so no
+// special-casing is needed.
+function writeFakeGo(dir) {
+  const path = join(dir, 'fake-go.sh');
+  writeFileSync(
+    path,
+    [
+      '#!/usr/bin/env bash',
+      'set -eu',
+      'case "$1" in',
+      '  list)',
+      '    echo "github.com/tsouza/cerberus/internal/fakepkg1"',
+      '    echo "github.com/tsouza/cerberus/internal/fakepkg2"',
+      '    ;;',
+      '  test)',
+      '    profile=""',
+      '    prev=""',
+      '    for arg in "$@"; do',
+      '      if [ "$prev" = "-coverprofile" ]; then profile="$arg"; fi',
+      '      prev="$arg"',
+      '    done',
+      '    echo "mode: set" > "$profile"',
+      '    echo "ok  	$profile	0.1s	coverage: 42.0% of statements in github.com/tsouza/cerberus/internal/fakepkg1,github.com/tsouza/cerberus/internal/fakepkg2"',
+      '    exit "${FAKE_GO_TEST_EXIT:-0}"',
+      '    ;;',
+      '  *)',
+      '    echo "fake-go: unsupported subcommand $1" >&2',
+      '    exit 1',
+      '    ;;',
+      'esac',
+      '',
+    ].join('\n'),
+  );
+  chmodSync(path, 0o755);
+  return path;
+}
+
+// collectingStream is the `stdout` test seam main() writes filtered lines
+// to — an injected sink rather than a monkey-patch of the real
+// process.stdout, which would race other tests' own reporter output under
+// the test runner's default per-file concurrency.
+function collectingStream() {
+  const chunks = [];
+  return {
+    write: (chunk) => {
+      chunks.push(chunk.toString());
+      return true;
+    },
+    get output() {
+      return chunks.join('');
+    },
+  };
+}
+
+test('libchdb.so present: joins go list output into -coverpkg, writes the profile, and filters the coverpkg echo off stdout', async () => {
+  const dir = tmpDir();
+  const libchdb = join(dir, 'libchdb.so');
+  writeFileSync(libchdb, '');
+  const go = writeFakeGo(dir);
+  const stdout = collectingStream();
+  try {
+    const status = await main({
+      cwd: dir,
+      go,
+      stdout,
+      env: floorlessEnv({ CHDB_INSTALL_PATH: libchdb, CERBERUS_RAPID_SEED: '20260903', SKIP_RATCHET_FANOUT: '1' }),
+    });
+    assert.equal(status, 0);
+    assert.equal(readFileSync(join(dir, 'cover-chdb.out'), 'utf8'), 'mode: set\n');
+    assert.match(stdout.output, /coverage: 42\.0% of statements\n/, 'the -coverpkg tail must be rewritten');
+    assert.ok(!stdout.output.includes('fakepkg1,github.com'), 'the raw package-list echo must not reach stdout unfiltered');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a failing go test propagates its real exit code without running the fan-out', async () => {
+  const dir = tmpDir();
+  const libchdb = join(dir, 'libchdb.so');
+  writeFileSync(libchdb, '');
+  const go = writeFakeGo(dir);
+  try {
+    const status = await main({
+      cwd: dir,
+      go,
+      stdout: collectingStream(),
+      env: floorlessEnv({
+        CHDB_INSTALL_PATH: libchdb,
+        CERBERUS_RAPID_SEED: '20260903',
+        SKIP_RATCHET_FANOUT: '1',
+        FAKE_GO_TEST_EXIT: '3',
+      }),
+    });
+    assert.equal(status, 3);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('SKIP_RATCHET_FANOUT unset: the real fan-out runs and produces the extra shard profiles', async () => {
+  const dir = tmpDir();
+  const libchdb = join(dir, 'libchdb.so');
+  writeFileSync(libchdb, '');
+  const go = writeFakeGo(dir);
+  try {
+    const status = await main({
+      cwd: dir,
+      go,
+      stdout: collectingStream(),
+      env: floorlessEnv({ CHDB_INSTALL_PATH: libchdb, CERBERUS_RAPID_SEED: '20260903', GO: go }),
+    });
+    assert.equal(status, 0);
+    // RATCHET_FANOUT=3: the main sweep above covers shard 1, this fan-out
+    // covers shards 2 and 3 — proving main() really invoked
+    // perf-coverage-fanout.mjs (with GO/TAGS/COVERPKG wired through), not
+    // just logged that it would.
+    assert.equal(readFileSync(join(dir, 'cover-chdb-ratchet-2.out'), 'utf8'), 'mode: set\n');
+    assert.equal(readFileSync(join(dir, 'cover-chdb-ratchet-3.out'), 'utf8'), 'mode: set\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/coverage-merge.mjs
+++ b/.github/scripts/coverage-merge.mjs
@@ -32,39 +32,32 @@
 // lanes. This script is the one step that legitimately knows, because it is
 // the step that decided.
 //
-// Deliberately UNCHANGED by this extraction: `coverage-chdb`'s own
-// conditional `go test`/COVERAGE_REQUIRE_LANES gate stays literal Justfile
-// bash — test/regression/tagged_test_enrollment_test.go statically parses
-// that exact recipe body as execution evidence for the chdb-tagged test
-// tail, and test/regression/coverage_recipe_fail_closed_test.go counts its
-// `go test -timeout` invocations via `just --dump`. Moving that recipe's
-// control flow into a script would require rewriting both scanners — real,
-// separate work tracked as tsouza/cerberus#3113.
+// `coverage-chdb`'s own conditional `go test`/COVERAGE_REQUIRE_LANES gate
+// used to stay literal Justfile bash for the same reason this file's own
+// header explained above: test/regression/tagged_test_enrollment_test.go and
+// test/regression/coverage_recipe_fail_closed_test.go both statically parsed
+// that exact recipe body as execution evidence. tsouza/cerberus#3113
+// extracted that half too, into coverage-chdb.mjs (see that module's header
+// for the fuller account) — the two scripts share isNonEmptyFile() (the
+// `test -s <file>` check) via lib/gh.mjs rather than each defining its own
+// copy.
 //
 // Usage: node .github/scripts/coverage-merge.mjs
 // Exit: 1 if cover.out is missing/empty, or if ratchet shard files exist
 // with no cover-chdb.out to fold them into; otherwise the exit status of the
 // coverage-summary.mjs floor gate it hands off to.
 
-import { copyFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { copyFileSync, readdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import process from 'node:process';
 
-import { error, log } from './lib/gh.mjs';
+import { error, isNonEmptyFile, log } from './lib/gh.mjs';
 import { writeFoldedProfile } from './lib/coverage-fold.mjs';
 
 const COVERAGE_SUMMARY_MJS = new URL('./coverage-summary.mjs', import.meta.url);
 const RATCHET_SHARD_PATTERN = /^cover-chdb-ratchet-.*\.out$/;
-
-function isNonEmptyFile(path) {
-  try {
-    return existsSync(path) && statSync(path).size > 0;
-  } catch {
-    return false;
-  }
-}
 
 // ratchetShardFiles — the cover-chdb-ratchet-*.out sibling shard profiles
 // among `names` (a directory listing), sorted. Mirrors the replaced bash's

--- a/.github/scripts/lib/gh.mjs
+++ b/.github/scripts/lib/gh.mjs
@@ -18,9 +18,12 @@
 //   - createFreshFileFd() / writeFreshFile(): CWE-377/378-safe creation of a
 //     file at a FIXED, well-known path (a log or PID file another script or
 //     workflow step finds by that same literal path afterward).
+//   - isNonEmptyFile(): `test -s <file>`-equivalent existence+size check,
+//     shared by every coverage-lane script that gates on a profile a prior
+//     step should have written.
 
 import { spawnSync } from 'node:child_process';
-import { appendFileSync, openSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, openSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
 
 // GitHub escapes `%`, `\r`, `\n` in workflow-command *data* (the message
@@ -73,6 +76,20 @@ export function group(title, fn) {
 // Plain stdout line (no annotation). Kept here so scripts import one module.
 export function log(line = '') {
   process.stdout.write(`${line}\n`);
+}
+
+// isNonEmptyFile — true when `path` exists and is a real, non-empty file.
+// Shared by coverage-merge.mjs and coverage-chdb.mjs, both of which gate a
+// step on whether a coverage profile a PRIOR step should have written is
+// actually there — the same `test -s <file>` check the bash they were
+// extracted from used. Never throws: a missing path or a permission error
+// both mean "not there", not a crash.
+export function isNonEmptyFile(path) {
+  try {
+    return existsSync(path) && statSync(path).size > 0;
+  } catch {
+    return false;
+  }
 }
 
 // The spawnSync options capture()/exec() forward. Anything outside this set is

--- a/.github/scripts/perf-coverage-fanout.test.mjs
+++ b/.github/scripts/perf-coverage-fanout.test.mjs
@@ -2,12 +2,14 @@
 // chDB-tagged TestCardinalityRatchet fan-out: an explicit per-process go
 // test -timeout that stays below the coverage-chdb-ratchet job's cap
 // (tsouza/cerberus#2645), the extra shards (2..RATCHET_FANOUT) sharded
-// without dropping or duplicating a corpus slice, the Justfile's own
-// PERF_SHARD_COUNT literal pinned to the same RATCHET_FANOUT this script
-// uses, the coverage recipe still carrying the main sweep WITHOUT `-skip`
-// (so test/regression/tagged_test_enrollment_test.go's static evidence
-// scanner keeps crediting it), and LEG_INDEX mode (the CI matrix leg path)
-// selecting exactly one leg's command.
+// without dropping or duplicating a corpus slice, coverage-chdb.mjs's own
+// PERF_SHARD_COUNT pinned to the same RATCHET_FANOUT this script uses (an
+// import, not a restated literal, since tsouza/cerberus#3113 moved the main
+// sweep from the Justfile — which cannot import a JS constant — into a
+// script that can), coverage-chdb.mjs's main sweep still carrying it WITHOUT
+// `-skip` (so test/regression/tagged_test_enrollment_test.go's static
+// evidence scanner keeps crediting it), and LEG_INDEX mode (the CI matrix
+// leg path) selecting exactly one leg's command.
 //
 // Runs on the cheap `check` lane (`node --test`), so a regression here fails
 // in milliseconds rather than 40+ minutes into a coverage job.
@@ -19,29 +21,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { RATCHET_TEST, RATCHET_RUN_PATTERN, RATCHET_FANOUT, RATCHET_TIMEOUT_MINUTES, legCommands, selectLeg } from './perf-coverage-fanout.mjs';
+import { CHDB_TAGS, mainSweepArgv } from './coverage-chdb.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-// coverage-default / coverage-chdb / coverage-merge / coverage all live
-// together in just/test.just, not the root Justfile (#3093's just/*.just
-// split) — reading that one file directly, rather than the root file,
-// keeps this scan's plain-text recipe-boundary slicing working without
-// pulling in a `just --dump` dependency for this cheap check-lane script.
-// coverage-merge's OWN logic moved out of that recipe body entirely (issue
-// #3095, epic #3091, coverage-merge.mjs) — the assertions that used to slice
-// its Justfile text now read that module's source instead; see
-// coverageMergeScriptSource() below.
-const justfile = readFileSync(path.join(here, '..', '..', 'just', 'test.just'), 'utf8');
 const coverageWorkflow = readFileSync(path.join(here, '..', 'workflows', 'coverage.yml'), 'utf8');
 const TAGS = 'chdb,agpl_oracle,chdb_agpl_oracle';
 const COVERPKG = 'github.com/tsouza/cerberus/internal/promql,github.com/tsouza/cerberus/test/perf';
-
-/** The coverage-chdb recipe body — the main sweep and its SKIP_RATCHET_FANOUT gate. */
-function coverageChdbRecipeBody() {
-  const start = justfile.indexOf('\ncoverage-chdb:\n');
-  const end = justfile.indexOf('\ncoverage-merge:');
-  assert.ok(start >= 0 && end >= 0 && end > start, 'Justfile: cannot isolate the coverage-chdb recipe');
-  return justfile.slice(start, end);
-}
 
 /**
  * coverage-merge's own logic — where the ratchet shard fold now lives
@@ -53,6 +38,19 @@ function coverageChdbRecipeBody() {
  */
 function coverageMergeScriptSource() {
   return readFileSync(path.join(here, 'coverage-merge.mjs'), 'utf8');
+}
+
+/**
+ * coverage-chdb's own main-sweep logic, extracted the same way
+ * (tsouza/cerberus#3113): the assertions below that used to slice the
+ * `coverage-chdb` Justfile recipe body as text now either import
+ * mainSweepArgv()/CHDB_TAGS directly (the structural checks legCommands()
+ * above already gets, rather than a text scan) or read this file's own
+ * source for the SKIP_RATCHET_FANOUT / PERF_SHARD_INDEX shape a plain
+ * argv array cannot express.
+ */
+function coverageChdbScriptSource() {
+  return readFileSync(path.join(here, 'coverage-chdb.mjs'), 'utf8');
 }
 
 /** The `timeout-minutes:` of a named coverage.yml job. */
@@ -139,44 +137,42 @@ test('the build tags reach every go command verbatim', () => {
   }
 });
 
-test('the coverage-chdb recipe still invokes the fan-out script locally, gated behind SKIP_RATCHET_FANOUT', () => {
-  const body = coverageChdbRecipeBody();
-  assert.match(body, /node \.github\/scripts\/perf-coverage-fanout\.mjs/);
-  assert.match(body, /TAGS=chdb,agpl_oracle,chdb_agpl_oracle/);
+test('coverage-chdb.mjs still invokes the fan-out script locally, gated behind SKIP_RATCHET_FANOUT', () => {
+  const src = coverageChdbScriptSource();
+  assert.match(src, /new URL\('\.\/perf-coverage-fanout\.mjs', import\.meta\.url\)/);
+  assert.match(src, /TAGS:\s*CHDB_TAGS/);
   assert.match(
-    body,
+    src,
     /SKIP_RATCHET_FANOUT/,
-    'coverage-chdb must gate its own (local-mode) fan-out call behind SKIP_RATCHET_FANOUT, or CI (which sets it) ' +
+    "coverage-chdb.mjs must gate its own (local-mode) fan-out call behind SKIP_RATCHET_FANOUT, or CI (which sets it) " +
       'would double-run the extra shards: once via coverage-chdb-ratchet, once inline here',
   );
 });
 
-test('the coverage-chdb recipe main sweep carries PERF_SHARD_INDEX=1 and a PERF_SHARD_COUNT matching RATCHET_FANOUT — the two constants must not drift apart', () => {
-  const body = coverageChdbRecipeBody();
-  const sweepLine = body.split('\n').find((l) => l.includes('PERF_SHARD_INDEX=1') && l.includes('go test'));
-  assert.ok(sweepLine, 'Justfile: could not find the main sweep line');
-  assert.ok(sweepLine.includes('-tags chdb,agpl_oracle,chdb_agpl_oracle'), 'main sweep: missing composite tag set');
-  assert.ok(sweepLine.includes('-coverprofile=cover-chdb.out'), 'main sweep: missing -coverprofile=cover-chdb.out');
-  assert.ok(sweepLine.includes('./...'), 'main sweep: must target the whole tree');
-  const m = /PERF_SHARD_COUNT=(\d+)/.exec(sweepLine);
-  assert.ok(m, 'Justfile: main sweep declares no PERF_SHARD_COUNT');
-  assert.equal(
-    Number(m[1]),
-    RATCHET_FANOUT,
-    `Justfile's PERF_SHARD_COUNT=${m[1]} on the main sweep must equal perf-coverage-fanout.mjs's own RATCHET_FANOUT=${RATCHET_FANOUT}`,
+test('coverage-chdb.mjs main sweep carries PERF_SHARD_INDEX=1 and a PERF_SHARD_COUNT matching RATCHET_FANOUT — the two constants must not drift apart', () => {
+  const src = coverageChdbScriptSource();
+  assert.match(src, /const PERF_SHARD_INDEX = 1;/, 'coverage-chdb.mjs: main sweep must declare PERF_SHARD_INDEX=1');
+  assert.match(
+    src,
+    /PERF_SHARD_COUNT:\s*String\(RATCHET_FANOUT\)/,
+    "coverage-chdb.mjs's main sweep must pass PERF_SHARD_COUNT from the imported RATCHET_FANOUT, not a restated " +
+      'literal — the whole point of moving the sweep into a script is that it CAN import the constant Just recipes ' +
+      'could not',
   );
+
+  const argv = mainSweepArgv(COVERPKG);
+  assert.equal(argv[argv.indexOf('-tags') + 1], CHDB_TAGS, 'main sweep: missing composite tag set');
+  assert.equal(argv[argv.indexOf('-coverprofile') + 1], 'cover-chdb.out', 'main sweep: missing -coverprofile=cover-chdb.out');
+  assert.ok(argv.includes('./...'), 'main sweep: must target the whole tree');
+  assert.equal(CHDB_TAGS, TAGS, "coverage-chdb.mjs's CHDB_TAGS must match this suite's own composite tag fixture");
 });
 
-test('the coverage-chdb recipe main sweep never carries -skip — it is the sole CI evidence for other chdb-tagged packages', () => {
-  const body = coverageChdbRecipeBody();
-  const sweepLine = body
-    .split('\n')
-    .find((l) => l.includes('PERF_SHARD_INDEX=1') && l.includes('go test'));
-  assert.ok(sweepLine, 'Justfile: could not find the main sweep line');
+test('coverage-chdb.mjs main sweep never carries -skip — it is the sole CI evidence for other chdb-tagged packages', () => {
+  const argv = mainSweepArgv(COVERPKG);
   assert.ok(
-    !sweepLine.includes('-skip'),
+    !argv.includes('-skip'),
     'the main sweep must not use -skip: test/regression/tagged_test_enrollment_test.go discards a go test ' +
-      'invocation outright the moment it sees -skip, dropping this sweep\'s enrollment evidence for every ' +
+      "invocation outright the moment it sees -skip, dropping this sweep's enrollment evidence for every " +
       'other chdb-tagged package it is the sole CI evidence for',
   );
 });

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -269,6 +269,7 @@ jobs:
           node --test .github/scripts/perf-coverage-fanout.test.mjs
           node --test .github/scripts/lib/coverage-fold.test.mjs
           node --test .github/scripts/coverage-merge.test.mjs
+          node --test .github/scripts/coverage-chdb.test.mjs
 
       # Computed as a step output rather than a static job-level `env:` GHA
       # expression: a `push` event needs a network call (resolve the source PR

--- a/just/test.just
+++ b/just/test.just
@@ -692,84 +692,26 @@ coverage-default:
 # (rather than failing) when the library is absent, so a bare local `just
 # coverage` without chDB installed still produces a default-tag-only profile,
 # same as before this recipe was split out of `coverage`. CI's caller sets
-# COVERAGE_REQUIRE_LANES=default+chdb (below), which turns that same skip
-# into a hard failure: test/regression/tagged_test_enrollment_test.go's
-# static evidence scanner treats the chdb-tagged `go test` here as proven
-# execution only because of that unconditional tail check, the same
-# fail-closed contract `coverage-merge`'s COVERAGE_LANES join to
-# coverage-summary.mjs enforces for the merged profile.
+# COVERAGE_REQUIRE_LANES=default+chdb, which turns that same skip into a hard
+# failure — enforced inside the script below now, not this recipe body.
+#
+# Extracted to .github/scripts/coverage-chdb.mjs (tsouza/cerberus#3113,
+# following coverage-merge's own extraction in #3095/#3091): the libchdb.so
+# check, the `go list`-derived -coverpkg, the go test invocation and its
+# streaming output filter, the SKIP_RATCHET_FANOUT branch, and the
+# COVERAGE_REQUIRE_LANES fail-closed tail all live there now — see that
+# module's header for the full behaviour and for exactly what
+# test/regression/tagged_test_enrollment_test.go,
+# coverage_recipe_fail_closed_test.go, rapid_seed_pin_test.go, and
+# perf-coverage-fanout.test.mjs each now read as execution evidence in its
+# place. CERBERUS_RAPID_SEED stays a literal env assignment HERE rather than
+# moving into the script: rapid_seed_pin_test.go's static scanner looks for
+# CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} in the RECIPE body, the same
+# place it has always looked for both coverage lanes.
 
 # Run the chdb-tagged coverage lane into cover-chdb.out. Skips itself without libchdb.so.
 coverage-chdb:
-    @if [ -e "{{CHDB_INSTALL_PATH}}" ]; then \
-        echo "==> chdb-tagged coverage"; \
-        COVERPKG="$(go list -tags chdb,agpl_oracle,chdb_agpl_oracle ./... | paste -sd, -)"; \
-        CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} PERF_SHARD_INDEX=1 PERF_SHARD_COUNT=3 go test -timeout 60m -tags chdb,agpl_oracle,chdb_agpl_oracle -coverpkg="$COVERPKG" -coverprofile=cover-chdb.out ./... | awk '{ sub(/of statements in github\.com\/.*/, "of statements"); print; fflush() }'; \
-        if [ "${SKIP_RATCHET_FANOUT:-}" != "1" ]; then \
-            CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} TAGS=chdb,agpl_oracle,chdb_agpl_oracle COVERPKG="$COVERPKG" node .github/scripts/perf-coverage-fanout.mjs; \
-        else \
-            echo "==> SKIP_RATCHET_FANOUT=1: shards 2..PERF_SHARD_COUNT run on their own coverage-chdb-ratchet CI matrix legs, not here"; \
-        fi; \
-    else \
-        echo "==> libchdb.so not found, skipping chdb lane"; \
-    fi
-    # Bumped from 40m to 60m on 2026-08-26: the first real push-to-main run
-    # after coverage.yml split into parallel coverage-default/coverage-chdb
-    # jobs (#2639) hit coverage-chdb's job-level 50-minute wrapper exactly
-    # ("The job has exceeded the maximum execution time of 50m0s") — the same
-    # fixture/corpus growth already documented below, regrown past the
-    # PERF_SHARD_COUNT=3 split's own headroom. The job-level timeout in
-    # coverage.yml moved with it (50m -> 75m) so the wrapper still has real
-    # margin over this internal hang detector, not just a matching ceiling.
-    #
-    # This lane's `go test` used to sweep ./... with no shard env, timed out
-    # at 40m, the same shape as the default-tag lane above. It stopped
-    # fitting that budget once TestCardinalityRatchet's corpus walk
-    # (test/perf, straight-line runtime in test/spec/**'s TXTAR count) grew
-    # past what 40 minutes covers: every push-to-main `coverage` run panicked
-    # with "test timed out after 40m0s", and per the goroutine dump, every
-    # t.Parallel() TestBaselineShards* sibling in the SAME test/perf binary
-    # sat blocked for the whole 40 minutes too, never reaching its own body.
-    # Unlike perf-guards-shard in chdb.yml (which shards the same test across
-    # 8 separate CI matrix legs), this WAS one job. The sweep below is
-    # otherwise UNCHANGED — same flags, same ./... package list, no `-skip`.
-    # `-skip` is deliberately avoided: test/regression/tagged_test_enrollment_
-    # test.go's static evidence scanner (parseTaggedGoTestArgs) discards a go
-    # test invocation OUTRIGHT the moment it sees `-skip`, since it cannot
-    # certify what was excluded — and this sweep is the SOLE CI evidence for
-    # a long tail of other chdb-tagged packages, so a `-skip` here would
-    # silently drop their enrollment evidence too. Instead the sweep only
-    # gains PERF_SHARD_INDEX=1 / PERF_SHARD_COUNT: TestCardinalityRatchet
-    # still runs here, still asserting, just over 1/PERF_SHARD_COUNT of the
-    # corpus.
-    #
-    # The other PERF_SHARD_COUNT-1 shards (tsouza/cerberus#2645): locally,
-    # perf-coverage-fanout.mjs still runs them itself, concurrently with each
-    # other on this same machine — the process fan-out technique
-    # property-fanout.mjs already established for the identical failure
-    # shape in test/property (see that script's own header for why
-    # t.Parallel() inside one process is not a safe alternative: chdb-go's
-    # shared globalSession). In CI, coverage.yml's `coverage-chdb` job sets
-    # SKIP_RATCHET_FANOUT=1 and those shards instead run on their OWN
-    # runners in the `coverage-chdb-ratchet` matrix — this used to be a
-    # serial tail on THIS job's own runner, and was the direct cause of two
-    # consecutive real timeouts on this lane. Either way, those extra shards
-    # do not need to be Justfile-visible themselves: TestCardinalityRatchet
-    # already has independent enrollment evidence via the perf-chdb recipe.
-    # The shard count (3) is perf-coverage-fanout.mjs's own RATCHET_FANOUT
-    # constant, restated here because Just recipes cannot import a JS
-    # constant; perf-coverage-fanout.test.mjs pins the two back together.
-    #
-    # Unconditional (outside the `if` block above, so it runs whether or not
-    # libchdb.so was found): a bare local `just coverage-chdb` stays a graceful
-    # skip, but a caller that opts in via COVERAGE_REQUIRE_LANES=default+chdb
-    # is asserting the chdb lane MUST have produced real evidence — CI sets
-    # this so an install that silently no-ops fails the job here instead of
-    # only surfacing three steps later as a narrower merged profile.
-    @if [ "${COVERAGE_REQUIRE_LANES:-}" = "default+chdb" ] && [ ! -s cover-chdb.out ]; then \
-        echo "error: COVERAGE_REQUIRE_LANES=default+chdb but cover-chdb.out was not produced (libchdb.so missing?)" >&2; \
-        exit 1; \
-    fi
+    @CHDB_INSTALL_PATH="{{CHDB_INSTALL_PATH}}" CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} node .github/scripts/coverage-chdb.mjs
 
 # Merge cover.out (default-tag lane, required) with cover-chdb.out
 # (chdb-tagged lane, optional) into cover-merged.out and run the floor gate.

--- a/test/regression/coverage_recipe_fail_closed_test.go
+++ b/test/regression/coverage_recipe_fail_closed_test.go
@@ -14,30 +14,49 @@ import (
 // tsouza/cerberus#2634 split the old single `coverage` recipe's two `go test`
 // pipelines into their own `coverage-default` / `coverage-chdb` recipes (so
 // CI can shard them across parallel jobs); `coverage-merge` folds the two
-// profiles and `coverage` chains all three for local use. The isolated span
-// below covers exactly those three recipes, by name, rather than the chaining
-// `coverage:` recipe, which contains no `go test` invocation itself.
+// profiles and `coverage` chains all three for local use.
 //
-// Reads via justDump() (#3093) for the three recipe bodies — they live in
-// just/test.just now, not the root Justfile — but the pipefail check stays a
-// direct root-Justfile read: `set shell := [...]` is a per-invocation `just`
-// SETTING, which can only be declared once, in the root file itself.
+// tsouza/cerberus#3113 then extracted the chdb-tagged `go test` invocation
+// itself out of the coverage-chdb recipe body into coverage-chdb.mjs's own
+// source (mirroring coverage-merge's own #3095 extraction) — so the
+// evidence for that HALF of this test moved from `just --dump`'s recipe-body
+// text to the script's source: it still must declare an explicit -timeout
+// and must not tolerate a failed run. The default-tag lane's `go test`
+// invocation is unchanged and is still read via justDump() (#3093); the
+// pipefail check stays a direct root-Justfile read: `set shell := [...]` is
+// a per-invocation `just` SETTING, which can only be declared once, in the
+// root file itself.
 func TestCoverageRecipeFailsClosedOnGoTestFailure(t *testing.T) {
 	t.Parallel()
 
 	d := justDump(t)
 	var recipe strings.Builder
-	for _, name := range []string{"coverage-default", "coverage-chdb", "coverage-merge"} {
+	for _, name := range []string{"coverage-default", "coverage-merge"} {
 		recipe.WriteString(d.recipe(t, name).bodyText(t))
 		recipe.WriteString("\n")
 	}
 	body := recipe.String()
 
-	if got := strings.Count(body, "go test -timeout"); got != 2 {
-		t.Fatalf("coverage recipes carry %d go test runs, want default and chdb-tagged runs", got)
+	if got := strings.Count(body, "go test -timeout"); got != 1 {
+		t.Fatalf("coverage-default/coverage-merge recipes carry %d literal go test run(s), want exactly the default-tag lane's", got)
 	}
 	if strings.Contains(body, "|| true") {
 		t.Fatalf("coverage recipes tolerate a failed command with `|| true`; a partial profile is not valid evidence")
+	}
+
+	scriptSource, err := os.ReadFile("../../.github/scripts/coverage-chdb.mjs")
+	if err != nil {
+		t.Fatalf("read coverage-chdb.mjs: %v", err)
+	}
+	script := string(scriptSource)
+	if !strings.Contains(script, "'-timeout', `${MAIN_SWEEP_TIMEOUT_MINUTES}m`,") {
+		t.Fatal("coverage-chdb.mjs's main sweep no longer declares an explicit go test -timeout")
+	}
+	if strings.Contains(script, "|| true") || strings.Contains(script, ".catch(") {
+		t.Fatal("coverage-chdb.mjs tolerates a failed command; a partial profile is not valid evidence")
+	}
+	if !strings.Contains(script, "if (code !== 0) return code;") {
+		t.Fatal("coverage-chdb.mjs no longer propagates its go test sweep's exit code")
 	}
 
 	rootJustfile, err := os.ReadFile("../../Justfile")

--- a/test/regression/tagged_test_enrollment_test.go
+++ b/test/regression/tagged_test_enrollment_test.go
@@ -32,6 +32,14 @@ const (
 
 	migrationExecutionScript = ".github/scripts/migration-e2e.mjs"
 	migrationExecutionClaim  = "migration tier selection, execution, attestation, and aggregate"
+
+	// coverageChdbRecipe/coverageChdbExecutionScript: tsouza/cerberus#3113
+	// extracted the chdb-tagged `go test` sweep out of the coverage-chdb
+	// Justfile recipe body into this script — see readCoverageChdbTaggedRun
+	// and taggedCoverageChdbLaneIsFailClosed below for what is verified about
+	// its source, and coverage-chdb.mjs's own header for the full account.
+	coverageChdbRecipe          = "coverage-chdb"
+	coverageChdbExecutionScript = ".github/scripts/coverage-chdb.mjs"
 )
 
 type taggedTestSymbol struct {
@@ -400,6 +408,7 @@ func discoverTaggedTestInvocations(t *testing.T, root string) ([]taggedTestInvoc
 	recipeNames := justDump(t).recipeNames()
 	justPipelineSafe := taggedJustPipelineIsFailClosed(string(rootJustfileBytes))
 	migrationRuns, migrationErr := readMigrationTaggedRuns(root)
+	coverageChdbRun, coverageChdbErr := readCoverageChdbTaggedRun(root)
 
 	var (
 		invocations []taggedTestInvocation
@@ -511,6 +520,45 @@ func discoverTaggedTestInvocations(t *testing.T, root string) ([]taggedTestInvoc
 						}
 						for _, problem := range recipeProblems {
 							problems = append(problems, fmt.Sprintf("%s -> just %s: %s", where, recipe, problem))
+						}
+						// tsouza/cerberus#3113: coverage-chdb's own `go test`
+						// moved out of this recipe body into coverage-chdb.mjs,
+						// invoked here as a plain top-level `node` statement (no
+						// shell `if` wraps it any more — the libchdb.so check and
+						// the COVERAGE_REQUIRE_LANES tail both live in the script
+						// now), so taggedGoTestsInRecipe above finds no `go test`
+						// text here at all. readCoverageChdbTaggedRun already
+						// verified the script's own source carries the same
+						// composite tag set and fail-closed tail
+						// taggedCoverageChdbLaneIsFailClosed used to check
+						// directly against this recipe's bash.
+						if recipe != coverageChdbRecipe {
+							continue
+						}
+						scriptCommands, cmdErr := taggedStaticCommands(body)
+						if cmdErr != nil {
+							problems = append(problems, fmt.Sprintf("%s -> just %s: cannot parse recipe shell: %v", where, recipe, cmdErr))
+							continue
+						}
+						for _, scriptCommand := range scriptCommands {
+							if scriptCommand.Executable != "node" || !taggedCommandNamesScript(scriptCommand, coverageChdbExecutionScript) {
+								continue
+							}
+							if coverageChdbErr != nil {
+								problems = append(problems, fmt.Sprintf("%s -> just %s: %v", where, recipe, coverageChdbErr))
+								continue
+							}
+							if problem := taggedEvidenceContextProblem(scriptCommand, scriptCommand.Env, "", false); problem != "" {
+								problems = append(problems, fmt.Sprintf("%s -> just %s: script invocation %q cannot prove execution: %s", where, recipe, scriptCommand.Raw, problem))
+								continue
+							}
+							invocation := coverageChdbRun
+							invocation.Workflow = workflowPath
+							invocation.Job = jobID
+							invocation.Entrypoint = taggedEntrypointScript
+							invocation.EntryName = coverageChdbExecutionScript
+							invocation.Raw = scriptCommand.Raw
+							invocations = append(invocations, invocation)
 						}
 					case "node":
 						if !taggedCommandNamesScript(command, migrationExecutionScript) {
@@ -1206,6 +1254,49 @@ func readMigrationTaggedRuns(root string) (map[string]migrationTaggedRun, error)
 	return runs, nil
 }
 
+// readCoverageChdbTaggedRun mirrors readMigrationTaggedRuns for the
+// coverage-chdb lane (tsouza/cerberus#3113): the composite-tag `go test`
+// invocation the coverage-chdb Justfile recipe used to carry directly now
+// lives in coverage-chdb.mjs's own source, so this reads THAT file's text
+// for the same literal invariants instead of `just --dump`'s recipe body —
+// the composite build-tag set, the exact go-test argv shape (mainSweepArgv),
+// the full-tree "./..." package target with no -skip, and the
+// COVERAGE_REQUIRE_LANES fail-closed tail taggedCoverageChdbLaneIsFailClosed
+// checks below. Returns a template taggedTestInvocation (Tags/ExplicitTag/
+// Packages only — Workflow/Job/Entrypoint/EntryName/Raw are filled in by the
+// caller once for each recipe invocation it actually finds).
+func readCoverageChdbTaggedRun(root string) (taggedTestInvocation, error) {
+	path := filepath.Join(root, filepath.FromSlash(coverageChdbExecutionScript))
+	sourceBytes, err := os.ReadFile(path)
+	if err != nil {
+		return taggedTestInvocation{}, fmt.Errorf("read coverage-chdb execution adapter: %w", err)
+	}
+	source := string(sourceBytes)
+
+	if !strings.Contains(source, `CHDB_TAGS = 'chdb,agpl_oracle,chdb_agpl_oracle'`) {
+		return taggedTestInvocation{}, fmt.Errorf("%s no longer declares the coverage-chdb composite build tag set", coverageChdbExecutionScript)
+	}
+	if !regexp.MustCompile(`'-tags',\s*CHDB_TAGS`).MatchString(source) {
+		return taggedTestInvocation{}, fmt.Errorf("%s no longer passes CHDB_TAGS to go test's -tags", coverageChdbExecutionScript)
+	}
+	if !strings.Contains(source, "'./...'") {
+		return taggedTestInvocation{}, fmt.Errorf("%s no longer targets the whole tree", coverageChdbExecutionScript)
+	}
+	if strings.Contains(source, "'-skip'") {
+		return taggedTestInvocation{}, fmt.Errorf("%s must not carry -skip — it is the sole CI evidence for other chdb-tagged packages", coverageChdbExecutionScript)
+	}
+	if !strings.Contains(source, "mainSweepArgv(coverpkg)") || !strings.Contains(source, "spawn(go, argv,") {
+		return taggedTestInvocation{}, fmt.Errorf("%s no longer executes its main sweep through go test", coverageChdbExecutionScript)
+	}
+	if !taggedCoverageChdbLaneIsFailClosed(source) {
+		return taggedTestInvocation{}, fmt.Errorf("%s no longer fails closed on COVERAGE_REQUIRE_LANES=default+chdb", coverageChdbExecutionScript)
+	}
+
+	invocation := newTaggedInvocation(map[string]bool{"chdb": true, "agpl_oracle": true, "chdb_agpl_oracle": true})
+	invocation.Packages = []string{"./..."}
+	return invocation, nil
+}
+
 func taggedCommandNamesScript(command taggedStaticCommand, script string) bool {
 	return len(command.Args) == 1 && !command.Args[0].Dynamic &&
 		filepath.ToSlash(strings.TrimPrefix(command.Args[0].Text, "./")) == strings.TrimPrefix(script, "./")
@@ -1380,33 +1471,37 @@ func taggedCoverageJoinIsFailClosed(body string) bool {
 }
 
 // taggedCoverageChdbLaneIsFailClosed mirrors taggedCoverageJoinIsFailClosed
-// for the coverage-chdb recipe tsouza/cerberus#2634 split out of the old
-// combined `coverage` recipe (so CI can run the default-tag and chdb-tagged
-// lanes as parallel jobs). The chdb-tagged `go test` still sits inside a
-// conditional (`if [ -e libchdb.so ]`) so a bare local `just coverage-chdb`
-// can gracefully skip it, but CI's caller sets
-// COVERAGE_REQUIRE_LANES=default+chdb, and the recipe's own unconditional
-// tail — reached whether or not that conditional ran — refuses to let that
-// combination pass without cover-chdb.out actually existing. That is the
-// same fail-closed shape taggedCoverageJoinIsFailClosed checks for the old
-// recipe's LANES/coverage-summary.mjs join, just anchored to a different,
-// self-contained guard instead of a downstream script call.
-func taggedCoverageChdbLaneIsFailClosed(body string) bool {
-	return strings.Contains(body, `"${COVERAGE_REQUIRE_LANES:-}" = "default+chdb"`) &&
-		strings.Contains(body, "! -s cover-chdb.out") &&
-		strings.Contains(body, "exit 1")
+// for the coverage-chdb lane, but reads coverage-chdb.mjs's own SOURCE
+// (tsouza/cerberus#3113 moved the chdb-tagged `go test` and its surrounding
+// control flow out of the Justfile recipe body and into that script — see
+// its header for the full account) rather than a Justfile recipe body. The
+// libchdb.so branch is unconditional Go/JS control flow inside the script
+// now, invisible to a shell-text scan either way; what still has to hold is
+// the script's own COVERAGE_REQUIRE_LANES tail — reached whether or not the
+// libchdb.so branch above it ran — which refuses to let
+// COVERAGE_REQUIRE_LANES=default+chdb pass without cover-chdb.out actually
+// existing. That is the same fail-closed shape taggedCoverageJoinIsFailClosed
+// checks for the old combined `coverage` recipe's LANES/coverage-summary.mjs
+// join, just anchored to a different, self-contained guard instead of a
+// downstream script call.
+func taggedCoverageChdbLaneIsFailClosed(source string) bool {
+	return strings.Contains(source, `env.COVERAGE_REQUIRE_LANES === 'default+chdb'`) &&
+		strings.Contains(source, "isNonEmptyFile(p(COVERAGE_PROFILE))") &&
+		strings.Contains(source, "return 1")
 }
 
 // taggedCoverageRecipeJoinIsFailClosed dispatches to the right fail-closed
 // check for a `just`-invoked recipe carrying a conditionally-executed
 // chdb-tagged coverage `go test`, or reports true (no check needed) for
-// every other recipe.
+// every other recipe. coverage-chdb no longer has an entry here: since
+// tsouza/cerberus#3113 its recipe body is a single unconditional `node`
+// statement with no shell control flow of its own to forgive — see
+// readCoverageChdbTaggedRun/taggedCoverageChdbLaneIsFailClosed, which check
+// the script it invokes directly instead.
 func taggedCoverageRecipeJoinIsFailClosed(recipe, body string) bool {
 	switch recipe {
 	case "coverage":
 		return taggedCoverageJoinIsFailClosed(body)
-	case "coverage-chdb":
-		return taggedCoverageChdbLaneIsFailClosed(body)
 	default:
 		return true
 	}
@@ -1485,14 +1580,16 @@ func taggedRecipeEvidenceProblem(
 	if contextProblem == "" {
 		return ""
 	}
-	// The measured coverage recipe(s) intentionally keep their chDB half
-	// optional for local use — both the combined `coverage` recipe and its
-	// split-out `coverage-chdb` half (tsouza/cerberus#2634). CI's caller
-	// turns that branch into fail-closed evidence either way: `coverage`
-	// via its LANES/coverage-summary.mjs join, `coverage-chdb` via its own
-	// unconditional COVERAGE_REQUIRE_LANES tail check — see
-	// taggedCoverageRecipeJoinIsFailClosed.
-	if (recipe == "coverage" || recipe == "coverage-chdb") && coverageJoin && environment["COVERAGE_REQUIRE_LANES"] == "default+chdb" &&
+	// The old combined `coverage` recipe intentionally kept its chDB half
+	// optional for local use (tsouza/cerberus#2634). CI's caller turns that
+	// branch into fail-closed evidence via its LANES/coverage-summary.mjs
+	// join — see taggedCoverageRecipeJoinIsFailClosed. coverage-chdb itself
+	// no longer takes this path at all: tsouza/cerberus#3113 replaced its
+	// recipe body with a single unconditional `node` statement (handled by
+	// its own script-invocation case in discoverTaggedTestInvocations), so
+	// it never raises an "unmodeled shell control flow" contextProblem here
+	// to forgive.
+	if recipe == "coverage" && coverageJoin && environment["COVERAGE_REQUIRE_LANES"] == "default+chdb" &&
 		strings.Contains(contextProblem, "unmodeled shell control flow") &&
 		invocation.ExplicitTag["chdb"] && invocation.ExplicitTag["agpl_oracle"] &&
 		invocation.ExplicitTag["chdb_agpl_oracle"] {
@@ -1559,9 +1656,21 @@ func taggedLaneOwnsInvocation(lane taggedLane, invocation taggedTestInvocation) 
 		}
 		return taggedLaneCommandClaimsDirect(lane.Command, invocation)
 	case taggedEntrypointScript:
-		return invocation.EntryName == migrationExecutionScript &&
-			lane.Owner.Workflow == ".github/workflows/migration-e2e.yml" &&
-			lane.Command == migrationExecutionClaim
+		switch invocation.EntryName {
+		case migrationExecutionScript:
+			return lane.Owner.Workflow == ".github/workflows/migration-e2e.yml" &&
+				lane.Command == migrationExecutionClaim
+		case coverageChdbExecutionScript:
+			// coverage-chdb.mjs is invoked FROM the coverage-chdb Justfile
+			// recipe (tsouza/cerberus#3113), so — unlike the migration
+			// script, which a workflow step calls directly — the claim it
+			// binds to is the same lane.Recipes membership
+			// taggedEntrypointRecipe checks above, just for a script
+			// entrypoint instead of a `go test` one.
+			return contains(lane.Recipes, coverageChdbRecipe)
+		default:
+			return false
+		}
 	default:
 		return false
 	}
@@ -1846,6 +1955,23 @@ func TestTaggedTestEnrollmentNegativeControls(t *testing.T) {
 		changed.Command = migrationExecutionClaim
 		assertCovered(t, candidate, taggedLaneRegistry{Lanes: []taggedLane{changed}})
 		changed.Command = "unrelated execution"
+		assertRejected(t, candidate, taggedLaneRegistry{Lanes: []taggedLane{changed}})
+	})
+	t.Run("coverage-chdb script claim", func(t *testing.T) {
+		// tsouza/cerberus#3113: coverage-chdb.mjs binds via lane.Recipes
+		// membership (it is invoked FROM the coverage-chdb Justfile recipe),
+		// not via lane.Command the way the migration script above does.
+		candidate := invocation
+		candidate.Workflow = ".github/workflows/coverage.yml"
+		candidate.Job = "coverage-chdb"
+		candidate.Entrypoint = taggedEntrypointScript
+		candidate.EntryName = coverageChdbExecutionScript
+		changed := lane
+		changed.Owner.Workflow = candidate.Workflow
+		changed.Owner.Jobs = []string{candidate.Job}
+		changed.Recipes = []string{coverageChdbRecipe}
+		assertCovered(t, candidate, taggedLaneRegistry{Lanes: []taggedLane{changed}})
+		changed.Recipes = []string{"other-recipe"}
 		assertRejected(t, candidate, taggedLaneRegistry{Lanes: []taggedLane{changed}})
 	})
 


### PR DESCRIPTION
## Summary

Extracts the `coverage-chdb` Justfile recipe body into `.github/scripts/coverage-chdb.mjs`,
following `coverage-merge`'s own `#3095`/`#3091` extraction. This half was left as literal bash
at the time because its exact shell text is statically parsed as chdb-tagged `go test` execution
evidence by three Go regression tests and one `node:test` suite — moving the invocation required
teaching all four to read the new script's source instead of `just --dump`'s recipe-body text.

- `.github/scripts/coverage-chdb.mjs` carries the `CHDB_INSTALL_PATH`/libchdb.so existence check
  (graceful skip when absent), the `go list`-derived `-coverpkg`, the composite-tag `go test`
  invocation with its streamed `-coverpkg`-echo line filter, the `SKIP_RATCHET_FANOUT` branch into
  `perf-coverage-fanout.mjs`, and the unconditional `COVERAGE_REQUIRE_LANES=default+chdb`
  fail-closed tail.
- The `coverage-chdb` recipe becomes one line:
  `@CHDB_INSTALL_PATH="{{CHDB_INSTALL_PATH}}" CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}} node .github/scripts/coverage-chdb.mjs`
- `isNonEmptyFile()` (the `test -s <file>` check) moved to `lib/gh.mjs` so `coverage-merge.mjs` and
  `coverage-chdb.mjs` share one implementation.
- `PERF_SHARD_COUNT` is now `RATCHET_FANOUT`, imported directly from `perf-coverage-fanout.mjs` —
  the Justfile recipe used to have to restate that constant as a literal (Just recipes cannot
  import a JS constant); a script can, so that drift risk is gone.

## Where each literal invariant moved

| Old check (recipe-body text) | New check | File |
|---|---|---|
| `"${COVERAGE_REQUIRE_LANES:-}" = "default+chdb"`, `! -s cover-chdb.out`, `exit 1` (`taggedCoverageChdbLaneIsFailClosed`) | `env.COVERAGE_REQUIRE_LANES === 'default+chdb'`, `isNonEmptyFile(p(COVERAGE_PROFILE))`, `return 1` read from `coverage-chdb.mjs`'s source | `tagged_test_enrollment_test.go` |
| `go test -tags chdb,agpl_oracle,chdb_agpl_oracle ... ./...` shape (`taggedGoTestsInRecipe` + `parseTaggedGoTestArgs`) | `readCoverageChdbTaggedRun` regex-checks the script's composite `CHDB_TAGS` constant, `mainSweepArgv()`'s shape, `./...`, no `-skip`, and that `spawn(go, argv, …)` actually runs it | `tagged_test_enrollment_test.go` |
| `coverage-chdb`'s special case inside `taggedRecipeEvidenceProblem` (forgiving "unmodeled shell control flow" from the old `if [ -e libchdb.so ]` block) | Removed — the new recipe body is a single unconditional `node` statement with **no** shell control flow left to forgive. The forgiveness path is now reachable only for the old combined `coverage` recipe (unaffected by this PR) | `tagged_test_enrollment_test.go` |
| `taggedLaneOwnsInvocation`'s `taggedEntrypointScript` case (previously hardcoded to the migration script/lane) | Extended (not generalized — same hand-written-per-script shape the issue asked for) with a `coverageChdbExecutionScript` case binding via `lane.Recipes` membership, the same claim a `recipe` entrypoint would need | `tagged_test_enrollment_test.go` |
| `strings.Count(body, "go test -timeout")` across `coverage-default` + `coverage-chdb` + `coverage-merge` bodies, asserted `== 2` | Count is now `1` (default-tag lane only, read via `justDump()`); coverage-chdb's half is a separate check against the script's source: an explicit `-timeout`, no `\|\| true`/`.catch(`, and `if (code !== 0) return code;` | `coverage_recipe_fail_closed_test.go` |
| `CERBERUS_RAPID_SEED={{COVERAGE_RAPID_SEED}}` in both lanes' recipe bodies | **Unchanged** — `CERBERUS_RAPID_SEED` stays a literal env assignment at the Justfile call site (not moved into the script), so this scanner needed no edit at all | `rapid_seed_pin_test.go` (not modified) |
| Three assertions slicing the `coverage-chdb` recipe body as text (fan-out call present, `PERF_SHARD_INDEX=1`/`PERF_SHARD_COUNT` line, no `-skip`) | Now import `mainSweepArgv()`/`CHDB_TAGS` directly from `coverage-chdb.mjs` and assert on the returned array structurally, the same pattern already used for `legCommands()` in this same file | `.github/scripts/perf-coverage-fanout.test.mjs` (not named in the issue text, but broke the same way and needed the same fix) |

One thing not named in the issue's own body: `perf-coverage-fanout.test.mjs` ALSO statically sliced
the `coverage-chdb` recipe body (three assertions) — it runs in `coverage.yml`'s `coverage-plan`
job's gate-script suite, so it would have broken silently otherwise. Fixed alongside the three named
files, using the same "read the script structurally" approach.

## New test coverage

`coverage-chdb.test.mjs` is the new `node:test` guard for the extracted script — the missing-env
and graceful-skip paths, the fail-closed tail (including the "file already present" case, which
must pass regardless of *why* the file exists), the main sweep's `-coverpkg` join and streamed
line filter, exit-code propagation on a failed `go test`, and a real end-to-end
`perf-coverage-fanout.mjs` invocation producing the extra shard profiles — all against a small fake
`go` executable, so no chDB is needed for the unit suite.

## What I verified for real vs. by careful reading

**Verified for real:**
- `node --check .github/scripts/coverage-chdb.mjs` and every other touched `.mjs` file.
- `go build ./test/regression/...` and `go vet ./test/regression/...` clean.
- Narrowed runs, all green: `TestEveryTaggedTestHasAnExecutingLane` (the live enrollment scan —
  proves every chdb-tagged package this sweep is the sole CI evidence for still resolves),
  `TestTaggedTestEnrollmentNegativeControls`, `TestCoverageRecipeFailsClosedOnGoTestFailure`,
  `TestRapidSeedPinCoversEveryRapidBinary`, `TestRapidSeedPinIsWiredIntoTheCoverageLanes`.
- Full `go test -race ./test/regression/...` — green, no regressions elsewhere in the package.
- `node --test` on all four touched/added `.mjs` suites (`coverage-chdb.test.mjs`,
  `perf-coverage-fanout.test.mjs`, `coverage-merge.test.mjs`, `doc-refs.test.mjs`) — all green.
- `gofumpt -l` / `goimports -local github.com/tsouza/cerberus -l` clean on touched Go files.
- `markdownlint-cli2` clean on the touched `README.md`.
- `actionlint` clean on the touched `coverage.yml`.
- **Real `just` invocations** (this environment has `libchdb.so` installed):
  - `just CHDB_INSTALL_PATH=/nonexistent/libchdb.so coverage-chdb` → graceful skip, exit 0.
  - `COVERAGE_REQUIRE_LANES=default+chdb just CHDB_INSTALL_PATH=/nonexistent/libchdb.so coverage-chdb`
    → fails closed, exit 1, identical message to before the extraction.
  - A bounded (150s) real `just coverage-chdb` run against the genuine `libchdb.so` and `go`
    toolchain: confirmed `go list -tags chdb,agpl_oracle,chdb_agpl_oracle ./...` resolves and its
    output reaches `go test` as `-coverpkg`, `go test` starts and begins writing `cover-chdb.out`
    (`mode: set` header observed on disk), before the bounded timeout terminated it.

**Not run to completion for real** (the full chdb-tagged sweep is documented at 35-50 minutes, and
this task's environment is shared with other concurrently-running agents, so I did not let it run
to completion):
- The full successful sweep producing a complete `cover-chdb.out` with real coverage data.
- The real (not `SKIP_RATCHET_FANOUT=1`) `perf-coverage-fanout.mjs` fan-out against actual
  chdb-tagged tests, producing real `cover-chdb-ratchet-{2,3}.out` shard profiles.
- The streamed `-coverpkg`-echo line filter rewriting a REAL `go test` summary line (only confirmed
  against the fake-`go` unit test's synthetic summary line, and by reading the regex against the
  bounded real run's — too-early-terminated — output).

For those three, I verified the port is faithful by careful line-by-line reading against the
original bash (same flags, same env, same conditional shape) AND by `coverage-chdb.test.mjs`'s
fake-`go` integration tests, which exercise the identical code paths (main sweep argv, streaming
filter, and a REAL — not mocked — invocation of `perf-coverage-fanout.mjs` with `GO`/`TAGS`/
`COVERPKG` wired through) end-to-end against a synthetic `go` that behaves like the real one for
every argument this script inspects.

## Acceptance criteria

- [x] `tagged_test_enrollment_test.go`, `coverage_recipe_fail_closed_test.go`, and
      `rapid_seed_pin_test.go` all pass with the chdb-tagged sweep now living in `coverage-chdb.mjs`.
- [x] `just coverage-chdb` reproduces the same behavior — verified for the skip path and the
      fail-closed tail via real `just` invocations; the full successful-sweep and real-fan-out
      paths are verified by a faithful port plus a comprehensive fake-`go` test suite, not a full
      35-50 minute real run (see above).
- [x] No loss of static execution evidence for the chdb-tagged package long tail — proven by
      `TestEveryTaggedTestHasAnExecutingLane` passing against the live tree.

Given the one real-environment gap noted above (the full sweep was not run to completion), this
uses `Part of #3113` rather than a standalone `Closes #3113` — happy to run the full lane on
request if stronger real-environment evidence is wanted before closing the issue.

Part of #3113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016H8AVBwHzAYcMi4kuYub9F
