### PR TITLE
fix(telemetry,ci): rename exp-hist metric for routing, calibrate datashard memory diagnostics

### DIFF
--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -548,6 +548,7 @@ async function main() {
             c.query_kind, c.initial_query_id,
             if(i.client_hostname != '', i.client_hostname, c.client_hostname) AS cerberus_host,
             c.Settings['max_memory_usage'] AS mem,
+            c.memory_usage AS mem_used,
             replaceRegexpAll(substring(c.query, 1, 300), '[\\t\\n\\r]+', ' ') AS query_snippet
      FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log) AS c
      GLOBAL LEFT JOIN (
@@ -561,8 +562,8 @@ async function main() {
        AND c.event_time >= toDateTime(${windowStart}) AND c.event_time <= toDateTime(${windowEnd})`,
   );
   const shardStmts = shardStmtRows.map((r) => {
-    const [s, d, kind, qid, host, mem, snippet] = r.split('\t');
-    return { startUs: Number(s), durUs: Number(d), kind, qid, host, mem, snippet };
+    const [s, d, kind, qid, host, mem, memUsed, snippet] = r.split('\t');
+    return { startUs: Number(s), durUs: Number(d), kind, qid, host, mem, memUsed: Number(memUsed), snippet };
   });
   const peakConcurrentShardStatements = maxConcurrent(shardStmts);
   const kindCounts = {};
@@ -719,16 +720,43 @@ async function main() {
     }
   }
 
+  // Real-usage headroom diagnostic, logged on EVERY run, pass or fail, so a
+  // MEMORY_LIMIT_EXCEEDED failure is never the first time this lane learns
+  // how close the tightest apportioned tier (highest observed kEff x
+  // DataShardCount) actually runs to a real query's measured memory_usage.
+  // Grouped by kEff, not by trace, since the question this answers is "does
+  // headroom shrink as kEff grows" — exactly the axis perShardMemoryBytes
+  // divides on.
+  const usageByKEff = new Map();
+  for (const r of selectRows) {
+    if (!(r.memUsed > 0)) continue;
+    const kEff = kEffByTrace.get(r.qid.slice(0, 32)) || 1;
+    const ceiling = Math.max(1, Math.floor(queryMaxMemoryBytes / (kEff * DATA_SHARD_COUNT)));
+    if (!usageByKEff.has(kEff)) usageByKEff.set(kEff, { max: 0, ceiling });
+    const bucket = usageByKEff.get(kEff);
+    if (r.memUsed > bucket.max) bucket.max = r.memUsed;
+  }
+  for (const [kEff, { max, ceiling }] of [...usageByKEff].sort((a, b) => a[0] - b[0])) {
+    log(`kEff=${kEff}: peak real memory_usage observed=${max} against configured ceiling=${ceiling} (headroom=${(((ceiling - max) / ceiling) * 100).toFixed(1)}%)`);
+  }
+
   const exceptionRows = chQueryTSV(
     initiatorPod,
-    `SELECT count() FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log)
-     WHERE type = 'ExceptionWhileProcessing'
-       AND (exception_code = 241 OR exception ILIKE '%Memory limit%')
-       AND event_time >= toDateTime(${windowStart}) AND event_time <= toDateTime(${windowEnd})`,
+    `SELECT c.initial_query_id, c.Settings['max_memory_usage'] AS mem,
+            replaceRegexpAll(substring(c.query, 1, 300), '[\\t\\n\\r]+', ' ') AS query_snippet
+     FROM clusterAllReplicas('${CH_CLUSTER}', system.query_log) AS c
+     WHERE c.type = 'ExceptionWhileProcessing'
+       AND (c.exception_code = 241 OR c.exception ILIKE '%Memory limit%')
+       AND c.event_time >= toDateTime(${windowStart}) AND c.event_time <= toDateTime(${windowEnd})`,
   );
-  const exceptionCount = Number(exceptionRows[0] || '0');
+  const exceptionCount = exceptionRows.length;
   if (exceptionCount > 0) {
     error(`${exceptionCount} MEMORY_LIMIT_EXCEEDED exception(s) recorded in system.query_log during the burst — perShardMemoryBytes did not bound memory pressure as predicted`);
+    for (const row of exceptionRows) {
+      const [qid, mem, snippet] = row.split('\t');
+      const kEff = kEffByTrace.get((qid || '').slice(0, 32)) || 1;
+      log(`  exception: initial_query_id=${qid}, kEff=${kEff}, configured max_memory_usage=${mem}, query=${snippet}`);
+    }
     failures++;
   }
 

--- a/.github/scripts/quickstart-canary.mjs
+++ b/.github/scripts/quickstart-canary.mjs
@@ -134,7 +134,7 @@ export const HOME_DASHBOARD_TARGETS = Object.freeze([
     datasourceUID: "cerberus-prometheus",
     kind: "prometheus",
     expression:
-      "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))",
+      "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_exp_hist[5m])))",
   }),
   Object.freeze({
     panelID: 3,

--- a/cmd/cerberus/otel_metrics_test.go
+++ b/cmd/cerberus/otel_metrics_test.go
@@ -49,7 +49,7 @@ func TestTelemetryInstall_ManualReader(t *testing.T) {
 
 	want := map[string]bool{
 		"cerberus_queries_total":                   false,
-		"cerberus_queries_duration_seconds":        false,
+		"cerberus_queries_duration_exp_hist":       false,
 		"cerberus_pipeline_stage_duration_seconds": false,
 		"cerberus_optimizer_rules_applied":         false,
 		"cerberus_clickhouse_rows_read":            false,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -217,7 +217,7 @@ each one so a rename cannot ship silently.
 | Metric                                     | Type               | Attributes                                                                                  |
 | ------------------------------------------ | ------------------ | ------------------------------------------------------------------------------------------- |
 | `cerberus_queries_total`                   | counter            | `cerberus_ql`, `cerberus_route`, `result`, `cerberus_error_reason`, `cerberus_status_class` |
-| `cerberus_queries_duration_seconds`        | histogram (native) | `cerberus_ql`, `cerberus_route`, `result`                                                   |
+| `cerberus_queries_duration_exp_hist`       | histogram (native) | `cerberus_ql`, `cerberus_route`, `result`                                                   |
 | `cerberus_pipeline_stage_duration_seconds` | histogram          | `stage`, `cerberus_ql`                                                                      |
 | `cerberus_optimizer_rules_applied`         | histogram          | —                                                                                           |
 | `cerberus_clickhouse_rows_read`            | histogram          | `cerberus_ql`                                                                               |
@@ -227,11 +227,15 @@ each one so a rename cannot ship silently.
 
 `cerberus_tempo_exemplar_failures_total` counts Tempo `/api/metrics/query_range` (and its gRPC `MetricsQueryRange` counterpart) exemplar-enrichment failures, split by which half of the best-effort exemplar attach failed: `stage="emit"` for a `chsql.EmitMetricsExemplars` render failure, `stage="execute"` for a ClickHouse query failure on the rendered SQL. Both failures still return the matrix response with an empty `exemplars` array — the same wire shape as a window with genuinely no exemplars — so this counter is the only way to notice a systematic exemplar outage without reading logs.
 
-`cerberus_queries_duration_seconds` is collected as a native/exponential
+`cerberus_queries_duration_exp_hist` is collected as a native/exponential
 histogram (cerberus issue #3170), not the classic explicit-bucket shape
 `cerberus_pipeline_stage_duration_seconds` and the other histograms above
-still use. A PromQL query against it has no `_bucket` series or `le` label:
-`histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))`
+still use — the `_exp_hist` suffix is required, not cosmetic: cerberus's
+own PromQL read path has no wire-format way to tell a native histogram
+from a classic one, so it routes on that suffix alone
+(`schema.Metrics.ExpHistogramSuffix`). A PromQL query against it has no
+`_bucket` series or `le` label:
+`histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_exp_hist[5m])))`
 is the whole expression, not `sum by (le, cerberus_ql) (rate(..._bucket[5m]))`.
 The switch removes this metric from the class of risk a wide classic
 histogram carries under the `RangeBucketGridNative` query-time cost guard
@@ -407,7 +411,7 @@ separate processes — a property of that deployment, not of the metric.
 The stages (`parse` / `lower` / `optimize` / `emit` / `execute`) do not
 sum to the request duration: response materialisation and the row drain
 sit outside them, and on the streaming paths the drain runs while the
-response is being written. Use `cerberus_queries_duration_seconds` for
+response is being written. Use `cerberus_queries_duration_exp_hist` for
 the end-to-end number and the stage histogram for the breakdown within
 the engine.
 

--- a/internal/telemetry/contract_test.go
+++ b/internal/telemetry/contract_test.go
@@ -40,7 +40,7 @@ func TestMetricNames_PublicContract(t *testing.T) {
 
 	want := map[string]bool{
 		"cerberus_queries_total":                   false,
-		"cerberus_queries_duration_seconds":        false,
+		"cerberus_queries_duration_exp_hist":       false,
 		"cerberus_pipeline_stage_duration_seconds": false,
 		"cerberus_optimizer_rules_applied":         false,
 		"cerberus_clickhouse_rows_read":            false,
@@ -86,7 +86,7 @@ func TestMetricUnits_PublicContract(t *testing.T) {
 
 	wantUnits := map[string]string{
 		"cerberus_queries_total":                   "{query}",
-		"cerberus_queries_duration_seconds":        "s",
+		"cerberus_queries_duration_exp_hist":       "s",
 		"cerberus_pipeline_stage_duration_seconds": "s",
 		"cerberus_optimizer_rules_applied":         "{rule}",
 		"cerberus_clickhouse_rows_read":            "{row}",

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -365,7 +365,7 @@ func mustBuild(meter metric.Meter) *Instruments {
 		panic("telemetry: build queries_total: " + err.Error())
 	}
 	queryDuration, err := meter.Float64Histogram(
-		"cerberus_queries_duration_seconds",
+		"cerberus_queries_duration_exp_hist",
 		metric.WithDescription("End-to-end query wall-clock, seconds."),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries(QueryDurationBoundaries...),

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -122,14 +122,14 @@ func TestHistogramBucketBoundaries(t *testing.T) {
 		wantBounds []float64
 		value      float64 // representative observation recorded by record
 	}{
-		{
-			metricName: "cerberus_queries_duration_seconds",
-			record: func(ctx context.Context) {
-				telemetry.Get().QueryDuration.Record(ctx, 0.3)
-			},
-			wantBounds: telemetry.QueryDurationBoundaries,
-			value:      0.3, // a realistic query duration → (0.25, 0.5]
-		},
+		// cerberus_queries_duration_exp_hist is deliberately absent here: it
+		// is collected as a native/exponential histogram in production
+		// (telemetry.go's queryDurationNativeHistogramView), which has no
+		// fixed explicit-bucket ladder to pin — TestQueryDurationNativeHistogramView
+		// (telemetry_test.go) covers its real exported shape instead. This
+		// table's provider never installs that View (see installManualReader),
+		// so asserting classic bounds here would pin a configuration
+		// production never actually uses for this metric.
 		{
 			metricName: "cerberus_pipeline_stage_duration_seconds",
 			record: func(ctx context.Context) {
@@ -215,12 +215,10 @@ func TestDurationBoundaries_SlowTailIsResolvable(t *testing.T) {
 		record     func(ctx context.Context, v float64)
 		values     []float64
 	}{
-		{
-			metricName: "cerberus_queries_duration_seconds",
-			bounds:     telemetry.QueryDurationBoundaries,
-			record:     func(ctx context.Context, v float64) { telemetry.Get().QueryDuration.Record(ctx, v) },
-			values:     []float64{45, 90, 200},
-		},
+		// cerberus_queries_duration_exp_hist is deliberately absent here —
+		// see TestHistogramBucketBoundaries's own comment: it has no fixed
+		// bucket ladder in production, so a "slow tail lands in a finite
+		// bucket" property doesn't apply to it.
 		{
 			metricName: "cerberus_pipeline_stage_duration_seconds",
 			bounds:     telemetry.StageDurationBoundaries,
@@ -270,7 +268,7 @@ func TestDurationBoundaries_SlowTailIsResolvable(t *testing.T) {
 // TestObserveQuery_RecordsCounterAndDuration covers the QueryTimer
 // happy path: a single Done(ResultOK) call must bump
 // cerberus_queries_total by one and record a point on
-// cerberus_queries_duration_seconds with matching attributes.
+// cerberus_queries_duration_exp_hist with matching attributes.
 func TestObserveQuery_RecordsCounterAndDuration(t *testing.T) {
 	reader := installManualReader(t)
 
@@ -298,7 +296,7 @@ func TestObserveQuery_RecordsCounterAndDuration(t *testing.T) {
 		t.Errorf("result attr: got %v ok=%v", v.AsString(), ok)
 	}
 
-	dur := findMetric(t, sm, "cerberus_queries_duration_seconds")
+	dur := findMetric(t, sm, "cerberus_queries_duration_exp_hist")
 	hist, ok := dur.Data.(metricdata.Histogram[float64])
 	if !ok {
 		t.Fatalf("queries.duration: unexpected data type %T", dur.Data)
@@ -617,7 +615,7 @@ func TestQueryMiddleware_PanicRecovered_RendersEnvelopeAndCountsError(t *testing
 	}
 	// The duration histogram must also record the panicked query so its
 	// count stays balanced with the total counter.
-	dur := findMetric(t, sm, "cerberus_queries_duration_seconds")
+	dur := findMetric(t, sm, "cerberus_queries_duration_exp_hist")
 	dh := dur.Data.(metricdata.Histogram[float64])
 	if len(dh.DataPoints) != 1 || dh.DataPoints[0].Count != 1 {
 		t.Errorf("query_duration: got %+v want one DP with count=1", dh.DataPoints)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -261,7 +261,7 @@ const (
 	queryDurationExpoHistogramMaxScale = 20
 )
 
-// queryDurationNativeHistogramView collects cerberus_queries_duration_seconds
+// queryDurationNativeHistogramView collects cerberus_queries_duration_exp_hist
 // (internal/telemetry/metrics.go's QueryDuration) as a native/exponential
 // histogram instead of the classic explicit-bucket-boundary aggregation its
 // own WithExplicitBucketBoundaries construction would otherwise get by
@@ -275,13 +275,24 @@ const (
 // timestamp), so that class of risk does not apply to them at all — see
 // cerberus issue #3165's investigation for the full comparison.
 //
+// The instrument's own registered name carries the `_exp_hist` suffix —
+// not just its aggregation — because cerberus's own PromQL read path has
+// no wire-format way to tell a native histogram from a classic one by
+// type; it routes purely on that suffix
+// (schema.Metrics.ExpHistogramSuffix, internal/schema/otel.go). Overriding
+// only the Aggregation here while leaving the instrument named
+// `cerberus_queries_duration_seconds` would collect the data correctly
+// but leave every PromQL query against it silently resolving to nothing,
+// since the read path would still look for a `_bucket` series that no
+// longer exists.
+//
 // StageDuration and the other histograms in metrics.go stay classic for now
 // — this metric is the one with a real prior incident and the one queried
 // in test/e2e/grafana/dashboards/cerberus.json, so it is the one worth the
 // dashboard-query-shape migration (native histogram PromQL has no `_bucket`
 // series or `le` label) that came with this change.
 var queryDurationNativeHistogramView = sdkmetric.NewView(
-	sdkmetric.Instrument{Name: "cerberus_queries_duration_seconds"},
+	sdkmetric.Instrument{Name: "cerberus_queries_duration_exp_hist"},
 	sdkmetric.Stream{
 		Aggregation: sdkmetric.AggregationBase2ExponentialHistogram{
 			MaxSize:  queryDurationExpoHistogramMaxSize,

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -56,7 +56,7 @@ func TestQueryDurationNativeHistogramView(t *testing.T) {
 	)
 	t.Cleanup(func() { _ = mp.Shutdown(t.Context()) })
 
-	hist, err := mp.Meter("test").Float64Histogram("cerberus_queries_duration_seconds")
+	hist, err := mp.Meter("test").Float64Histogram("cerberus_queries_duration_exp_hist")
 	if err != nil {
 		t.Fatalf("Float64Histogram: %v", err)
 	}

--- a/test/e2e/grafana/compose/dashboards/cerberus.json
+++ b/test/e2e/grafana/compose/dashboards/cerberus.json
@@ -119,7 +119,7 @@
         "type": "prometheus",
         "uid": "cerberus-prometheus"
       },
-      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
+      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_exp_hist (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -196,7 +196,7 @@
             "uid": "cerberus-prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_exp_hist[5m])))",
           "legendFormat": "p95 {{cerberus_ql}}",
           "range": true,
           "refId": "A"

--- a/test/e2e/grafana/dashboards/cerberus.json
+++ b/test/e2e/grafana/dashboards/cerberus.json
@@ -119,7 +119,7 @@
         "type": "prometheus",
         "uid": "cerberus-prometheus"
       },
-      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
+      "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_exp_hist (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -196,7 +196,7 @@
             "uid": "cerberus-prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_exp_hist[5m])))",
           "legendFormat": "p95 {{cerberus_ql}}",
           "range": true,
           "refId": "A"

--- a/test/e2e/k3s/grafana-dashboards.yaml
+++ b/test/e2e/k3s/grafana-dashboards.yaml
@@ -155,7 +155,7 @@ data:
             "type": "prometheus",
             "uid": "cerberus-prometheus"
           },
-          "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_seconds (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
+          "description": "P95 query latency per head (PromQL / LogQL / TraceQL), computed from cerberus_queries_duration_exp_hist (a native/exponential histogram, cerberus issue #3170) with histogram_quantile.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -232,7 +232,7 @@ data:
                 "uid": "cerberus-prometheus"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_seconds[5m])))",
+              "expr": "histogram_quantile(0.95, sum by (cerberus_ql) (rate(cerberus_queries_duration_exp_hist[5m])))",
               "legendFormat": "p95 {{cerberus_ql}}",
               "range": true,
               "refId": "A"


### PR DESCRIPTION
## Summary

Root-caused and fixed both failures from the `e2e` workflow run that went red right after PR #3173 merged to `main` (https://github.com/tsouza/cerberus/actions/runs/34178809542):

1. **Dashboard "P95 latency by language" panel showing "No data"** (deterministic, both runs since #3171). PR #3171 switched `cerberus_queries_duration_seconds` to a native/exponential histogram in the OTel SDK layer and updated its panel query to the native shape, but never renamed the exported metric. Cerberus's own PromQL read path has no wire-format way to tell a native histogram from a classic one — it routes purely on the `_exp_hist` name suffix (`schema.Metrics.ExpHistogramSuffix`). Without that suffix the read path still looks for a classic `_bucket` companion series that no longer exists and silently returns empty. Fixed by renaming to `cerberus_queries_duration_exp_hist` (#3171 hasn't shipped in any tagged release yet, so a straight rename is safe — no dual-emit period needed per the contract test's own stated policy).

2. **`e2e-datashard-verify`: `MEMORY_LIMIT_EXCEEDED`** (flaky, ~0.09% of statements, unrelated to recent commits — the same lane has failed on *different* assertions almost daily for the past two days). Root cause: the datashard lane deliberately collapses split thresholds to reach `kEff` up to `CERBERUS_SHARD_MAX_K=8`, which floors the per-shard ClickHouse memory budget as low as ~64MB for wide Map-column trace/log queries, but `CERBERUS_CH_QUERY_MAX_MEMORY` was never recalibrated for that divisor. The apportionment formula itself is provably correct (no "not within" failures). Rather than guess a new cap, added diagnostic logging (real `memory_usage` per kEff bucket, plus per-exception query/kEff detail) so the next natural run of this lane — it runs on every push and nightly regardless — gives real numbers to size the cap from, the same way `DataShardFanoutCap` was originally calibrated from a measured run.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/telemetry/... ./cmd/cerberus/... ./internal/api/...`
- [x] `gofumpt -l` / `goimports -l` clean on touched Go files
- [x] `node --test .github/scripts/e2e-datashard-verify.test.mjs` / `quickstart-canary.test.mjs`
- [x] `node --check` on both edited `.mjs` scripts
- [x] JSON/YAML syntax validated on all three dashboard files
- [x] `markdownlint-cli2 docs/observability.md`
- [ ] CI (`lint`, `strict-scan`, compat lanes, `e2e`/`compose-smoke`/`dashboard` — the crawl fix needs a live Grafana render to confirm the panel now shows data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
