### PR TITLE
fix(chclient): kill in-flight statement before releasing fanout gate on cancel

### DIFF
--- a/internal/chclient/columnar.go
+++ b/internal/chclient/columnar.go
@@ -257,6 +257,15 @@ func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql
 		return nil, false, fmt.Errorf("chclient: query: %w", c.classifyDriverErr(ctx, err))
 	}
 
+	// queryContext must run BEFORE the fan-out gate acquire below, unlike the
+	// pre-#3128-cancellation-fix ordering: acquireDataShardFanout's release
+	// closure reads this dispatch's query_id off ctx (queryIDFromContext) to
+	// target a cancellation-driven KILL QUERY at the right statement, and it
+	// can only see whatever ctx was captured at Acquire time — a query_id
+	// stamped AFTER the acquire would never be visible to that closure.
+	ctx = c.queryContext(ctx)
+	queryID := queryIDFromContext(ctx)
+
 	// Data-shard fan-out admission (cerberus issues #3081, #3128) — the
 	// columnar dial's own equivalent of queryOpen's acquire. Unlike the row
 	// path (whose ClickHouse-side statement stays open for as long as the
@@ -274,8 +283,6 @@ func (d columnarDecoder) queryCursorColumnar(c *Client, ctx context.Context, sql
 		return nil, true, fmt.Errorf("chclient: query: %w", c.classifyDriverErr(ctx, err))
 	}
 
-	ctx = c.queryContext(ctx)
-	queryID := queryIDFromContext(ctx)
 	ctx, span := startExecuteSpan(ctx, sql, c.addr)
 
 	dec := &columnarCursor{

--- a/internal/chclient/fanout_gate.go
+++ b/internal/chclient/fanout_gate.go
@@ -82,30 +82,60 @@ import (
 // query_id (queryIDFromContext, stamped by queryContext before the gate is
 // ever acquired) on a FRESH, uncancelled, short-lived connection/context —
 // never the dispatch's own already-cancelled one. SYNC blocks until
-// ClickHouse itself confirms the statement is dead (or was already gone,
-// the common race-free-outcome when the statement finished naturally in the
-// tiny window between local cancellation and this call landing), so the
-// gate weight only releases once ClickHouse agrees the capacity is
-// genuinely free. A failed or slow KILL QUERY (network error reaching CH,
-// bounded by killDataShardQueryTimeout) is logged, never fatal — the weight
-// still releases unconditionally afterward, so a KILL QUERY failure can
-// never leak gate capacity, only (rarely) fail to close this specific race.
+// ClickHouse itself confirms the COORDINATING statement is dead (or was
+// already gone, the common race-free outcome when it finished naturally in
+// the tiny window between local cancellation and this call landing) before
+// the gate weight releases — see this file's own "Residual gap" doc below
+// for why that confirmation, real and useful as it is, does not by itself
+// prove every downstream per-shard statement the coordinator had already
+// fanned out has also stopped. A failed or slow KILL QUERY (network error
+// reaching CH, bounded by killDataShardQueryTimeout) is logged, never
+// fatal — the weight still releases unconditionally afterward, so a KILL
+// QUERY failure can never leak gate capacity, only (rarely) fail to close
+// this specific race.
 //
 // The normal, non-cancelled finish path is untouched: ctx.Err() is nil, the
 // check is a cheap single field read, and no extra round-trip is ever made
 // for the overwhelming majority of dispatches that simply finish.
 //
-// Residual risk: the KILL QUERY round-trip itself can only be as reliable as
-// reaching ClickHouse on a fresh connection within killDataShardQueryTimeout
-// — if THAT call also fails to confirm (CH itself unreachable, or the
-// dispatch's ctx carried no query_id because no trace was present), the gate
-// weight still releases (never leaked) but without the extra confirmation,
-// so the pre-fix race can in principle still occur in that narrow,
-// already-degraded scenario. Route A's admission gap this file closes
-// (Route A was completely ungated before #3128's move) plus this
-// cancellation fix together make the gate a hard ceiling on ClickHouse's own
-// concurrent per-shard statement count under the overwhelming majority of
-// real cancellation scenarios; only the doubly-degraded case above remains.
+// Residual gap, CONFIRMED against a real cluster (cerberus issue #3128, e2e
+// dispatch run 34040395235, AFTER this fix landed): `datashard (N=2)` and
+// `(N=4)` both still show a real, if smaller, point-2 overshoot —
+// N=2: peak concurrent 9 > cap 8 (down from the pre-fix 10); N=4: peak
+// concurrent 23 > cap 8 (down from the pre-fix 24). This fix closes the ONE
+// mechanism it was written for (cerberus's own premature client-side
+// release racing clickhouse-go's fire-and-forget ClientCancel — proven by
+// this file's own unit tests) and measurably shrinks the real overshoot,
+// but does NOT make e2e-datashard-verify.mjs's point 2 assertion pass on
+// either leg. Two candidate explanations for the remainder, NEITHER
+// confirmed nor ruled out yet (both need direct instrumentation against a
+// real cluster, correlating cerberus's own gate-hold intervals against
+// system.query_log's wall-clock windows, to disambiguate):
+//
+//  1. `KILL QUERY ... SYNC` run against the COORDINATOR's own query_id (the
+//     is_initial_query=1 statement cerberus dispatched) confirms only that
+//     the coordinator's own local execution stopped. Point 2 measures
+//     is_initial_query=0 rows — the CHILD statements ClickHouse's own
+//     Distributed table engine fans out internally to the real data-shard
+//     nodes — and nothing in this file's mechanism proves ClickHouse
+//     propagates that cancellation down to those children synchronously
+//     with the coordinator's own SYNC confirmation; a child already
+//     dispatched before the KILL lands could keep running to a natural
+//     QueryFinish on its own node.
+//  2. The pre-existing alternate hypothesis this issue was filed with
+//     (still open, never disambiguated from (1) above): a query_log child
+//     row's `query_start_time_microseconds` + `query_duration_ms` window
+//     may include time the statement spent QUEUED inside ClickHouse before
+//     cerberus's own gate-held admission window began, inflating measured
+//     overlap beyond anything the gate ever actually admitted concurrently
+//     — independent of cancellation entirely, and more exposed at higher
+//     DataShardCount (more child statements contending for the same
+//     server-side thread pool per logical dispatch).
+//
+// Route A's admission gap this file closes (Route A was completely
+// ungated before #3128's move) is a genuine, confirmed improvement over the
+// pre-move state regardless. Tracked on issue #3128, still open, until the
+// point-2 assertion passes cleanly on both legs.
 
 // ErrDataShardFanoutGateBusy is the sentinel wrapped into the error
 // [Client.acquireDataShardFanout] returns when the request's own ctx

--- a/internal/chclient/fanout_gate.go
+++ b/internal/chclient/fanout_gate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"golang.org/x/sync/semaphore"
@@ -48,16 +49,14 @@ import (
 // this file's ENTIRE mechanism is structurally unreached, matching the
 // pre-#3081 behaviour bit-for-bit.
 //
-// KNOWN LIMITATION (cerberus issue #3128's post-move investigation, real e2e
+// CANCELLATION FIX (cerberus issue #3128's post-move investigation, real e2e
 // dispatch runs 34032272914's second attempt: N=2 peak concurrent 10 > cap 8,
 // N=4 peak concurrent 24 > cap 8; every run's own client-side accounting
 // stayed within cap the whole time, ruled out with a temporary held-weight
-// counter that never once observed an over-cap acquisition): this gate
-// bounds client-BELIEVED concurrent dispatch weight, not ClickHouse's own
-// real concurrent per-shard statement count, and the two are not the same
-// thing under cancellation. acquireDataShardFanout's release fires the
-// instant queryOpen/queryCursorColumnar's underlying c.conn.Query / pool.Do
-// call RETURNS — but when that call returns because ctx was cancelled
+// counter that never once observed an over-cap acquisition). The root cause:
+// acquireDataShardFanout's release used to fire the instant
+// queryOpen/queryCursorColumnar's underlying c.conn.Query / pool.Do call
+// RETURNED — but when that call returns because ctx was cancelled
 // (internal/solver/executor.go's errgroup.WithContext cancels every sibling
 // shard's ctx the instant ANY one of a routed query's kEff concurrently-
 // admitted shards errors, and an HTTP client disconnect/timeout cancels
@@ -65,29 +64,48 @@ import (
 // (conn_process.go, both process() and firstBlock()) sends a single
 // ClientCancel packet and closes the LOCAL connection immediately — it does
 // NOT wait for ClickHouse to confirm the (possibly still-running, possibly
-// Distributed-fanned-out) statement has actually stopped. This package
-// therefore releases that dispatch's weight the instant the LOCAL socket
-// closes, while the REAL per-shard ClickHouse statement(s) it dispatched may
-// keep running server-side for an uncontrolled further interval — during
-// which this gate believes that capacity is free and admits a new dispatch
-// on top of it. The observed overshoot magnitude is consistent with exactly
-// this: on both real runs above, (peak concurrent - cap) is an integer
-// multiple of DataShardCount (16 = 4x4 on N=4, 2 = 1x2 on N=2) — i.e. a
-// small, plausible number of premature-cancellation releases, not a
-// diffuse accounting error.
+// Distributed-fanned-out) statement has actually stopped. Releasing the
+// gate weight right there let a new dispatch admit on top of ClickHouse-side
+// work that had not actually stopped yet. The observed overshoot magnitude
+// was consistent with exactly this: on both real runs above, (peak
+// concurrent - cap) was an integer multiple of DataShardCount (16 = 4x4 on
+// N=4, 2 = 1x2 on N=2) — i.e. a small, plausible number of
+// premature-cancellation releases, not a diffuse accounting error.
 //
-// A durable fix needs this package to distinguish "the local dispatch
-// finished" from "ClickHouse actually stopped executing it" on the
-// cancellation path specifically — e.g. issuing `KILL QUERY WHERE query_id
-// = ? SYNC` (ShardQueryIDs/mintQueryID already mint one for every dispatch)
-// on a fresh, uncancelled connection before releasing weight acquired by a
-// dispatch that is unwinding via ctx cancellation rather than a normal
-// server-side finish — and has not been implemented or validated against a
-// real cluster yet. Route A's admission gap this file closes is still a
-// genuine improvement over the pre-move state (Route A was completely
-// ungated before), but the gate is not yet a hard ceiling on ClickHouse's
-// own concurrent per-shard statement count under cancellation. Tracked on
-// issue #3128 until the cancellation path is fixed for real.
+// The fix: acquireDataShardFanout's release closure now checks ctx.Err() at
+// the instant it runs (not the error the underlying call returned — a typed
+// *clickhouse.Exception means CH already finished the statement on its own
+// and needs no help). A non-nil ctx.Err() means THIS dispatch's own ctx was
+// cancelled or hit its deadline — the reason the call returned, not a normal
+// server-side finish — so before releasing the weight, killDataShardQuery
+// issues `KILL QUERY WHERE query_id = ? SYNC` for this dispatch's own
+// query_id (queryIDFromContext, stamped by queryContext before the gate is
+// ever acquired) on a FRESH, uncancelled, short-lived connection/context —
+// never the dispatch's own already-cancelled one. SYNC blocks until
+// ClickHouse itself confirms the statement is dead (or was already gone,
+// the common race-free-outcome when the statement finished naturally in the
+// tiny window between local cancellation and this call landing), so the
+// gate weight only releases once ClickHouse agrees the capacity is
+// genuinely free. A failed or slow KILL QUERY (network error reaching CH,
+// bounded by killDataShardQueryTimeout) is logged, never fatal — the weight
+// still releases unconditionally afterward, so a KILL QUERY failure can
+// never leak gate capacity, only (rarely) fail to close this specific race.
+//
+// The normal, non-cancelled finish path is untouched: ctx.Err() is nil, the
+// check is a cheap single field read, and no extra round-trip is ever made
+// for the overwhelming majority of dispatches that simply finish.
+//
+// Residual risk: the KILL QUERY round-trip itself can only be as reliable as
+// reaching ClickHouse on a fresh connection within killDataShardQueryTimeout
+// — if THAT call also fails to confirm (CH itself unreachable, or the
+// dispatch's ctx carried no query_id because no trace was present), the gate
+// weight still releases (never leaked) but without the extra confirmation,
+// so the pre-fix race can in principle still occur in that narrow,
+// already-degraded scenario. Route A's admission gap this file closes
+// (Route A was completely ungated before #3128's move) plus this
+// cancellation fix together make the gate a hard ceiling on ClickHouse's own
+// concurrent per-shard statement count under the overwhelming majority of
+// real cancellation scenarios; only the doubly-degraded case above remains.
 
 // ErrDataShardFanoutGateBusy is the sentinel wrapped into the error
 // [Client.acquireDataShardFanout] returns when the request's own ctx
@@ -140,6 +158,13 @@ func NewDataShardFanoutGate(cfg Config) (gate *semaphore.Weighted, cap int64) {
 // ties it directly to its own synchronous pool.Do call, since that call
 // already blocks until the statement is fully drained).
 //
+// The returned release closure closes over ctx (the SAME context the
+// caller's dispatch runs under, already stamped with the per-dispatch
+// query_id by queryContext — see the callers' own doc for why that
+// ordering matters) so it can distinguish, at the instant it actually
+// runs, a normal server-side finish from a cancellation-driven unwind: see
+// this file's own "CANCELLATION FIX" doc above.
+//
 // A nil c.dataShardFanoutGate (DataShardCount <= 1, see
 // NewDataShardFanoutGate) returns a no-op release and a nil error
 // immediately — the pre-#3081 behaviour, unconditionally.
@@ -157,9 +182,73 @@ func (c *Client) acquireDataShardFanout(ctx context.Context) (release func(), er
 	var once sync.Once
 	return func() {
 		once.Do(func() {
+			// ctx.Err() != nil means THIS dispatch's own ctx — the one
+			// Acquire was just called with above — was cancelled or hit its
+			// deadline: that is why the caller's underlying c.conn.Query /
+			// pool.Do call returned, not a normal server-side finish (which
+			// leaves ctx.Err() nil even when the call itself errored with a
+			// typed *clickhouse.Exception). Only the cancellation-unwind
+			// path pays for the extra KILL QUERY round-trip; a normal finish
+			// falls straight through to Release below, unconditionally.
+			if ctx.Err() != nil {
+				if queryID := queryIDFromContext(ctx); queryID != "" {
+					c.killDataShardQuery(queryID)
+				}
+			}
 			c.dataShardFanoutGate.Release(weight)
 		})
 	}, nil
+}
+
+// killDataShardQueryTimeout bounds how long killDataShardQuery waits for
+// KILL QUERY ... SYNC to confirm a cancelled dispatch's ClickHouse-side
+// statement has genuinely stopped (or was already gone) before giving up.
+// acquireDataShardFanout's release always frees the gate weight afterward
+// regardless of the outcome — this bound only caps how long that release
+// can be delayed by an unresponsive ClickHouse, so a hung KILL QUERY can
+// never leak gate capacity, merely delay its release by at most this long.
+// Named so the bound is never a bare literal (invariant 13).
+const killDataShardQueryTimeout = 5 * time.Second
+
+// killDataShardQuerySQL targets a single per-dispatch query_id. SYNC blocks
+// until ClickHouse confirms the query is actually dead — or reports nothing
+// to kill, the common case when the statement had already finished on its
+// own in the small race window between local cancellation and this call
+// landing — rather than merely accepting the request. Raw SQL text is fine
+// here (unlike internal/chsql's plan-emission layer, invariant 10): this is
+// an administrative statement against ClickHouse's own process table, not
+// emitted query plan SQL.
+const killDataShardQuerySQL = `KILL QUERY WHERE query_id = ? SYNC`
+
+// killDataShardQuery issues killDataShardQuerySQL for queryID on a FRESH,
+// uncancelled, short-lived context — deliberately NOT derived from the
+// dispatch's own (already-cancelled) ctx, which would make the KILL request
+// itself fail the exact same way before ever reaching ClickHouse. It calls
+// c.conn.Exec directly rather than c.queryOpen or the public Client.Exec:
+// this administrative statement is not itself a shard dispatch, so it must
+// never recursively acquire c.dataShardFanoutGate (queryOpen's seam), and
+// its outcome is not a signal about ClickHouse's general health, so it must
+// never touch the circuit breaker (Client.Exec's gating) in either
+// direction. clickhouse-go/v2's connection pool hands this call a fresh
+// pooled connection even while the dispatch's own connection is mid-cancel,
+// since that pooled connection was already evicted by connect.cancel()
+// (this file's own "CANCELLATION FIX" doc) rather than being handed out
+// again.
+//
+// Every non-nil outcome is logged at WARN for observability (the same
+// breakerLogger() package-level accessor breaker.go's own transition logs
+// use) but never treated as fatal: acquireDataShardFanout's release always
+// frees the gate weight once this returns, regardless of whether it
+// succeeded, timed out, or found no matching query to kill.
+func (c *Client) killDataShardQuery(queryID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), killDataShardQueryTimeout)
+	defer cancel()
+	if err := c.conn.Exec(ctx, killDataShardQuerySQL, queryID); err != nil {
+		breakerLogger().Warn(
+			"chclient: data-shard fanout gate: KILL QUERY on a cancelled dispatch did not confirm the statement stopped",
+			"query_id", queryID, "error", err,
+		)
+	}
 }
 
 // gatedRows decorates a driver.Rows so its Close() also releases the

--- a/internal/chclient/fanout_gate_test.go
+++ b/internal/chclient/fanout_gate_test.go
@@ -343,3 +343,209 @@ func TestQueryOpen_ConcurrentDataShardFanout_NeverExceedsCap(t *testing.T) {
 		})
 	}
 }
+
+// --- Cancellation-driven KILL QUERY (cerberus issue #3128's cancellation fix) -
+
+// recordedExec pins one c.conn.Exec call an execRecordingConn observed, so a
+// test can assert both that killDataShardQuery ran and what it sent.
+type recordedExec struct {
+	sql  string
+	args []any
+}
+
+// execRecordingConn embeds chaosConn (so it satisfies driver.Conn without
+// repeating every method chaosConn already fakes) and additionally records
+// every Exec call it receives. acquireDataShardFanout's release path calls
+// c.conn.Exec directly (killDataShardQuery, never c.queryOpen or the public
+// Client.Exec) to issue KILL QUERY, so recording Exec calls here is the seam
+// that lets a test observe whether that call happened at all, without
+// standing up a real ClickHouse connection.
+type execRecordingConn struct {
+	chaosConn
+	mu    sync.Mutex
+	execs []recordedExec
+}
+
+func (c *execRecordingConn) Exec(ctx context.Context, sql string, args ...any) error {
+	c.mu.Lock()
+	c.execs = append(c.execs, recordedExec{sql: sql, args: append([]any(nil), args...)})
+	c.mu.Unlock()
+	return c.chaosConn.Exec(ctx, sql, args...)
+}
+
+func (c *execRecordingConn) execCalls() []recordedExec {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]recordedExec(nil), c.execs...)
+}
+
+// TestAcquireDataShardFanout_CancelledDispatch_IssuesKillQueryBeforeRelease is
+// the direct regression test for the cancellation gap fanout_gate.go's own
+// "CANCELLATION FIX" doc describes: when the dispatch's ctx is cancelled
+// BEFORE release() runs — mirroring internal/solver/executor.go's
+// errgroup.WithContext cancelling a sibling shard, or an HTTP client
+// disconnect cancelling r.Context() — release() must issue KILL QUERY for
+// this dispatch's own query_id BEFORE it frees the gate weight. Asserting
+// the ordering (not just that the Exec call eventually happened) is what
+// makes this test able to fail against a wrong implementation that, say,
+// released the weight first and fired KILL QUERY asynchronously afterward —
+// exactly the race this fix exists to close.
+func TestAcquireDataShardFanout_CancelledDispatch_IssuesKillQueryBeforeRelease(t *testing.T) {
+	t.Parallel()
+	const dataShardCount = 4
+	conn := &execRecordingConn{}
+	m, _ := newTestConnMetrics(t)
+	cfg := Config{DataShardCount: dataShardCount, MaxOpenConns: dataShardCount}
+	c := assembleClientFromConn(cfg, conn, m)
+	t.Cleanup(func() { _ = c.Close() })
+
+	const queryID = "trace-cancelled-qid"
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = withQueryID(ctx, queryID)
+
+	release, err := c.acquireDataShardFanout(ctx)
+	if err != nil {
+		t.Fatalf("acquireDataShardFanout: %v", err)
+	}
+
+	// The gate is now fully saturated; a concurrent acquire must be denied
+	// until release() runs.
+	if c.dataShardFanoutGate.TryAcquire(1) {
+		t.Fatal("gate admitted a second acquire while the first dispatch's weight was still held")
+	}
+
+	// Simulate the dispatch unwinding via ctx cancellation (NOT a normal
+	// server-side finish) BEFORE release fires — exactly the ordering
+	// queryOpen/queryCursorColumnar produce when the underlying call returns
+	// because ctx was cancelled.
+	cancel()
+
+	releaseDone := make(chan struct{})
+	go func() {
+		release()
+		close(releaseDone)
+	}()
+
+	select {
+	case <-releaseDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("release() did not return within 5s")
+	}
+
+	execs := conn.execCalls()
+	if len(execs) != 1 {
+		t.Fatalf("Exec calls = %d, want exactly 1 (the KILL QUERY)", len(execs))
+	}
+	if execs[0].sql != killDataShardQuerySQL {
+		t.Errorf("Exec sql = %q, want %q", execs[0].sql, killDataShardQuerySQL)
+	}
+	if len(execs[0].args) != 1 || execs[0].args[0] != queryID {
+		t.Errorf("Exec args = %v, want [%q]", execs[0].args, queryID)
+	}
+
+	// The weight must be fully released after release() returns (KILL QUERY
+	// never leaks the gate weight, success or failure).
+	if !c.dataShardFanoutGate.TryAcquire(dataShardCount) {
+		t.Fatal("gate weight was not fully released after a cancelled dispatch's release()")
+	}
+}
+
+// TestAcquireDataShardFanout_NormalFinish_NoKillQuery is the required
+// negative counterpart: a dispatch whose ctx was NEVER cancelled — an
+// ordinary server-side finish, success or a genuine ClickHouse-side error
+// alike — must NOT pay for a KILL QUERY round-trip. Without this test, an
+// implementation that always issues KILL QUERY on every release (defeating
+// the "rare unwind path only" design) would still pass the positive test
+// above.
+func TestAcquireDataShardFanout_NormalFinish_NoKillQuery(t *testing.T) {
+	t.Parallel()
+	const dataShardCount = 4
+	conn := &execRecordingConn{}
+	m, _ := newTestConnMetrics(t)
+	cfg := Config{DataShardCount: dataShardCount, MaxOpenConns: dataShardCount}
+	c := assembleClientFromConn(cfg, conn, m)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = withQueryID(ctx, "trace-normal-qid")
+
+	release, err := c.acquireDataShardFanout(ctx)
+	if err != nil {
+		t.Fatalf("acquireDataShardFanout: %v", err)
+	}
+
+	// ctx stays live (never cancelled) — a normal finish.
+	release()
+
+	if execs := conn.execCalls(); len(execs) != 0 {
+		t.Fatalf("Exec calls = %d, want 0 (a normal finish must never issue KILL QUERY): %v", len(execs), execs)
+	}
+	if !c.dataShardFanoutGate.TryAcquire(dataShardCount) {
+		t.Fatal("gate weight was not fully released after a normal finish's release()")
+	}
+}
+
+// TestAcquireDataShardFanout_CancelledDispatch_NoQueryID_SkipsKillQuery
+// confirms the no-trace edge case (ensureQueryID's own contract: an
+// un-instrumented ctx carries no query_id) degrades safely: cancellation is
+// still detected, but with no query_id to target, killDataShardQuery cannot
+// run — release() must still free the weight rather than hang or panic.
+func TestAcquireDataShardFanout_CancelledDispatch_NoQueryID_SkipsKillQuery(t *testing.T) {
+	t.Parallel()
+	const dataShardCount = 2
+	conn := &execRecordingConn{}
+	m, _ := newTestConnMetrics(t)
+	cfg := Config{DataShardCount: dataShardCount, MaxOpenConns: dataShardCount}
+	c := assembleClientFromConn(cfg, conn, m)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// No withQueryID: mirrors the no-op-tracer case, where queryIDFromContext
+	// returns "".
+
+	release, err := c.acquireDataShardFanout(ctx)
+	if err != nil {
+		t.Fatalf("acquireDataShardFanout: %v", err)
+	}
+	cancel()
+	release()
+
+	if execs := conn.execCalls(); len(execs) != 0 {
+		t.Fatalf("Exec calls = %d, want 0 (no query_id to target)", len(execs))
+	}
+	if !c.dataShardFanoutGate.TryAcquire(dataShardCount) {
+		t.Fatal("gate weight was not fully released when cancellation carried no query_id")
+	}
+}
+
+// TestAcquireDataShardFanout_ReleaseIsIdempotent_KillsOnlyOnce confirms the
+// sync.Once wrapping the release body also guards killDataShardQuery: a
+// caller that invokes the returned release closure more than once (gatedRows
+// permits double-Close, mirroring some driver.Rows implementations) must
+// issue KILL QUERY exactly once, not once per call.
+func TestAcquireDataShardFanout_ReleaseIsIdempotent_KillsOnlyOnce(t *testing.T) {
+	t.Parallel()
+	const dataShardCount = 2
+	conn := &execRecordingConn{}
+	m, _ := newTestConnMetrics(t)
+	cfg := Config{DataShardCount: dataShardCount, MaxOpenConns: dataShardCount}
+	c := assembleClientFromConn(cfg, conn, m)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = withQueryID(ctx, "trace-double-release-qid")
+
+	release, err := c.acquireDataShardFanout(ctx)
+	if err != nil {
+		t.Fatalf("acquireDataShardFanout: %v", err)
+	}
+	cancel()
+	release()
+	release()
+	release()
+
+	if execs := conn.execCalls(); len(execs) != 1 {
+		t.Fatalf("Exec calls = %d, want exactly 1 across 3 release() calls", len(execs))
+	}
+}


### PR DESCRIPTION
## Summary

Part of #3128 (epic #3074). `fanout_gate.go`'s own "KNOWN LIMITATION" doc (added by #3132)
root-caused the remaining gap: `acquireDataShardFanout`'s release used to fire the instant
`queryOpen`/`queryCursorColumnar`'s underlying `c.conn.Query`/`pool.Do` call returned — even when
that call returned because ctx was cancelled (a sibling shard's `errgroup` cancellation in
`internal/solver/executor.go`, or an HTTP client disconnect/timeout cancelling `r.Context()`).
clickhouse-go v2's own `connect.cancel()` sends a single `ClientCancel` packet and closes the LOCAL
connection immediately, without waiting for ClickHouse to confirm the (possibly still-running,
possibly Distributed-fanned-out) statement actually stopped — so the gate believed capacity was
free while ClickHouse kept executing, letting a new dispatch admit on top of it.

- `acquireDataShardFanout`'s release closure now checks `ctx.Err()` at the instant it runs (not the
  error the underlying call returned — a typed `*clickhouse.Exception` means ClickHouse already
  finished the statement on its own and needs no help). A non-nil `ctx.Err()` means THIS dispatch's
  own ctx was cancelled or hit its deadline — the reason the call returned, not a normal
  server-side finish.
- On that cancellation-unwind path only, `killDataShardQuery` issues
  `KILL QUERY WHERE query_id = ? SYNC` for this dispatch's own query_id (`queryIDFromContext`,
  already stamped by `queryContext`) on a FRESH, uncancelled, short-lived connection/context —
  never the dispatch's own already-cancelled one — calling `c.conn.Exec` directly so it neither
  recurses into the fan-out gate nor touches the circuit breaker. `SYNC` blocks until ClickHouse
  confirms the coordinating statement is dead or was already gone (the common race-free outcome),
  so the gate weight only releases once ClickHouse agrees. A failed/slow KILL QUERY is logged
  (bounded by a 5s timeout) and never fatal — the weight still releases unconditionally afterward,
  so it can never leak.
- The normal, non-cancelled finish path is untouched: a single cheap `ctx.Err()` read, no extra
  round-trip for the overwhelming majority of dispatches.
- `queryCursorColumnar`'s `queryContext` call moves before the fan-out gate acquire (it used to run
  after): the release closure needs the per-dispatch query_id already stamped on the ctx it
  captures at `Acquire` time, and a query_id stamped afterward would never be visible to it.

## Real CI evidence — the fix helps, but does NOT fully close #3128

`e2e.yml` dispatched on this branch, run
[34040395235](https://github.com/tsouza/cerberus/actions/runs/34040395235):

- `datashard (N=2)`: `real per-shard statements observed: 1863; peak concurrent=9` — **9 > cap 8**,
  down from the pre-fix baseline of 10 (`fanout_gate.go`'s own prior doc, dispatch run 34032272914).
- `datashard (N=4)`: `real per-shard statements observed: 4210; peak concurrent=23` — **23 > cap 8**,
  down from the pre-fix baseline of 24.

Both legs still fail point 2. This PR's fix demonstrably closes the ONE mechanism it targets — the
client-side premature release racing clickhouse-go's fire-and-forget `ClientCancel` — proven by the
new unit tests below, and it measurably shrinks the real overshoot on both legs, but a real,
smaller overshoot remains on both. `fanout_gate.go`'s doc now names two unconfirmed candidate
explanations for the remainder (see its own "Residual gap" section):

1. `KILL QUERY ... SYNC` against the coordinator's own query_id confirms only that the
   *coordinator's* local execution stopped — point 2 measures `is_initial_query=0` child rows,
   ClickHouse's own Distributed-engine-internal fan-out to the real data-shard nodes, and nothing
   here proves that cancellation propagates down to those children synchronously with the
   coordinator's own SYNC confirmation.
2. The pre-existing, never-disambiguated alternate hypothesis from the original issue text: a
   `query_log` child row's wall-clock window may include time spent queued inside ClickHouse before
   cerberus's own gate-held admission window began, independent of cancellation entirely.

Disambiguating the two needs direct instrumentation correlating cerberus's own gate-hold intervals
against `system.query_log` timestamps on a real cluster — out of scope for this PR's own budget;
left for further investigation on #3128, which stays open.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `gofumpt -l .` / `goimports -local github.com/tsouza/cerberus -l .` clean.
- `go test -race ./internal/chclient/... ./internal/solver/...` — all green.
- New tests in `internal/chclient/fanout_gate_test.go`:
  - `TestAcquireDataShardFanout_CancelledDispatch_IssuesKillQueryBeforeRelease` — a cancelled
    dispatch issues exactly one `KILL QUERY` (with the right query_id) before the gate weight is
    observably released.
  - `TestAcquireDataShardFanout_NormalFinish_NoKillQuery` — a normal finish issues none.
  - `TestAcquireDataShardFanout_CancelledDispatch_NoQueryID_SkipsKillQuery` — the no-trace edge case
    degrades to a plain release, never leaking the weight.
  - `TestAcquireDataShardFanout_ReleaseIsIdempotent_KillsOnlyOnce` — repeated `release()` calls
    issue KILL QUERY exactly once.
  - Verified these can actually fail: temporarily disabling the `ctx.Err()` check reproduces
    failures in the positive and idempotency tests (not tautological).

## Status vs #3128's acceptance criteria

- Root cause of the cancellation-driven premature release: **confirmed and fixed** (this PR).
- `e2e-datashard-verify.mjs` point 1 (genuine solver-split kEff>1 observed): unaffected by this PR,
  already tracked separately.
- `e2e-datashard-verify.mjs` point 2 (peak concurrent per-shard statement count ≤ cap): **still
  fails on both N=2 and N=4**, though the real overshoot shrank on both legs. #3128's acceptance
  criteria are NOT fully met yet.

Part of #3128 — leaving it open with this evidence rather than closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016H8AVBwHzAYcMi4kuYub9F
