### PR TITLE
fix(ci): bump gremlins fork pin to fix the workdir file-descriptor leak

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -265,7 +265,7 @@ jobs:
       - name: install gremlins
         run: >
           node .github/scripts/go-module-fetch.mjs --
-          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-phase-timeout-consume
+          go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-workdir-fd-leak-consume
       # `workers: 0` keeps gremlins' default (runtime.NumCPU()); a
       # non-zero value caps the parallel `go test` fan-out per the
       # comment above the matrix entry.

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -134,7 +134,7 @@ installs the matching binary so that fast path is the default.
 `mutation.yml` installs the `tsouza/gremlins` fork rather than upstream `go-gremlins/gremlins@v0.6.0`:
 
 ```bash
-go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-phase-timeout-consume
+go install github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-workdir-fd-leak-consume
 ```
 
 The fixes it carries defend one thing between them: that the number a run reports is a number the
@@ -253,14 +253,24 @@ in the suite rather than an artefact.
 `.gremlins.yaml`'s `exclude-files` paths are interpreted relative to the run's scope, not the repo
 root, and the matcher is RE2 with no lookahead. A path in the wrong form silently excludes nothing.
 
+**`workdir.CachedDealer` closes both copy handles.** Every worker's working-directory setup
+(`CachedDealer.Get`) walks the whole source tree once and copies every regular file, but `doCopy`
+never closed either the source or destination `os.File` it opened — two leaked file descriptors per
+copied file, for the process's lifetime, on every run. Invisible until a consuming repo's tree size,
+times concurrent workers, times two, crosses the runner's open-file ulimit: cerberus's own CI first
+hit `open ...: too many open files` panics after a release added ~2,300 files to its source tree
+(cerberus #3154). Fixed with `defer s.Close()` / `defer d.Close()` in `doCopy`.
+
 The fork ships two branches on purpose. `cerberus-sigterm-fix` at tag
-`v0.6.0-cerberus-run-phase-timeout` is the branch the upstream pull request is built from, and keeps
+`v0.6.0-cerberus-workdir-fd-leak` is the branch the upstream pull request is built from, and keeps
 the upstream module path `github.com/go-gremlins/gremlins` so the diff stays reviewable.
-`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-run-phase-timeout-consume` is the branch
+`cerberus-sigterm-fix-consume` at tag `v0.6.0-cerberus-workdir-fd-leak-consume` is the branch
 `mutation.yml` installs; it adds one commit renaming the `go.mod` module path to
 `github.com/tsouza/gremlins` and rewriting the internal imports, because `go install` otherwise
 rejects the module with `module declares its path as: github.com/go-gremlins/gremlins`. The fixes
-themselves are identical across the two.
+themselves are identical across the two. Both branches carry every fix documented above them in
+this section — each new fix fast-forwards both branches and gets its own pair of tags, so a tag name
+here always names the LATEST fix landed, not a snapshot frozen at that fix alone.
 
 Unlike the module forks, this one sits outside the Dependabot watch flow: it is a build-time tool
 rather than a Go module dependency.

--- a/test/regression/mutation_timeout_max_test.go
+++ b/test/regression/mutation_timeout_max_test.go
@@ -88,7 +88,7 @@ const (
 //     Reverting to an earlier tag makes every report carry the undifferentiated
 //     status, and the gate FAILS on it rather than silently scoring the union:
 //     the closed status set there refuses to score a report it cannot read.
-const gremlinsForkTag = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-run-phase-timeout-consume"
+const gremlinsForkTag = "github.com/tsouza/gremlins/cmd/gremlins@v0.6.0-cerberus-workdir-fd-leak-consume"
 
 // TestMutationLaneCapsPerMutantTimeout (#1294) pins the one bound that keeps the
 // mutation lane from killing its own runner.


### PR DESCRIPTION
## What

Bumps the pinned `tsouza/gremlins` fork tag from
`v0.6.0-cerberus-run-phase-timeout-consume` to
`v0.6.0-cerberus-workdir-fd-leak-consume`, which fixes a real file-descriptor
leak in `internal/engine/workdir/workdir.go`'s `doCopy`: it opened both a
source and destination `os.File` per copied file and never closed either
one. `CachedDealer.Get` walks the WHOLE source tree once per distinct
worker, so every worker's working-directory setup leaked two descriptors
per file, for the process's entire lifetime.

This stayed invisible until source-tree-size × concurrent-workers × 2
crossed the runner's open-file ulimit. Shipping v1.20.0 crossed it: the
release's own perf-regression-gate baseline (#3150/#3151) added ~2,300
files to this repo's tracked tree, and several `gremlins` legs started
panicking with `open ...: too many open files` mid-run (#3154).

Fixed at the source in the fork itself (both `cerberus-sigterm-fix` and
`cerberus-sigterm-fix-consume` branches, so the upstream-reviewable variant
and the `go install`-able variant stay in sync per the existing convention
documented in `docs/toolchain.md`) with `defer s.Close()` / `defer
d.Close()`. Verified there directly: the fork's own `workdir` package tests
pass, and a repro harness (copy a 3,000-file tree under a 256 open-file
ulimit) fails before the fix and succeeds after it.

## Why this is non-blocking but still worth shipping now

`gremlins` is an explicit `RELEASE_INFORMATIONAL_CHECKS` entry — it never
blocked v1.20.0's actual publish. This is a real, previously-latent bug in
CI tooling this repo owns, filed and fixed the same way any other tracked
bug is.

Closes #3154

## Test plan

- [x] `go build ./...` + `go test ./internal/engine/workdir/...` in the fork, both branches
- [x] Direct repro: 3,000-file copy under `ulimit -n 256` fails pre-fix, succeeds post-fix
- [x] `go test ./test/regression/... -run 'Gremlins|Mutation'` in this repo, green
- [x] Grepped for stale references to the old tag across the tree — none remain
