### PR TITLE
investigate(chclient): round 4 of DataShardFanoutGate server-side profiling (#3128)

### DIFF
--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -583,6 +583,20 @@ async function main() {
     if (!fullQuery) {
       log(`diagnostic: could not recover full query text for over-width dispatch ${sampleQid} (parent row fell outside the window) — skipping isolated re-run`);
     } else {
+      log(`diagnostic: FULL query text for over-width dispatch ${sampleQid}:\n${fullQuery}`);
+
+      // parallel-replicas + table-engine + cluster-topology check: is the
+      // extra fan-out actually replica-level parallelism (a DIFFERENT
+      // mechanism from Distributed data-shard fan-out, invisible to
+      // DataShardFanoutGate either way) rather than a self-referencing
+      // subquery under distributed_product_mode=global?
+      log('diagnostic: parallel-replicas settings on the connection cerberus actually uses:');
+      log(chQuerySingleRaw(initiatorPod, `SELECT name, value, changed FROM system.settings WHERE name ILIKE '%parallel_replica%'`) || '(no rows)');
+      log('diagnostic: otel_traces_local table engine:');
+      log(chQuerySingleRaw(initiatorPod, `SELECT database, name, engine FROM system.tables WHERE name = 'otel_traces_local'`) || '(no rows)');
+      log('diagnostic: system.clusters topology (shard_num, replica_num, host_name):');
+      log(chQuerySingleRaw(initiatorPod, `SELECT cluster, shard_num, replica_num, host_name FROM system.clusters WHERE cluster = '${CH_CLUSTER}' ORDER BY shard_num, replica_num`) || '(no rows)');
+
       const distributedSettingsArgs = [
         '--skip_unavailable_shards=0',
         '--fallback_to_stale_replicas_for_distributed_queries=0',

--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -153,6 +153,27 @@ function chQueryTSV(pod, sql) {
   return res.stdout.split('\n').map((l) => l.trimEnd()).filter((l) => l.length > 0);
 }
 
+// chQuerySingleRaw returns a single scalar/row result as ONE trimmed raw
+// string, unlike chQueryTSV which splits stdout on '\n' into rows — that
+// split is wrong for a query whose OWN result value could itself contain an
+// embedded newline (e.g. reading back a full query TEXT verbatim, as the
+// round-4 isolated-re-run diagnostic below does), which would otherwise
+// masquerade as more than one row. Returns '' (never exits) when the query
+// legitimately produced no result — a diagnostic-only lookup, so a miss is
+// informational, not fatal.
+function chQuerySingleRaw(pod, sql) {
+  const res = kubectl([
+    'exec', pod, '--',
+    'clickhouse-client',
+    '--user', CH_USER,
+    '--password', CH_PASSWORD,
+    '--database', DB,
+    '--format', 'TSVRaw',
+    '--query', sql,
+  ]);
+  return res.status === 0 ? res.stdout.trim() : '';
+}
+
 function chExec(pod, sql) {
   const res = kubectl(['exec', pod, '--', 'clickhouse-client', '--user', CH_USER, '--password', CH_PASSWORD, '--query', sql]);
   if (res.status !== 0) {
@@ -246,11 +267,81 @@ function maxConcurrent(intervals) {
   return max;
 }
 
+// ---- diagnostic (informational only, cerberus issue #3128 round 4) ----
+// fanout_gate.go's own "Residual gap, round 3 findings" doc leaves finding 3
+// ("real ClickHouse-side multiplication independent of cerberus's own
+// dispatch code") open and names two concrete next steps: a resource-
+// pressure / retry-event check, and getting ClickHouse's own planner
+// (EXPLAIN PIPELINE / an isolated re-run) to say whether the extra per-shard
+// children are load-dependent or structural. Everything below gathers
+// evidence for that; NOTHING in this section ever increments `failures` —
+// finding 3 is not yet proven, so nothing here asserts a threshold on it.
+
+// retryPressureEvents — ClickHouse system.events counters that a connection-
+// level retry or transport failure under load would increment (ClickHouse's
+// own src/Common/ProfileEvents.cpp names each). Diffed before/after the
+// burst per pod so a genuine increase (not a cumulative since-boot count) is
+// what gets reported.
+const retryPressureEvents = [
+  'DistributedConnectionFailTry',
+  'DistributedConnectionFailAtAll',
+  'DistributedConnectionMissingTable',
+  'DistributedConnectionStaleReplica',
+  'NetworkErrors',
+  'NetworkSendErrors',
+  'NetworkReceiveErrors',
+  'ReadBufferFromFileDescriptorReadFailed',
+  'ZooKeeperHardwareExceptions',
+];
+
+function eventsSnapshot(pods, names) {
+  const inList = names.map((n) => `'${n}'`).join(', ');
+  const snap = {};
+  for (const pod of pods) {
+    const rows = chQueryTSV(pod, `SELECT event, value FROM system.events WHERE event IN (${inList})`);
+    const perPod = {};
+    for (const row of rows) {
+      const [event, value] = row.split('\t');
+      perPod[event] = Number(value);
+    }
+    snap[pod] = perPod;
+  }
+  return snap;
+}
+
+function logEventDiffs(before, after, pods, names) {
+  for (const pod of pods) {
+    const deltas = names
+      .map((n) => [n, (after[pod]?.[n] || 0) - (before[pod]?.[n] || 0)])
+      .filter(([, d]) => d > 0);
+    log(
+      deltas.length > 0
+        ? `  ${pod}: ${deltas.map(([n, d]) => `${n}=+${d}`).join(', ')}`
+        : `  ${pod}: no retry/pressure event increase`,
+    );
+  }
+}
+
+// diagnosticSettleSeconds bounds the grace period between an isolated
+// diagnostic re-run's clickhouse-client call returning and this script's own
+// SYSTEM FLUSH LOGS — the re-run's own query_log row is enqueued at query
+// finish (before the client call returns) but the internal system-log
+// buffer flush that makes it durably queryable is asynchronous, so a bare
+// zero-wait FLUSH LOGS could race it. Named so the grace period is never a
+// bare literal (invariant 13).
+const diagnosticSettleSeconds = 2;
+
+// roundFourDiagQueryIDPrefix tags the isolated re-run's own query_id so it
+// can never collide with a real dispatch's mintQueryID-derived id (which is
+// always exactly 32 hex chars + "-" + more hex, never this literal prefix).
+const roundFourDiagQueryIDPrefix = 'issue3128-round4-diag';
+
 async function main() {
   const initiatorPod = anyClickhousePodName();
   const allPods = allClickhousePodNames();
   log(`datashard verify: namespace=${NS} db=${DB} cluster=${CH_CLUSTER} dataShardCount=${DATA_SHARD_COUNT} fanoutCap=${DATA_SHARD_FANOUT_CAP} pods=${allPods.join(',')}`);
   let failures = 0;
+  const eventsBefore = eventsSnapshot(allPods, retryPressureEvents);
 
   const restartsBefore = restartCounts(allPods);
 
@@ -273,6 +364,27 @@ async function main() {
 
   const windowStart = Math.floor(burstStartMs / 1000) - 5;
   const windowEnd = Math.floor(burstEndMs / 1000) + FLUSH_WAIT_SECONDS + 10;
+
+  // ---- diagnostic: retry/pressure events + CPU/memory pressure during the burst ----
+  // See this file's "diagnostic (informational only, cerberus issue #3128
+  // round 4)" section above — never gates the run.
+  log('diagnostic: retry/connection-failure event deltas during the burst, per ClickHouse pod:');
+  const eventsAfter = eventsSnapshot(allPods, retryPressureEvents);
+  logEventDiffs(eventsBefore, eventsAfter, allPods, retryPressureEvents);
+
+  const pressureMetricRows = chQueryTSV(
+    initiatorPod,
+    `SELECT hostName() AS host, metric, max(value) AS peak
+     FROM clusterAllReplicas('${CH_CLUSTER}', system.asynchronous_metric_log)
+     WHERE event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})
+       AND (metric ILIKE '%CPU%' OR metric ILIKE '%Memory%' OR metric ILIKE '%Throttl%')
+     GROUP BY host, metric
+     ORDER BY host, metric`,
+  );
+  log(`diagnostic: peak CPU/Memory/Throttle asynchronous_metric_log values during the burst window (cross-reference against cerberus-values-datashard.yaml's "sized down" pod resources — requests.cpu=100m, limits.memory=1Gi, no cpu limit configured):`);
+  for (const row of pressureMetricRows) {
+    log(`  ${row}`);
+  }
 
   // ---- point 1: a genuine solver-split (kEff > 1) query happened ----
   // clusterAllReplicas (not a local query, and not scoped to `initiatorPod`
@@ -444,6 +556,75 @@ async function main() {
     // dispatch that structurally fans out wider than DataShardCount.
     const selfMaxConcurrent = maxConcurrent(rows.map((r) => [r.startUs, r.durUs]));
     log(`  over-width dispatch ${qid}: ${rows.length} children (expected <= ${DATA_SHARD_COUNT}), own internal peak concurrency=${selfMaxConcurrent}; sample query: ${rows[0].snippet}`);
+  }
+
+  // ---- diagnostic: is one over-width dispatch's own SQL over-width even in
+  // ISOLATION (no concurrent burst load)? ----
+  // If ClickHouse's own planner deterministically fans this SQL out wider
+  // than DataShardCount regardless of load, re-running it alone reproduces
+  // the same child count. If the extra children only appear under the
+  // burst's concurrent-connection pressure, the isolated re-run matches
+  // DataShardCount exactly — evidence FOR (not proof of) the
+  // resource-contention/retry hypothesis fanout_gate.go's own doc names as
+  // the untested next step. See this file's "diagnostic (informational
+  // only, cerberus issue #3128 round 4)" section above — never gates the run.
+  if (overWidthGroups.length > 0) {
+    const [sampleQid] = overWidthGroups[0];
+    // chQuerySingleRaw, not chQueryTSV — the query TEXT being read back is
+    // itself the result value here, and chQueryTSV's line-split would
+    // corrupt it if it ever contained an embedded newline (see that
+    // function's own doc).
+    const fullQuery = chQuerySingleRaw(
+      initiatorPod,
+      `SELECT query FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
+       WHERE query_id = '${sampleQid}' AND is_initial_query = 1 AND type = 'QueryFinish'
+       LIMIT 1`,
+    );
+    if (!fullQuery) {
+      log(`diagnostic: could not recover full query text for over-width dispatch ${sampleQid} (parent row fell outside the window) — skipping isolated re-run`);
+    } else {
+      const distributedSettingsArgs = [
+        '--skip_unavailable_shards=0',
+        '--fallback_to_stale_replicas_for_distributed_queries=0',
+        '--load_balancing=first_or_random',
+        '--distributed_product_mode=global',
+      ];
+      log(`diagnostic: EXPLAIN PIPELINE for over-width dispatch ${sampleQid}'s own SQL (DataShardCount=${DATA_SHARD_COUNT} expected fan-out width):`);
+      const explainRes = kubectl([
+        'exec', initiatorPod, '--',
+        'clickhouse-client', '--user', CH_USER, '--password', CH_PASSWORD, '--database', DB,
+        ...distributedSettingsArgs,
+        '--query', `EXPLAIN PIPELINE ${fullQuery}`,
+      ]);
+      log(explainRes.status === 0 ? explainRes.stdout.trim() || '(empty)' : `  (EXPLAIN PIPELINE failed, informational only: ${explainRes.stderr.trim()})`);
+
+      const diagQueryID = `${roundFourDiagQueryIDPrefix}-${Date.now()}`;
+      log(`diagnostic: re-running the SAME SQL in ISOLATION (query_id=${diagQueryID}, no concurrent burst load)`);
+      const rerunRes = kubectl([
+        'exec', initiatorPod, '--',
+        'clickhouse-client', '--user', CH_USER, '--password', CH_PASSWORD, '--database', DB,
+        ...distributedSettingsArgs,
+        '--query_id', diagQueryID,
+        '--query', fullQuery,
+      ]);
+      if (rerunRes.status !== 0) {
+        log(`diagnostic: isolated re-run failed, informational only: ${rerunRes.stderr.trim()}`);
+      } else {
+        await sleep(diagnosticSettleSeconds * 1000);
+        chExec(initiatorPod, `SYSTEM FLUSH LOGS ON CLUSTER ${CH_CLUSTER}`);
+        const isolatedChildRows = chQueryTSV(
+          initiatorPod,
+          `SELECT count() FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
+           WHERE initial_query_id = '${diagQueryID}' AND is_initial_query = 0
+             AND query_kind = 'Select' AND type = 'QueryFinish'`,
+        );
+        const isolatedChildCount = Number(isolatedChildRows[0] || '0');
+        const verdict = isolatedChildCount > DATA_SHARD_COUNT
+          ? 'STILL over-width even in isolation: the multiplication is NOT purely load-dependent — points at a structural planner/setting effect'
+          : 'matches DataShardCount exactly in isolation: the over-width shape needs concurrent load/connection pressure to reproduce, consistent with a real ClickHouse-side retry/contention effect';
+        log(`diagnostic: isolated re-run produced ${isolatedChildCount} per-shard Select children (DataShardCount=${DATA_SHARD_COUNT}) — ${verdict}`);
+      }
+    }
   }
 
   if (peakConcurrentSelectOnly > DATA_SHARD_FANOUT_CAP) {

--- a/internal/chclient/distributed_query_settings.go
+++ b/internal/chclient/distributed_query_settings.go
@@ -148,6 +148,17 @@ package chclient
 //     compareRootLookup — LEFT JOINs the metric pipeline's own Scan against
 //     a second, independent Scan(s.SpansTable) that resolves each trace's
 //     root span.
+//   - Every LIMIT-bounded plain /api/search — internal/chsql/
+//     search_trace_limit.go's emitSearchTraceLimit — emits its own row
+//     source TWICE (an outer drain query plus an inner top-N
+//     trace-ranking subquery), an `IN` self-reference of the identical
+//     shape the four shapes above make deliberately, just without a
+//     literal JOIN keyword. Added to this list by cerberus issue #3128
+//     round 4, which additionally found this shape's self-reference
+//     under-charges internal/chclient/fanout_gate.go's own admission-
+//     control weight (that file's own "ROUND 4" doc has the real-cluster
+//     evidence and the fix) — a gap the four shapes above may share too,
+//     tracked by cerberus issue #3141 rather than assumed fixed here.
 //
 // On a single-shard/non-Distributed deployment `otel_traces` is a plain
 // MergeTree table, so none of these ever double-references a Distributed

--- a/internal/chclient/fanout_gate.go
+++ b/internal/chclient/fanout_gate.go
@@ -313,10 +313,11 @@ import (
 // observations (12-31) against whatever replicaCount those earlier dispatch
 // runs happened to run.
 //
-// NOT fixed here. A correct fix needs the resolved per-pod
-// DataShardFanoutCap to know its own share of the operator's INTENDED
-// cluster-wide budget — e.g. dividing by replicaCount at the Helm chart /
-// config layer — and doing that correctly also has to account for
+// NOT fixed here — cerberus issue #3128 stays OPEN for this second cause. A
+// correct fix needs the resolved per-pod DataShardFanoutCap to know its own
+// share of the operator's INTENDED cluster-wide budget — e.g. dividing by
+// replicaCount at the Helm chart / config layer — and doing that correctly
+// also has to account for
 // docs/project_per_head_split's per-head split mode (each head can run a
 // DIFFERENT replicaCount under `split.<head>.replicaCount`, and each such
 // pod would need its OWN correctly-apportioned share) and the

--- a/internal/chclient/fanout_gate.go
+++ b/internal/chclient/fanout_gate.go
@@ -270,6 +270,66 @@ import (
 // it corrects the WEIGHT one specific, proven dispatch shape charges
 // against the unchanged cap, exactly the kind of real fix the issue asks
 // for.
+//
+// ROUND 4 — a SECOND, real, still-open contributing cause: this gate's
+// admission ceiling is PER-PROCESS, but a real deployment runs multiple
+// cerberus PODS. Re-verifying the SearchTraceLimit fix above against a real
+// e2e dispatch (run 34052929455) confirmed it is a genuine, measurable
+// improvement — `datashard (N=4)`'s Select-only peak concurrent dropped from
+// 15-16 (pre-fix) to 14 (post-fix) — but 14 still exceeds
+// DataShardFanoutCap=8. Direct inspection of the SAME run's own cluster
+// state (its kubectl describe/get-pods dump) found the reason: this e2e
+// lane's cerberus Deployment runs TWO pods (`cerberus-6f8d687c45-7pqdl` and
+// `cerberus-6f8d687c45-zp4wp`, both Running, both serving traffic behind the
+// SAME k8s Service) — deploy/helm/cerberus/values.yaml's own top-level
+// `replicaCount` defaults to 2, and neither test/e2e/k3s/cerberus-values.yaml
+// nor cerberus-values-datashard.yaml overrides it down to 1 for this lane.
+//
+// c.dataShardFanoutGate (this file) is a field on *Client, constructed ONCE
+// per process by assembleClientFromConn — a bare in-memory
+// *semaphore.Weighted with no cross-process visibility whatsoever. Each of
+// the two pods therefore runs its OWN independent copy of this gate, each
+// independently admitting up to DataShardFanoutCap (8) units of weight. A k8s
+// Service round-robins (or randomly load-balances) the burst's concurrent
+// HTTP requests across both pods, so the REAL aggregate ceiling ClickHouse
+// can see across the whole Deployment is up to `replicaCount x
+// DataShardFanoutCap` (up to 16 here), not DataShardFanoutCap alone — this
+// gate's own doc and docs/solver.md's sibling "one process-wide dispatch-
+// token semaphore" section have always described the MECHANISM as
+// process-wide (matching NewDataShardFanoutGate's own doc: cap "mirrors how
+// the pre-move mechanism defaulted to the solver's own connection Gate's
+// size", itself an inherently per-process MaxOpenConns pool), but neither
+// this file nor docs/solver.md had previously connected that scope to what
+// it means once replicaCount > 1: DataShardFanoutCap stops being a real
+// cluster-wide ceiling on ClickHouse's own concurrent per-shard exposure —
+// the exact resource-safety property #3081/#3128 exist to guarantee — and
+// silently becomes `replicaCount` times looser instead. 14 (measured, two
+// pods, post-SearchTraceLimit-fix) sits comfortably under 16 (the two-pod
+// theoretical ceiling this explains) and clearly above 8 (the single-pod cap
+// the test asserts against), which is exactly the signature this cause
+// predicts — not proof beyond doubt (no per-pod query_log breakdown was
+// captured this round), but a coherent, evidenced explanation consistent
+// with every number gathered so far, including round 3's own higher
+// observations (12-31) against whatever replicaCount those earlier dispatch
+// runs happened to run.
+//
+// NOT fixed here. A correct fix needs the resolved per-pod
+// DataShardFanoutCap to know its own share of the operator's INTENDED
+// cluster-wide budget — e.g. dividing by replicaCount at the Helm chart /
+// config layer — and doing that correctly also has to account for
+// docs/project_per_head_split's per-head split mode (each head can run a
+// DIFFERENT replicaCount under `split.<head>.replicaCount`, and each such
+// pod would need its OWN correctly-apportioned share) and the
+// `autoscaling.enabled` HPA case (values.yaml: "When true, replicaCount is
+// ignored" — the real pod count becomes dynamic, which a value baked in at
+// Helm render time cannot track). Getting either wrong without real
+// multi-pod e2e coverage of split mode would risk trading a real,
+// evidenced bug for a guessed, unverified one — exactly what this
+// investigation's own discipline (round 3's "REFUTED" entry above) exists
+// to avoid. Cerberus issue #3128 stays open for this: the concrete next
+// step is a replica-count-aware cap (or a genuine cross-pod coordination
+// mechanism) with its own dedicated multi-replica e2e verification, not a
+// guess landed alongside this round's unrelated SearchTraceLimit fix.
 
 // ErrDataShardFanoutGateBusy is the sentinel wrapped into the error
 // [Client.acquireDataShardFanout] returns when the request's own ctx

--- a/internal/chclient/fanout_gate.go
+++ b/internal/chclient/fanout_gate.go
@@ -362,6 +362,18 @@ func WithDataShardFanoutMultiplier(ctx context.Context, multiplier int) context.
 	return context.WithValue(ctx, dataShardFanoutMultiplierKey, multiplier)
 }
 
+// DataShardFanoutMultiplierFromContext returns the multiplier
+// WithDataShardFanoutMultiplier installed, and whether one was installed at
+// all — the QueryTimeoutFromContext pattern (timeout.go's own doc: "so the
+// layer that installs the carrier can prove it did"), exported so
+// internal/engine's own execContext tests can assert the stamp fires on
+// exactly the plan shapes it should, without duplicating
+// dataShardFanoutMultiplierFromContext's default-fallback logic.
+func DataShardFanoutMultiplierFromContext(ctx context.Context) (int, bool) {
+	n, ok := ctx.Value(dataShardFanoutMultiplierKey).(int)
+	return n, ok
+}
+
 // dataShardFanoutMultiplierFromContext returns the multiplier
 // WithDataShardFanoutMultiplier installed, or defaultDataShardFanoutMultiplier
 // (1) when none was set or the stored value is non-positive.

--- a/internal/chclient/fanout_gate.go
+++ b/internal/chclient/fanout_gate.go
@@ -188,9 +188,88 @@ import (
 // Route A's admission gap this file closes (Route A was completely
 // ungated before #3128's move) is a genuine, confirmed improvement over the
 // pre-move state regardless, and the seeder-contamination fix (1 above) is a
-// genuine, confirmed improvement over the pre-round-3 measurement. Tracked
-// on issue #3128, still open, until finding 3's real cause is located and
-// point 2 passes cleanly on both legs.
+// genuine, confirmed improvement over the pre-round-3 measurement.
+//
+// ROUND 4 — finding 3's root cause, LOCATED (cerberus issue #3128, real e2e
+// dispatch runs 34050971889 and 34051673070). Direct ClickHouse-side
+// introspection this investigation's prior tooling could not reach — an
+// EXPLAIN PIPELINE against a real over-width dispatch's own SQL, and an
+// ISOLATED re-run of that exact SQL with zero concurrent burst load —
+// settled the question round 3 left open:
+//
+//   - The isolated re-run (query_id tagged, no concurrent load at all)
+//     reproduced the SAME over-width child count as the live burst
+//     (N=2: 3 children for a DataShardCount=2 dispatch; N=4: 15 children
+//     for a DataShardCount=4 dispatch) — PROOF the multiplication is
+//     deterministic and structural, not a load/retry/connection-pressure
+//     effect. This REFUTES the "connection-level retries under concurrent
+//     pressure" hypothesis this doc's round-3 text floated as the likely
+//     next step, and separately REFUTES a ClickHouse parallel-replicas
+//     mechanism (a real candidate given the EXPLAIN PIPELINE shape below):
+//     `system.settings` read back from the SAME connection showed
+//     enable_parallel_replicas=0 (changed=0 — ClickHouse's own default,
+//     never touched by cerberus or the chart) on this ClickHouse 26.3
+//     server, where enable_parallel_replicas is the master gate the
+//     legacy max_parallel_replicas=1000 default cannot bypass on its own.
+//   - The full, untruncated SQL text of the over-width dispatch (recovered
+//     from its own is_initial_query=1 system.query_log row) is the plain,
+//     non-structural TraceQL search shape round 3's finding 2 already
+//     examined — WITH the /api/search trace-limit restriction round 3's
+//     trace happened not to carry:
+//
+//       SELECT s.* FROM (SELECT * FROM otel_traces WHERE <window> AND
+//         match(...)) AS s
+//       WHERE TraceId IN (
+//         SELECT TraceId FROM (SELECT * FROM otel_traces WHERE <window>
+//           AND match(...)) GROUP BY TraceId
+//         ORDER BY min(Timestamp) DESC, TraceId LIMIT 20)
+//
+//     internal/chsql/search_trace_limit.go's emitSearchTraceLimit renders
+//     EXACTLY this shape, and its own doc already names the mechanism in
+//     plain words: "the input subquery is emitted twice (outer drain +
+//     inner ranking)". Both arms scan the SAME otel_traces Distributed
+//     table. Round 3's finding 2 examined a query shape without an active
+//     /api/search trace limit and correctly found no self-reference for
+//     THAT shape — round 3 did not generalise to the (far more common in
+//     practice) limited-search shape, which is what this round's sampled
+//     dispatch happened to be.
+//   - distributedProductMode=global (cerberus issue #3118, pinned
+//     UNCONDITIONALLY on every query — see distributed_query_settings.go)
+//     rewrites the inner `TraceId IN (subquery)` into a GLOBAL IN: the
+//     subquery is materialised ONCE by fanning the SAME Distributed table
+//     out across the cluster (the EXPLAIN PIPELINE this round captured
+//     shows exactly this — a CreatingSets node wrapping a Union of
+//     ReadFromMergeTree, the local shard's direct read under
+//     prefer_localhost_replica, and ReadFromRemote, the other shards),
+//     ON TOP OF the outer query's own independent Distributed fan-out for
+//     the drain. One SearchTraceLimit-shaped dispatch therefore makes
+//     ClickHouse execute the SAME Distributed scan roughly twice over —
+//     genuinely more real per-shard Select statements than the
+//     DataShardCount-wide weight acquireDataShardFanout charges it, a real
+//     gap in the gate's charging model, not a measurement artefact.
+//
+// THE FIX: acquireDataShardFanout now multiplies its charged weight by a
+// per-request fan-out multiplier (WithDataShardFanoutMultiplier, default 1)
+// that internal/engine.Engine.execContext stamps to
+// searchTraceLimitFanoutMultiplier (2) whenever the plan being dispatched
+// contains a chplan.SearchTraceLimit node — the ONE shape this round
+// directly proved against a real cluster. distributed_query_settings.go's
+// own doc already named three OTHER shapes that self-reference a
+// Distributed table under distributed_product_mode=global (TraceQL
+// structural operators, `select(nestedSet*)`, `| compare(...)`) that this
+// round's e2e burst never exercises (it fires only a bare, non-structural
+// TraceQL attribute search, a PromQL range query, and a LogQL range query)
+// and this fix does NOT audit or multiplier-charge — cerberus issue #3141
+// tracks auditing and, where warranted, extending the SAME multiplier
+// mechanism to those shapes with their own real-cluster evidence, the same
+// rigor this round applied to SearchTraceLimit, rather than a guessed
+// blanket multiplier applied without verification.
+//
+// Cerberus issue #3128's own filing text explicitly forbids a raised
+// DataShardFanoutCap as the resolution; this fix does not touch the cap —
+// it corrects the WEIGHT one specific, proven dispatch shape charges
+// against the unchanged cap, exactly the kind of real fix the issue asks
+// for.
 
 // ErrDataShardFanoutGateBusy is the sentinel wrapped into the error
 // [Client.acquireDataShardFanout] returns when the request's own ctx
@@ -235,8 +314,68 @@ func NewDataShardFanoutGate(cfg Config) (gate *semaphore.Weighted, cap int64) {
 	return semaphore.NewWeighted(cap), cap
 }
 
+// dataShardFanoutMultiplierKeyType/dataShardFanoutMultiplierKey carry the
+// per-request data-shard fan-out multiplier WithDataShardFanoutMultiplier
+// installs — see that function's own doc for why this exists (cerberus
+// issue #3128 round 4).
+type dataShardFanoutMultiplierKeyType struct{}
+
+var dataShardFanoutMultiplierKey = dataShardFanoutMultiplierKeyType{}
+
+// defaultDataShardFanoutMultiplier is what acquireDataShardFanout charges
+// absent a WithDataShardFanoutMultiplier override — the pre-round-4
+// behaviour, unconditionally: weight = DataShardCount exactly, matching
+// every plan shape that makes exactly one real per-shard Distributed
+// statement per dispatch. Named so the multiplier is never a bare literal
+// (invariant 13).
+const defaultDataShardFanoutMultiplier = 1
+
+// WithDataShardFanoutMultiplier returns a ctx that scales
+// acquireDataShardFanout's charged weight by multiplier x DataShardCount
+// instead of the default DataShardCount alone (cerberus issue #3128 round
+// 4 — see this file's own "ROUND 4" doc above for the real-cluster evidence
+// that motivated this).
+//
+// This exists because acquireDataShardFanout charges a FIXED weight per
+// dispatch on the assumption that one chclient dispatch makes exactly one
+// real Distributed-table fan-out. That assumption is false for a plan shape
+// that references the SAME Distributed table more than once WITHIN one
+// physical SQL statement — internal/chsql/search_trace_limit.go's
+// emitSearchTraceLimit is the first PROVEN instance (its own doc: "the
+// input subquery is emitted twice"), and distributed_query_settings.go
+// separately documents three OTHER shapes with the same self-reference
+// property (TraceQL structural operators, nestedSet annotate, compare) that
+// have not been round-4-verified against a real cluster and so do NOT set
+// this yet (cerberus issue #3141 tracks that audit). A shape that has not
+// been proven to over-fan-out must never claim it has — this carrier
+// exists precisely so that claim is made per-shape, with evidence, not
+// guessed globally.
+//
+// multiplier <= 0 is treated as defaultDataShardFanoutMultiplier (1) — a
+// caller bug should never UNDER-charge the gate below what the pre-round-4
+// mechanism already charged.
+//
+// A context value, not a Client field, so it is per-request: two concurrent
+// dispatches, one SearchTraceLimit-shaped and one not, never
+// cross-contaminate each other's charged weight.
+func WithDataShardFanoutMultiplier(ctx context.Context, multiplier int) context.Context {
+	return context.WithValue(ctx, dataShardFanoutMultiplierKey, multiplier)
+}
+
+// dataShardFanoutMultiplierFromContext returns the multiplier
+// WithDataShardFanoutMultiplier installed, or defaultDataShardFanoutMultiplier
+// (1) when none was set or the stored value is non-positive.
+func dataShardFanoutMultiplierFromContext(ctx context.Context) int {
+	if n, ok := ctx.Value(dataShardFanoutMultiplierKey).(int); ok && n > 0 {
+		return n
+	}
+	return defaultDataShardFanoutMultiplier
+}
+
 // acquireDataShardFanout acquires this dispatch's share of the aggregate
-// data-shard fan-out budget — weight c.dataShardCount, floored to 1 — and
+// data-shard fan-out budget — weight c.dataShardCount x the per-request
+// multiplier WithDataShardFanoutMultiplier installs (default 1, see that
+// function's own doc — cerberus issue #3128 round 4), floored to 1 — and
 // returns the idempotent release closure the caller MUST invoke exactly
 // once the dispatch's ClickHouse-side work has finished (queryOpen ties it
 // to the returned driver.Rows' Close via gatedRows; queryCursorColumnar
@@ -257,7 +396,7 @@ func (c *Client) acquireDataShardFanout(ctx context.Context) (release func(), er
 	if c.dataShardFanoutGate == nil {
 		return func() {}, nil
 	}
-	weight := c.dataShardCount
+	weight := c.dataShardCount * int64(dataShardFanoutMultiplierFromContext(ctx))
 	if weight < 1 {
 		weight = 1
 	}

--- a/internal/chclient/fanout_gate_test.go
+++ b/internal/chclient/fanout_gate_test.go
@@ -519,6 +519,114 @@ func TestAcquireDataShardFanout_CancelledDispatch_NoQueryID_SkipsKillQuery(t *te
 	}
 }
 
+// --- WithDataShardFanoutMultiplier (cerberus issue #3128 round 4) -----------
+
+// TestAcquireDataShardFanout_DefaultMultiplier_ChargesDataShardCountExactly
+// pins the unchanged pre-round-4 behavior: a ctx with no
+// WithDataShardFanoutMultiplier charges exactly dataShardCount, neither more
+// (a cap sized to exactly dataShardCount still saturates) nor less (the full
+// dataShardCount is available again once released).
+func TestAcquireDataShardFanout_DefaultMultiplier_ChargesDataShardCountExactly(t *testing.T) {
+	t.Parallel()
+	const dataShardCount = 3
+	conn := &execRecordingConn{}
+	m, _ := newTestConnMetrics(t)
+	cfg := Config{DataShardCount: dataShardCount, MaxOpenConns: dataShardCount}
+	c := assembleClientFromConn(cfg, conn, m)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release, err := c.acquireDataShardFanout(ctx)
+	if err != nil {
+		t.Fatalf("acquireDataShardFanout: %v", err)
+	}
+	if c.dataShardFanoutGate.TryAcquire(1) {
+		t.Fatal("gate admitted an extra unit of weight — default multiplier charged less than dataShardCount")
+	}
+	release()
+	if !c.dataShardFanoutGate.TryAcquire(dataShardCount) {
+		t.Fatal("gate did not release the full dataShardCount weight — default multiplier charged more than dataShardCount")
+	}
+}
+
+// TestAcquireDataShardFanout_WithMultiplier_ScalesChargedWeight is the direct
+// regression test for the round-4 fix: WithDataShardFanoutMultiplier(ctx, 2)
+// must charge exactly 2*dataShardCount, not dataShardCount — the gap that let
+// a SearchTraceLimit-shaped dispatch (internal/chsql/search_trace_limit.go's
+// own double-scan) under-charge the gate for its real ClickHouse-side
+// fan-out width.
+func TestAcquireDataShardFanout_WithMultiplier_ScalesChargedWeight(t *testing.T) {
+	t.Parallel()
+	const (
+		dataShardCount = 3
+		multiplier     = 2
+	)
+	conn := &execRecordingConn{}
+	m, _ := newTestConnMetrics(t)
+	cfg := Config{DataShardCount: dataShardCount, MaxOpenConns: dataShardCount * multiplier}
+	c := assembleClientFromConn(cfg, conn, m)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = WithDataShardFanoutMultiplier(ctx, multiplier)
+
+	release, err := c.acquireDataShardFanout(ctx)
+	if err != nil {
+		t.Fatalf("acquireDataShardFanout: %v", err)
+	}
+	// The gate must be saturated at 2*dataShardCount, not dataShardCount: one
+	// more unit must be denied...
+	if c.dataShardFanoutGate.TryAcquire(1) {
+		t.Fatal("gate admitted an extra unit of weight — multiplier was not applied")
+	}
+	release()
+	// ...and releasing must free the FULL 2*dataShardCount, not merely
+	// dataShardCount (which would prove the multiplier was charged on acquire
+	// but silently dropped on release, leaking capacity).
+	if !c.dataShardFanoutGate.TryAcquire(dataShardCount * multiplier) {
+		t.Fatal("gate did not release the full multiplier*dataShardCount weight")
+	}
+}
+
+// TestAcquireDataShardFanout_NonPositiveMultiplier_FallsBackToDefault confirms
+// dataShardFanoutMultiplierFromContext's own documented guard: a caller bug
+// that installs a zero or negative multiplier must never UNDER-charge the
+// gate below the pre-round-4 dataShardCount baseline.
+func TestAcquireDataShardFanout_NonPositiveMultiplier_FallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	for _, multiplier := range []int{0, -1} {
+		multiplier := multiplier
+		t.Run(fmt.Sprintf("multiplier=%d", multiplier), func(t *testing.T) {
+			t.Parallel()
+			const dataShardCount = 2
+			conn := &execRecordingConn{}
+			m, _ := newTestConnMetrics(t)
+			cfg := Config{DataShardCount: dataShardCount, MaxOpenConns: dataShardCount}
+			c := assembleClientFromConn(cfg, conn, m)
+			t.Cleanup(func() { _ = c.Close() })
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = WithDataShardFanoutMultiplier(ctx, multiplier)
+
+			release, err := c.acquireDataShardFanout(ctx)
+			if err != nil {
+				t.Fatalf("acquireDataShardFanout: %v", err)
+			}
+			if c.dataShardFanoutGate.TryAcquire(1) {
+				t.Fatalf("multiplier=%d: gate admitted an extra unit — charged less than the dataShardCount floor", multiplier)
+			}
+			release()
+			if !c.dataShardFanoutGate.TryAcquire(dataShardCount) {
+				t.Fatalf("multiplier=%d: gate did not release the full dataShardCount weight", multiplier)
+			}
+		})
+	}
+}
+
 // TestAcquireDataShardFanout_ReleaseIsIdempotent_KillsOnlyOnce confirms the
 // sync.Once wrapping the release body also guards killDataShardQuery: a
 // caller that invokes the returned release closure more than once (gatedRows

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -312,6 +312,17 @@ func (e *Engine) execContext(ctx context.Context, plan chplan.Node, language str
 	if planHasTSGridNative(plan) {
 		ctx = chclient.WithTSGridSetting(ctx)
 	}
+	// SearchTraceLimit-shaped plans only (cerberus issue #3128 round 4): tell
+	// chclient's data-shard fan-out gate this ONE dispatch makes roughly
+	// TWICE the real per-shard Distributed statements a plain dispatch does
+	// — internal/chsql/search_trace_limit.go's own doc: "the input subquery
+	// is emitted twice (outer drain + inner ranking)", both scanning the
+	// SAME Distributed table under distributed_product_mode=global. A no-op
+	// on a DataShardCount<=1 deployment (acquireDataShardFanout never reads
+	// this ctx value when its gate is nil) and on every OTHER plan shape.
+	if planHasSearchTraceLimit(plan) {
+		ctx = chclient.WithDataShardFanoutMultiplier(ctx, searchTraceLimitFanoutMultiplier)
+	}
 	// Always-on, result-equivalent: let any GROUP BY / sort spill to disk
 	// rather than blow the per-query memory cap (MEMORY_LIMIT_EXCEEDED / 241).
 	memCap := e.queryMemoryCap()
@@ -798,6 +809,41 @@ func planHasTSGridNative(plan chplan.Node) bool {
 				found = true
 				return false
 			}
+		}
+		return true
+	})
+	return found
+}
+
+// searchTraceLimitFanoutMultiplier is the WithDataShardFanoutMultiplier
+// value execContext stamps for a SearchTraceLimit-shaped plan (cerberus
+// issue #3128 round 4): internal/chsql/search_trace_limit.go's
+// emitSearchTraceLimit emits its own row source EXACTLY twice (an outer
+// drain query plus an inner top-N trace-ranking subquery, both scanning the
+// same Distributed table under distributed_product_mode=global), so 2 is a
+// structural fact about that ONE emitter, not a measured/tuned constant.
+// Named so the multiplier is never a bare literal (invariant 13).
+const searchTraceLimitFanoutMultiplier = 2
+
+// planHasSearchTraceLimit reports whether plan contains a
+// chplan.SearchTraceLimit node — internal/chsql/search_trace_limit.go's
+// emitSearchTraceLimit emits this shape's row source twice (see that
+// emitter's own doc), so a dispatch carrying one makes roughly twice the
+// real per-shard Distributed statements a plain dispatch does once
+// DataShardCount > 1 (cerberus issue #3128 round 4).
+//
+// chplan.WalkDeep, not chplan.Walk, for the same reason
+// planHasTSGridNative uses it: stampSearchTraceLimit only ever wraps a
+// plain Scan/Filter(Scan) row source directly (search_limit.go's
+// plainSearchSource), so a SearchTraceLimit node is not expected to hang
+// off an Expr slot Walk would miss today — but WalkDeep costs nothing extra
+// here and stays correct if a future lowering ever nests one there.
+func planHasSearchTraceLimit(plan chplan.Node) bool {
+	found := false
+	chplan.WalkDeep(plan, func(n chplan.Node) bool {
+		if _, ok := n.(*chplan.SearchTraceLimit); ok {
+			found = true
+			return false
 		}
 		return true
 	})

--- a/internal/engine/search_trace_limit_fanout_multiplier_test.go
+++ b/internal/engine/search_trace_limit_fanout_multiplier_test.go
@@ -1,0 +1,86 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// searchTraceLimitTestPlan builds a minimal SearchTraceLimit-shaped plan —
+// the plain-search row source (a bare Scan) wrapped by SearchTraceLimit, the
+// exact shape internal/traceql/search_limit.go's stampSearchTraceLimit
+// produces for a LIMIT-bounded /api/search request.
+func searchTraceLimitTestPlan() chplan.Node {
+	return &chplan.SearchTraceLimit{
+		Input:           &chplan.Scan{Table: "otel_traces"},
+		TraceIDColumn:   "TraceId",
+		TimestampColumn: "Timestamp",
+		TraceLimit:      20,
+	}
+}
+
+// TestPlanHasSearchTraceLimit pins the positive and negative cases: a plan
+// carrying a chplan.SearchTraceLimit node (even nested below the root, the
+// way a `| select(...)` wrap or similar would place it) is detected, and an
+// unrelated plan is not.
+func TestPlanHasSearchTraceLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare SearchTraceLimit root", func(t *testing.T) {
+		t.Parallel()
+		if !planHasSearchTraceLimit(searchTraceLimitTestPlan()) {
+			t.Fatal("planHasSearchTraceLimit == false for a bare SearchTraceLimit plan")
+		}
+	})
+
+	t.Run("nested below a Project", func(t *testing.T) {
+		t.Parallel()
+		plan := &chplan.Project{Input: searchTraceLimitTestPlan()}
+		if !planHasSearchTraceLimit(plan) {
+			t.Fatal("planHasSearchTraceLimit == false for a SearchTraceLimit nested below a Project")
+		}
+	})
+
+	t.Run("no SearchTraceLimit node", func(t *testing.T) {
+		t.Parallel()
+		plan := &chplan.Project{Input: &chplan.Scan{Table: "otel_traces"}}
+		if planHasSearchTraceLimit(plan) {
+			t.Fatal("planHasSearchTraceLimit == true for a plan with no SearchTraceLimit node")
+		}
+	})
+}
+
+// TestExecContext_SearchTraceLimit_StampsFanoutMultiplier is the direct
+// regression test for cerberus issue #3128 round 4: a SearchTraceLimit-shaped
+// plan must carry chclient.WithDataShardFanoutMultiplier(ctx,
+// searchTraceLimitFanoutMultiplier) after execContext runs, and an unrelated
+// plan must NOT carry it at all — the pre-round-4 default
+// (dataShardFanoutMultiplierFromContext's own fallback) must apply
+// unchanged.
+func TestExecContext_SearchTraceLimit_StampsFanoutMultiplier(t *testing.T) {
+	t.Parallel()
+	e := &Engine{}
+
+	t.Run("SearchTraceLimit plan", func(t *testing.T) {
+		t.Parallel()
+		ctx, _ := e.execContext(context.Background(), searchTraceLimitTestPlan(), "tempo", nil)
+		got, ok := chclient.DataShardFanoutMultiplierFromContext(ctx)
+		if !ok {
+			t.Fatal("execContext did not stamp a data-shard fanout multiplier for a SearchTraceLimit plan")
+		}
+		if got != searchTraceLimitFanoutMultiplier {
+			t.Fatalf("stamped multiplier = %d, want %d", got, searchTraceLimitFanoutMultiplier)
+		}
+	})
+
+	t.Run("unrelated plan", func(t *testing.T) {
+		t.Parallel()
+		plan := &chplan.Project{Input: &chplan.Scan{Table: "otel_traces"}}
+		ctx, _ := e.execContext(context.Background(), plan, "tempo", nil)
+		if _, ok := chclient.DataShardFanoutMultiplierFromContext(ctx); ok {
+			t.Fatal("execContext stamped a data-shard fanout multiplier for a plan with no SearchTraceLimit node")
+		}
+	})
+}


### PR DESCRIPTION
## Round 4 of the DataShardFanoutGate investigation (issue #3128)

Rounds 1-3 (PRs #3132, #3137, #3138) fixed Route A's total lack of admission
control, a cancellation-driven premature gate-release race, and a test-scope
bug (the verify script counting the e2e seeder's own unrelated Insert/Alter
traffic) — and REFUTED a self-join-amplification hypothesis via direct Go
code tracing. What remains, per `internal/chclient/fanout_gate.go`'s own
"Residual gap, round 3 findings" doc: real, concurrent ClickHouse-side
multiplication of per-shard Select statements, confirmed present, root cause
not yet located.

This PR adds direct ClickHouse-side introspection this investigation's prior
tooling (an external e2e verify script + cerberus's own client-side logs)
could not reach, per the doc's own named next steps.

**Work in progress — will be updated as the investigation concludes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
