### PR TITLE
fix(e2e): wait for clean inter-node health before the affinity burst

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -2086,7 +2086,14 @@ what actually runs.
   confirming the `load_balancing=first_or_random` +
   `load_balancing_first_offset=0` mechanism
   (`internal/chclient/distributed_query_settings.go`), not just its
-  consequence. INFORMATIONAL — never a PR gate.
+  consequence. Before firing the burst, polls `system.clusters.errors_count`
+  to a clean state (bounded by `HEALTH_POLL_SECONDS`, default 60) — pod
+  readiness (`e2e-datashard-up`'s own gate) proves a container passed its
+  probe, not that every node can already reach every peer replica, and a
+  burst fired during that gap can observe a replica-selection decision still
+  influenced by the connection errors ClickHouse's own error-count decay
+  window has not yet cleared (cerberus issue #3148). INFORMATIONAL — never a
+  PR gate.
   - Env: `NAMESPACE` (default `cerberus`), `CERBERUS_URL` (default
     `http://localhost:8080`), `DB` (default `otel`), `CH_USER`/`CH_PASSWORD`
     (default `cerberus`/`cerberus`), `CH_CLUSTER` (default `bwc_cluster`),

--- a/.github/scripts/e2e-datashard-replica-affinity-verify.mjs
+++ b/.github/scripts/e2e-datashard-replica-affinity-verify.mjs
@@ -61,8 +61,29 @@
 //   REPLICAS                expected replicas PER shard             (required, must be >= 2)
 //   REQUEST_COUNT           sequential solver-splitting requests fired (default 3)
 //   FLUSH_WAIT_SECONDS      settle time before SYSTEM FLUSH LOGS    (default 10)
+//   HEALTH_POLL_SECONDS     bounded wait for a clean errors_count   (default 60)
 //
 // Exit 0 = every assertion passed; 1 = any failed (with ::error:: annotation).
+//
+// THE RACE THIS SCRIPT MUST NOT LOSE (cerberus issue #3148, same class as
+// #3109/PR #3125's mode-toggle readiness race): `just e2e-datashard-up`'s
+// readiness gate is `kubectl rollout status`, which only proves every
+// ClickHouse pod's own container passed its liveness/readiness probe — NOT
+// that every node's inter-node connections to its PEER replicas are already
+// healthy. A pod can report Ready to Kubernetes seconds before it can
+// actually dial a sibling shard's replica; the FIRST time an initiator
+// reaches a still-starting peer, that dial is refused, and ClickHouse
+// increments that replica's `error_count` server-side
+// (`PoolWithFailoverBase::Pool::error_count`, decaying only over
+// `distributed_replica_error_half_life`, 60s default) — during that decay
+// window `first_or_random` can legitimately prefer a NON-offset-0 replica,
+// which is exactly the false positive this leg exists to rule out (observed
+// live: run 34103918151, cerberus issue #3148). `system.clusters.errors_count`
+// is that same error-tracking state, readable directly, so this script polls
+// it to a clean state (every row's `errors_count = 0`) before firing the
+// affinity-verify burst — proving the fan-out load only starts once the
+// cluster has actually settled, rather than inferring settlement from pod
+// readiness alone.
 
 import process from 'node:process';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -79,6 +100,7 @@ const DATA_SHARD_COUNT = Number(process.env.DATA_SHARD_COUNT || '0');
 const REPLICAS = Number(process.env.REPLICAS || '0');
 const REQUEST_COUNT = Number(process.env.REQUEST_COUNT || '3');
 const FLUSH_WAIT_SECONDS = Number(process.env.FLUSH_WAIT_SECONDS || '10');
+const HEALTH_POLL_SECONDS = Number(process.env.HEALTH_POLL_SECONDS || '60');
 
 if (!DATA_SHARD_COUNT || DATA_SHARD_COUNT < 2) {
   error(`DATA_SHARD_COUNT must be a real data-shard count (>= 2), got ${process.env.DATA_SHARD_COUNT}`);
@@ -143,6 +165,42 @@ function hostnameShardReplica(hostname) {
   return { shard: Number(m[1]), replica: Number(m[2]) };
 }
 
+// waitForCleanClusterHealth polls system.clusters until every (shard,
+// replica) row's errors_count is 0, or HEALTH_POLL_SECONDS elapses — see the
+// module doc's "THE RACE THIS SCRIPT MUST NOT LOSE" section for why pod
+// readiness alone cannot stand in for inter-node connection health. Returns
+// the elapsed seconds on success; throws with the last-seen dirty rows on
+// timeout, since a burst fired into a cluster that never settled would only
+// reproduce the false positive this poll exists to close out.
+async function waitForCleanClusterHealth(pod) {
+  const deadline = Date.now() + HEALTH_POLL_SECONDS * 1000;
+  const pollIntervalMs = 2000;
+  let lastDirty = [];
+  for (;;) {
+    const rows = chQueryTSV(
+      pod,
+      `SELECT shard_num, replica_num, errors_count
+       FROM system.clusters WHERE cluster = '${CH_CLUSTER}'
+       ORDER BY shard_num, replica_num`,
+    );
+    lastDirty = rows
+      .map((r) => r.split('\t'))
+      .filter(([, , errorsCount]) => Number(errorsCount) !== 0);
+    if (lastDirty.length === 0) {
+      return (HEALTH_POLL_SECONDS * 1000 - (deadline - Date.now())) / 1000;
+    }
+    if (Date.now() >= deadline) {
+      const detail = lastDirty.map(([shard, replica, n]) => `shard=${shard} replica=${replica} errors_count=${n}`).join('; ');
+      throw new Error(
+        `system.clusters never reached a clean state (errors_count=0 for every replica) within ` +
+          `${HEALTH_POLL_SECONDS}s: ${detail} — firing the affinity burst now would risk observing a ` +
+          `replica-selection decision still influenced by the connection errors this poll exists to wait out`,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
 async function main() {
   const pod = clickhousePodName(kubectl, NS);
   log(`replica-affinity verify: namespace=${NS} db=${DB} cluster=${CH_CLUSTER} dataShardCount=${DATA_SHARD_COUNT} replicas=${REPLICAS} pod=${pod}`);
@@ -171,6 +229,18 @@ async function main() {
     process.exit(1);
   }
   log(`topology confirmed: ${clusterRows.length} shard(s), ${REPLICAS} replica(s) each`);
+
+  // ---- settle window: wait for a genuinely healthy inter-node state ----
+  // See the module doc's "THE RACE THIS SCRIPT MUST NOT LOSE" section —
+  // `just e2e-datashard-up`'s pod-readiness gate proves nothing about
+  // whether every node can already reach every peer replica.
+  try {
+    const settleSeconds = await waitForCleanClusterHealth(pod);
+    log(`cluster health confirmed clean (errors_count=0 for every replica) after ${settleSeconds.toFixed(1)}s`);
+  } catch (e) {
+    error(e.message);
+    process.exit(1);
+  }
 
   // ---- fire REQUEST_COUNT sequential solver-splitting requests ----
   const burstStartMs = Date.now();


### PR DESCRIPTION
## What

`datashard-replica-affinity` failed once with a genuine, non-vacuous
assertion failure (run 34103918151, cerberus#3148): one trace's 48
statements split across two different replicas of the same data shard. Two
immediate retries against the identical commit passed cleanly.

## Root cause

The cluster-state dump from the failing run showed a schema-bootstrap
connection refusal at pod age ~65s. That's the same class of event
`internal/chclient/distributed_query_settings.go`'s own decision record
names as the load-balancing pin's one real precondition: a refused
connection increments ClickHouse's own per-replica `error_count` server-side
(`PoolWithFailoverBase::Pool::error_count`), which decays only over
`distributed_replica_error_half_life` (60s default). During that window,
`first_or_random` can legitimately prefer a non-offset-0 replica — exactly
what this leg observed.

`just e2e-datashard-up`'s readiness gate is `kubectl rollout status`, which
only proves each ClickHouse pod's own container passed its liveness/readiness
probe — not that every node's inter-node connections to its peers are
already healthy. That gap is the same shape as #3109/PR #3125's mode-toggle
readiness race, just on a different signal.

## Fix

Before firing the affinity-verify burst, poll `system.clusters.errors_count`
(the same server-side state the root-cause analysis points at) to a clean
state — bounded by a new `HEALTH_POLL_SECONDS` env var, default 60s, failing
loudly rather than silently proceeding if the cluster never settles.

## Scope

Confined to the e2e test-infrastructure timing for this one lane, matching
the original issue's own scope note: no cerberus runtime behavior changes,
and the `load_balancing=first_or_random` + `load_balancing_first_offset=0`
pin itself is untouched.

Closes #3148

## Test plan

- [x] `node --check` on the modified script
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean
- [x] `markdownlint-cli2 .github/scripts/README.md` clean
- [ ] This lane is INFORMATIONAL (never a PR gate) and only runs on
      push/schedule/workflow_dispatch against a real k3d datashard cluster —
      cannot be exercised from this PR itself; the next scheduled/dispatched
      run of `datashard-replica-affinity` is the real verification.
