### PR TITLE
feat(loki): make /patterns' volume floor configurable

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1424,6 +1424,7 @@ func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 	h.Lang.AttrStrategies = h.AttrStrategies
 	h.QueryTimeout = cfg.ClickHouse.QueryTimeout
 	h.TailWriteTimeout = cfg.LokiTailWriteTimeout
+	h.PatternsMinVolume = cfg.LokiPatternsMinVolume
 	// LabelCatalogEnabled (cerberus issue #2770) is the resolved chopt
 	// loki_catalog_mv verdict — the SAME cfg.SchemaLokiCatalogMV DDLConfig
 	// threads to gate provisioning the catalog table in the first place, so

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -412,6 +412,12 @@ ClickHouse >= 25.9** (the left-open window fix, PR #86588). See
 | ---------------------------------- | ----------- | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | `CERBERUS_LOKI_TAIL_WRITE_TIMEOUT` | —           | duration | `10s`   | Bound on a single `/loki/api/v1/tail` WebSocket write before a slow / dead client is torn down. `> 0`. |
 
+## Loki metadata
+
+| Variable                            | Config file | Type | Default | Description                                                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------------------- | ----------- | ---- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CERBERUS_LOKI_PATTERNS_MIN_VOLUME` | —           | int  | `30`    | Minimum total sample count a `/loki/api/v1/patterns` cluster must reach before it is returned, mirroring upstream Loki's `minClusterSize` (verified against `pkg/pattern/ingester_querier.go`, cerberus issue #2081). `30` default. `0` is a valid, explicit choice that disables the floor entirely — every detected template is returned, matching cerberus's pre-#2205 behaviour. |
+
 ## Schema overrides and Prometheus resource labels
 
 Two further setting families shape ClickHouse interaction but are resolved by

--- a/internal/api/loki/handler.go
+++ b/internal/api/loki/handler.go
@@ -126,6 +126,17 @@ type Handler struct {
 	// Handler keep the historical 10s bound.
 	TailWriteTimeout time.Duration
 
+	// PatternsMinVolume is the minimum total sample count a
+	// /loki/api/v1/patterns cluster must reach before it is returned,
+	// mirroring upstream Loki's minClusterSize (cerberus issue #2081).
+	// Wired from CERBERUS_LOKI_PATTERNS_MIN_VOLUME (Config.LokiPatternsMinVolume)
+	// in cmd/cerberus. Unlike TailWriteTimeout above, zero is a MEANINGFUL
+	// configured value here (it disables the floor, returning every
+	// detected template — cerberus's pre-#2205 behaviour), not an
+	// unset marker, so New sets this to defaultPatternsMinVolume directly
+	// rather than falling back to it at the point of use.
+	PatternsMinVolume int
+
 	// TextIndexLineFilter is chopt text_index_line_filter's resolved
 	// verdict (cerberus issue #2773), wired from cmd/cerberus's boot
 	// EnabledSet at construction (mirroring Limiter/QueryTimeout/Version
@@ -188,12 +199,13 @@ func New(client Querier, s schema.Logs, logger *slog.Logger) *Handler {
 	}
 	opt := optimizer.Default()
 	return &Handler{
-		Client:    client,
-		Schema:    s,
-		Optimizer: opt,
-		Logger:    logger,
-		Engine:    &engine.Engine{Optimizer: opt, Client: client},
-		Lang:      &logql.Lang{Schema: s},
+		Client:            client,
+		Schema:            s,
+		Optimizer:         opt,
+		Logger:            logger,
+		Engine:            &engine.Engine{Optimizer: opt, Client: client},
+		Lang:              &logql.Lang{Schema: s},
+		PatternsMinVolume: defaultPatternsMinVolume,
 	}
 }
 

--- a/internal/api/loki/patterns.go
+++ b/internal/api/loki/patterns.go
@@ -25,10 +25,14 @@ import (
 const (
 	defaultPatternsLineLimit = 1000
 
-	// minimumPatternVolume mirrors upstream Loki's minClusterSize: a
+	// defaultPatternsMinVolume mirrors upstream Loki's minClusterSize: a
 	// template must account for at least this many log lines before it is
-	// useful enough to return to the pattern panel.
-	minimumPatternVolume = 30
+	// useful enough to return to the pattern panel. Handler.New sets
+	// Handler.PatternsMinVolume to this value; cmd/cerberus overrides it
+	// from CERBERUS_LOKI_PATTERNS_MIN_VOLUME (Config.LokiPatternsMinVolume,
+	// cerberus issue #2081's follow-up) for operators whose log streams
+	// don't clear the upstream-matching default.
+	defaultPatternsMinVolume = 30
 
 	// maximumPatternSeries mirrors upstream Loki's maxPatterns response
 	// bound. The volume sort below makes the retained series the most
@@ -120,7 +124,7 @@ func (h *Handler) handlePatterns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	patterns := minePatterns(lines, start, end, step)
+	patterns := minePatterns(lines, start, end, step, h.PatternsMinVolume)
 
 	writeJSON(w, http.StatusOK, Response{
 		Status: "success",
@@ -174,7 +178,7 @@ func buildPatternsSQL(s schema.Logs, matchers []*labels.Matcher, start, end time
 // instance (confirmed independent — a Miner owns its own token tree and
 // cluster slice, no shared state), so lines never mix templates across
 // levels.
-func minePatterns(lines []chclient.TimestampedLine, start, end time.Time, step time.Duration) []Pattern {
+func minePatterns(lines []chclient.TimestampedLine, start, end time.Time, step time.Duration, minVolume int) []Pattern {
 	type patternWithVolume struct {
 		pattern Pattern
 		volume  int64
@@ -207,7 +211,7 @@ func minePatterns(lines []chclient.TimestampedLine, start, end time.Time, step t
 			}
 			samples := projectSamples(c.Samples(), start, end)
 			volume := sampleVolume(samples)
-			if volume < minimumPatternVolume {
+			if volume < int64(minVolume) {
 				continue
 			}
 			weighted = append(weighted, patternWithVolume{

--- a/internal/api/loki/patterns_e2e_seed_volume_internal_test.go
+++ b/internal/api/loki/patterns_e2e_seed_volume_internal_test.go
@@ -10,12 +10,12 @@ import (
 
 // TestMinePatternsClearsE2ESeedFloor pins the class of regression that
 // broke the "dashboard" e2e gate for 12+ hours after #2205 added the
-// minimumPatternVolume floor (mirroring upstream Loki's minClusterSize):
+// defaultPatternsMinVolume floor (mirroring upstream Loki's minClusterSize):
 // the rolling e2e seed (test/e2e/seed/cmd/seed/main.go's insertLogsSQL)
 // generates otel_logs rows for {service_name="api"} that, once the
 // rolling re-seeder (`just e2e-seed-rolling`, 30 s ticks) has accumulated
 // a realistic handful of ticks, must produce at least one drain cluster
-// whose volume clears minimumPatternVolume — otherwise the
+// whose volume clears defaultPatternsMinVolume — otherwise the
 // /loki/api/v1/patterns e2e assertion
 // (test/e2e/playwright/loki_ux.spec.ts:152, "patterns: the /patterns
 // endpoint extracts drain clusters from log bodies") sees
@@ -76,15 +76,15 @@ func TestMinePatternsClearsE2ESeedFloor(t *testing.T) {
 		}
 	}
 
-	got := minePatterns(lines, start, end, minimumPatternSampleResolution)
+	got := minePatterns(lines, start, end, minimumPatternSampleResolution, defaultPatternsMinVolume)
 	if len(got) == 0 {
 		t.Fatalf("0 clusters after %d re-seed ticks (%d api lines in the query window) — "+
-			"the e2e seed fixture no longer clears minimumPatternVolume=%d; "+
+			"the e2e seed fixture no longer clears defaultPatternsMinVolume=%d; "+
 			"see test/e2e/seed/cmd/seed/main.go's insertLogsSQL",
-			realisticDwellTicks, len(lines), minimumPatternVolume)
+			realisticDwellTicks, len(lines), defaultPatternsMinVolume)
 	}
-	if v := patternTestVolume(got[0]); v < minimumPatternVolume {
-		t.Fatalf("best cluster volume=%d want >= minimumPatternVolume=%d after %d re-seed ticks",
-			v, minimumPatternVolume, realisticDwellTicks)
+	if v := patternTestVolume(got[0]); v < defaultPatternsMinVolume {
+		t.Fatalf("best cluster volume=%d want >= defaultPatternsMinVolume=%d after %d re-seed ticks",
+			v, defaultPatternsMinVolume, realisticDwellTicks)
 	}
 }

--- a/internal/api/loki/patterns_semantics_internal_test.go
+++ b/internal/api/loki/patterns_semantics_internal_test.go
@@ -7,20 +7,21 @@ import (
 
 	"github.com/tsouza/cerberus/internal/api/format"
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/schema"
 )
 
 func TestMinePatternsVolumeFloor(t *testing.T) {
 	t.Parallel()
 
 	const (
-		belowFloorCount = minimumPatternVolume - 1
-		atFloorCount    = minimumPatternVolume
+		belowFloorCount = defaultPatternsMinVolume - 1
+		atFloorCount    = defaultPatternsMinVolume
 	)
 	base := time.Unix(0, 0).UTC()
 	lines := repeatedPatternLines(base, "rare alpha quiet path", belowFloorCount)
 	lines = append(lines, repeatedPatternLines(base, "common beta loud route", atFloorCount)...)
 
-	got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution)
+	got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution, defaultPatternsMinVolume)
 	if len(got) != 1 {
 		t.Fatalf("patterns=%d want 1: %+v", len(got), got)
 	}
@@ -37,26 +38,26 @@ func TestMinePatternsVolumeSortAndSeriesCap(t *testing.T) {
 
 	const candidateSeries = maximumPatternSeries + 1
 	base := time.Unix(0, 0).UTC()
-	lines := make([]chclient.TimestampedLine, 0, candidateSeries*minimumPatternVolume+1)
+	lines := make([]chclient.TimestampedLine, 0, candidateSeries*defaultPatternsMinVolume+1)
 	var highestVolumePattern string
 	for i := 0; i < candidateSeries; i++ {
 		body := distinctPatternBody(i)
-		lines = append(lines, repeatedPatternLines(base, body, minimumPatternVolume)...)
+		lines = append(lines, repeatedPatternLines(base, body, defaultPatternsMinVolume)...)
 		if i == candidateSeries-1 {
 			highestVolumePattern = body
 			lines = append(lines, chclient.TimestampedLine{Timestamp: base, Body: body, Severity: "INFO"})
 		}
 	}
 
-	got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution)
+	got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution, defaultPatternsMinVolume)
 	if len(got) != maximumPatternSeries {
 		t.Fatalf("patterns=%d want hard cap %d", len(got), maximumPatternSeries)
 	}
 	if got[0].Pattern != highestVolumePattern {
 		t.Fatalf("first pattern=%q want highest-volume %q", got[0].Pattern, highestVolumePattern)
 	}
-	if volume := patternTestVolume(got[0]); volume != minimumPatternVolume+1 {
-		t.Fatalf("first volume=%d want %d", volume, minimumPatternVolume+1)
+	if volume := patternTestVolume(got[0]); volume != defaultPatternsMinVolume+1 {
+		t.Fatalf("first volume=%d want %d", volume, defaultPatternsMinVolume+1)
 	}
 	for i := 1; i < len(got); i++ {
 		if patternTestVolume(got[i-1]) < patternTestVolume(got[i]) {
@@ -66,13 +67,49 @@ func TestMinePatternsVolumeSortAndSeriesCap(t *testing.T) {
 	}
 }
 
+// TestNewDefaultsPatternsMinVolume confirms Handler.New sets
+// PatternsMinVolume to the package default (30, cerberus issue #2081's
+// upstream-matching floor) so a Handler built without going through
+// cmd/cerberus's config wiring keeps the historical behaviour.
+func TestNewDefaultsPatternsMinVolume(t *testing.T) {
+	t.Parallel()
+
+	h := New(nil, schema.DefaultOTelLogs(), nil)
+	if h.PatternsMinVolume != defaultPatternsMinVolume {
+		t.Fatalf("PatternsMinVolume = %d; want %d", h.PatternsMinVolume, defaultPatternsMinVolume)
+	}
+}
+
+// TestMinePatternsConfigurableMinVolume confirms the volume floor
+// (CERBERUS_LOKI_PATTERNS_MIN_VOLUME / Handler.PatternsMinVolume) is honored
+// as a parameter rather than hardcoded: a lower threshold retains a cluster
+// the default would drop, and 0 disables the floor entirely (every detected
+// template returned, cerberus's pre-#2205 behaviour).
+func TestMinePatternsConfigurableMinVolume(t *testing.T) {
+	t.Parallel()
+
+	const belowDefaultFloor = defaultPatternsMinVolume - 1
+	base := time.Unix(0, 0).UTC()
+	lines := repeatedPatternLines(base, "rare alpha quiet path", belowDefaultFloor)
+
+	if got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution, defaultPatternsMinVolume); len(got) != 0 {
+		t.Fatalf("default floor: patterns=%d want 0 (below the %d-line default floor): %+v", len(got), defaultPatternsMinVolume, got)
+	}
+	if got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution, belowDefaultFloor); len(got) != 1 {
+		t.Fatalf("lowered floor=%d: patterns=%d want 1", belowDefaultFloor, len(got))
+	}
+	if got := minePatterns(lines, base, base.Add(time.Minute), minimumPatternSampleResolution, 0); len(got) != 1 {
+		t.Fatalf("floor=0 (disabled): patterns=%d want 1", len(got))
+	}
+}
+
 func TestMinePatternsUsesRequestedStep(t *testing.T) {
 	t.Parallel()
 
 	const requestedStep = 15 * time.Second
 	base := time.Unix(0, 0).UTC()
-	lines := make([]chclient.TimestampedLine, 0, minimumPatternVolume)
-	for i := 0; i < minimumPatternVolume; i++ {
+	lines := make([]chclient.TimestampedLine, 0, defaultPatternsMinVolume)
+	for i := 0; i < defaultPatternsMinVolume; i++ {
 		lines = append(lines, chclient.TimestampedLine{
 			Timestamp: base.Add(time.Duration(i) * time.Second),
 			Body:      "common beta loud route",
@@ -80,7 +117,7 @@ func TestMinePatternsUsesRequestedStep(t *testing.T) {
 		})
 	}
 
-	got := minePatterns(lines, base, base.Add(30*time.Second), requestedStep)
+	got := minePatterns(lines, base, base.Add(30*time.Second), requestedStep, defaultPatternsMinVolume)
 	if len(got) != 1 {
 		t.Fatalf("patterns=%d want 1: %+v", len(got), got)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,17 @@ type Config struct {
 	// internal/api/loki/tail.go via CERBERUS_LOKI_TAIL_WRITE_TIMEOUT.
 	LokiTailWriteTimeout time.Duration
 
+	// LokiPatternsMinVolume is the minimum total sample count a
+	// /loki/api/v1/patterns cluster must reach before it is returned,
+	// mirroring upstream Loki's minClusterSize (verified against
+	// `pkg/pattern/ingester_querier.go` in cerberus issue #2081). Promoted
+	// from the hardcoded 30 in internal/api/loki/patterns.go via
+	// CERBERUS_LOKI_PATTERNS_MIN_VOLUME so an operator whose log streams
+	// don't clear the upstream-matching default can lower it; `0` is a
+	// valid, explicit choice that disables the floor entirely (every
+	// detected template is returned, the pre-#2205 behaviour).
+	LokiPatternsMinVolume int
+
 	// PromMetadataLookback is how far back a WINDOWLESS Prom
 	// metadata-discovery request (/api/v1/labels,
 	// /api/v1/label/<l>/values, /api/v1/series with no start/end)
@@ -981,6 +992,7 @@ const (
 	envHTTPMaxHeaderBytes           = "CERBERUS_HTTP_MAX_HEADER_BYTES"
 	envHTTPMaxBodyBytes             = "CERBERUS_HTTP_MAX_BODY_BYTES"
 	envLokiTailWriteTO              = "CERBERUS_LOKI_TAIL_WRITE_TIMEOUT"
+	envLokiPatternsMinVolume        = "CERBERUS_LOKI_PATTERNS_MIN_VOLUME"
 	envPromMetadataLookback         = "CERBERUS_PROM_METADATA_LOOKBACK"
 	envDeltaPrefixLookback          = "CERBERUS_DELTA_PREFIX_LOOKBACK"
 	envDeltaPrefixReadEnabled       = "CERBERUS_DELTA_PREFIX_READ_ENABLED"
@@ -1237,11 +1249,11 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	maxSamples, err := getInt64(v, envQueryMaxSamples)
+	maxSamples, err := queryMaxSamplesFromEnv(v)
 	if err != nil {
 		return Config{}, err
 	}
-	maxSamples, err = resolveQueryMaxSamples(maxSamples)
+	lokiPatternsMinVolume, err := lokiPatternsMinVolumeFromEnv(v)
 	if err != nil {
 		return Config{}, err
 	}
@@ -1339,6 +1351,7 @@ func FromEnv() (Config, error) {
 		HTTPAddr:                             getString(v, envHTTPAddr),
 		HTTPServer:                           surface.httpServer,
 		LokiTailWriteTimeout:                 surface.lokiTailWriteTimeout,
+		LokiPatternsMinVolume:                lokiPatternsMinVolume,
 		PromMetadataLookback:                 surface.promMetadataLookback,
 		DeltaPrefixLookback:                  deltaPrefixLookback,
 		DeltaPrefixReadEnabled:               deltaPrefixReadEnabled,
@@ -1426,6 +1439,7 @@ var allEnvKeys = []string{
 	envHTTPMaxHeaderBytes,
 	envHTTPMaxBodyBytes,
 	envLokiTailWriteTO,
+	envLokiPatternsMinVolume,
 	envPromMetadataLookback,
 	envDeltaPrefixLookback,
 	envDeltaPrefixReadEnabled,
@@ -1597,7 +1611,9 @@ func newDefaults() *viper.Viper {
 	v.SetDefault(envHTTPIdleTimeout, defaultHTTPIdleTimeout.String())
 	v.SetDefault(envHTTPMaxHeaderBytes, defaultHTTPMaxHeaderBytes)
 	v.SetDefault(envHTTPMaxBodyBytes, defaultHTTPMaxBodyBytes)
-	v.SetDefault(envLokiTailWriteTO, defaultLokiTailWriteTimeout.String())
+	// Grouped into one call — see setLokiDefaults's own doc — purely to keep
+	// this function under golangci-lint's funlen cap.
+	setLokiDefaults(v)
 	v.SetDefault(envPromMetadataLookback, defaultPromMetadataLookback.String())
 	// Grouped into one call — see setDeltaPrefixAndRBGNDefaults's own doc —
 	// purely to keep this function under golangci-lint's funlen cap; the
@@ -1641,6 +1657,16 @@ func newDefaults() *viper.Viper {
 	setAdmitDefaults(v)
 	v.SetDefault(envEnabledHeads, defaultEnabledHeads)
 	return v
+}
+
+// setLokiDefaults seeds the Loki-head knob defaults together. Extracted
+// from newDefaults purely to keep that function under golangci-lint's
+// funlen cap (mirrors setDeltaPrefixAndRBGNDefaults's / setAdmitDefaults's
+// own established precedent just below) — the two defaults are otherwise
+// unrelated beyond both being Loki-specific.
+func setLokiDefaults(v *viper.Viper) {
+	v.SetDefault(envLokiTailWriteTO, defaultLokiTailWriteTimeout.String())
+	v.SetDefault(envLokiPatternsMinVolume, defaultLokiPatternsMinVolume)
 }
 
 // setDeltaPrefixAndRBGNDefaults seeds the DELTA-prefix reconstruction
@@ -1890,6 +1916,12 @@ const defaultHTTPMaxBodyBytes int64 = 4 << 20
 // /tail WebSocket write before a slow / dead client is torn down.
 const defaultLokiTailWriteTimeout time.Duration = 10 * time.Second
 
+// defaultLokiPatternsMinVolume promotes the previously-hardcoded
+// minimumPatternVolume in internal/api/loki/patterns.go: the minimum total
+// sample count a /patterns cluster must reach before it is returned,
+// verified against upstream Loki's minClusterSize (cerberus issue #2081).
+const defaultLokiPatternsMinVolume = 30
+
 // defaultPromMetadataLookback is zero on purpose: "no explicit lookback
 // configured", which leaves the windowless metadata scan on the Prom
 // handler's own conservative fallback horizon. A non-zero default here would
@@ -1981,6 +2013,19 @@ func resolveQueryMaxSamples(n int64) (int64, error) {
 	default:
 		return 0, fmt.Errorf("%s: must be > 0, 0 (use default), or -1 (disable); got %d", envQueryMaxSamples, n)
 	}
+}
+
+// queryMaxSamplesFromEnv reads CERBERUS_QUERY_MAX_SAMPLES and resolves it via
+// resolveQueryMaxSamples. Factored out of FromEnv purely to keep that
+// function under golangci-lint's funlen cap; resolveQueryMaxSamples stays a
+// standalone function since query_max_samples_test.go exercises it directly
+// against raw int64 inputs.
+func queryMaxSamplesFromEnv(v *viper.Viper) (int64, error) {
+	n, err := getInt64(v, envQueryMaxSamples)
+	if err != nil {
+		return 0, err
+	}
+	return resolveQueryMaxSamples(n)
 }
 
 // defaultRBGNMaxRows / defaultRBGNMaxDensityUnits mirror
@@ -2125,6 +2170,23 @@ func queryTimeoutFromEnv(v *viper.Viper) (time.Duration, error) {
 		return 0, fmt.Errorf("%s: must be >= 0, got %s", envQueryTimeout, queryTimeout)
 	}
 	return queryTimeout, nil
+}
+
+// lokiPatternsMinVolumeFromEnv reads CERBERUS_LOKI_PATTERNS_MIN_VOLUME.
+// Factored out of FromEnv purely to keep that function under
+// golangci-lint's funlen cap. Unlike queryTimeoutFromEnv above, `0` is not
+// coerced back to the default — it is a valid, explicit "disable the
+// floor" choice (see Config.LokiPatternsMinVolume's doc comment) — so the
+// only rejected value is negative.
+func lokiPatternsMinVolumeFromEnv(v *viper.Viper) (int, error) {
+	minVolume, err := getInt(v, envLokiPatternsMinVolume)
+	if err != nil {
+		return 0, err
+	}
+	if minVolume < 0 {
+		return 0, fmt.Errorf("%s: must be >= 0, got %d", envLokiPatternsMinVolume, minVolume)
+	}
+	return minVolume, nil
 }
 
 // dataShardFanoutCapOverrideFromEnv reads CERBERUS_SOLVER_DATA_SHARD_FANOUT_CAP,

--- a/internal/config/envdocs.go
+++ b/internal/config/envdocs.go
@@ -213,6 +213,10 @@ var envDocGroups = []envDocGroup{
 		Name:  "Loki streaming",
 		Intro: "",
 	},
+	{
+		Name:  "Loki metadata",
+		Intro: "",
+	},
 }
 
 // envDocs is the hand-authored metadata for every CERBERUS_* key the viper
@@ -354,6 +358,7 @@ var envDocs = []EnvDoc{
 
 	// --- Loki streaming ---
 	{envLokiTailWriteTO, docTypeDuration, "Loki streaming", "Bound on a single `/loki/api/v1/tail` WebSocket write before a slow / dead client is torn down. `> 0`."},
+	{envLokiPatternsMinVolume, "int", "Loki metadata", "Minimum total sample count a `/loki/api/v1/patterns` cluster must reach before it is returned, mirroring upstream Loki's `minClusterSize` (verified against `pkg/pattern/ingester_querier.go`, cerberus issue #2081). `30` default. `0` is a valid, explicit choice that disables the floor entirely — every detected template is returned, matching cerberus's pre-#2205 behaviour."},
 }
 
 // EnvDocs returns the documentation metadata for every CERBERUS_* key the

--- a/internal/config/loki_patterns_min_volume_test.go
+++ b/internal/config/loki_patterns_min_volume_test.go
@@ -1,0 +1,51 @@
+package config
+
+import "testing"
+
+// TestFromEnv_LokiPatternsMinVolume pins CERBERUS_LOKI_PATTERNS_MIN_VOLUME:
+// default 30 (matches upstream Loki's minClusterSize, cerberus issue #2081),
+// an explicit override, the `0` = "no floor" escape hatch (cerberus's
+// pre-#2205 behaviour), and rejection of a negative value.
+func TestFromEnv_LokiPatternsMinVolume(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		clearAllEnv(t)
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.LokiPatternsMinVolume != 30 {
+			t.Errorf("LokiPatternsMinVolume = %d; want 30", cfg.LokiPatternsMinVolume)
+		}
+	})
+	t.Run("override", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envLokiPatternsMinVolume, "5")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.LokiPatternsMinVolume != 5 {
+			t.Errorf("LokiPatternsMinVolume = %d; want 5", cfg.LokiPatternsMinVolume)
+		}
+	})
+	t.Run("zero disables the floor", func(t *testing.T) {
+		clearAllEnv(t)
+		t.Setenv(envLokiPatternsMinVolume, "0")
+		cfg, err := FromEnv()
+		if err != nil {
+			t.Fatalf("FromEnv: %v", err)
+		}
+		if cfg.LokiPatternsMinVolume != 0 {
+			t.Errorf("LokiPatternsMinVolume = %d; want 0 (explicit, not coerced back to the default)", cfg.LokiPatternsMinVolume)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		for _, val := range []string{"-1", "nope"} {
+			clearAllEnv(t)
+			t.Setenv(envLokiPatternsMinVolume, val)
+			if _, err := FromEnv(); err == nil {
+				t.Errorf("FromEnv accepted %s=%q; want error", envLokiPatternsMinVolume, val)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Follow-up to a support conversation: an operator's Grafana Drilldown "Patterns" tab
came back empty for a log stream that used to show data. Root-caused to
`internal/api/loki/patterns.go`'s hardcoded `minimumPatternVolume = 30` floor
(added in #2205 to match upstream Loki's `minClusterSize`, closing issue #2081) —
any detected template accounting for fewer than 30 lines within the query window
is silently dropped, which is correct-per-upstream but leaves no way to tune it
for a stream whose traffic or template diversity never clears that bar.

Makes the floor configurable rather than hardcoded:

- `CERBERUS_LOKI_PATTERNS_MIN_VOLUME` (`Config.LokiPatternsMinVolume`,
  `Handler.PatternsMinVolume`), default `30` — byte-identical to today's
  behavior when unset.
- `0` is a valid, explicit choice that disables the floor entirely, restoring
  cerberus's pre-#2205 behavior (every detected template returned) for an
  operator who'd rather see everything than tune a threshold.
- A negative value is rejected at startup.

`Handler.New` sets `PatternsMinVolume` to the package default directly (rather
than falling back to it at the point of use, like `TailWriteTimeout` does) — see
the field's doc comment for why: `0` is a meaningful configured value here, not
an unset marker, so the usual "zero falls back to default" idiom would make it
impossible to explicitly disable the floor.

`docs/configuration.md` is regenerated (`just gen-config-docs`) with a new
"Loki metadata" section for the one new key.

## Test plan

- `go test ./internal/config/... ./internal/api/loki/... ./cmd/...` — all pass,
  including new cases: default/override/explicit-zero/negative-rejected at the
  config layer, and `Handler.New`'s default plus a lowered/zeroed floor changing
  `minePatterns`' output at the handler layer.
- `golangci-lint run ./internal/config/... ./internal/api/loki/... ./cmd/cerberus/...` — 0 issues.
- `just gen-config-docs` — regenerated cleanly, diff reviewed.
- CI on this PR.
