### PR TITLE
refactor(ci): promote the datashard inter-node health poll to a shared helper

### DIFF
--- a/.github/scripts/chaos-run.mjs
+++ b/.github/scripts/chaos-run.mjs
@@ -61,6 +61,7 @@
 import process from 'node:process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { error, notice, log, capture } from './lib/gh.mjs';
+import { pollUntil } from './lib/poll.mjs';
 
 // ---- env / constants -------------------------------------------------
 
@@ -93,7 +94,6 @@ const CERBERUS_RECOVERY_DEADLINE_MS = 90_000; // replica reschedule + readyz gre
 const BREAKER_TRIP_DEADLINE_MS = 30_000; // drive volume until 503+Retry-After:5 lands
 const PARTITION_TRIP_DEADLINE_MS = 60_000; // slower: each dial blocks up to DialTimeout
 const METRIC_SETTLE_DEADLINE_MS = 90_000; // OTLP flush lag before self-metrics corroborate
-const POLL_INTERVAL_MS = 2_000;
 const SETTLE_INTERVAL_MS = 3_000;
 
 // Breaker HALF-OPEN -> CLOSED drive (ch-pod-kill heal). When CH comes back the
@@ -382,30 +382,6 @@ function restartSum(selector) {
     .map((s) => parseInt(s.trim(), 10))
     .filter((n) => Number.isFinite(n))
     .reduce((a, b) => a + b, 0);
-}
-
-// ---- bounded poll ----------------------------------------------------
-
-// pollUntil — invoke `fn` (async, returns truthy on success) every
-// intervalMs until it succeeds or deadlineMs elapses. Returns true on
-// success, false on timeout. The ASSERT-side retry primitive: faults are
-// one-shot + idempotent, recovery checks retry to their deadline.
-async function pollUntil(fn, { deadlineMs, intervalMs = POLL_INTERVAL_MS, label = '' } = {}) {
-  const start = Date.now();
-  let attempt = 0;
-  while (Date.now() - start < deadlineMs) {
-    attempt += 1;
-    let ok = false;
-    try {
-      ok = await fn(attempt);
-    } catch (e) {
-      ok = false;
-      log(`    [poll ${label}] attempt ${attempt} threw: ${String(e?.message || e)}`);
-    }
-    if (ok) return true;
-    await sleep(intervalMs);
-  }
-  return false;
 }
 
 // ---- shared assertions -----------------------------------------------

--- a/.github/scripts/e2e-datashard-replica-affinity-verify.mjs
+++ b/.github/scripts/e2e-datashard-replica-affinity-verify.mjs
@@ -79,16 +79,19 @@
 // window `first_or_random` can legitimately prefer a NON-offset-0 replica,
 // which is exactly the false positive this leg exists to rule out (observed
 // live: run 34103918151, cerberus issue #3148). `system.clusters.errors_count`
-// is that same error-tracking state, readable directly, so this script polls
-// it to a clean state (every row's `errors_count = 0`) before firing the
-// affinity-verify burst — proving the fan-out load only starts once the
-// cluster has actually settled, rather than inferring settlement from pod
-// readiness alone.
+// is that same error-tracking state, readable directly, so this script waits
+// for a clean state (every row's `errors_count = 0`) via
+// `lib/k8s.mjs`'s `waitForClusterHealth` — promoted there by cerberus issue
+// #3172 so any OTHER datashard-lane script that fires load right after
+// cluster-up can wait out the same race, not just this one — before firing
+// the affinity-verify burst. That proves the fan-out load only starts once
+// the cluster has actually settled, rather than inferring settlement from
+// pod readiness alone.
 
 import process from 'node:process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { error, notice, log, capture } from './lib/gh.mjs';
-import { makeKubectl, clickhousePodName, chQuery } from './lib/k8s.mjs';
+import { makeKubectl, clickhousePodName, chQuery, waitForClusterHealth } from './lib/k8s.mjs';
 
 const NS = process.env.NAMESPACE || 'cerberus';
 const CERBERUS_URL = process.env.CERBERUS_URL || 'http://localhost:8080';
@@ -165,42 +168,6 @@ function hostnameShardReplica(hostname) {
   return { shard: Number(m[1]), replica: Number(m[2]) };
 }
 
-// waitForCleanClusterHealth polls system.clusters until every (shard,
-// replica) row's errors_count is 0, or HEALTH_POLL_SECONDS elapses — see the
-// module doc's "THE RACE THIS SCRIPT MUST NOT LOSE" section for why pod
-// readiness alone cannot stand in for inter-node connection health. Returns
-// the elapsed seconds on success; throws with the last-seen dirty rows on
-// timeout, since a burst fired into a cluster that never settled would only
-// reproduce the false positive this poll exists to close out.
-async function waitForCleanClusterHealth(pod) {
-  const deadline = Date.now() + HEALTH_POLL_SECONDS * 1000;
-  const pollIntervalMs = 2000;
-  let lastDirty = [];
-  for (;;) {
-    const rows = chQueryTSV(
-      pod,
-      `SELECT shard_num, replica_num, errors_count
-       FROM system.clusters WHERE cluster = '${CH_CLUSTER}'
-       ORDER BY shard_num, replica_num`,
-    );
-    lastDirty = rows
-      .map((r) => r.split('\t'))
-      .filter(([, , errorsCount]) => Number(errorsCount) !== 0);
-    if (lastDirty.length === 0) {
-      return (HEALTH_POLL_SECONDS * 1000 - (deadline - Date.now())) / 1000;
-    }
-    if (Date.now() >= deadline) {
-      const detail = lastDirty.map(([shard, replica, n]) => `shard=${shard} replica=${replica} errors_count=${n}`).join('; ');
-      throw new Error(
-        `system.clusters never reached a clean state (errors_count=0 for every replica) within ` +
-          `${HEALTH_POLL_SECONDS}s: ${detail} — firing the affinity burst now would risk observing a ` +
-          `replica-selection decision still influenced by the connection errors this poll exists to wait out`,
-      );
-    }
-    await sleep(pollIntervalMs);
-  }
-}
-
 async function main() {
   const pod = clickhousePodName(kubectl, NS);
   log(`replica-affinity verify: namespace=${NS} db=${DB} cluster=${CH_CLUSTER} dataShardCount=${DATA_SHARD_COUNT} replicas=${REPLICAS} pod=${pod}`);
@@ -235,7 +202,10 @@ async function main() {
   // `just e2e-datashard-up`'s pod-readiness gate proves nothing about
   // whether every node can already reach every peer replica.
   try {
-    const settleSeconds = await waitForCleanClusterHealth(pod);
+    const settleSeconds = await waitForClusterHealth(kubectl, pod, CH_OPTS, {
+      cluster: CH_CLUSTER,
+      deadlineMs: HEALTH_POLL_SECONDS * 1000,
+    });
     log(`cluster health confirmed clean (errors_count=0 for every replica) after ${settleSeconds.toFixed(1)}s`);
   } catch (e) {
     error(e.message);

--- a/.github/scripts/e2e-datashard-verify.mjs
+++ b/.github/scripts/e2e-datashard-verify.mjs
@@ -86,6 +86,7 @@
 //   BURST_SECONDS           sustained concurrent-load duration  (default 20)
 //   BURST_CONCURRENCY       concurrent requests in flight       (default 6)
 //   FLUSH_WAIT_SECONDS      settle time before SYSTEM FLUSH LOGS (default 10)
+//   HEALTH_POLL_SECONDS     bounded wait for a clean errors_count (default 60)
 //
 // Exit 0 = every assertion passed; 1 = any failed (with ::error:: annotation).
 
@@ -93,7 +94,7 @@ import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { error, notice, log, capture } from './lib/gh.mjs';
-import { makeKubectl, clickhousePodName, chQuery } from './lib/k8s.mjs';
+import { makeKubectl, clickhousePodName, chQuery, waitForClusterHealth } from './lib/k8s.mjs';
 
 const NS = process.env.NAMESPACE || 'cerberus';
 const CERBERUS_URL = process.env.CERBERUS_URL || 'http://localhost:8080';
@@ -107,6 +108,7 @@ const CERBERUS_ENV_CONFIGMAP = process.env.CERBERUS_ENV_CONFIGMAP || 'cerberus-e
 const BURST_SECONDS = Number(process.env.BURST_SECONDS || '20');
 const BURST_CONCURRENCY = Number(process.env.BURST_CONCURRENCY || '6');
 const FLUSH_WAIT_SECONDS = Number(process.env.FLUSH_WAIT_SECONDS || '10');
+const HEALTH_POLL_SECONDS = Number(process.env.HEALTH_POLL_SECONDS || '60');
 
 // requireDataShardCount is called from main, NOT at import time: this module
 // is imported by its own test suite for the pure interval arithmetic below,
@@ -399,6 +401,25 @@ async function main() {
   const oomedBefore = new Set(oomKilledPods(allPods));
   if (oomedBefore.size > 0) {
     log(`pre-burst baseline: ${oomedBefore.size} ClickHouse pod(s) already carry an OOMKilled lastState from before this script ran (${[...oomedBefore].join(', ')}) — only a NEW OOMKill is attributed to the burst`);
+  }
+
+  // ---- settle window: wait for a genuinely healthy inter-node state ----
+  // `just e2e-datashard-up`'s pod-readiness gate (`kubectl rollout status`)
+  // proves nothing about whether every data shard can already dial every
+  // OTHER shard — the same startup race e2e-datashard-replica-affinity-
+  // verify.mjs exists to rule out (cerberus issue #3148), and this script
+  // fires load against the exact same Distributed cross-shard fan-out right
+  // after cluster-up, so it is exposed to it too (cerberus issue #3172:
+  // waitForClusterHealth was previously private to that one script).
+  try {
+    const settleSeconds = await waitForClusterHealth(kubectl, initiatorPod, CH_OPTS, {
+      cluster: CH_CLUSTER,
+      deadlineMs: HEALTH_POLL_SECONDS * 1000,
+    });
+    log(`cluster health confirmed clean (errors_count=0 for every replica) after ${settleSeconds.toFixed(1)}s`);
+  } catch (e) {
+    error(e.message);
+    process.exit(1);
   }
 
   const burstStartMs = Date.now();

--- a/.github/scripts/lib/k8s.mjs
+++ b/.github/scripts/lib/k8s.mjs
@@ -21,8 +21,14 @@
 // through, each behind a two-line row-splitting wrapper of its own), so a
 // new script needing a different output format passes it here rather than
 // re-implementing the `kubectl exec ... clickhouse-client` invocation.
+// `waitForClusterHealth` (cerberus issue #3172) is the same story one level
+// up: it started as `e2e-datashard-replica-affinity-verify.mjs`'s own
+// private poll loop and was promoted here so every datashard-lane script
+// that fires load right after `just e2e-datashard-up` can wait out the
+// same startup race, not just the one script that first hit it.
 
 import { error } from './gh.mjs';
+import { pollUntil } from './poll.mjs';
 
 // Returns a `kubectl(args, opts) => capture() result` closure pinned to the
 // given namespace.
@@ -70,4 +76,68 @@ export function chQuery(kubectl, target, opts, sql) {
     process.exit(1);
   }
   return res.stdout.trim();
+}
+
+// clusterHealthPollIntervalMs is deliberately wider than pollUntil's own
+// DEFAULT_POLL_INTERVAL_MS: each iteration here spawns a fresh `kubectl
+// exec` + `clickhouse-client` subprocess (chQuery has no persistent-session
+// mode), and the phenomenon this poll waits out — ClickHouse's own
+// distributed_replica_error_half_life — decays over 60s by default, so
+// sub-second responsiveness buys nothing a caller could observe. 5s cuts a
+// worst-case 60s wait from ~30 subprocess spawns to ~12 while staying far
+// finer than the 60s time constant it is tracking.
+const clusterHealthPollIntervalMs = 5_000;
+
+// waitForClusterHealth polls `system.clusters` until every (shard, replica)
+// row's errors_count is 0, or deadlineMs elapses (cerberus issue #3148,
+// promoted to this shared module by issue #3172 — same class as #3109/PR
+// #3125's mode-toggle readiness race).
+//
+// THE RACE THIS EXISTS TO CLOSE: `just e2e-datashard-up`'s readiness gate
+// is `kubectl rollout status`, which only proves each ClickHouse pod's own
+// container passed its liveness/readiness probe — NOT that its inter-node
+// connections to every OTHER data shard (and, on a multi-replica-per-shard
+// topology, every peer replica) are already dialable. The first cross-node
+// dial issued before that settles gets refused, and ClickHouse increments
+// the target's `system.clusters.errors_count` server-side
+// (`PoolWithFailoverBase::Pool::error_count`) — during that decay window a
+// verify script observing replica/shard selection, or firing load that
+// assumes a settled cluster, would see behavior the startup race caused
+// rather than the steady-state behavior it means to check. This is why the
+// wait belongs here rather than in any ONE verify script: every datashard-
+// lane script that fires load right after cluster-up is exposed to it.
+//
+// `target` and `chOpts` are chQuery's own (a pod name or `deploy/foo`, and
+// `{ database, user, password }`). Returns the elapsed seconds on success.
+// Throws with the last-seen dirty rows on timeout — firing load into a
+// cluster that never settled would only reproduce the exact race this poll
+// exists to wait out.
+export async function waitForClusterHealth(kubectl, target, chOpts, { cluster, deadlineMs, intervalMs = clusterHealthPollIntervalMs } = {}) {
+  const start = Date.now();
+  let lastDirty = [];
+  const ok = await pollUntil(
+    async () => {
+      const out = chQuery(
+        kubectl,
+        target,
+        { ...chOpts, format: 'TSVRaw' },
+        `SELECT shard_num, replica_num, errors_count
+         FROM system.clusters WHERE cluster = '${cluster}'
+         ORDER BY shard_num, replica_num`,
+      );
+      const rows = out.split('\n').map((l) => l.trimEnd()).filter((l) => l.length > 0);
+      lastDirty = rows.map((r) => r.split('\t')).filter(([, , errorsCount]) => Number(errorsCount) !== 0);
+      return lastDirty.length === 0;
+    },
+    { deadlineMs, intervalMs, label: 'cluster-health' },
+  );
+  if (!ok) {
+    const detail = lastDirty.map(([shard, replica, n]) => `shard=${shard} replica=${replica} errors_count=${n}`).join('; ');
+    throw new Error(
+      `system.clusters never reached a clean state (errors_count=0 for every replica) within ` +
+        `${(deadlineMs / 1000).toFixed(0)}s: ${detail} — firing load now would risk observing a ` +
+        `decision still influenced by the connection errors this poll exists to wait out`,
+    );
+  }
+  return (Date.now() - start) / 1000;
 }

--- a/.github/scripts/lib/k8s.test.mjs
+++ b/.github/scripts/lib/k8s.test.mjs
@@ -16,7 +16,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { makeKubectl, clickhousePodName, chQuery, chQueryRaw } from './k8s.mjs';
+import { makeKubectl, clickhousePodName, chQuery, chQueryRaw, waitForClusterHealth } from './k8s.mjs';
 
 // fakeCapture — records every invocation and answers from a queue of
 // canned { status, stdout, stderr } results, FIFO.
@@ -69,4 +69,35 @@ test('chQuery returns trimmed stdout on success', () => {
   const { capture } = fakeCapture([{ status: 0, stdout: '  42\n', stderr: '' }]);
   const kubectl = makeKubectl(capture, 'cerberus');
   assert.equal(chQuery(kubectl, 'chpod', { database: 'otel' }, 'SELECT count()'), '42');
+});
+
+test('waitForClusterHealth resolves once every replica reports errors_count=0', async () => {
+  const { capture, calls } = fakeCapture([{ status: 0, stdout: '0\t0\t0\n0\t1\t0\n', stderr: '' }]);
+  const kubectl = makeKubectl(capture, 'cerberus');
+  const elapsed = await waitForClusterHealth(kubectl, 'chpod', { database: 'otel' }, {
+    cluster: 'bwc_cluster', deadlineMs: 1000, intervalMs: 0,
+  });
+  assert.ok(elapsed >= 0);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].join(' '), /--format TSVRaw/);
+  assert.match(calls[0].join(' '), /cluster = 'bwc_cluster'/);
+});
+
+test('waitForClusterHealth retries until errors_count clears', async () => {
+  const { capture, calls } = fakeCapture([
+    { status: 0, stdout: '0\t0\t3\n', stderr: '' }, // dirty — retries
+    { status: 0, stdout: '0\t0\t0\n', stderr: '' }, // clean — resolves
+  ]);
+  const kubectl = makeKubectl(capture, 'cerberus');
+  await waitForClusterHealth(kubectl, 'chpod', {}, { cluster: 'bwc_cluster', deadlineMs: 1000, intervalMs: 0 });
+  assert.equal(calls.length, 2);
+});
+
+test('waitForClusterHealth rejects with dirty-row detail once deadlineMs elapses', async () => {
+  const capture = () => ({ status: 0, stdout: '0\t0\t7\n1\t0\t2\n', stderr: '' });
+  const kubectl = makeKubectl(capture, 'cerberus');
+  await assert.rejects(
+    () => waitForClusterHealth(kubectl, 'chpod', {}, { cluster: 'bwc_cluster', deadlineMs: 15, intervalMs: 5 }),
+    /shard=0 replica=0 errors_count=7; shard=1 replica=0 errors_count=2/,
+  );
 });

--- a/.github/scripts/lib/poll.mjs
+++ b/.github/scripts/lib/poll.mjs
@@ -1,0 +1,40 @@
+// poll.mjs — the generic deadline+interval polling primitive shared across
+// the e2e/chaos Node scripts (cerberus issue #3172). Started as a private
+// helper inside chaos-run.mjs; promoted here because a second script
+// (e2e-datashard-replica-affinity-verify.mjs) had already re-derived the
+// same deadline+poll+sleep loop by hand rather than reusing it, and nothing
+// stopped a third from doing the same — a bug fixed in one hand-rolled copy
+// would not have propagated to the others.
+
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { log } from './gh.mjs';
+
+// DEFAULT_POLL_INTERVAL_MS matches chaos-run.mjs's own pre-promotion
+// POLL_INTERVAL_MS exactly, so moving pollUntil here changes nothing for
+// any of its existing call sites that rely on the default.
+export const DEFAULT_POLL_INTERVAL_MS = 2_000;
+
+// pollUntil invokes `fn` (async, returns truthy on success) every
+// intervalMs until it succeeds or deadlineMs elapses. Returns true on
+// success, false on timeout. A thrown `fn` counts as one failed attempt
+// (logged, not re-thrown) rather than aborting the poll — the ASSERT-side
+// retry primitive: faults are one-shot + idempotent, recovery checks retry
+// to their deadline.
+export async function pollUntil(fn, { deadlineMs, intervalMs = DEFAULT_POLL_INTERVAL_MS, label = '' } = {}) {
+  const start = Date.now();
+  let attempt = 0;
+  while (Date.now() - start < deadlineMs) {
+    attempt += 1;
+    let ok = false;
+    try {
+      ok = await fn(attempt);
+    } catch (e) {
+      ok = false;
+      log(`    [poll ${label}] attempt ${attempt} threw: ${String(e?.message || e)}`);
+    }
+    if (ok) return true;
+    await sleep(intervalMs);
+  }
+  return false;
+}

--- a/.github/scripts/lib/poll.test.mjs
+++ b/.github/scripts/lib/poll.test.mjs
@@ -1,0 +1,76 @@
+// poll.test.mjs — node:test guard for lib/poll.mjs's pollUntil (cerberus
+// issue #3172). Every case uses a 0ms intervalMs so the suite runs
+// instantly regardless of the real deadline being asserted against.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { pollUntil } from './poll.mjs';
+
+test('pollUntil returns true the first time fn succeeds', async () => {
+  let calls = 0;
+  const ok = await pollUntil(
+    async () => {
+      calls++;
+      return calls === 2;
+    },
+    { deadlineMs: 1000, intervalMs: 0 },
+  );
+  assert.equal(ok, true);
+  assert.equal(calls, 2);
+});
+
+test('pollUntil returns false once deadlineMs elapses without success', async () => {
+  let calls = 0;
+  const ok = await pollUntil(
+    async () => {
+      calls++;
+      return false;
+    },
+    { deadlineMs: 20, intervalMs: 5 },
+  );
+  assert.equal(ok, false);
+  assert.ok(calls >= 1);
+});
+
+test('a thrown attempt counts as a failure, not an abort', async () => {
+  let calls = 0;
+  const ok = await pollUntil(
+    async () => {
+      calls++;
+      if (calls === 1) throw new Error('transient');
+      return true;
+    },
+    { deadlineMs: 1000, intervalMs: 0 },
+  );
+  assert.equal(ok, true);
+  assert.equal(calls, 2);
+});
+
+test('fn receives a 1-based attempt counter', async () => {
+  const seen = [];
+  await pollUntil(
+    async (attempt) => {
+      seen.push(attempt);
+      return seen.length === 3;
+    },
+    { deadlineMs: 1000, intervalMs: 0 },
+  );
+  assert.deepEqual(seen, [1, 2, 3]);
+});
+
+test('intervalMs defaults to DEFAULT_POLL_INTERVAL_MS when omitted', async () => {
+  // A deadline shorter than the default 2s interval must still get exactly
+  // one attempt before timing out — proves the default is actually wired,
+  // not silently zero (which would spin instead of sleeping).
+  let calls = 0;
+  const ok = await pollUntil(
+    async () => {
+      calls++;
+      return false;
+    },
+    { deadlineMs: 10 },
+  );
+  assert.equal(ok, false);
+  assert.equal(calls, 1);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,6 +667,7 @@ jobs:
       # against.
       - name: Self-test the e2e-up family .mjs helpers
         run: |
+          node --test .github/scripts/lib/poll.test.mjs
           node --test .github/scripts/lib/k8s.test.mjs
           node --test .github/scripts/k3d-image-import.test.mjs
           node --test .github/scripts/e2e-datasource-sync.test.mjs


### PR DESCRIPTION
## Summary

Closes #3172 — the three non-blocking ACPR findings on PR #3162's inter-node health-poll fix:

- **Not shared**: `waitForCleanClusterHealth` lived only in `e2e-datashard-replica-affinity-verify.mjs`. `e2e-datashard-verify.mjs` fires load against the same cross-shard `Distributed` fan-out right after `just e2e-datashard-up` reports ready and inherited the identical unprotected race. Promoted to `lib/k8s.mjs`'s `waitForClusterHealth` and wired into **both** scripts.
- **DRY**: extracted `pollUntil` out of `chaos-run.mjs` into `lib/poll.mjs` (with its own unit tests). `chaos-run.mjs`'s 16 existing call sites now import the shared implementation instead of a private copy.
- **Efficiency**: each poll iteration spawned a fresh `kubectl exec` + `clickhouse-client` subprocess. Widened the poll interval from 2s to 5s — justified by the phenomenon this poll tracks (ClickHouse's `distributed_replica_error_half_life`, 60s default decay) — cutting a worst-case run from ~30 subprocess spawns to ~12.
- Fixed the minor nit: elapsed time is now a plain `(Date.now() - start) / 1000` instead of back-derived through the deadline.

## Test plan

- [x] `node --check` on every touched/new `.mjs` file
- [x] Full `.github/scripts` test suite (`find .github/scripts -name "*.test.mjs" | xargs node --test`) — 1482/1482 passing, including new `lib/poll.test.mjs` and expanded `lib/k8s.test.mjs`
- [x] `node .github/scripts/forbid-sql-raw.mjs` clean
- [ ] CI (`lint`, `e2e`/datashard lanes — chaos-run.mjs and the two datashard verify scripts are only exercisable against a real k3d cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
