### PR TITLE
fix(prom): collapse label-values resource-arm scan to one per table

### DIFF
--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -1836,25 +1836,25 @@ func (h *Handler) unionLabelValuesSQL(tables []string, name string, start, end t
 			Where(withWindow(mapAtNotEmptyFrag(attrsCol, k))).
 			Frag()
 	}
-	parts := make([]chsql.Frag, 0, len(tables)*len(candidates)*2)
+	parts := make([]chsql.Frag, 0, len(tables)*(len(candidates)+1))
 	for _, t := range tables {
 		for _, k := range candidates {
 			parts = append(parts, attrsArm(t, k))
-			// Resource arm: read the same candidate key out of the
-			// ResourceAttributes map so a value stored only under a
-			// resource attribute (k8s.namespace.name, …) surfaces on
-			// /label/<name>/values. ResourceAttributes is absent from
-			// proj_series, so this arm cannot route onto the projection; it
-			// keeps the WHERE-bounded DISTINCT (partition-pruned by the
-			// now-anchored window). The arm is allowlist-gated and rare, so
-			// staying off the projection is by design, not a regression.
-			if resourceArm {
-				resArm := chsql.NewQuery().
-					Select(chsql.As(distinctMapAtFrag(resCol, k), "value")).
-					From(chsql.PhysicalTable(t)).
-					Where(withWindow(mapAtNotEmptyFrag(resCol, k)))
-				parts = append(parts, resArm.Frag())
-			}
+		}
+		// Resource arm: read the same candidate keys out of the
+		// ResourceAttributes map so a value stored only under a resource
+		// attribute (k8s.namespace.name, …) surfaces on
+		// /label/<name>/values. ResourceAttributes is absent from
+		// proj_series, so this arm cannot route onto the projection — by
+		// design, not a regression (it is allowlist-gated and rare). ONE
+		// scan per table covers every candidate (issue #3168): a per-candidate
+		// scan here, like the attrs arm above, multiplied a 7-spelling
+		// candidate powerset into 7 full unaccelerated table scans — the
+		// combination this arm's own "rare, one scan" design and
+		// PromLabelToOTelCandidates' own "cheap, it's a per-row coalesce"
+		// design each assumed the other wouldn't compound with.
+		if resourceArm {
+			parts = append(parts, resourceLabelValuesArmFrag(resCol, t, candidates, pred))
 		}
 	}
 	outer := chsql.NewQuery().
@@ -2022,12 +2022,18 @@ func distinctIdent(col string) chsql.Frag {
 	return chsql.Distinct(chsql.Col(col))
 }
 
+// mapAtFrag emits `<col>[?]`, binding key as a positional `?` argument —
+// the bare Map subscript distinctMapAtFrag, mapAtNotEmptyFrag, and
+// resourceLabelValuesArmFrag each build on.
+func mapAtFrag(col, key string) chsql.Frag {
+	return func(b *chsql.Builder) { b.MapAt(col, key) }
+}
+
 // distinctMapAtFrag emits `DISTINCT <col>[?]` and binds key as a
 // positional argument — the projection shape for "distinct values of
 // label <key> stored in the Attributes map".
 func distinctMapAtFrag(col, key string) chsql.Frag {
-	mapAt := chsql.Frag(func(b *chsql.Builder) { b.MapAt(col, key) })
-	return chsql.Distinct(mapAt)
+	return chsql.Distinct(mapAtFrag(col, key))
 }
 
 // mapAtNotEmptyFrag emits `<col>[?] != ?` and binds both the map key
@@ -2037,8 +2043,38 @@ func distinctMapAtFrag(col, key string) chsql.Frag {
 // the whole expression stays inside the typed Frag surface (the public
 // Raw / Concat escape hatches were retired).
 func mapAtNotEmptyFrag(col, key string) chsql.Frag {
-	mapAt := chsql.Frag(func(b *chsql.Builder) { b.MapAt(col, key) })
-	return chsql.Neq(mapAt, chsql.Lit(""))
+	return chsql.Neq(mapAtFrag(col, key), chsql.Lit(""))
+}
+
+// resourceLabelValuesArmFrag builds ONE scan of table t surfacing every
+// candidate spelling's ResourceAttributes values, replacing
+// unionLabelValuesSQL's historical one-full-scan-per-candidate shape
+// (cerberus issue #3168). It renders:
+//
+//	SELECT arrayJoin(arrayFilter(v -> v != '', [<col>[k0], <col>[k1], …])) AS value
+//	FROM t [WHERE pred]
+//
+// arrayFilter drops the empty-string sentinel CH returns for an absent Map
+// key BEFORE arrayJoin explodes the survivors into rows, so a row missing
+// every candidate contributes zero rows — arrayJoin on an empty array
+// yields none — with no separate not-empty predicate needed, unlike the
+// per-candidate mapAtNotEmptyFrag arm above. pred is the caller's window
+// bound alone (h.metadataWindowPred), not withWindow's row-content filter:
+// this arm's not-empty check already lives inside the SELECT.
+func resourceLabelValuesArmFrag(resCol, t string, candidates []string, pred chsql.Frag) chsql.Frag {
+	lookups := make([]chsql.Frag, len(candidates))
+	for i, k := range candidates {
+		lookups[i] = mapAtFrag(resCol, k)
+	}
+	notEmpty := chsql.Lambda1("v", chsql.Neq(chsql.BareIdent("v"), chsql.Lit("")))
+	values := chsql.Call("arrayJoin", chsql.Call("arrayFilter", notEmpty, chsql.Array(lookups...)))
+	q := chsql.NewQuery().
+		Select(chsql.As(values, "value")).
+		From(chsql.PhysicalTable(t))
+	if pred != nil {
+		q.Where(pred)
+	}
+	return q.Frag()
 }
 
 // matcherSubqueryFrag wraps the legacy chsql.Emit output (sql + args)

--- a/internal/api/prom/metadata_test.go
+++ b/internal/api/prom/metadata_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -160,19 +161,23 @@ func TestLabelValues_Endpoint(t *testing.T) {
 	if !strings.Contains(q.lastSQL, "Attributes`[?]") {
 		t.Errorf("expected SQL to reference Attributes map access; got %q", q.lastSQL)
 	}
-	// Per UNION arm the bind order is:
-	//   <name (SELECT DISTINCT Attributes[?])>,
-	//   <name (WHERE Attributes[?] != ?)>,
-	//   <"" (WHERE empty-sentinel Lit)>.
-	// All `name` slots should be "job"; the empty-sentinel slots should be "".
-	for i, a := range q.lastArgs {
-		var want any = "job"
-		if i%3 == 2 {
-			want = ""
-		}
-		if a != want {
-			t.Errorf("arg[%d] = %v, want %v", i, a, want)
-		}
+	// Per metric table (gauge, sum, histogram) the bind order is now
+	// (issue #3168 collapsed the resource arm to one scan per table instead
+	// of one per candidate):
+	//   attrs arm:    <name (SELECT DISTINCT Attributes[?])>,
+	//                 <name (HAVING/WHERE Attributes[?] != ?)>,
+	//                 <"" (empty-sentinel Lit)>;
+	//   resource arm: <"" (arrayFilter's `v != ''` sentinel, bound before
+	//                 the array literal)>,
+	//                 <name (the one candidate's ResourceAttributes[?]
+	//                 array element)>.
+	perTable := []any{"job", "job", "", "", "job"}
+	wantArgs := make([]any, 0, len(perTable)*3)
+	for range 3 {
+		wantArgs = append(wantArgs, perTable...)
+	}
+	if !reflect.DeepEqual(q.lastArgs, wantArgs) {
+		t.Errorf("args = %#v, want %#v", q.lastArgs, wantArgs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #3168: `GET /api/v1/label/<name>/values` for any allowlisted resource
label with 2+ rewritable underscores (e.g. `deployment_environment_name`,
and the same mechanism affects `k8s_cluster_name`, `k8s_node_name`,
`k8s_pod_name`, `k8s_container_name`) could time out.

`format.PromLabelToOTelCandidates` expands a name with N rewritable
underscores into a powerset of dot/slash/underscore spellings (7 candidates
for 2 underscores) — its own doc justifies this as cheap, assuming a
per-row coalesce cost model. `unionLabelValuesSQL` didn't build that: it
appended one independent `SELECT DISTINCT` sub-query per `(table ×
candidate)` pair into a `UNION ALL`, for BOTH arms. The attrs arm
(`Attributes` map) routes onto the `proj_series` projection per candidate —
fast even repeated. The resource arm (`ResourceAttributes` map) has no
such projection (by design — it's allowlist-gated and was assumed rare), so
multiplying it by the 7-candidate powerset turned "rare, one full scan" into
"7 full scans of the same table" — 21 unaccelerated raw scans across 3
metric tables, on top of 21 fast projection-backed ones. Verified live
against a real deployment reproducing the exact 120.42s timeout, and
confirmed via `system.processes` that the in-flight SQL matched this
42-sub-query structure.

## Fix

Collapses the resource arm from one scan per `(table, candidate)` to one
scan per table:

```sql
SELECT arrayJoin(arrayFilter(v -> v != '', [ResourceAttributes[k0], ResourceAttributes[k1], …])) AS value
FROM t [WHERE <window>]
```

`arrayFilter` drops the empty-string sentinel ClickHouse returns for an
absent Map key before `arrayJoin` explodes the survivors into rows, so a
row missing every candidate contributes zero rows — no separate not-empty
predicate needed, unlike the per-candidate `mapAtNotEmptyFrag` shape the
attrs arm still uses. The attrs arm is unchanged: it already routes onto
`proj_series` per candidate, so its own repetition wasn't implicated in the
reported timeout (flagged in #3168 as worth checking separately, not fixed
here).

Also factors the `MapAt`-Frag construction (`mapAtFrag`) both
`distinctMapAtFrag` and `mapAtNotEmptyFrag` were duplicating inline, so the
new resource-arm builder reuses it rather than a third copy.

## Test plan

- `go test ./internal/api/prom/...` and `go test -tags chdb
  ./internal/api/prom/...` — both pass, including real chDB execution of
  the rewritten SQL (not just structural assertions).
- `TestLabelValues_Endpoint` updated to pin the new, smaller per-table bind
  shape (5 args/table instead of two separate 3-arg-per-candidate arms) —
  the old assertion encoded the very shape this PR intentionally changes.
- `golangci-lint run ./internal/api/prom/...` — 0 issues.
- `node .github/scripts/forbid-sql-raw.mjs` — clean (typed Frag API only,
  invariant 10).
- CI on this PR.
