### PR TITLE
fix(helm): require zookeeperPath at chart-render time when schema.replicated is enabled

### DIFF
--- a/.github/scripts/chart-render-assert.mjs
+++ b/.github/scripts/chart-render-assert.mjs
@@ -16,6 +16,7 @@
 //   13. storagePolicyName operator override wins in every storage mode.
 //   14. ClickHouse Service sessionAffinity default-on / opt-out.
 //   15. dataShards.count (EXPERIMENTAL): count==1 byte-identical to the bare default; count>1 per-shard objects and env wiring, PDB split, keeper guard, fanoutCap apportionment, the experimental opt-in gate.
+//   16. schema.replicated.enabled requires a non-empty zookeeperPath (values.schema.json if/then), instead of rendering a config that crash-loops at cerberus's own boot-time validation.
 //
 // Env contract:
 //   CHART_DIR   chart directory (default: deploy/helm/cerberus)
@@ -567,6 +568,34 @@ function count(haystack, needle) {
   const pdbBareDefault = tpl([...OBJECT_STORE, '--set', 'clickhouse.bundled.podDisruptionBudget.enabled=true'])
   const pdbExplicitOne = tpl([...OBJECT_STORE, '--set', 'clickhouse.bundled.podDisruptionBudget.enabled=true', '--set', 'clickhouse.bundled.dataShards.count=1'])
   check(pdbBareDefault === pdbExplicitOne, 'PodDisruptionBudget: dataShards.count=1 renders BYTE-IDENTICAL to the bare default')
+}
+
+// --- 16. schema.replicated.enabled requires a non-empty zookeeperPath --------
+// (cerberus issue #3176). Without the values.schema.json `if`/`then`
+// conditional this section pins, `schema.replicated.enabled: true` with the
+// chart's own default empty zookeeperPath renders CERBERUS_SCHEMA_DATABASE_
+// REPLICATED="true" with no ..._PATH — internal/schema/ddl.Config.Validate()
+// correctly rejects that at cerberus's own boot time, but only as a crash-
+// loop; the whole point of this schema addition is catching it here instead,
+// at `helm template`/`--dry-run`/`lint` time.
+{
+  const missingPath = tplFail(['--set', 'schema.replicated.enabled=true', '-s', 'templates/configmap-env.yaml'])
+  check(missingPath !== null, 'schema.replicated.enabled=true with the default empty zookeeperPath: render FAILS')
+  check(missingPath !== null && /zookeeperPath/.test(missingPath), 'the rejection names zookeeperPath')
+
+  const withPath = tpl([
+    '--set', 'schema.replicated.enabled=true',
+    '--set', 'schema.replicated.zookeeperPath=/clickhouse/databases/otel/{shard}/{replica}',
+    '-s', 'templates/configmap-env.yaml',
+  ])
+  check(withPath.includes('CERBERUS_SCHEMA_DATABASE_REPLICATED: "true"'), 'schema.replicated.enabled=true + zookeeperPath set: renders CERBERUS_SCHEMA_DATABASE_REPLICATED')
+  check(
+    withPath.includes('CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH: "/clickhouse/databases/otel/{shard}/{replica}"'),
+    'schema.replicated.enabled=true + zookeeperPath set: renders CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH',
+  )
+
+  const bareDefault = tpl(['-s', 'templates/configmap-env.yaml'])
+  check(!bareDefault.includes('CERBERUS_SCHEMA_DATABASE_REPLICATED'), 'schema.replicated left at its default (disabled): still renders clean, no REPLICATED keys at all')
 }
 
 process.exit(ok ? 0 : 1)

--- a/deploy/helm/cerberus/values.schema.json
+++ b/deploy/helm/cerberus/values.schema.json
@@ -260,6 +260,13 @@
           "properties": {
             "enabled": { "type": "boolean" },
             "zookeeperPath": { "type": "string" }
+          },
+          "if": {
+            "properties": { "enabled": { "const": true } }
+          },
+          "then": {
+            "required": ["zookeeperPath"],
+            "properties": { "zookeeperPath": { "minLength": 1 } }
           }
         },
         "storagePolicy": { "type": "string" },


### PR DESCRIPTION
## Summary

Closes #3176.

Setting `schema.replicated.enabled: true` without also setting `zookeeperPath` lowers to `CERBERUS_SCHEMA_DATABASE_REPLICATED=true` with no `CERBERUS_SCHEMA_DATABASE_REPLICATED_PATH` (the chart default is an empty string). `internal/schema/ddl.Config.Validate()` correctly rejects this whenever `autoCreate.database` is on, but the only failure mode an operator ever sees is every cerberus pod crash-looping at startup — nothing at the chart level caught it before deploy.

Added a `values.schema.json` `if`/`then` conditional requiring a non-empty `zookeeperPath` whenever `replicated.enabled` is `true`, so `helm template` / `helm install --dry-run` / `helm lint` reject it directly:

```
$ helm template rn deploy/helm/cerberus --set clickhouse.bundled.enabled=true --set schema.replicated.enabled=true
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cerberus:
- schema.replicated: Must validate "then" as "if" was valid
- schema.replicated.zookeeperPath: String length must be greater than or equal to 1
```

Verified every existing `ci/*-values.yaml` fixture still renders clean (the two that set `schema.replicated.enabled: true` — `ha-values.yaml`, `bwc-datashards-values.yaml` — already set `zookeeperPath` alongside it, so neither trips the new constraint).

Added `chart-render-assert.mjs` section 16 (the negative-case test the issue asked for): the bad case (`enabled=true`, default empty `zookeeperPath`) fails render and the rejection names `zookeeperPath`; the good case (both set) renders both env keys; the default (disabled) case stays untouched.

## Test plan

- [x] `helm template` against the bad config: fails with the schema error shown above
- [x] `helm template` against the good config: renders `CERBERUS_SCHEMA_DATABASE_REPLICATED` + `..._PATH`
- [x] All 15 `deploy/helm/cerberus/ci/*-values.yaml` fixtures render clean
- [x] `helm lint deploy/helm/cerberus` clean
- [x] `CHART_DIR=deploy/helm/cerberus node .github/scripts/chart-render-assert.mjs` — 146/146 checks pass (5 new)
- [x] `CHART_DIR=deploy/helm/cerberus KUBE_VERSION=1.33.0 node .github/scripts/chart-kubeconform.mjs` — all resources valid
- [x] `deploy/helm/cerberus/README.md` unchanged (values.yaml itself untouched, no helm-docs drift)
- [ ] CI `chart-validate` (the actual required check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
