### PR TITLE
docs(release): document the verified Homebrew migration workaround

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4065,6 +4065,23 @@ The machine ends up with the new cask in the Caskroom, the old binary on `PATH`,
 and no error printed anywhere. The users it strands are the ones who installed
 cerberus *earliest*.
 
+That first paragraph describes the DESIGNED behavior; current Homebrew (4.6.20, verified live
+against the real tap, cerberus#3156) does not reach it. A same-tap formula-to-cask migration hits
+a cask-trust gate `brew update` cannot pass unattended — it prints a warning naming a `brew trust`
+command that does not exist (`brew help trust` → unknown command) and stops, never reaching the
+`… has been migrated …` announcement this section otherwise describes. Manually running
+`brew install --cask tsouza/tap/cerberus` afterward DOES auto-trust the cask, but still hits the
+keg-link refusal from the paragraph above, since the formula was never uninstalled — so an
+affected user needs both steps, in order:
+
+```sh
+brew uninstall --formula cerberus
+brew install --cask tsouza/tap/cerberus
+```
+
+See issue #3156 for the full reproduction; it is open pending either a change in Homebrew's own
+cask-trust behavior for tap migrations or a repo-side workaround nobody has found yet.
+
 The target is written as the bare tap name, which is how homebrew/core spells its
 own formula-to-cask migrations. Homebrew splits it on `/`: a two-part value has no
 name component and is read as "same package, that tap", installing the


### PR DESCRIPTION
## What

The Homebrew tap section of `docs/operations.md` described how the
formula-to-cask migration is *designed* to work, without acknowledging that
current Homebrew (4.6.20, verified against the real `tsouza/tap`) doesn't
actually reach that behavior for a same-tap migration.

Reproduced live in a `homebrew/brew` Linuxbrew container, exactly replaying
`.github/scripts/brew-upgrade-path.mjs`'s scenario (full writeup on #3156):

- `brew update` hits a cask-trust gate and refuses to auto-install, printing
  a warning that names a `brew trust` command which doesn't exist.
- `brew install --cask tsouza/tap/cerberus` run manually afterward DOES
  auto-trust the cask, but still can't link over the still-installed
  formula's binary — the exact stuck-version symptom from the original bug
  report, reproduced from a different angle.
- The one sequence that actually completes the migration:
  `brew uninstall --formula cerberus && brew install --cask tsouza/tap/cerberus`.

This documents that verified workaround so anyone following these docs
isn't left believing `brew update` alone will carry them across.

## Scope

Docs only — the underlying gap (`brew update` can't complete this migration
unattended) is Homebrew-side behavior this repo doesn't control, tracked in
#3156. No code change here; this PR just stops the docs from claiming a
behavior that doesn't currently hold.

## Test plan

- [x] `markdownlint-cli2 docs/operations.md` clean
- [x] `python3 scripts/align-md-tables.py docs/operations.md` — no table drift
