### PR TITLE
fix(e2e): scope datashard fanout point-2 to Select-only, add datashard_only dispatch scope

### DIFF
--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -462,7 +462,17 @@ async function main() {
   const overWidthSampleLimit = 10;
   log(`dispatches (by initial_query_id) whose own child count exceeds DataShardCount=${DATA_SHARD_COUNT}: ${overWidthGroups.length} of ${childrenByQid.size} total`);
   for (const [qid, rows] of overWidthGroups.slice(0, overWidthSampleLimit)) {
-    log(`  over-width dispatch ${qid}: ${rows.length} children (expected <= ${DATA_SHARD_COUNT}); sample query: ${rows[0].snippet}`);
+    // selfMaxConcurrent — this ONE group's own children, swept in isolation.
+    // 1 means the group's own children never overlap EACH OTHER (a
+    // sequential-round-trip pattern: N separate ClickHouse statements, one
+    // after another, all sharing one query_id) — each already paid its own
+    // separate gate acquire/release, so the group itself is not what
+    // breaches the cap even though its own row COUNT exceeds DataShardCount.
+    // > 1 means this group's own children genuinely ran concurrently WITH
+    // EACH OTHER — real evidence of one gate acquisition under-charging a
+    // dispatch that structurally fans out wider than DataShardCount.
+    const selfMaxConcurrent = maxConcurrent(rows.map((r) => [r.startUs, r.durUs]));
+    log(`  over-width dispatch ${qid}: ${rows.length} children (expected <= ${DATA_SHARD_COUNT}), own internal peak concurrency=${selfMaxConcurrent}; sample query: ${rows[0].snippet}`);
   }
 
   if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {

--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -395,14 +395,18 @@ async function main() {
   const shardStmtRows = chQueryTSV(
     initiatorPod,
     `SELECT toUnixTimestamp64Micro(query_start_time_microseconds) AS start_us, query_duration_ms * 1000 AS dur_us,
-            query_kind, initial_query_id
+            query_kind, initial_query_id,
+            replaceRegexpAll(substring(query, 1, 120), '[\\t\\n\\r]+', ' ') AS query_snippet
      FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
      WHERE is_initial_query = 0 AND type = 'QueryFinish'
        AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
   );
   const shardStmts = shardStmtRows.map((r) => {
-    const [s, d, kind, qid] = r.split('\t');
-    return { startUs: Number(s), durUs: Number(d), kind, qid };
+    // TSVRaw does not escape tabs/newlines in a value, so query_snippet is
+    // flattened to single spaces (above) BEFORE this split ever runs —
+    // otherwise an embedded newline would masquerade as a row break here.
+    const [s, d, kind, qid, snippet] = r.split('\t');
+    return { startUs: Number(s), durUs: Number(d), kind, qid, snippet };
   });
   const intervals = shardStmts.map((r) => [r.startUs, r.durUs]);
   const peakConcurrentShardStatements = maxConcurrent(intervals);
@@ -427,15 +431,49 @@ async function main() {
   const selectIntervals = selectRows.map((r) => [r.startUs, r.durUs]);
   const { max: peakConcurrentSelectOnly, atUs: selectPeakAtUs } = maxConcurrentAt(selectIntervals);
   log(`Select-only per-shard statements observed: ${selectIntervals.length}; peak concurrent (Select-only)=${peakConcurrentSelectOnly}`);
+
+  // DIAGNOSTIC (round 3): DataShardFanoutGate charges exactly weight
+  // DataShardCount for every dispatch (acquireDataShardFanout), on the
+  // assumption that ONE cerberus-side dispatch produces EXACTLY
+  // DataShardCount real per-shard children. A query shape that
+  // self-references a Distributed table more than once — TraceQL's
+  // structural operators, nested-set-annotate, `compare` (all rewritten
+  // under distributed_product_mode=global, cerberus issue #3118 —
+  // .github/../distributed_query_settings.go's own doc lists every such
+  // shape) — computes its GLOBAL-rewritten side as an INDEPENDENT
+  // Distributed-wide fan-out, producing its OWN DataShardCount children on
+  // top of the outer query's own, so ONE gate acquisition can legitimately
+  // correspond to MORE than DataShardCount real concurrent per-shard
+  // statements. Grouping every Select child by its own initial_query_id
+  // (the coordinator's own query_id, so every child of ONE dispatch groups
+  // together regardless of timing) surfaces this directly: any group whose
+  // COUNT exceeds DataShardCount is real, independent evidence of
+  // under-charged weight for that dispatch, distinct from both candidate
+  // explanations this file's own gate doc previously listed.
+  const childrenByQid = new Map();
+  for (const r of selectRows) {
+    if (!childrenByQid.has(r.qid)) childrenByQid.set(r.qid, []);
+    childrenByQid.get(r.qid).push(r);
+  }
+  const overWidthGroups = [...childrenByQid.entries()].filter(([, rows]) => rows.length > DATA_SHARD_COUNT);
+  // Cap how many over-width groups get their own log line — the point is a
+  // representative sample for manual correlation, not an exhaustive dump
+  // that could run to hundreds of lines on a bad run.
+  const overWidthSampleLimit = 10;
+  log(`dispatches (by initial_query_id) whose own child count exceeds DataShardCount=${DATA_SHARD_COUNT}: ${overWidthGroups.length} of ${childrenByQid.size} total`);
+  for (const [qid, rows] of overWidthGroups.slice(0, overWidthSampleLimit)) {
+    log(`  over-width dispatch ${qid}: ${rows.length} children (expected <= ${DATA_SHARD_COUNT}); sample query: ${rows[0].snippet}`);
+  }
+
   if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {
-    // DIAGNOSTIC (round 3): dump exactly which query_ids were live at the
-    // peak instant, so this run's cerberus pod log (this same investigation
-    // round's acquire/release diagnostic, captured in the workflow's
-    // failure-dump step) can be greped for these EXACT ids to see each
-    // one's own real gate-hold interval and whether its release ran the
+    // Dump exactly which query_ids were live at the peak instant, so this
+    // run's cerberus pod log (this same investigation round's
+    // acquire/release diagnostic, captured in the workflow's failure-dump
+    // step) can be greped for these EXACT ids to see each one's own real
+    // gate-hold interval and whether its release ran the
     // cancellation/KILL-QUERY path.
     const live = peakOverlapRows(selectRows, selectPeakAtUs);
-    log(`Select-only peak overlap detail at t=${selectPeakAtUs}us (${live.length} live query_ids): ${live.map((r) => `${r.qid}[start=${r.startUs},dur=${r.durUs}]`).join(', ')}`);
+    log(`Select-only peak overlap detail at t=${selectPeakAtUs}us (${live.length} live query_ids): ${live.map((r) => `${r.qid}[start=${r.startUs},dur=${r.durUs}] query=${r.snippet}`).join(' || ')}`);
   }
 
   if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {

--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -231,15 +231,6 @@ async function runBurst() {
 
 // ---- sweep-line: max concurrently-overlapping [start, start+duration] intervals ----
 function maxConcurrent(intervals) {
-  return maxConcurrentAt(intervals).max;
-}
-
-// maxConcurrentAt is maxConcurrent's own sweep, also returning the instant
-// (atUs) the peak first occurs at — cerberus issue #3128 residual-gap round
-// 3 needs the peak's own timestamp to pull back exactly which rows were
-// live then (see peakOverlapRows below) for correlation against cerberus's
-// own gate acquire/release diagnostic log.
-function maxConcurrentAt(intervals) {
   const events = [];
   for (const [startUs, durUs] of intervals) {
     events.push([startUs, 1]);
@@ -248,25 +239,11 @@ function maxConcurrentAt(intervals) {
   events.sort((a, b) => (a[0] - b[0]) || (a[1] - b[1]));
   let cur = 0;
   let max = 0;
-  let atUs = 0;
-  for (const [ts, delta] of events) {
+  for (const [, delta] of events) {
     cur += delta;
-    if (cur > max) {
-      max = cur;
-      atUs = ts;
-    }
+    if (cur > max) max = cur;
   }
-  return { max, atUs };
-}
-
-// peakOverlapRows returns every row (from `rows`, each carrying startUs/durUs
-// plus arbitrary extra fields) whose own [startUs, startUs+durUs] interval
-// covers atUs — i.e. exactly the statements live at the instant the peak
-// overlap occurs. Diagnostic-only (cerberus issue #3128 residual-gap round
-// 3): lets a real over-cap peak be pulled back to the specific query_ids
-// responsible, rather than only the aggregate count.
-function peakOverlapRows(rows, atUs) {
-  return rows.filter((r) => r.startUs <= atUs && atUs < r.startUs + Math.max(r.durUs, 1));
+  return max;
 }
 
 async function main() {
@@ -361,11 +338,9 @@ async function main() {
 
   // ---- point 2: real concurrent per-shard statement count stays within cap ----
   //
-  // DIAGNOSTIC EXTENSION (cerberus issue #3128 residual-gap round 3): also
-  // pull query_kind and initial_query_id for every is_initial_query=0 row.
-  // Neither was needed for the original point-2 bound itself, but both are
-  // needed to disambiguate why the real overlap still exceeds the cap after
-  // the cancellation fix (PR #3137):
+  // query_kind and initial_query_id (cerberus issue #3128 residual-gap round
+  // 3) are pulled for every is_initial_query=0 row for two permanent reasons
+  // beyond the original point-2 bound:
   //   - query_kind distinguishes a real DataShardFanoutGate-bound dispatch
   //     (query_kind='Select', reaching ClickHouse through
   //     internal/chclient's queryOpen/queryCursorColumnar, the ONLY seam
@@ -382,21 +357,28 @@ async function main() {
   //     is_initial_query=0 query_kind='Insert' children exactly like a
   //     Select does, and the original query with no query_kind filter
   //     counts them identically — inflating measured overlap with
-  //     statements the gate was never designed to bound.
-  //   - initial_query_id — the FULL value, not the 32-char trace prefix
-  //     point 1/point 4 truncate to — is exactly the per-dispatch
-  //     ClickHouse query_id cerberus's own TEMPORARY gate diagnostic log
-  //     (internal/chclient/fanout_gate.go's logDataShardFanoutEvent, this
-  //     same investigation round) reports under its own "query_id" field:
-  //     mintQueryID's "<traceID>-<spanID>-<counter>" shape already IS the
-  //     coordinator's own query_id, so a real over-cap peak's rows can be
-  //     joined back to cerberus's own gate-hold interval by an EXACT string
-  //     match, not merely by shared trace.
+  //     statements the gate was never designed to bound. CONFIRMED against
+  //     real dispatch run 34043234494 to fully explain at least one N=2
+  //     failure on its own (unfiltered peak 9 > cap 8; Select-only peak
+  //     7 <= cap 8).
+  //   - initial_query_id (the coordinator's own globally-unique
+  //     "<traceID>-<spanID>-<counter>" query_id — mintQueryID's process-wide
+  //     atomic counter makes two distinct dispatches sharing one id
+  //     structurally impossible) groups every child back to the ONE
+  //     dispatch that produced it, independent of timing. A group whose own
+  //     child count exceeds DataShardCount is real evidence that dispatch's
+  //     gate acquisition (a fixed weight of DataShardCount) under-charged
+  //     its real ClickHouse-side fan-out width — internal/chclient/
+  //     fanout_gate.go's own "Residual gap" doc has the full investigation
+  //     trail for what this has and has not been narrowed down to so far.
+  //     A short query snippet is kept alongside each sample so a future
+  //     occurrence can be matched against a known query SHAPE without
+  //     needing a fresh full-text capture.
   const shardStmtRows = chQueryTSV(
     initiatorPod,
     `SELECT toUnixTimestamp64Micro(query_start_time_microseconds) AS start_us, query_duration_ms * 1000 AS dur_us,
             query_kind, initial_query_id,
-            replaceRegexpAll(substring(query, 1, 4000), '[\\t\\n\\r]+', ' ') AS query_snippet
+            replaceRegexpAll(substring(query, 1, 300), '[\\t\\n\\r]+', ' ') AS query_snippet
      FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
      WHERE is_initial_query = 0 AND type = 'QueryFinish'
        AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
@@ -429,27 +411,16 @@ async function main() {
   // queryCursorColumnar (this gate's one seam) ever dispatches.
   const selectRows = shardStmts.filter((r) => r.kind === 'Select');
   const selectIntervals = selectRows.map((r) => [r.startUs, r.durUs]);
-  const { max: peakConcurrentSelectOnly, atUs: selectPeakAtUs } = maxConcurrentAt(selectIntervals);
+  const peakConcurrentSelectOnly = maxConcurrent(selectIntervals);
   log(`Select-only per-shard statements observed: ${selectIntervals.length}; peak concurrent (Select-only)=${peakConcurrentSelectOnly}`);
 
-  // DIAGNOSTIC (round 3): DataShardFanoutGate charges exactly weight
-  // DataShardCount for every dispatch (acquireDataShardFanout), on the
-  // assumption that ONE cerberus-side dispatch produces EXACTLY
-  // DataShardCount real per-shard children. A query shape that
-  // self-references a Distributed table more than once — TraceQL's
-  // structural operators, nested-set-annotate, `compare` (all rewritten
-  // under distributed_product_mode=global, cerberus issue #3118 —
-  // .github/../distributed_query_settings.go's own doc lists every such
-  // shape) — computes its GLOBAL-rewritten side as an INDEPENDENT
-  // Distributed-wide fan-out, producing its OWN DataShardCount children on
-  // top of the outer query's own, so ONE gate acquisition can legitimately
-  // correspond to MORE than DataShardCount real concurrent per-shard
-  // statements. Grouping every Select child by its own initial_query_id
-  // (the coordinator's own query_id, so every child of ONE dispatch groups
-  // together regardless of timing) surfaces this directly: any group whose
-  // COUNT exceeds DataShardCount is real, independent evidence of
-  // under-charged weight for that dispatch, distinct from both candidate
-  // explanations this file's own gate doc previously listed.
+  // Over-width dispatches: grouped by initial_query_id (see the point-2
+  // query's own doc above for why this is a safe, exact join key). Kept as
+  // a permanent, low-cost signal for cerberus issue #3128's still-open
+  // finding 3 (internal/chclient/fanout_gate.go's own "Residual gap" doc) —
+  // a real ClickHouse-side or transport-level effect, confirmed NOT caused
+  // by any cerberus dispatch-multiplication mechanism, that produces more
+  // real per-shard children than DataShardCount for some dispatches.
   const childrenByQid = new Map();
   for (const r of selectRows) {
     if (!childrenByQid.has(r.qid)) childrenByQid.set(r.qid, []);
@@ -473,22 +444,6 @@ async function main() {
     // dispatch that structurally fans out wider than DataShardCount.
     const selfMaxConcurrent = maxConcurrent(rows.map((r) => [r.startUs, r.durUs]));
     log(`  over-width dispatch ${qid}: ${rows.length} children (expected <= ${DATA_SHARD_COUNT}), own internal peak concurrency=${selfMaxConcurrent}; sample query: ${rows[0].snippet}`);
-  }
-
-  if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {
-    // Dump exactly which query_ids were live at the peak instant, so this
-    // run's cerberus pod log (this same investigation round's
-    // acquire/release diagnostic, captured in the workflow's failure-dump
-    // step) can be greped for these EXACT ids to see each one's own real
-    // gate-hold interval and whether its release ran the
-    // cancellation/KILL-QUERY path.
-    const live = peakOverlapRows(selectRows, selectPeakAtUs);
-    // Truncated further here (peakOverlapSnippetChars) — the full-length
-    // snippet already surfaces via the over-width-group sample above; this
-    // line only needs enough to eyeball the query SHAPE per live row
-    // without the log line growing unboundedly with the live-row count.
-    const peakOverlapSnippetChars = 150;
-    log(`Select-only peak overlap detail at t=${selectPeakAtUs}us (${live.length} live query_ids): ${live.map((r) => `${r.qid}[start=${r.startUs},dur=${r.durUs}] query=${r.snippet.slice(0, peakOverlapSnippetChars)}`).join(' || ')}`);
   }
 
   if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {

--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -14,13 +14,20 @@
 //   1. A genuine solver-split (kEff > 1) query reached the Distributed
 //      target at all — otherwise the whole leg would be vacuous (it would
 //      "pass" whether or not DataShardFanoutGate does anything).
-//   2. The real, concurrent, cluster-wide per-shard statement count
-//      (system.query_log rows with is_initial_query=0, i.e. what
-//      `Distributed` actually dispatched to each data shard) never exceeded
+//   2. The real, concurrent, cluster-wide per-shard SELECT statement count
+//      (system.query_log rows with is_initial_query=0 AND
+//      query_kind='Select', i.e. what `Distributed` actually dispatched to
+//      each data shard for a query cerberus itself served) never exceeded
 //      DATA_SHARD_FANOUT_CAP at any instant during the burst —
 //      DataShardFanoutGate's own real, unconditional ceiling
 //      (Σ kEff_i × DataShardCount ≤ DataShardFanoutCap), not merely the
-//      trivially-safe N=2 case.
+//      trivially-safe N=2 case. Scoped to query_kind='Select' (cerberus
+//      issue #3128 residual-gap round 3) because is_initial_query=0 also
+//      counts Insert/Alter children from `just e2e-seed-rolling`'s rolling
+//      seeder, which writes directly to ClickHouse over the native
+//      protocol — bypassing cerberus, and so DataShardFanoutGate, entirely
+//      — throughout this script's own burst window; the unfiltered total is
+//      still logged for visibility but is informational only.
 //   3. No 5xx from cerberus during the burst — the admission-control path is
 //      "degrade parallelism, never reject" (docs/solver.md point 3); a 503
 //      here would mean that promise broke once a REAL data-shard fan-out
@@ -224,6 +231,15 @@ async function runBurst() {
 
 // ---- sweep-line: max concurrently-overlapping [start, start+duration] intervals ----
 function maxConcurrent(intervals) {
+  return maxConcurrentAt(intervals).max;
+}
+
+// maxConcurrentAt is maxConcurrent's own sweep, also returning the instant
+// (atUs) the peak first occurs at — cerberus issue #3128 residual-gap round
+// 3 needs the peak's own timestamp to pull back exactly which rows were
+// live then (see peakOverlapRows below) for correlation against cerberus's
+// own gate acquire/release diagnostic log.
+function maxConcurrentAt(intervals) {
   const events = [];
   for (const [startUs, durUs] of intervals) {
     events.push([startUs, 1]);
@@ -232,11 +248,25 @@ function maxConcurrent(intervals) {
   events.sort((a, b) => (a[0] - b[0]) || (a[1] - b[1]));
   let cur = 0;
   let max = 0;
-  for (const [, delta] of events) {
+  let atUs = 0;
+  for (const [ts, delta] of events) {
     cur += delta;
-    if (cur > max) max = cur;
+    if (cur > max) {
+      max = cur;
+      atUs = ts;
+    }
   }
-  return max;
+  return { max, atUs };
+}
+
+// peakOverlapRows returns every row (from `rows`, each carrying startUs/durUs
+// plus arbitrary extra fields) whose own [startUs, startUs+durUs] interval
+// covers atUs — i.e. exactly the statements live at the instant the peak
+// overlap occurs. Diagnostic-only (cerberus issue #3128 residual-gap round
+// 3): lets a real over-cap peak be pulled back to the specific query_ids
+// responsible, rather than only the aggregate count.
+function peakOverlapRows(rows, atUs) {
+  return rows.filter((r) => r.startUs <= atUs && atUs < r.startUs + Math.max(r.durUs, 1));
 }
 
 async function main() {
@@ -353,44 +383,67 @@ async function main() {
   //     Select does, and the original query with no query_kind filter
   //     counts them identically — inflating measured overlap with
   //     statements the gate was never designed to bound.
-  //   - initial_query_id lets an over-cap Select-only overlap (if any
-  //     remains after excluding Insert rows) be joined back to
-  //     kEffByTrace/the coordinator's own trace, and — via cerberus's own
-  //     TEMPORARY acquire/release diagnostic log
+  //   - initial_query_id — the FULL value, not the 32-char trace prefix
+  //     point 1/point 4 truncate to — is exactly the per-dispatch
+  //     ClickHouse query_id cerberus's own TEMPORARY gate diagnostic log
   //     (internal/chclient/fanout_gate.go's logDataShardFanoutEvent, this
-  //     same investigation round) — back to the exact gate-hold interval
-  //     cerberus itself believed it held for that dispatch.
+  //     same investigation round) reports under its own "query_id" field:
+  //     mintQueryID's "<traceID>-<spanID>-<counter>" shape already IS the
+  //     coordinator's own query_id, so a real over-cap peak's rows can be
+  //     joined back to cerberus's own gate-hold interval by an EXACT string
+  //     match, not merely by shared trace.
   const shardStmtRows = chQueryTSV(
     initiatorPod,
     `SELECT toUnixTimestamp64Micro(query_start_time_microseconds) AS start_us, query_duration_ms * 1000 AS dur_us,
-            query_kind, substring(initial_query_id, 1, 32) AS trace
+            query_kind, initial_query_id
      FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
      WHERE is_initial_query = 0 AND type = 'QueryFinish'
        AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
   );
   const shardStmts = shardStmtRows.map((r) => {
-    const [s, d, kind, trace] = r.split('\t');
-    return { startUs: Number(s), durUs: Number(d), kind, trace };
+    const [s, d, kind, qid] = r.split('\t');
+    return { startUs: Number(s), durUs: Number(d), kind, qid };
   });
   const intervals = shardStmts.map((r) => [r.startUs, r.durUs]);
   const peakConcurrentShardStatements = maxConcurrent(intervals);
   const kindCounts = {};
   for (const r of shardStmts) kindCounts[r.kind] = (kindCounts[r.kind] || 0) + 1;
-  log(`real per-shard statements observed: ${intervals.length}; peak concurrent=${peakConcurrentShardStatements}; by query_kind: ${JSON.stringify(kindCounts)}`);
+  log(`real per-shard statements observed: ${intervals.length}; peak concurrent (ALL query_kind, informational only)=${peakConcurrentShardStatements}; by query_kind: ${JSON.stringify(kindCounts)}`);
 
-  // Select-only overlap: what DataShardFanoutGate could ever have been
-  // responsible for bounding, excluding the rolling seeder's direct-CH
-  // Insert traffic entirely.
-  const selectIntervals = shardStmts.filter((r) => r.kind === 'Select').map((r) => [r.startUs, r.durUs]);
-  const peakConcurrentSelectOnly = maxConcurrent(selectIntervals);
+  // Select-only overlap is the ceiling DataShardFanoutGate actually bounds
+  // (cerberus issue #3128 residual-gap round 3, confirmed against real
+  // dispatch run 34043234494): `is_initial_query=0` also counts children of
+  // `just e2e-seed-rolling`'s rolling seeder (test/e2e/seed/cmd/seed),
+  // which connects to ClickHouse DIRECTLY over the native protocol —
+  // bypassing cerberus, and so acquireDataShardFanout, entirely — and keeps
+  // INSERTing into the same public `Distributed`-engine tables throughout
+  // this script's own burst window. Those Insert (and DDL/Alter, from the
+  // seeder's own stale-row-pruning mutations) children were never subject
+  // to the gate, so counting them against DataShardFanoutCap tests
+  // something the gate was never built to bound. The real assertion is
+  // scoped to query_kind='Select' — the only kind chclient's queryOpen /
+  // queryCursorColumnar (this gate's one seam) ever dispatches.
+  const selectRows = shardStmts.filter((r) => r.kind === 'Select');
+  const selectIntervals = selectRows.map((r) => [r.startUs, r.durUs]);
+  const { max: peakConcurrentSelectOnly, atUs: selectPeakAtUs } = maxConcurrentAt(selectIntervals);
   log(`Select-only per-shard statements observed: ${selectIntervals.length}; peak concurrent (Select-only)=${peakConcurrentSelectOnly}`);
+  if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {
+    // DIAGNOSTIC (round 3): dump exactly which query_ids were live at the
+    // peak instant, so this run's cerberus pod log (this same investigation
+    // round's acquire/release diagnostic, captured in the workflow's
+    // failure-dump step) can be greped for these EXACT ids to see each
+    // one's own real gate-hold interval and whether its release ran the
+    // cancellation/KILL-QUERY path.
+    const live = peakOverlapRows(selectRows, selectPeakAtUs);
+    log(`Select-only peak overlap detail at t=${selectPeakAtUs}us (${live.length} live query_ids): ${live.map((r) => `${r.qid}[start=${r.startUs},dur=${r.durUs}]`).join(', ')}`);
+  }
 
-  if (peakConcurrentShardStatements > DATA_SHARD_FANOUT_CAP) {
-    error(`peak concurrent per-shard ClickHouse statement count ${peakConcurrentShardStatements} exceeded DataShardFanoutCap=${DATA_SHARD_FANOUT_CAP} — the admission-control ceiling did not hold under real load`);
+  if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {
+    error(`peak concurrent per-shard ClickHouse Select statement count ${peakConcurrentSelectOnly} exceeded DataShardFanoutCap=${DATA_SHARD_FANOUT_CAP} — the admission-control ceiling did not hold under real load`);
     failures++;
   }
-  if (peakConcurrentShardStatements <= DATA_SHARD_COUNT) {
-    error(`peak concurrent per-shard statement count ${peakConcurrentShardStatements} never exceeded a single statement's own fan-out width (DataShardCount=${DATA_SHARD_COUNT}) — the burst never produced genuine CONCURRENT admitted requests, so DataShardFanoutGate's cross-request bound was never exercised`);
+  if (peakConcurrentSelectOnly <= DATA_SHARD_COUNT) {
+    error(`peak concurrent per-shard Select statement count ${peakConcurrentSelectOnly} never exceeded a single statement's own fan-out width (DataShardCount=${DATA_SHARD_COUNT}) — the burst never produced genuine CONCURRENT admitted requests, so DataShardFanoutGate's cross-request bound was never exercised`);
     failures++;
   }
 
@@ -461,7 +514,7 @@ async function main() {
     error(`e2e-datashard-verify: ${failures} assertion(s) failed`);
     process.exit(1);
   }
-  notice(`e2e-datashard-verify: all assertions passed (dataShardCount=${DATA_SHARD_COUNT}, fanoutCap=${DATA_SHARD_FANOUT_CAP}, peakConcurrentShardStatements=${peakConcurrentShardStatements}, maxKEffObserved=${maxKEffObserved})`);
+  notice(`e2e-datashard-verify: all assertions passed (dataShardCount=${DATA_SHARD_COUNT}, fanoutCap=${DATA_SHARD_FANOUT_CAP}, peakConcurrentSelectOnly=${peakConcurrentSelectOnly}, peakConcurrentAllQueryKinds=${peakConcurrentShardStatements}, maxKEffObserved=${maxKEffObserved})`);
 }
 
 main().catch((e) => {

--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -330,19 +330,61 @@ async function main() {
   }
 
   // ---- point 2: real concurrent per-shard statement count stays within cap ----
+  //
+  // DIAGNOSTIC EXTENSION (cerberus issue #3128 residual-gap round 3): also
+  // pull query_kind and initial_query_id for every is_initial_query=0 row.
+  // Neither was needed for the original point-2 bound itself, but both are
+  // needed to disambiguate why the real overlap still exceeds the cap after
+  // the cancellation fix (PR #3137):
+  //   - query_kind distinguishes a real DataShardFanoutGate-bound dispatch
+  //     (query_kind='Select', reaching ClickHouse through
+  //     internal/chclient's queryOpen/queryCursorColumnar, the ONLY seam
+  //     this gate wraps) from an is_initial_query=0 row that was never
+  //     subject to the gate AT ALL: `just e2e-seed-rolling`'s rolling
+  //     seeder (test/e2e/seed/cmd/seed) connects to ClickHouse DIRECTLY
+  //     over the native protocol (bypassing cerberus, and so
+  //     acquireDataShardFanout, entirely) and keeps INSERTing into the same
+  //     public `Distributed`-engine tables (otel_logs, otel_traces,
+  //     otel_metrics_*) every 30s for the lane's whole lifetime, INCLUDING
+  //     during this script's own burst window (`e2e-seed-stop` is not
+  //     called until `just e2e-datashard-down`, well after this script
+  //     returns). Each such INSERT fans out to DataShardCount
+  //     is_initial_query=0 query_kind='Insert' children exactly like a
+  //     Select does, and the original query with no query_kind filter
+  //     counts them identically — inflating measured overlap with
+  //     statements the gate was never designed to bound.
+  //   - initial_query_id lets an over-cap Select-only overlap (if any
+  //     remains after excluding Insert rows) be joined back to
+  //     kEffByTrace/the coordinator's own trace, and — via cerberus's own
+  //     TEMPORARY acquire/release diagnostic log
+  //     (internal/chclient/fanout_gate.go's logDataShardFanoutEvent, this
+  //     same investigation round) — back to the exact gate-hold interval
+  //     cerberus itself believed it held for that dispatch.
   const shardStmtRows = chQueryTSV(
     initiatorPod,
-    `SELECT toUnixTimestamp64Micro(query_start_time_microseconds) AS start_us, query_duration_ms * 1000 AS dur_us
+    `SELECT toUnixTimestamp64Micro(query_start_time_microseconds) AS start_us, query_duration_ms * 1000 AS dur_us,
+            query_kind, substring(initial_query_id, 1, 32) AS trace
      FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
      WHERE is_initial_query = 0 AND type = 'QueryFinish'
        AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
   );
-  const intervals = shardStmtRows.map((r) => {
-    const [s, d] = r.split('\t').map(Number);
-    return [s, d];
+  const shardStmts = shardStmtRows.map((r) => {
+    const [s, d, kind, trace] = r.split('\t');
+    return { startUs: Number(s), durUs: Number(d), kind, trace };
   });
+  const intervals = shardStmts.map((r) => [r.startUs, r.durUs]);
   const peakConcurrentShardStatements = maxConcurrent(intervals);
-  log(`real per-shard statements observed: ${intervals.length}; peak concurrent=${peakConcurrentShardStatements}`);
+  const kindCounts = {};
+  for (const r of shardStmts) kindCounts[r.kind] = (kindCounts[r.kind] || 0) + 1;
+  log(`real per-shard statements observed: ${intervals.length}; peak concurrent=${peakConcurrentShardStatements}; by query_kind: ${JSON.stringify(kindCounts)}`);
+
+  // Select-only overlap: what DataShardFanoutGate could ever have been
+  // responsible for bounding, excluding the rolling seeder's direct-CH
+  // Insert traffic entirely.
+  const selectIntervals = shardStmts.filter((r) => r.kind === 'Select').map((r) => [r.startUs, r.durUs]);
+  const peakConcurrentSelectOnly = maxConcurrent(selectIntervals);
+  log(`Select-only per-shard statements observed: ${selectIntervals.length}; peak concurrent (Select-only)=${peakConcurrentSelectOnly}`);
+
   if (peakConcurrentShardStatements > DATA_SHARD_FANOUT_CAP) {
     error(`peak concurrent per-shard ClickHouse statement count ${peakConcurrentShardStatements} exceeded DataShardFanoutCap=${DATA_SHARD_FANOUT_CAP} — the admission-control ceiling did not hold under real load`);
     failures++;

--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -396,7 +396,7 @@ async function main() {
     initiatorPod,
     `SELECT toUnixTimestamp64Micro(query_start_time_microseconds) AS start_us, query_duration_ms * 1000 AS dur_us,
             query_kind, initial_query_id,
-            replaceRegexpAll(substring(query, 1, 120), '[\\t\\n\\r]+', ' ') AS query_snippet
+            replaceRegexpAll(substring(query, 1, 4000), '[\\t\\n\\r]+', ' ') AS query_snippet
      FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
      WHERE is_initial_query = 0 AND type = 'QueryFinish'
        AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
@@ -473,7 +473,12 @@ async function main() {
     // gate-hold interval and whether its release ran the
     // cancellation/KILL-QUERY path.
     const live = peakOverlapRows(selectRows, selectPeakAtUs);
-    log(`Select-only peak overlap detail at t=${selectPeakAtUs}us (${live.length} live query_ids): ${live.map((r) => `${r.qid}[start=${r.startUs},dur=${r.durUs}] query=${r.snippet}`).join(' || ')}`);
+    // Truncated further here (peakOverlapSnippetChars) — the full-length
+    // snippet already surfaces via the over-width-group sample above; this
+    // line only needs enough to eyeball the query SHAPE per live row
+    // without the log line growing unboundedly with the live-row count.
+    const peakOverlapSnippetChars = 150;
+    log(`Select-only peak overlap detail at t=${selectPeakAtUs}us (${live.length} live query_ids): ${live.map((r) => `${r.qid}[start=${r.startUs},dur=${r.durUs}] query=${r.snippet.slice(0, peakOverlapSnippetChars)}`).join(' || ')}`);
   }
 
   if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1970,6 +1970,17 @@ jobs:
           kubectl -n cerberus describe pods 2>&1 | tee /tmp/cluster-describe.log || true
           echo "=== cerberus logs ==="
           kubectl -n cerberus logs deploy/cerberus --tail 200 || true
+          # TEMPORARY (cerberus issue #3128 residual-gap round 3): the tail
+          # above is far too short to catch the gate acquire/release
+          # diagnostic (internal/chclient/fanout_gate.go's
+          # logDataShardFanoutEvent) — a full-burst dispatch volume runs into
+          # the thousands of lines, all displaced out of a 200-line tail by
+          # ordinary request logging. --since bounds the volume instead of a
+          # line count, so every diagnostic line from the whole job (bring-up
+          # through this dump) survives regardless of how much other log
+          # volume sits in between.
+          echo "=== cerberus data-shard fanout gate diagnostic (issue #3128, temporary) ==="
+          kubectl -n cerberus logs deploy/cerberus --since=30m | grep 'data-shard fanout gate diagnostic' || true
           echo "=== data-shard clickhouse pods ==="
           for p in $(kubectl -n cerberus get pod -l app.kubernetes.io/component=clickhouse -o jsonpath='{.items[*].metadata.name}'); do \
             echo "--- $p ---"; \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,6 +143,25 @@ on:
           - k3d
           - compose
           - both
+      datashard_only:
+        description: >-
+          Skip every OTHER job in this workflow and run only `datashard`
+          (both matrix legs) plus `datashard-replica-affinity` — for a
+          focused, fast-turnaround dispatch while investigating the
+          DataShardFanoutGate admission-control lane (cerberus issue #3128)
+          without competing with compose-smoke/dashboard/chaos/bwc-minio for
+          shared runner capacity on every iteration. `datashard` itself has
+          no `needs:` dependency on any other job in this workflow, so this
+          is a pure skip of unrelated work, not a reordering. Every other
+          job's own `if:` gains `&& !inputs.datashard_only` (or, for the
+          handful of root jobs a whole pipeline cascades from, a new
+          standalone `if:`) so a plain `false` here (every non-dispatch
+          trigger, and a dispatch that leaves it unset) is a complete no-op —
+          byte-identical to this workflow's behaviour before this input
+          existed.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -189,6 +208,12 @@ jobs:
   # nothing on an ordinary pull request.
   compose-smoke-scope:
     name: compose-smoke-scope
+    # See workflow_dispatch.inputs.datashard_only's own doc: a focused
+    # datashard-only dispatch skips this job (and, by cascade, every other
+    # job this one roots — compose-smoke-setup/-shard/-shard-info/
+    # -crawl-merge and the compose-smoke/crawl-terminal aggregators below,
+    # which need their own explicit skip since they run under `always()`).
+    if: ${{ !inputs.datashard_only }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -741,7 +766,12 @@ jobs:
     # branch-protection context, but release.yml's preflight reads it by name on
     # the merge commit, so it must always exist and always be honest about what
     # ran.
-    if: always()
+    #
+    # datashard_only also skips this aggregator explicitly, not just its
+    # compose-smoke-scope root — always() would otherwise still fire it, and
+    # its own script below treats a datashard_only-caused scope skip as "the
+    # lane never decided", a hard failure rather than a clean no-op.
+    if: always() && !inputs.datashard_only
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -813,7 +843,12 @@ jobs:
     needs: [compose-smoke-scope, compose-smoke-setup, compose-smoke-shard-info]
     # always() so a cancelled/skipped crawl matrix still reaches this reader —
     # a plain `needs:` would skip it in exactly the case it exists to catch.
-    if: always()
+    #
+    # datashard_only also skips this reader explicitly — assert-crawl-
+    # terminal.mjs treats a skipped compose-smoke-scope (SCOPE_RESULT !=
+    # 'success') as "the lane never decided", a hard failure, not a
+    # datashard_only-aware no-op.
+    if: always() && !inputs.datashard_only
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -878,9 +913,15 @@ jobs:
     # `on:` block). The crawl shard is the ~50min long pole and is dispatched
     # only on schedule + manual dispatch + release/* PRs (INCLUDE_CRAWL below),
     # so a merge-commit run still gets the fast smoke-only matrix.
+    #
+    # datashard_only skips this root too — dashboard's own aggregator script
+    # already treats a skipped dashboard-setup as "nothing to aggregate" and
+    # exits 0, so nothing downstream of this job needs its own explicit
+    # datashard_only check.
     if: >-
-      github.event_name != 'pull_request' ||
-      startsWith(github.head_ref, 'release/')
+      !inputs.datashard_only &&
+      (github.event_name != 'pull_request' ||
+      startsWith(github.head_ref, 'release/'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -1437,7 +1478,7 @@ jobs:
     # stays on `check` + `lint` + `compose-smoke`. Runs on push-to-main +
     # nightly + manual dispatch alongside the dashboard job.
     name: startup-bench
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && !inputs.datashard_only
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -1530,7 +1571,7 @@ jobs:
     # nightly + manual dispatch ONLY, never on pull_request, and is NOT a
     # branch-protection required check. A regression is caught at
     # merge-to-main time and reverted from main, not blocked pre-merge.
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && !inputs.datashard_only
     runs-on: ubuntu-latest
     # 40 to match the dashboard budget. Shared bring-up (e2e-up +
     # seed-rolling + wait-otel) is ~10-15 min; the phase-1 fault scenarios
@@ -1722,7 +1763,7 @@ jobs:
   # matrices — it is a separate single-cluster lane, not a Playwright shard.
   bwc-minio:
     name: bwc-minio (${{ matrix.scenario }})
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && !inputs.datashard_only
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -765,18 +765,23 @@ jobs:
     # green in seconds rather than going missing. It is no longer a
     # branch-protection context, but release.yml's preflight reads it by name on
     # the merge commit, so it must always exist and always be honest about what
-    # ran.
-    #
-    # datashard_only also skips this aggregator explicitly, not just its
-    # compose-smoke-scope root — always() would otherwise still fire it, and
-    # its own script below treats a datashard_only-caused scope skip as "the
-    # lane never decided", a hard failure rather than a clean no-op.
-    if: always() && !inputs.datashard_only
+    # ran. MUST stay a bare always() — test/regression/ci_lane_registry_test.go
+    # requires every aggregate registry lane's context job to use exactly
+    # always(), precisely so a failed or skipped producer can never prevent
+    # this context from reporting; a compound `always() && ...` condition
+    # fails that check (it could itself be skipped). datashard_only's own
+    # skip is therefore handled INSIDE the script below, as the first check,
+    # rather than in this job's own `if:`.
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: gate on every required shard
         run: |
+          if [ "${{ inputs.datashard_only }}" = "true" ]; then
+            echo "datashard_only dispatch — compose-smoke-scope was intentionally skipped upstream, nothing to aggregate."
+            exit 0
+          fi
           echo "scope  = ${{ needs.compose-smoke-scope.result }} (in_scope=${{ needs.compose-smoke-scope.outputs.in_scope }})"
           echo "setup  = ${{ needs.compose-smoke-setup.result }}"
           echo "shards = ${{ needs.compose-smoke-shard.result }}"
@@ -843,17 +848,19 @@ jobs:
     needs: [compose-smoke-scope, compose-smoke-setup, compose-smoke-shard-info]
     # always() so a cancelled/skipped crawl matrix still reaches this reader —
     # a plain `needs:` would skip it in exactly the case it exists to catch.
-    #
-    # datashard_only also skips this reader explicitly — assert-crawl-
-    # terminal.mjs treats a skipped compose-smoke-scope (SCOPE_RESULT !=
-    # 'success') as "the lane never decided", a hard failure, not a
-    # datashard_only-aware no-op.
-    if: always() && !inputs.datashard_only
+    # MUST stay a bare always() — test/regression/ci_lane_registry_test.go
+    # requires every aggregate registry lane's context job to use exactly
+    # always(); a compound `always() && ...` condition fails that check.
+    # datashard_only's own skip is handled inside the step below instead
+    # (assert-crawl-terminal.mjs would otherwise treat a datashard_only-caused
+    # compose-smoke-scope skip as "the lane never decided", a hard failure).
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - name: assert the surface crawl reached a verdict
+        if: ${{ !inputs.datashard_only }}
         run: node .github/scripts/assert-crawl-terminal.mjs
         env:
           SCOPE_RESULT: ${{ needs.compose-smoke-scope.result }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2011,17 +2011,6 @@ jobs:
           kubectl -n cerberus describe pods 2>&1 | tee /tmp/cluster-describe.log || true
           echo "=== cerberus logs ==="
           kubectl -n cerberus logs deploy/cerberus --tail 200 || true
-          # TEMPORARY (cerberus issue #3128 residual-gap round 3): the tail
-          # above is far too short to catch the gate acquire/release
-          # diagnostic (internal/chclient/fanout_gate.go's
-          # logDataShardFanoutEvent) — a full-burst dispatch volume runs into
-          # the thousands of lines, all displaced out of a 200-line tail by
-          # ordinary request logging. --since bounds the volume instead of a
-          # line count, so every diagnostic line from the whole job (bring-up
-          # through this dump) survives regardless of how much other log
-          # volume sits in between.
-          echo "=== cerberus data-shard fanout gate diagnostic (issue #3128, temporary) ==="
-          kubectl -n cerberus logs deploy/cerberus --since=30m | grep 'data-shard fanout gate diagnostic' || true
           echo "=== data-shard clickhouse pods ==="
           for p in $(kubectl -n cerberus get pod -l app.kubernetes.io/component=clickhouse -o jsonpath='{.items[*].metadata.name}'); do \
             echo "--- $p ---"; \

--- a/internal/chclient/fanout_gate.go
+++ b/internal/chclient/fanout_gate.go
@@ -98,44 +98,99 @@ import (
 // check is a cheap single field read, and no extra round-trip is ever made
 // for the overwhelming majority of dispatches that simply finish.
 //
-// Residual gap, CONFIRMED against a real cluster (cerberus issue #3128, e2e
-// dispatch run 34040395235, AFTER this fix landed): `datashard (N=2)` and
-// `(N=4)` both still show a real, if smaller, point-2 overshoot —
-// N=2: peak concurrent 9 > cap 8 (down from the pre-fix 10); N=4: peak
-// concurrent 23 > cap 8 (down from the pre-fix 24). This fix closes the ONE
-// mechanism it was written for (cerberus's own premature client-side
-// release racing clickhouse-go's fire-and-forget ClientCancel — proven by
-// this file's own unit tests) and measurably shrinks the real overshoot,
-// but does NOT make e2e-datashard-verify.mjs's point 2 assertion pass on
-// either leg. Two candidate explanations for the remainder, NEITHER
-// confirmed nor ruled out yet (both need direct instrumentation against a
-// real cluster, correlating cerberus's own gate-hold intervals against
-// system.query_log's wall-clock windows, to disambiguate):
+// Residual gap, round 3 findings (cerberus issue #3128, real e2e dispatch
+// runs 34043234494 through 34048062673, AFTER this fix landed): `datashard
+// (N=2)` and `(N=4)` both still show a real point-2 overshoot even after the
+// cancellation fix above. Direct instrumentation against a real cluster
+// (a temporary chclient acquire/release diagnostic, and an
+// e2e-datashard-verify.mjs point-2 query extended with query_kind,
+// initial_query_id, and full query text — both since removed, see the PR
+// that added and removed them for the full trace) resolved THREE separate
+// questions this investigation had open, two of them conclusively:
 //
-//  1. `KILL QUERY ... SYNC` run against the COORDINATOR's own query_id (the
-//     is_initial_query=1 statement cerberus dispatched) confirms only that
-//     the coordinator's own local execution stopped. Point 2 measures
-//     is_initial_query=0 rows — the CHILD statements ClickHouse's own
-//     Distributed table engine fans out internally to the real data-shard
-//     nodes — and nothing in this file's mechanism proves ClickHouse
-//     propagates that cancellation down to those children synchronously
-//     with the coordinator's own SYNC confirmation; a child already
-//     dispatched before the KILL lands could keep running to a natural
-//     QueryFinish on its own node.
-//  2. The pre-existing alternate hypothesis this issue was filed with
-//     (still open, never disambiguated from (1) above): a query_log child
-//     row's `query_start_time_microseconds` + `query_duration_ms` window
-//     may include time the statement spent QUEUED inside ClickHouse before
-//     cerberus's own gate-held admission window began, inflating measured
-//     overlap beyond anything the gate ever actually admitted concurrently
-//     — independent of cancellation entirely, and more exposed at higher
-//     DataShardCount (more child statements contending for the same
-//     server-side thread pool per logical dispatch).
+//  1. CONFIRMED AND FIXED — seeder contamination. is_initial_query=0 also
+//     counts `just e2e-seed-rolling`'s rolling seeder (test/e2e/seed/cmd/
+//     seed), which writes to ClickHouse DIRECTLY over the native protocol —
+//     bypassing cerberus, and so this gate, entirely — throughout the
+//     burst window. Its Insert/Alter children were never subject to this
+//     gate, so counting them against DataShardFanoutCap tested something
+//     the gate was never built to bound. e2e-datashard-verify.mjs's point 2
+//     now scopes its assertion to query_kind='Select' — the only kind this
+//     gate's one seam (queryOpen/queryCursorColumnar) ever dispatches. This
+//     alone fully explained at least one real run's N=2 failure (unfiltered
+//     peak 9 > cap 8; Select-only peak 7 <= cap 8, with the 2-statement
+//     excess being exactly 1 Insert + 1 unrelated overlap).
+//  2. REFUTED — self-join / distributed_product_mode=global amplification.
+//     A dispatch whose own child count exceeds DataShardCount (grouped by
+//     the CHILDREN's shared initial_query_id, which is exactly the
+//     coordinator's own globally-unique per-dispatch query_id —
+//     mintQueryID's process-wide atomic counter makes two distinct
+//     dispatches sharing one id structurally impossible) was hypothesized
+//     to be a query that self-references the Distributed table more than
+//     once (distributed_query_settings.go's settingDistributedProductMode
+//     doc lists the shapes: TraceQL structural operators, nested-set-
+//     annotate, `compare`). Real over-width dispatches were pulled back to
+//     their FULL emitted SQL text (not the 120-char prefix Select-only
+//     filtering alone needed) and traced through the actual Go dispatch
+//     path (internal/api/tempo's handleSearch -> engine.QueryPlan for the
+//     dominant offending shape, a plain non-structural TraceQL attribute
+//     filter): the emitted SQL is a flat, single-table
+//     `SELECT ... FROM otel_traces WHERE ... AND match(...)` with no JOIN,
+//     subquery, or CTE, dispatched through EXACTLY ONE chclient.Client.Query
+//     -> QueryCursor call — Route A, one queryOpen call, one gate
+//     acquisition of weight DataShardCount, confirmed by direct code
+//     tracing (internal/engine/engine.go's QueryPlan, internal/chclient/
+//     client.go's Query/QueryCursor) to be the ONLY dispatch this logical
+//     HTTP request makes. Self-join amplification, solver route-B K-shard
+//     multiplication, and a same-context multi-round-trip pattern are all
+//     therefore ruled out for this shape: cerberus's own code makes exactly
+//     one physical dispatch, and the FULL emitted SQL never re-reads the
+//     Distributed source.
+//  3. CONFIRMED PRESENT, ROOT CAUSE NOT YET LOCATED — real ClickHouse-side
+//     multiplication independent of cerberus's own dispatch code. With (1)
+//     and (2) fully accounted for, MANY real dispatches' own initial_query_id
+//     groups still show far more Select-kind is_initial_query=0 children
+//     than DataShardCount predicts (observed: a DataShardCount=2 dispatch
+//     with 3 children, own internal peak concurrency 2 — consistent with one
+//     extra, largely-sequential statement; a DataShardCount=4 dispatch with
+//     15-18 children, own internal peak concurrency up to 10 — genuinely
+//     CONCURRENT children, not sequential retries, at roughly 2.5x the
+//     expected fan-out width). Ruled out as causes: cerberus's own gate
+//     bookkeeping (PR #3132's held-weight counter, and this round's own
+//     acquire/release diagnostic, never observed an over-cap acquisition or
+//     a cancellation-driven release in the windows captured); query_id
+//     collision (structurally impossible, see above); cluster topology
+//     (deploy/helm/cerberus/templates/clickhouse/configmap-config.yaml's
+//     `remote_servers` renders exactly DataShardCount `<shard>` blocks, each
+//     with exactly `replicas` (1, this e2e lane) `<replica>` entries,
+//     confirmed by direct template inspection); and every cerberus-side
+//     dispatch-multiplication mechanism named in (2). ClickHouse's own
+//     documented cancellation-propagation behavior (KILL QUERY / a native
+//     ClientCancel both drive the SAME in-process pipeline-cancel path that
+//     synchronously waits for shard-side cancel acks — see
+//     RemoteQueryExecutor::cancel()/tryCancel() in ClickHouse's own source)
+//     argues AGAINST hypothesis 1 above being the dominant mechanism either,
+//     though it has not been exhaustively re-tested now that (1) and (2) are
+//     closed. What remains is consistent with a real, hard ClickHouse-
+//     server-side or transport-layer effect (e.g. connection-level retries
+//     under genuine concurrent-connection pressure against this e2e lane's
+//     deliberately thin per-shard pod sizing — see cerberus-values-
+//     datashard.yaml's own "sized down" doc) that creates extra per-shard
+//     statement executions this gate has no visibility into and cannot
+//     bound from the client side. Cerberus issue #3128's own filing text
+//     explicitly forbids a raised threshold as the resolution, so this is
+//     NOT worked around here; it stays open, and the concrete next step is
+//     ClickHouse-side profiling (system.text_log at a higher verbosity
+//     during a burst, or EXPLAIN PIPELINE against the exact offending SQL)
+//     that this investigation's tooling (an external e2e verify script and
+//     cerberus's own client-side logs) cannot reach.
 //
 // Route A's admission gap this file closes (Route A was completely
 // ungated before #3128's move) is a genuine, confirmed improvement over the
-// pre-move state regardless. Tracked on issue #3128, still open, until the
-// point-2 assertion passes cleanly on both legs.
+// pre-move state regardless, and the seeder-contamination fix (1 above) is a
+// genuine, confirmed improvement over the pre-round-3 measurement. Tracked
+// on issue #3128, still open, until finding 3's real cause is located and
+// point 2 passes cleanly on both legs.
 
 // ErrDataShardFanoutGateBusy is the sentinel wrapped into the error
 // [Client.acquireDataShardFanout] returns when the request's own ctx
@@ -209,12 +264,6 @@ func (c *Client) acquireDataShardFanout(ctx context.Context) (release func(), er
 	if aerr := c.dataShardFanoutGate.Acquire(ctx, weight); aerr != nil {
 		return nil, fmt.Errorf("chclient: data-shard fanout gate acquire: %w: %w", ErrDataShardFanoutGateBusy, aerr)
 	}
-	// TEMPORARY diagnostic (cerberus issue #3128's residual-gap round 3) —
-	// see this file's own "Residual gap" doc above for what it disambiguates,
-	// and logDataShardFanoutEvent's own doc for why it is scoped to only the
-	// dispatches that can actually be joined back to system.query_log.
-	queryID := queryIDFromContext(ctx)
-	logDataShardFanoutEvent(queryID, "acquire", weight, false)
 	var once sync.Once
 	return func() {
 		once.Do(func() {
@@ -226,50 +275,14 @@ func (c *Client) acquireDataShardFanout(ctx context.Context) (release func(), er
 			// typed *clickhouse.Exception). Only the cancellation-unwind
 			// path pays for the extra KILL QUERY round-trip; a normal finish
 			// falls straight through to Release below, unconditionally.
-			cancelled := ctx.Err() != nil
-			if cancelled {
-				if queryID != "" {
+			if ctx.Err() != nil {
+				if queryID := queryIDFromContext(ctx); queryID != "" {
 					c.killDataShardQuery(queryID)
 				}
 			}
-			logDataShardFanoutEvent(queryID, "release", weight, cancelled)
 			c.dataShardFanoutGate.Release(weight)
 		})
 	}, nil
-}
-
-// logDataShardFanoutEvent is the TEMPORARY diagnostic instrumentation for
-// cerberus issue #3128's residual-gap investigation, round 3 — added to
-// correlate cerberus's own gate-hold intervals (this log's wall-clock
-// timestamps, which slog stamps automatically) against
-// system.query_log's is_initial_query=0 child-row windows
-// (.github/scripts/e2e-datashard-verify.mjs's point-2 query), to
-// disambiguate the two candidate explanations fanout_gate.go's own
-// "Residual gap" doc lists for why the gate's admitted concurrency and the
-// real cluster-observed concurrency still diverge.
-//
-// Logged at INFO (not DEBUG) so it surfaces in the e2e lane's pod logs
-// without a log-level bump — CERBERUS_LOG_LEVEL defaults to "info"
-// (internal/config/config.go's defaultLogLevel) and neither
-// cerberus-values.yaml nor cerberus-values-datashard.yaml overrides it for
-// this lane.
-//
-// queryID is the dispatch's own per-query_id (queryIDFromContext) — empty
-// only for the no-trace case (ensureQueryID's own contract), which this
-// diagnostic skips entirely since an empty id can never be joined back to a
-// system.query_log row anyway.
-//
-// This function, and every call site above, is scoped for removal once the
-// investigation concludes — see the PR that introduces it for the decision
-// on whether any part of it graduates to permanent instrumentation.
-func logDataShardFanoutEvent(queryID, phase string, weight int64, cancelled bool) {
-	if queryID == "" {
-		return
-	}
-	breakerLogger().Info(
-		"chclient: data-shard fanout gate diagnostic (issue #3128 round 3, temporary)",
-		"phase", phase, "query_id", queryID, "weight", weight, "cancelled", cancelled,
-	)
 }
 
 // killDataShardQueryTimeout bounds how long killDataShardQuery waits for

--- a/internal/chclient/fanout_gate.go
+++ b/internal/chclient/fanout_gate.go
@@ -209,6 +209,12 @@ func (c *Client) acquireDataShardFanout(ctx context.Context) (release func(), er
 	if aerr := c.dataShardFanoutGate.Acquire(ctx, weight); aerr != nil {
 		return nil, fmt.Errorf("chclient: data-shard fanout gate acquire: %w: %w", ErrDataShardFanoutGateBusy, aerr)
 	}
+	// TEMPORARY diagnostic (cerberus issue #3128's residual-gap round 3) —
+	// see this file's own "Residual gap" doc above for what it disambiguates,
+	// and logDataShardFanoutEvent's own doc for why it is scoped to only the
+	// dispatches that can actually be joined back to system.query_log.
+	queryID := queryIDFromContext(ctx)
+	logDataShardFanoutEvent(queryID, "acquire", weight, false)
 	var once sync.Once
 	return func() {
 		once.Do(func() {
@@ -220,14 +226,50 @@ func (c *Client) acquireDataShardFanout(ctx context.Context) (release func(), er
 			// typed *clickhouse.Exception). Only the cancellation-unwind
 			// path pays for the extra KILL QUERY round-trip; a normal finish
 			// falls straight through to Release below, unconditionally.
-			if ctx.Err() != nil {
-				if queryID := queryIDFromContext(ctx); queryID != "" {
+			cancelled := ctx.Err() != nil
+			if cancelled {
+				if queryID != "" {
 					c.killDataShardQuery(queryID)
 				}
 			}
+			logDataShardFanoutEvent(queryID, "release", weight, cancelled)
 			c.dataShardFanoutGate.Release(weight)
 		})
 	}, nil
+}
+
+// logDataShardFanoutEvent is the TEMPORARY diagnostic instrumentation for
+// cerberus issue #3128's residual-gap investigation, round 3 — added to
+// correlate cerberus's own gate-hold intervals (this log's wall-clock
+// timestamps, which slog stamps automatically) against
+// system.query_log's is_initial_query=0 child-row windows
+// (.github/scripts/e2e-datashard-verify.mjs's point-2 query), to
+// disambiguate the two candidate explanations fanout_gate.go's own
+// "Residual gap" doc lists for why the gate's admitted concurrency and the
+// real cluster-observed concurrency still diverge.
+//
+// Logged at INFO (not DEBUG) so it surfaces in the e2e lane's pod logs
+// without a log-level bump — CERBERUS_LOG_LEVEL defaults to "info"
+// (internal/config/config.go's defaultLogLevel) and neither
+// cerberus-values.yaml nor cerberus-values-datashard.yaml overrides it for
+// this lane.
+//
+// queryID is the dispatch's own per-query_id (queryIDFromContext) — empty
+// only for the no-trace case (ensureQueryID's own contract), which this
+// diagnostic skips entirely since an empty id can never be joined back to a
+// system.query_log row anyway.
+//
+// This function, and every call site above, is scoped for removal once the
+// investigation concludes — see the PR that introduces it for the decision
+// on whether any part of it graduates to permanent instrumentation.
+func logDataShardFanoutEvent(queryID, phase string, weight int64, cancelled bool) {
+	if queryID == "" {
+		return
+	}
+	breakerLogger().Info(
+		"chclient: data-shard fanout gate diagnostic (issue #3128 round 3, temporary)",
+		"phase", phase, "query_id", queryID, "weight", weight, "cancelled", cancelled,
+	)
 }
 
 // killDataShardQueryTimeout bounds how long killDataShardQuery waits for


### PR DESCRIPTION
## Summary

Round 3 of the `#3128` residual-gap investigation (after PR #3132 moved the gate to
`chclient`, and PR #3137 fixed a cancellation-driven premature release). Real e2e evidence
this round disambiguated the two candidate explanations `internal/chclient/fanout_gate.go`'s
own doc had listed, and found a confirmed, real fix plus a third, still-open finding.

## What real e2e data showed

Six real `datashard (N=2)`/`(N=4)` dispatches (runs 34043234494, 34044750341, 34045532414,
34046317882, 34047093904, 34048827814/34048062673) against this branch, using a temporary
gate acquire/release diagnostic (since removed) and an extended `e2e-datashard-verify.mjs`
point-2 query, established three things:

1. **CONFIRMED AND FIXED — seeder contamination.** `is_initial_query=0` also counts
   `just e2e-seed-rolling`'s rolling seeder (`test/e2e/seed/cmd/seed`), which writes to
   ClickHouse directly over the native protocol — bypassing cerberus, and so
   `DataShardFanoutGate`, entirely — throughout the burst window. Its `Insert`/`Alter`
   children were never subject to this gate. Run 34043234494 showed this fully explains at
   least one real N=2 failure on its own (unfiltered peak 9 > cap 8; Select-only peak
   7 <= cap 8). **Fix:** `e2e-datashard-verify.mjs`'s point-2 assertion now scopes to
   `query_kind='Select'` — the only kind `DataShardFanoutGate`'s one seam
   (`queryOpen`/`queryCursorColumnar`) ever dispatches — keeping the unfiltered total as an
   informational log line only.
2. **REFUTED — self-join / `distributed_product_mode=global` amplification.** Hypothesized
   that a dispatch whose own child count exceeds `DataShardCount` (grouped by the children's
   shared `initial_query_id`, a globally-unique per-dispatch id by construction —
   `mintQueryID`'s process-wide atomic counter) was a query self-referencing the Distributed
   table more than once (the shapes `distributed_query_settings.go` already documents:
   TraceQL structural operators, nested-set-annotate, `compare`). Pulling the **full** emitted
   SQL for real over-width dispatches and tracing the dominant offending shape (a plain,
   non-structural TraceQL attribute filter, `{ resource.service.name =~ ".+" }`) through the
   actual Go dispatch path (`internal/api/tempo`'s `handleSearch` → `engine.QueryPlan` →
   exactly one `chclient.Client.Query`/`QueryCursor` call) showed a flat, single-table
   `SELECT ... FROM otel_traces WHERE ... AND match(...)` with no JOIN, subquery, or CTE,
   dispatched exactly once. Self-join amplification, solver route-B K-shard multiplication,
   and a same-context multi-round-trip pattern are all ruled out for this shape.
3. **CONFIRMED PRESENT, ROOT CAUSE NOT YET LOCATED.** With (1) and (2) accounted for, many
   real dispatches' own `initial_query_id` groups still show far more Select-kind
   `is_initial_query=0` children than `DataShardCount` predicts — e.g. a `DataShardCount=2`
   dispatch with 3 children (own internal peak concurrency 2 — one largely-sequential extra
   statement), and a `DataShardCount=4` dispatch with 15-18 children (own internal peak
   concurrency up to 10 — genuinely concurrent, not sequential retries, at roughly 2.5x the
   expected fan-out width). Ruled out: cerberus's own gate bookkeeping (PR #3132's held-weight
   counter, and this round's own diagnostic, never observed an over-cap acquisition or a
   cancellation-driven release); query_id collision (structurally impossible); cluster
   topology (`configmap-config.yaml`'s `remote_servers` renders exactly `DataShardCount`
   `<shard>` blocks, each with exactly 1 `<replica>`, confirmed by template inspection); every
   cerberus-side dispatch-multiplication mechanism from (2). ClickHouse's own documented
   cancellation-propagation behavior (`KILL QUERY` / a native `ClientCancel` both drive the
   same in-process pipeline-cancel path that synchronously waits for shard-side cancel acks)
   argues against hypothesis 1 from the prior round being the dominant mechanism either. What
   remains is consistent with a real, hard ClickHouse-server-side or transport-layer effect
   (e.g. connection-level retries under genuine concurrent-connection pressure against this
   e2e lane's deliberately thin per-shard pod sizing) that creates extra per-shard statement
   executions this gate has no visibility into and cannot bound from the client side.

`internal/chclient/fanout_gate.go`'s own doc comment has the full trail with file:line
citations for every claim above.

## What this PR changes

- `.github/scripts/e2e-datashard-verify.mjs`: point 2 now asserts on `query_kind='Select'`
  concurrency (the real fix for finding 1), keeps `query_kind`/`initial_query_id`/a short
  query snippet as a permanent, low-cost diagnostic for finding 3 (an over-width-dispatch
  check, capped at 10 sample lines), and logs the unfiltered total for visibility only.
- `internal/chclient/fanout_gate.go`: doc-only — documents all three round-3 findings.
- `.github/workflows/e2e.yml`: adds a `datashard_only` `workflow_dispatch` boolean input that
  skips every other job in this workflow (`compose-smoke`, `dashboard`, `chaos`, `bwc-minio`,
  …) so a focused investigation dispatch (`gh workflow run e2e.yml -f datashard_only=true`)
  takes ~7-10 minutes instead of 20-40+, without competing for shared runner capacity. This is
  permanent CI infrastructure value independent of #3128's own resolution.
- Temporary instrumentation added mid-investigation (a chclient acquire/release diagnostic
  log, a `--since=30m` log grep in the workflow's failure-dump step, a 4000-char query-text
  capture, and a peak-overlap-instant dump) has been removed now that it answered the
  questions it was added for — see the commit history on this branch for the full trail if a
  future round needs to revisit the same technique.
- `test/regression/ci_lane_registry_test.go`'s `TestCILaneRegistry` caught a real bug in an
  earlier commit on this branch: `compose-smoke` and `crawl-terminal` are registered aggregate
  lanes (`.github/ci-lanes.json`) whose context job MUST use an exact `always()` condition, so
  a failed/skipped producer can never prevent the aggregate from reporting. My first attempt
  at scoping them under `datashard_only` used a compound `always() && !inputs.datashard_only`,
  which fails that check. Fixed by keeping both jobs' own `if:` a bare `always()` and moving
  the `datashard_only` short-circuit inline (a first-line exit in `compose-smoke`'s script; a
  per-step `if:` on `crawl-terminal`'s single step) — reproduced locally with
  `go test -race ./test/regression/... -run TestCILaneRegistry` before and after the fix.

## Local verification

- `go build ./...`, `go vet ./...` — clean.
- `go test -race ./internal/chclient/... ./internal/solver/... ./test/regression/...` — pass
  (no test changes to chclient/solver; the fix this round is entirely in the e2e verify script
  + workflow + docs, and `test/regression` is included because it caught the ci-lanes bug
  above).
- `gofumpt -l .` / `goimports -local github.com/tsouza/cerberus -l .` — clean on the changed
  Go file.
- `just lint-actions` (actionlint) — clean on the workflow change.

## Real e2e verification

Final dispatch on this branch's HEAD (`datashard_only=true`), run
[34049573728](https://github.com/tsouza/cerberus/actions/runs/34049573728) — also confirms the
`ci_lane_registry` fix works end-to-end: `compose-smoke`/`crawl-terminal` report a clean, fast
`success` (their scripts' own `datashard_only` short-circuit), every other unrelated job
reports `skipped`, and only `datashard`/`datashard-replica-affinity` do real work:

| Leg | Select-only peak concurrent | `DataShardFanoutCap` | Result |
|---|---|---|---|
| `datashard (N=4)` | 21 | 8 | still fails point 2 (finding 3, open) |
| `datashard (N=2)` | — | 8 | hit an unrelated, pre-existing infra flake (`TestReSeedRowCountStability/base-traces`, already documented as unrelated by PR #3132) before reaching `e2e-datashard-verify` at all |

N=2's Select-only computation itself is unaffected — it succeeded on every earlier run in this
investigation (7, 10, 14, 18 across runs 34043234494 through 34048827814), all confirming the
same pattern: the seeder-contamination fix (finding 1) is real and confirmed — it fully
explained at least one observed N=2 failure in isolation (run 34043234494: unfiltered 9 > 8,
Select-only 7 <= 8). Finding 3's residual gap is real, confirmed NOT to be a cerberus
admission-control or dispatch-multiplication defect, and remains open on both legs across
every run. Point 2 does **not** pass cleanly on either leg with this PR alone.

## What remains open on #3128

Finding 3's exact ClickHouse-server-side/transport mechanism is not yet located. The concrete
next step is ClickHouse-side profiling (`system.text_log` at a higher verbosity during a
burst, or `EXPLAIN PIPELINE` against the exact offending SQL) that this investigation's
tooling (an external e2e verify script and cerberus's own client-side logs) cannot reach.
Issue #3128's own filing text explicitly forbids a raised threshold as the resolution, so
this PR does not attempt one — the acceptance criteria are not yet met, and #3128 stays open
for a follow-up round.

Part of #3128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016H8AVBwHzAYcMi4kuYub9F
