### PR TITLE
feat(telemetry): collect cerberus_queries_duration_seconds as a native histogram

### DIFF
--- a/.github/scripts/quickstart-canary.mjs
+++ b/.github/scripts/quickstart-canary.mjs
@@ -134,7 +134,7 @@ export const HOME_DASHBOARD_TARGETS = Object.freeze([
     datasourceUID: "cerberus-prometheus",
     kind: "prometheus",
     expression:
-      "histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket[5m])))",
+      "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))",
   }),
   Object.freeze({
     panelID: 3,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -214,18 +214,30 @@ attribute keys are a public contract — dashboards and alert rules
 reference them verbatim, and `internal/telemetry/contract_test.go` pins
 each one so a rename cannot ship silently.
 
-| Metric                                     | Type      | Attributes                                                                                  |
-| ------------------------------------------ | --------- | ------------------------------------------------------------------------------------------- |
-| `cerberus_queries_total`                   | counter   | `cerberus_ql`, `cerberus_route`, `result`, `cerberus_error_reason`, `cerberus_status_class` |
-| `cerberus_queries_duration_seconds`        | histogram | `cerberus_ql`, `cerberus_route`, `result`                                                   |
-| `cerberus_pipeline_stage_duration_seconds` | histogram | `stage`, `cerberus_ql`                                                                      |
-| `cerberus_optimizer_rules_applied`         | histogram | —                                                                                           |
-| `cerberus_clickhouse_rows_read`            | histogram | `cerberus_ql`                                                                               |
-| `cerberus_clickhouse_bytes_read`           | histogram | `cerberus_ql`                                                                               |
-| `cerberus_query_inflight`                  | gauge     | `cerberus_ql`                                                                               |
-| `cerberus_tempo_exemplar_failures_total`   | counter   | `stage`                                                                                     |
+| Metric                                     | Type               | Attributes                                                                                  |
+| ------------------------------------------ | ------------------ | ------------------------------------------------------------------------------------------- |
+| `cerberus_queries_total`                   | counter            | `cerberus_ql`, `cerberus_route`, `result`, `cerberus_error_reason`, `cerberus_status_class` |
+| `cerberus_queries_duration_seconds`        | histogram (native) | `cerberus_ql`, `cerberus_route`, `result`                                                   |
+| `cerberus_pipeline_stage_duration_seconds` | histogram          | `stage`, `cerberus_ql`                                                                      |
+| `cerberus_optimizer_rules_applied`         | histogram          | —                                                                                           |
+| `cerberus_clickhouse_rows_read`            | histogram          | `cerberus_ql`                                                                               |
+| `cerberus_clickhouse_bytes_read`           | histogram          | `cerberus_ql`                                                                               |
+| `cerberus_query_inflight`                  | gauge              | `cerberus_ql`                                                                               |
+| `cerberus_tempo_exemplar_failures_total`   | counter            | `stage`                                                                                     |
 
 `cerberus_tempo_exemplar_failures_total` counts Tempo `/api/metrics/query_range` (and its gRPC `MetricsQueryRange` counterpart) exemplar-enrichment failures, split by which half of the best-effort exemplar attach failed: `stage="emit"` for a `chsql.EmitMetricsExemplars` render failure, `stage="execute"` for a ClickHouse query failure on the rendered SQL. Both failures still return the matrix response with an empty `exemplars` array — the same wire shape as a window with genuinely no exemplars — so this counter is the only way to notice a systematic exemplar outage without reading logs.
+
+`cerberus_queries_duration_seconds` is collected as a native/exponential
+histogram (cerberus issue #3170), not the classic explicit-bucket shape
+`cerberus_pipeline_stage_duration_seconds` and the other histograms above
+still use. A PromQL query against it has no `_bucket` series or `le` label:
+`histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))`
+is the whole expression, not `sum by (le, cerberus_ql) (rate(..._bucket[5m]))`.
+The switch removes this metric from the class of risk a wide classic
+histogram carries under the `RangeBucketGridNative` query-time cost guard
+(`internal/chsql/range_bucket_grid_native_bound.go`) — this metric already
+tripped that guard once, at a 24h self-monitoring window, before the
+guard's own recalibration fixed that specific incident.
 
 #### ClickHouse connection lifecycle
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -240,9 +240,55 @@ func newMeterProvider(ctx context.Context, cfg Config, res *resource.Resource) (
 	mp := sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exp, readerOpts...)),
 		sdkmetric.WithResource(res),
+		sdkmetric.WithView(queryDurationNativeHistogramView),
 	)
 	return mp, mp.Shutdown, nil
 }
+
+// queryDurationExpoHistogramMaxSize and …MaxScale are the OTel exponential
+// histogram spec's own documented defaults (the same values every major
+// OTel SDK ships when a caller doesn't override them): up to 160 buckets,
+// starting at the maximum resolution scale (20) and auto-narrowing as
+// measurements arrive. sdkmetric.AggregationBase2ExponentialHistogram's own
+// zero value is NOT a usable "use the SDK default" sentinel — its err()
+// rejects MaxSize <= 0, and sdkmetric.NewView silently drops (logs via
+// go.opentelemetry.io/otel's global error handler, otherwise unnoticed) an
+// Aggregation that fails validation, falling back to the classic default
+// this View exists to override. An unvalidated zero-value struct here would
+// make queryDurationNativeHistogramView a silent no-op.
+const (
+	queryDurationExpoHistogramMaxSize  = 160
+	queryDurationExpoHistogramMaxScale = 20
+)
+
+// queryDurationNativeHistogramView collects cerberus_queries_duration_seconds
+// (internal/telemetry/metrics.go's QueryDuration) as a native/exponential
+// histogram instead of the classic explicit-bucket-boundary aggregation its
+// own WithExplicitBucketBoundaries construction would otherwise get by
+// default (cerberus issue #3170). A classic histogram stores one physical
+// row per (series, `le` rung) — that storage shape, not this metric's own
+// cardinality, is what let the nightly e2e stack's own self-monitoring
+// dashboard trip the unrelated RangeBucketGridNative density guard once
+// before (range_bucket_grid_native_bound.go's "Issue #2522 recalibration"
+// section, querying this exact metric at a 24h/15s window). Native
+// histograms store the whole distribution as one compact row per (series,
+// timestamp), so that class of risk does not apply to them at all — see
+// cerberus issue #3165's investigation for the full comparison.
+//
+// StageDuration and the other histograms in metrics.go stay classic for now
+// — this metric is the one with a real prior incident and the one queried
+// in test/e2e/grafana/dashboards/cerberus.json, so it is the one worth the
+// dashboard-query-shape migration (native histogram PromQL has no `_bucket`
+// series or `le` label) that came with this change.
+var queryDurationNativeHistogramView = sdkmetric.NewView(
+	sdkmetric.Instrument{Name: "cerberus_queries_duration_seconds"},
+	sdkmetric.Stream{
+		Aggregation: sdkmetric.AggregationBase2ExponentialHistogram{
+			MaxSize:  queryDurationExpoHistogramMaxSize,
+			MaxScale: queryDurationExpoHistogramMaxScale,
+		},
+	},
+)
 
 // newLoggerProvider builds the OTLP gRPC logger provider that gives
 // the third o11y pillar (logs) the same wire-level treatment as traces

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -8,6 +8,7 @@ import (
 
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
@@ -33,6 +34,51 @@ func TestNew_NoopWhenEndpointEmpty(t *testing.T) {
 
 	if err := providers.Shutdown(t.Context()); err != nil {
 		t.Errorf("Shutdown: %v", err)
+	}
+}
+
+// TestQueryDurationNativeHistogramView pins that
+// queryDurationNativeHistogramView actually activates rather than silently
+// no-opping. sdkmetric.AggregationBase2ExponentialHistogram's own zero
+// value fails the SDK's internal validation (MaxSize <= 0) and
+// sdkmetric.NewView drops an invalid Aggregation without returning an
+// error — the resulting View still matches the instrument but falls back
+// to the classic default aggregation, which would make this whole cerberus
+// issue #3170 change a no-op nobody would notice locally. Recording
+// through a real MeterProvider with this View installed and asserting the
+// collected data point is genuinely metricdata.ExponentialHistogram (not
+// metricdata.Histogram) is the only way to catch that class of mistake.
+func TestQueryDurationNativeHistogramView(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithView(queryDurationNativeHistogramView),
+	)
+	t.Cleanup(func() { _ = mp.Shutdown(t.Context()) })
+
+	hist, err := mp.Meter("test").Float64Histogram("cerberus_queries_duration_seconds")
+	if err != nil {
+		t.Fatalf("Float64Histogram: %v", err)
+	}
+	hist.Record(t.Context(), 1.23)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(t.Context(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(rm.ScopeMetrics) != 1 || len(rm.ScopeMetrics[0].Metrics) != 1 {
+		t.Fatalf("ScopeMetrics = %#v, want exactly one metric", rm.ScopeMetrics)
+	}
+	m := rm.ScopeMetrics[0].Metrics[0]
+	expo, ok := m.Data.(metricdata.ExponentialHistogram[float64])
+	if !ok {
+		t.Fatalf("metric %q Data = %T, want metricdata.ExponentialHistogram[float64] — the View is not activating (falling back to the classic default aggregation)", m.Name, m.Data)
+	}
+	if len(expo.DataPoints) != 1 {
+		t.Fatalf("DataPoints = %#v, want exactly one", expo.DataPoints)
+	}
+	if got := expo.DataPoints[0].Count; got != 1 {
+		t.Errorf("DataPoints[0].Count = %d, want 1", got)
 	}
 }
 

--- a/test/e2e/grafana/compose/dashboards/cerberus.json
+++ b/test/e2e/grafana/compose/dashboards/cerberus.json
@@ -119,7 +119,7 @@
         "type": "prometheus",
         "uid": "cerberus-prometheus"
       },
-      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds_bucket with histogram_quantile.",
+      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -196,7 +196,7 @@
             "uid": "cerberus-prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))",
           "legendFormat": "p95 {{cerberus_ql}}",
           "range": true,
           "refId": "A"

--- a/test/e2e/grafana/dashboards/cerberus.json
+++ b/test/e2e/grafana/dashboards/cerberus.json
@@ -119,7 +119,7 @@
         "type": "prometheus",
         "uid": "cerberus-prometheus"
       },
-      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds_bucket with histogram_quantile.",
+      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -196,7 +196,7 @@
             "uid": "cerberus-prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))",
           "legendFormat": "p95 {{cerberus_ql}}",
           "range": true,
           "refId": "A"

--- a/test/e2e/k3s/grafana-dashboards.yaml
+++ b/test/e2e/k3s/grafana-dashboards.yaml
@@ -155,7 +155,7 @@ data:
             "type": "prometheus",
             "uid": "cerberus-prometheus"
           },
-          "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds_bucket with histogram_quantile.",
+          "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -232,7 +232,7 @@ data:
                 "uid": "cerberus-prometheus"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum by (le, cerberus_ql) (rate(cerberus_queries_duration_seconds_bucket[5m])))",
+              "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))",
               "legendFormat": "p95 {{cerberus_ql}}",
               "range": true,
               "refId": "A"


### PR DESCRIPTION
## Summary

Fixes #3170. Cerberus's own shipped self-telemetry histograms were all
classic (explicit-bucket) histograms, built via
`metric.WithExplicitBucketBoundaries(...)` with no `sdkmetric.WithView`
overriding the aggregation anywhere in the `MeterProvider` construction.

This session's investigation into a real production incident (#3165,
#3167, #3168) established that a classic histogram's storage shape — one
physical row per (series, `le` rung) — is exactly what makes a wide,
high-cardinality histogram vulnerable to the `RangeBucketGridNative`
density guard, and that native/exponential histograms are structurally
exempt from that risk class entirely: they store the whole distribution as
one compact row per (series, timestamp), so `groups` (series × rung count)
never gets multiplied by bucket count in storage.

`cerberus_queries_duration_seconds` specifically already tripped this exact
guard once before — `range_bucket_grid_native_bound.go`'s own "Issue #2522
recalibration" section documents the nightly e2e stack's own self-monitoring
dashboard hitting it at a 24h/15s window. That was fixed by recalibrating
the guard, not by removing the risk from cerberus's own metric — the next
label added to `QueryTimer.Done` or the next long-window self-monitoring
dashboard carries the same latent exposure forward.

## Change

- `internal/telemetry/telemetry.go`: adds `sdkmetric.WithView(...)`
  collecting `cerberus_queries_duration_seconds` as
  `AggregationBase2ExponentialHistogram{MaxSize: 160, MaxScale: 20}` — the
  OTel spec's own documented defaults, explicitly set rather than left at
  the zero value. That distinction matters: the `Aggregation`'s zero value
  (`MaxSize: 0`) fails the SDK's own internal validation and
  `sdkmetric.NewView` silently drops an invalid `Aggregation`
  (logged only via OTel's global error handler), falling back to the
  classic default this whole change exists to override — an easy way to
  ship a no-op that looks correct at a glance.
- A new activation test (`TestQueryDurationNativeHistogramView`) collects
  through a real `MeterProvider` with the View installed and asserts the
  resulting data point is genuinely `metricdata.ExponentialHistogram`, not
  `metricdata.Histogram` — specifically to catch the no-op-by-invalid-zero-value
  mistake above, since every *other* existing telemetry test builds its own
  bare test `MeterProvider` without this View and would not have noticed.
- Updates both checked-in e2e Grafana dashboards' "P95 latency by language"
  panel to the native-histogram PromQL shape: no `_bucket` series, no `le`
  label — `histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))`.
  Verified this exact aggregate-then-quantile shape over a native histogram
  is a covered spec fixture (`test/spec/promql/histogram_quantile_native_agg_groupby.txtar`).
- Updates `docs/observability.md`'s self-metrics table and prose.

No collector config changes needed: the e2e/dogfood pipeline's
`clickhouseexporter` routes by OTLP data type, and cerberus's default
schema already provisions the exponential-histogram destination table
(`schema.Metrics.ExpHistogramTable`) unconditionally.

`StageDuration` and the other histograms in `metrics.go` stay classic for
now — deliberately scoped to the one metric with a real prior incident and
a checked-in dashboard query, not converting everything at once (open
question left in #3170 for anyone who wants to extend this later).

## Test plan

- `go build ./...`, `go test ./internal/telemetry/...` — pass, including
  the new activation test.
- `golangci-lint run ./internal/telemetry/...` — 0 issues.
- Verified both dashboard JSON files still parse (`python3 -m json.tool`).
- CI on this PR (the `dashboard` / `dashboard-crawl-terminal` e2e lanes
  exercise the updated panel against a live stack).
