### PR TITLE
fix(ci): make Playwright chromium apt cache survive unprivileged restore

### DIFF
--- a/.github/actions/setup-playwright-browsers/action.yml
+++ b/.github/actions/setup-playwright-browsers/action.yml
@@ -75,11 +75,61 @@ runs:
     # image bump just falls back to a normal fetch rather than corrupting
     # anything - a cache miss here costs nothing beyond what today already
     # pays.
+    #
+    # The path is a staging dir under $HOME, NOT /var/cache/apt/archives
+    # itself, because actions/cache's restore step runs as the unprivileged
+    # runner user. Observed directly on a real job (dashboard-shard
+    # shard-smoke-a-monolith, run
+    # https://github.com/tsouza/cerberus/actions/runs/34047093904/job/101524009418):
+    # every restore hits
+    #   tar: .../var/cache/apt/archives/fonts-freefont-ttf_...: Cannot open: Permission denied
+    # for the same ~9 packages every time (fonts-freefont-ttf,
+    # fonts-ipafont-gothic, fonts-tlwg-loma-otf, fonts-unifont,
+    # fonts-wqy-zenhei, xfonts-cyrillic, xfonts-encodings, xfonts-scalable,
+    # xfonts-utils - confirmed 100% reproducible across every sampled
+    # compose-smoke-shard and dashboard-shard job, on both ubuntu-latest
+    # `monolith` and `split` shards, across runs a day apart). These are
+    # genuine chromium OS deps (Playwright's own `install-deps chromium`
+    # pulls in exactly this font set for script-rendering support), but
+    # ubuntu-latest ships them ALREADY fetched and root-owned at these exact
+    # paths (most likely a side effect of the pre-installed Google Chrome on
+    # the runner image sharing the same font dependencies), so the
+    # unprivileged tar extraction can never overwrite them - this cache has
+    # never once restored cleanly. The failure is silently non-fatal (a cache
+    # restore/save failure only ever produces a `::warning::`, never fails
+    # the job - see actions/cache's own documented read-only/failure
+    # behaviour), which is exactly why nobody noticed: every job still goes
+    # green, just having quietly paid a full apt re-fetch on every single
+    # run instead of the one-fetch-per-Playwright-version this cache exists
+    # to buy. Caching a staging dir under $HOME sidesteps the collision
+    # entirely - nothing on the image ever pre-populates it - and the two
+    # steps below bridge it to and from /var/cache/apt/archives with
+    # best-effort, no-clobber copies.
+    # `v2` in the key (not just the path change above) is load-bearing:
+    # actions/cache bakes the ABSOLUTE paths it archived into the saved
+    # blob, so restoring under the OLD key with the NEW `path:` would still
+    # extract straight back to /var/cache/apt/archives - the exact
+    # permission collision this fix exists to avoid - because the stale
+    # blob under the old key was saved with those old paths, not these new
+    # ones. Bumping the key forces a clean cache under the new staging
+    # scheme instead of ever touching that stale blob.
     - name: Cache apt archives for chromium OS deps
       uses: actions/cache@v5
       with:
-        path: /var/cache/apt/archives/*.deb
-        key: playwright-chromium-apt-${{ runner.os }}-${{ steps.pw.outputs.version }}
+        path: ~/.cache/apt-archives-chromium/*.deb
+        key: playwright-chromium-apt-v2-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+    # Bridge INTO apt's own cache dir: `-n` (no-clobber) means this can never
+    # fail to overwrite a root-owned file the way the direct-path cache used
+    # to - it just skips any name apt already has, and apt re-fetches
+    # anything it still can't reuse (harmless, per the checksum-verification
+    # note above). Best-effort: an empty/missing staging dir (cache miss) is
+    # a silent no-op, not an error.
+    - name: Merge staged apt archives into apt's cache dir
+      shell: bash
+      run: |
+        mkdir -p ~/.cache/apt-archives-chromium
+        sudo cp -n ~/.cache/apt-archives-chromium/*.deb /var/cache/apt/archives/ 2>/dev/null || true
 
     # apt's defaults are patient with a degraded mirror (long per-request
     # timeout, several internal retries per source) - fine when the mirror is
@@ -189,3 +239,19 @@ runs:
           echo "Playwright browser cache miss - downloading chromium + OS deps."
           install_with_retry 1200 2 npx playwright install --with-deps chromium
         fi
+
+    # Bridge back OUT of apt's cache dir, so the staging directory holds
+    # whatever apt-get freshly fetched above and actions/cache's own
+    # (automatic, end-of-job) save step - which also runs unprivileged - can
+    # read and archive it. `sudo cp -n` first (apt's fetched .debs are
+    # root-owned) then `chown` the staging copies to the runner user;
+    # `-n` here means a .deb this job already had staged (from a prior
+    # partial restore) is left alone rather than re-copied and re-chowned
+    # pointlessly. Best-effort: nothing to copy on an apt-op-free run is a
+    # silent no-op, not an error.
+    - name: Copy freshly-fetched apt archives back into the staging directory
+      shell: bash
+      run: |
+        mkdir -p ~/.cache/apt-archives-chromium
+        sudo cp -n /var/cache/apt/archives/*.deb ~/.cache/apt-archives-chromium/ 2>/dev/null || true
+        sudo chown "$(id -u):$(id -g)" ~/.cache/apt-archives-chromium/*.deb 2>/dev/null || true


### PR DESCRIPTION
## Problem

`.github/actions/setup-playwright-browsers/action.yml` caches the `.deb` packages `npx playwright install-deps chromium` fetches, keyed on the resolved Playwright version, directly at `/var/cache/apt/archives/*.deb`. `actions/cache`'s restore step runs as the unprivileged `runner` user, but ubuntu-latest ships several of chromium's OS-dep `.deb`s already fetched and root-owned at those exact paths — so the restore's `tar -x` can never overwrite them.

Real, reproducible evidence (dashboard-shard `shard-smoke-a-monolith`, run https://github.com/tsouza/cerberus/actions/runs/34047093904/job/101524009418):

```
Cache hit for: playwright-chromium-apt-Linux-1.62.1
/usr/bin/tar: ../../../../../var/cache/apt/archives/fonts-freefont-ttf_20211204+svn4273-2_all.deb: Cannot open: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/fonts-ipafont-gothic_00303-21ubuntu1_all.deb: Cannot open: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/fonts-tlwg-loma-otf_1%3a0.7.3-1_all.deb: Cannot open: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/fonts-unifont_1%3a15.1.01-1build1_all.deb: Cannot open: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/fonts-wqy-zenhei_0.9.45-8_all.deb: Cannot open: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/xfonts-cyrillic_1%3a1.0.5+nmu1_all.deb: Cannot open: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/xfonts-encodings_1%3a1.0.5-0ubuntu2_all.deb: Cannot open: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/xfonts-scalable_1%3a1.0.3-1.3_all.deb: Cannot open: Permission denied
/usr/bin/tar: ../../../../../var/cache/apt/archives/xfonts-utils_1%3a7.7+6build3_amd64.deb: Cannot open: Permission denied
Warning: Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
Cache not found for input keys: playwright-chromium-apt-Linux-1.62.1
```

**Confirmed 100% reproducible**: I pulled the full logs of every `compose-smoke-shard` and `dashboard-shard` job from two independent runs roughly 9 hours apart (a `workflow_dispatch` run and the nightly `schedule` run) — 8 jobs total, spanning both `monolith` and `split` shard modes. Every single one hit the exact same permission-denied error on the exact same 9 packages, restored 0 files, and fell back to `Cache not found for input keys`.

This is not correctness-impacting: `actions/cache` restore/save failures are documented as non-fatal (they emit `::warning::`, never fail the step or job), which is exactly why every one of these jobs' overall conclusion stayed `success` — this bug has been silently defeating the cache since it was introduced, paying a full apt re-fetch on every single shard of every single run instead of the one-fetch-per-Playwright-version the cache exists to buy.

I also confirmed no earlier step in the same job (`free-disk-space`, `registry-login`, `setup-buildx`, image pulls, `compose up`, etc.) touches apt or `/var/cache/apt/archives` — nothing in this job populates those paths before the composite action's own steps run, so the pre-existing root-owned files are baked into the runner image itself. A public independent write-up (a blog post analysing Playwright CI installs) lists this exact same package set (`fonts-freefont-ttf fonts-ipafont-gothic fonts-tlwg-loma-otf fonts-unifont fonts-wqy-zenhei xfonts-cyrillic xfonts-encodings xfonts-scalable xfonts-utils`) as genuine chromium OS deps `install-deps` pulls in — so these aren't unrelated cruft, they're real deps that happen to already be pre-fetched and root-owned on the image (most plausibly because ubuntu-latest ships Google Chrome pre-installed, sharing the same font dependencies).

## Fix

Cache a user-writable staging directory under `$HOME` (`~/.cache/apt-archives-chromium`) instead of `/var/cache/apt/archives` directly, and bridge the two directories with best-effort, no-clobber copies:

1. **Before** `apt-get`/`install-deps` runs: `sudo cp -n` anything staged into `/var/cache/apt/archives/` — no-clobber means it can never fail trying to overwrite a root-owned file; apt just re-fetches anything it still can't reuse (harmless, per this file's own existing checksum-verification note).
2. **After** the install step: `sudo cp -n` freshly-fetched `.deb`s back into the staging dir, then `sudo chown` them to the runner user, so `actions/cache`'s own (automatic, unprivileged) save step can read and archive them.

The cache **key** is also bumped (`playwright-chromium-apt-v2-...`) — this is load-bearing, not cosmetic: `actions/cache` bakes the *absolute paths* it archived into the saved blob, so restoring under the *old* key with the *new* `path:` would still extract straight back to `/var/cache/apt/archives` (the exact collision this PR fixes), because the stale blob was saved with the old paths.

Doc comments on the action explain the two-directory bridge and cite the real evidence, so a future reader doesn't "simplify" it back to the broken single-path shape.

## Verification

- `actionlint` (pinned `v1.7.12`, matching `just lint-actions`) — clean.
- Verified the merge/copy-back bash logic locally with a scratch script simulating the exact permission collision (a mode-444 stand-in for a root-owned pre-existing file, plus a freshly-"fetched" file) across two simulated runs — confirms: round 1 (cache miss) stages both the pre-existing and freshly-fetched `.deb`s as owner-writable; round 2 (cache hit) merges the staged `.deb` into a fresh "system" dir via `cp -n` without erroring on the pre-existing collision, and the previously-fetched dep is present without a re-fetch.
- Dispatched `e2e.yml` for real on this branch **twice**, back to back
  (`gh workflow run e2e.yml --ref fix/playwright-apt-cache-permission`), and
  watched `dashboard-shard` jobs directly via the Actions API (the composite
  action is shared verbatim across `compose-smoke-shard` /
  `compose-smoke-shard-info` / `dashboard-shard`, so exercising one exercises
  the fix identically for all three). Both dispatches genuinely completed;
  this is real, observed CI evidence, not inferred:
  - **First dispatch** (run
    [34048572841](https://github.com/tsouza/cerberus/actions/runs/34048572841),
    job `dashboard-shard (shard-smoke-a-monolith)`): genuine cache **miss**
    under the new key (`Cache not found for input keys:
    playwright-chromium-apt-v2-Linux-1.62.1`) — expected, since nothing had
    ever been saved under it. The merge/copy-back steps ran as clean no-ops
    and successes respectively. A sibling shard in the same run
    (`shard-split-isolation-split`) won the save race and logged `Cache
    saved with key: playwright-chromium-apt-v2-Linux-1.62.1` with no
    permission errors.
  - **Second dispatch** (run
    [34049245977](https://github.com/tsouza/cerberus/actions/runs/34049245977),
    job `dashboard-shard (shard-smoke-a-monolith)`): a genuine cache **hit**
    with a fully clean restore:
    ```
    Cache hit for: playwright-chromium-apt-v2-Linux-1.62.1
    Cache restored successfully
    Cache restored from key: playwright-chromium-apt-v2-Linux-1.62.1
    ```
    Zero `Permission denied` lines anywhere in the job log, the merge step
    (`sudo cp -n` into `/var/cache/apt/archives/`) completed cleanly, and the
    job's overall conclusion was `success`.

This is the exact restore-then-reuse cycle the old direct-path cache could
never complete even once; both directions of the bridge are now verified
against real runner behaviour, not just local reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016H8AVBwHzAYcMi4kuYub9F
