### PR TITLE
fix(release): use RELEASE_PAT to push the release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,11 +428,26 @@ jobs:
       # step.
       is_latest: ${{ steps.is_latest.outputs.is_latest }}
     steps:
+      # Token: RELEASE_PAT, for the SAME reason as `eol-retire` (see that job's
+      # own comment) plus one GitHub restricts unconditionally: the ephemeral
+      # `github.token` a checkout defaults to can NEVER carry OAuth `workflow`
+      # scope — not a repo setting, not something `permissions: contents:
+      # write` above grants — so `git push` later in this job (the tag-push
+      # step) is rejected outright whenever the merge commit being tagged
+      # itself touched a `.github/workflows/*` file: `! [remote rejected]
+      # v1.20.0 -> v1.20.0 (refusing to allow a GitHub App to create or update
+      # workflow ".github/workflows/release.yml" without `workflows`
+      # permission)`. First hit shipping v1.20.0 itself: the release-gate fix
+      # merged onto the tagged commit touched release.yml (cerberus #3157).
+      # RELEASE_PAT is an admin-owned PAT that does carry `workflow` scope; the
+      # `|| secrets.GITHUB_TOKEN` fallback is the same best-effort, unsupported
+      # path as `eol-retire`'s.
       - uses: actions/checkout@v7
         with:
           # fetch-depth: 0 so goreleaser's changelog + the `:latest` highest-
           # stable computation below see the full tag history.
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: ./.github/actions/setup-go
 


### PR DESCRIPTION
## What

`goreleaser`'s `checkout` step used the default ephemeral `GITHUB_TOKEN`,
which GitHub can never grant OAuth `workflow` scope to — not something the
job's own `permissions:` block or any repo setting can override. That made
the "Create + push tag" step reject outright whenever the commit being
tagged touched a `.github/workflows/*` file:

```
! [remote rejected]   v1.20.0 -> v1.20.0 (refusing to allow a GitHub App to
create or update workflow ".github/workflows/release.yml" without
`workflows` permission)
```

Shipping v1.20.0 hit this directly: preflight passed cleanly (confirming
#3157's fix), but the tagged merge commit was #3157's own merge, which
touched `release.yml` — so the tag push failed and the release never
published.

## Fix

Checkout with `RELEASE_PAT` (falling back to `GITHUB_TOKEN`), the exact
pattern `eol-retire` already uses to bypass a different `GITHUB_TOKEN`
limitation (the `release/*.x` ruleset's admin-only deletion bypass — see
that job's own comment). The user has already granted the PAT `workflow`
scope.

## Test plan

- [x] `actionlint .github/workflows/release.yml` clean
- [x] `go test ./test/regression/... -run 'Release'` green
