### PR TITLE
fix(ci,test): make checks that examined nothing fail

### DIFF
--- a/.github/scripts/forbid-chplan-fn-literal.mjs
+++ b/.github/scripts/forbid-chplan-fn-literal.mjs
@@ -13,13 +13,16 @@
 
 import { readFileSync } from 'node:fs';
 import process from 'node:process';
-import { error, log, lsFiles } from './lib/gh.mjs';
+import { error, log, lsFilesRequired } from './lib/gh.mjs';
 
 const RESOLUTION_BOUNDARY = /^internal\/chsql\/fnresolution(?:_completeness)?(?:_test)?\.go$/;
 const RAW_FN_LITERAL = /\b(?:chplan\.)?Fn\s*\(\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`[^`]*`)/g;
 
 let violations = 0;
-for (const file of lsFiles(['*.go', ':!:vendor/**', ':!:.claude/**'])) {
+for (const file of lsFilesRequired(
+  ['*.go', ':!:vendor/**', ':!:.claude/**'],
+  'forbid-chplan-fn-literal',
+)) {
   const rel = file.replace(/\\/g, '/');
   if (RESOLUTION_BOUNDARY.test(rel)) continue;
 

--- a/.github/scripts/forbid-skip.mjs
+++ b/.github/scripts/forbid-skip.mjs
@@ -24,7 +24,7 @@
 //
 // Exit codes: 0 = clean, 1 = a banned pattern was found (or bad $CHECK).
 
-import { lsFiles, error, log, capture } from './lib/gh.mjs';
+import { lsFilesRequired, error, log, capture } from './lib/gh.mjs';
 import process from 'node:process';
 
 const CHECK = process.env.CHECK || '';
@@ -34,9 +34,8 @@ const CHECK = process.env.CHECK || '';
 // Returns { matched, output }. We shell out to grep (not a JS regex) so
 // the ERE semantics + multi-file `-H` line addressing match the original
 // byte-for-byte.
-function grepFiles({ pathspecs, grepFlags, regex }) {
-  const files = lsFiles(pathspecs);
-  if (files.length === 0) return { matched: false, output: '' };
+function grepFiles({ pathspecs, grepFlags, regex, scan }) {
+  const files = lsFilesRequired(pathspecs, `forbid-skip: ${scan}`);
   const res = capture('grep', [...grepFlags, '-e', regex, '--', ...files]);
   // grep exit 0 = match found, 1 = no match, >1 = real error.
   if (res.status > 1) {
@@ -49,8 +48,8 @@ function grepFiles({ pathspecs, grepFlags, regex }) {
 // perlSlurp — replicate the `git ls-files -z | xargs -0 perl -0777 -ne` shape.
 // Runs the perl program once per matched file (xargs would batch, but per
 // $ARGV the line-number arithmetic is identical) and concatenates output.
-function perlSlurp({ pathspecs, program }) {
-  const files = lsFiles(pathspecs);
+function perlSlurp({ pathspecs, program, scan }) {
+  const files = lsFilesRequired(pathspecs, `forbid-skip: ${scan}`);
   let out = '';
   for (const f of files) {
     const res = capture('perl', ['-0777', '-ne', program, f]);
@@ -76,6 +75,7 @@ function fail(message) {
 const CHECKS = {
   't-skip': () => {
     const { matched, output } = grepFiles({
+      scan: 't-skip',
       pathspecs: ['*_test.go', ':!:compatibility/*/upstream/**'],
       grepFlags: ['-nE'],
       regex: 't\\.Skip[fN]?\\(',
@@ -95,6 +95,7 @@ const CHECKS = {
     // OTHER spec in the file, so a lane can report green having run one
     // test. All three are t.Skip in TypeScript.
     const skips = grepFiles({
+      scan: 'playwright-skip',
       pathspecs: ['*.spec.ts', '*.spec.js', ':!:**/node_modules/**'],
       grepFlags: ['-nEH'],
       regex: '(^|[^A-Za-z0-9_$.])(test|it|describe|suite)(\\.describe)?\\.(skip|fixme|only)\\s*\\(',
@@ -110,6 +111,7 @@ const CHECKS = {
   'soft-assert': () => {
     let bad = false;
     const softAssert = grepFiles({
+      scan: 'soft-assert',
       pathspecs: ['*_test.go', ':!:compatibility/*/upstream/**'],
       grepFlags: ['-nEH'],
       regex:
@@ -121,6 +123,7 @@ const CHECKS = {
     }
     // Multi-line silent-recover scan — identical perl program to ci.yml.
     const matches = perlSlurp({
+      scan: 'soft-assert',
       pathspecs: ['*_test.go', ':!:compatibility/*/upstream/**'],
       program:
         'while (/defer\\s+recover\\s*\\(\\s*\\)|defer\\s+func\\s*\\(\\s*\\)\\s*\\{[^{}]*_\\s*=\\s*recover\\s*\\(\\s*\\)/g) {\n  my $pre = substr($_, 0, $-[0]);\n  my $line = ($pre =~ tr/\\n//) + 1;\n  print "$ARGV:$line: silent-recover pattern\\n";\n}',
@@ -138,6 +141,7 @@ const CHECKS = {
 
   'should-skip': () => {
     const matches = perlSlurp({
+      scan: 'should-skip',
       pathspecs: [
         'compatibility/**/*.yml',
         'compatibility/**/*.yaml',
@@ -156,6 +160,7 @@ const CHECKS = {
 
   'escape-hatch': () => {
     const { matched, output } = grepFiles({
+      scan: 'escape-hatch',
       pathspecs: [
         '*.ts',
         '*.tsx',
@@ -189,6 +194,7 @@ const CHECKS = {
     // needs mixed case — `-i` closes a scan gap (`@WIP`, `@Skip`, ...) without
     // risking a false positive on unrelated text.
     const tags = grepFiles({
+      scan: 'feature-discipline',
       pathspecs: ['*.feature', ':!:**/node_modules/**'],
       grepFlags: ['-nEHi'],
       regex: '(^|[ \\t])@(wip|skip|ignore|manual|todo|pending)([ \\t]|$)',
@@ -203,6 +209,7 @@ const CHECKS = {
     // calling Skip / Skipf / SkipNow on the TestingT godog hands it, would
     // suppress the assertion with the gate none the wiser.
     const goSkips = grepFiles({
+      scan: 'feature-discipline',
       pathspecs: ['test/e2e/migration/**/*.go'],
       grepFlags: ['-nEH'],
       regex: 'godog\\.(ErrSkip|ErrPending)|\\.Skip(f|Now)?\\(',

--- a/.github/scripts/gh.test.mjs
+++ b/.github/scripts/gh.test.mjs
@@ -14,11 +14,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { closeSync, existsSync, lstatSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync, writeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { assertSafeArg, capture, createFreshFileFd, lsFiles, writeFreshFile } from './lib/gh.mjs';
+import { assertSafeArg, capture, createFreshFileFd, lsFiles, lsFilesRequired, writeFreshFile } from './lib/gh.mjs';
 
 test('capture forwards the options it documents', () => {
   const res = capture('sh', ['-c', 'printf "%s" "$MARKER"'], {
@@ -153,6 +154,8 @@ test('writeFreshFile is fine when nothing exists at the path yet', () => {
 // scan reported clean on content it would reject the moment it was staged.
 // `newRepo()` builds a throwaway git repository so the assertion is against
 // the real CLI, not a mock.
+const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
+
 function newRepo() {
   const dir = mkdtempSync(join(tmpdir(), 'gh-lsfiles-'));
   const run = (args) => {
@@ -199,5 +202,34 @@ test('lsFiles honours an exclude pathspec against an untracked file, same as a t
   assert.ok(
     !files.some((f) => f.includes('upstream')),
     `exclude pathspec did not apply to an untracked path: ${JSON.stringify(files)}`,
+  );
+});
+
+// lsFilesRequired is what makes a discipline scan able to FAIL. A scan whose
+// pathspec matches nothing reports success having examined nothing, and that
+// success is indistinguishable from a real pass — the shape the whole-tree
+// audit found in five forbid-skip arms and in forbid-chplan-fn-literal, while
+// their sibling forbid-sql-raw had always guarded against it.
+test('lsFilesRequired returns the files when the pathspec matches', () => {
+  const { dir } = newRepo();
+  const files = lsFilesRequired(['*.go'], 'probe', { cwd: dir });
+  assert.ok(files.length > 0, 'a matching pathspec must return its files');
+});
+
+test('lsFilesRequired exits non-zero when the pathspec matches nothing', () => {
+  const { dir } = newRepo();
+  // Run in a child so the process.exit(1) is observable rather than fatal.
+  const lib = pathToFileURL(join(SCRIPT_DIR, 'lib', 'gh.mjs')).href;
+  const script =
+    `const { lsFilesRequired } = await import(${JSON.stringify(lib)});\n` +
+    `lsFilesRequired(['*.nonesuch'], 'probe', { cwd: ${JSON.stringify(dir)} });`;
+  const res = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+    encoding: 'utf8',
+  });
+  assert.notEqual(res.status, 0, 'a pathspec matching zero files must fail the scan');
+  assert.match(
+    `${res.stdout}${res.stderr}`,
+    /matched zero files/,
+    'the failure must say the scan is broken, not the tree',
   );
 });

--- a/.github/scripts/lib/gh.mjs
+++ b/.github/scripts/lib/gh.mjs
@@ -203,6 +203,32 @@ export function lsFiles(pathspecs, opts = {}) {
   return res.stdout.split('\0').filter((p) => p.length > 0);
 }
 
+// lsFilesRequired() — lsFiles for a SCAN, where matching nothing is a
+// broken pathspec rather than a clean tree.
+//
+// A discipline scan whose pathspec matches zero files reports success having
+// examined nothing, and that success is indistinguishable from a real pass.
+// It is the failure mode `forbid-sql-raw` has always guarded against with
+// "pathspec matched zero files — the scan is broken, not the tree", and the
+// one the whole-tree audit found the other scans lacked: five `forbid-skip`
+// arms and `forbid-chplan-fn-literal` all exited 0 on an empty input.
+//
+// The guard is on the pathspec SET, not on each element: a set may name a
+// pattern with no files today (`*.spec.js` beside `*.spec.ts`) and still be
+// scanning a real corpus. What must never be empty is what the scan actually
+// reads.
+export function lsFilesRequired(pathspecs, scanName, opts = {}) {
+  const files = lsFiles(pathspecs, opts);
+  if (files.length === 0) {
+    error(
+      `${scanName}: pathspec matched zero files — the scan is broken, not the tree ` +
+        `(pathspecs: ${pathspecs.join(' ')})`,
+    );
+    process.exit(1);
+  }
+  return files;
+}
+
 // appendStepSummary() — append markdown to the job summary, when the
 // runner exposes $GITHUB_STEP_SUMMARY. No-op (logged) off-runner.
 export function appendStepSummary(markdown) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2276,7 +2276,18 @@ const defaultQueryTimeout time.Duration = 2 * time.Minute
 // gets a deterministic resource-exhausted rejection instead of racing
 // ClickHouse's server-total cap mid-stream and 502-ing. 0 disables the
 // setting entirely (ClickHouse server defaults apply).
-const defaultCHQueryMaxMemory int64 = 1 << 30 // 1073741824 bytes
+const defaultCHQueryMaxMemory int64 = DefaultCHQueryMaxMemory
+
+// DefaultCHQueryMaxMemory is defaultCHQueryMaxMemory's exported twin, so a
+// package that DERIVES a value from this default can pin itself to it
+// rather than restate the number.
+//
+// internal/engine's no-cap spill threshold is exactly this divided by its
+// own denominator, and .go-arch-lint.yml forbids engine importing config —
+// but it excludes _test.go, so the derivation is pinned where it belongs,
+// in engine's own test, against this constant instead of a local literal
+// that a bump to the default would leave behind.
+const DefaultCHQueryMaxMemory int64 = 1 << 30 // 1073741824 bytes
 
 // ClickHouse connection-pool defaults (#81). MaxIdleConns / MaxOpenConns
 // reproduce clickhouse-go/v2's previously-implicit defaults verbatim so the

--- a/internal/engine/spill_test.go
+++ b/internal/engine/spill_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/config"
 )
 
 const (
@@ -65,7 +66,12 @@ func TestApplySpillSettings_Unconditional(t *testing.T) {
 func TestSpillThresholdBytes_MatchesDefaultCapThreshold(t *testing.T) {
 	t.Parallel()
 
-	const defaultMaxMemoryUsage = gib // mirrors config.defaultCHQueryMaxMemory
+	// Read from internal/config, not restated here: a package-local literal
+	// stays green through the very bump this test says it catches, which is
+	// what made the "derived value" claim above untrue. .go-arch-lint.yml
+	// forbids engine importing config in production code and excludes
+	// _test.go, so this is the one place the two can be compared.
+	const defaultMaxMemoryUsage = config.DefaultCHQueryMaxMemory
 	if want := defaultMaxMemoryUsage / spillCapDenominator; spillThresholdBytes != want {
 		t.Errorf("no-cap spill threshold %d; want %d (default max_memory_usage %d / %d)",
 			spillThresholdBytes, want, defaultMaxMemoryUsage, spillCapDenominator)

--- a/internal/optimizer/property_extended_test.go
+++ b/internal/optimizer/property_extended_test.go
@@ -61,6 +61,28 @@ func seedPropertyDB(t *testing.T) *sql.DB {
 	return db
 }
 
+// requireVerified fails when a row-set equivalence loop finished without
+// ever getting past its `continue` — i.e. having verified nothing.
+//
+// Each loop skips an iteration whose PRE-optimization plan does not execute,
+// which is the right call for one unlucky generated plan and a silent
+// catastrophe for all of them: a chDB upgrade, a seed-schema change or an
+// emitter change that renders SQL chDB rejects makes every iteration skip,
+// and the test reports PASS while asserting nothing. These four are the only
+// tests in the tree that check the optimizer preserves RESULTS rather than
+// SQL text, so going inert costs exactly the coverage they exist for. The
+// t.Logf per skip is invisible without -v.
+func requireVerified(t *testing.T, verified, iterations int, rule string) {
+	t.Helper()
+	if verified == 0 {
+		t.Fatalf(
+			"%s: all %d iterations skipped on a pre-optimization execution error, so the "+
+				"row-set equivalence property was never checked — the test is inert, not passing",
+			rule, iterations,
+		)
+	}
+}
+
 // TestPropertyFilterFusion_RowSetEquivalent: build a Filter(Filter(Scan))
 // with two independent predicates and check that running FilterFusion
 // yields the same rows as the unoptimized plan. Each iteration picks
@@ -75,6 +97,7 @@ func TestPropertyFilterFusion_RowSetEquivalent(t *testing.T) {
 	ctx := context.Background()
 	d := optimizer.New(optimizer.FilterFusion{})
 
+	verified := 0
 	for i := 0; i < N; i++ {
 		plan := chplan.Node(&chplan.Filter{
 			Input: &chplan.Filter{
@@ -96,7 +119,9 @@ func TestPropertyFilterFusion_RowSetEquivalent(t *testing.T) {
 		if !rowsetEqual(pre, post) {
 			t.Fatalf("iter=%d row-set diverged\nplan: %s\npre: %s\npost: %s", i, dumpPlan(plan), dumpRows(pre), dumpRows(post))
 		}
+		verified++
 	}
+	requireVerified(t, verified, N, "FilterFusion")
 }
 
 // TestPropertyConstantFoldSemantic_RowSetEquivalent: build a Filter
@@ -128,6 +153,7 @@ func TestPropertyConstantFoldSemantic_RowSetEquivalent(t *testing.T) {
 		{chplan.OpNe, 1, 2},
 	}
 
+	verified := 0
 	for i := 0; i < N; i++ {
 		pair := literalPairs[rng.Intn(len(literalPairs))]
 		// Wrap the literal binary in `<literal-binary> AND <leaf>` to
@@ -158,7 +184,9 @@ func TestPropertyConstantFoldSemantic_RowSetEquivalent(t *testing.T) {
 		if !rowsetEqual(pre, post) {
 			t.Fatalf("iter=%d row-set diverged\nplan: %s\npre: %s\npost: %s", i, dumpPlan(plan), dumpRows(pre), dumpRows(post))
 		}
+		verified++
 	}
+	requireVerified(t, verified, N, "ConstantFoldSemantic")
 }
 
 // TestPropertyConstantFoldHeuristic_RowSetEquivalent: build a Filter
@@ -185,6 +213,7 @@ func TestPropertyConstantFoldHeuristic_RowSetEquivalent(t *testing.T) {
 		// returning ALL rows) since the runner may distinguish those.
 	}
 
+	verified := 0
 	for i := 0; i < N; i++ {
 		id := identities[rng.Intn(len(identities))]
 		leaf := generateLeafPredicate(rng)
@@ -209,7 +238,9 @@ func TestPropertyConstantFoldHeuristic_RowSetEquivalent(t *testing.T) {
 		if !rowsetEqual(pre, post) {
 			t.Fatalf("iter=%d row-set diverged\nplan: %s\npre: %s\npost: %s", i, dumpPlan(plan), dumpRows(pre), dumpRows(post))
 		}
+		verified++
 	}
+	requireVerified(t, verified, N, "ConstantFoldHeuristic")
 }
 
 // TestPropertyProjectionPushdown_RowSetEquivalent: pin that narrowing
@@ -225,6 +256,7 @@ func TestPropertyProjectionPushdown_RowSetEquivalent(t *testing.T) {
 	ctx := context.Background()
 	d := optimizer.New(optimizer.ProjectionPushdown{})
 
+	verified := 0
 	for i := 0; i < N; i++ {
 		// Subset of [MetricName, Value, TimeUnix].
 		cols := append([]string(nil), propertyColumns...)
@@ -251,5 +283,7 @@ func TestPropertyProjectionPushdown_RowSetEquivalent(t *testing.T) {
 		if !rowsetEqual(pre, post) {
 			t.Fatalf("iter=%d row-set diverged\nplan: %s\npre: %s\npost: %s", i, dumpPlan(plan), dumpRows(pre), dumpRows(post))
 		}
+		verified++
 	}
+	requireVerified(t, verified, N, "ProjectionPushdown")
 }

--- a/internal/optimizer/property_test.go
+++ b/internal/optimizer/property_test.go
@@ -345,9 +345,19 @@ func runPlan(ctx context.Context, db *sql.DB, plan chplan.Node) ([][]any, error)
 	}
 	defer func() { _ = rows.Close() }()
 
-	colCount := projectionCount(rewritten)
+	// Ask the driver how many columns the result actually has. Deriving it
+	// by parsing the SELECT list cannot see through `SELECT *`, which counts
+	// as ONE projection and expands to the table's full width at scan time —
+	// so every iteration of a `SELECT *`-shaped plan failed with "expected 4
+	// destination arguments in Scan, not 1", took the loop's `continue`, and
+	// the property was never checked.
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("columns: %w", err)
+	}
+	colCount := len(cols)
 	if colCount == 0 {
-		return nil, fmt.Errorf("cannot determine projection count for %q", rewritten)
+		return nil, fmt.Errorf("result set has no columns for %q", rewritten)
 	}
 
 	var out [][]any
@@ -534,39 +544,6 @@ func splitOuterAlias(s string) (expr, alias string) {
 		}
 	}
 	return s, ""
-}
-
-func projectionCount(query string) int {
-	const sel = "SELECT "
-	upper := strings.ToUpper(query)
-	if !strings.HasPrefix(upper, sel) {
-		return 0
-	}
-	rest := query[len(sel):]
-	depth := 0
-	for i := 0; i < len(rest); i++ {
-		switch rest[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-		}
-		if depth == 0 && i+6 <= len(rest) && strings.EqualFold(rest[i:i+6], " FROM ") {
-			head := rest[:i]
-			return len(splitTopLevelCommas(head))
-		}
-	}
-	// `SELECT *` with no FROM in the literal text (rare): one slot.
-	if strings.TrimSpace(rest) == "*" {
-		return 1
-	}
-	// `SELECT *` with FROM at the outermost level should have been
-	// caught above; an unrecognised shape falls through with the
-	// count of `*` columns in our fixed schema.
-	if strings.HasPrefix(rest, "*") {
-		return 4 // MetricName, Attributes, TimeUnix, Value
-	}
-	return 0
 }
 
 // decodeCellLocal mirrors decodeCell in test/spec/runner_chdb.go.

--- a/internal/routerrules/regression_floor_test.go
+++ b/internal/routerrules/regression_floor_test.go
@@ -108,6 +108,20 @@ func TestRegressionFloorSaneRange(t *testing.T) {
 					p.Overall.Precision, saneRangePrecisionFloor, p.WatermarkPctile, p.MinSupport, p.Prevalence)
 			}
 		}
+		// A recall floor over an EMPTY population is satisfied by nothing
+		// existing: severityRecall returns 1.0 when a severity has no
+		// planted classes, which reads identically to "everything was
+		// caught". Assert the population first, so a generator change that
+		// stopped planting severe classes fails here instead of sailing
+		// through a perfect score.
+		if p.SeverePositives == 0 {
+			t.Errorf("no severe (class, expected-rule) pairs planted at wm=%.2f msup=%d prev=%.2f — the severe-recall floor would pass vacuously",
+				p.WatermarkPctile, p.MinSupport, p.Prevalence)
+		}
+		if p.MarginalPositives == 0 {
+			t.Errorf("no marginal (class, expected-rule) pairs planted at wm=%.2f msup=%d prev=%.2f — the marginal-recall figure is vacuous",
+				p.WatermarkPctile, p.MinSupport, p.Prevalence)
+		}
 		// Severe recall stays perfect everywhere, including off-nominal prevalence.
 		if p.SevereRecall < severeRecallFloor {
 			t.Errorf("severe recall %.3f below floor %.3f at wm=%.2f msup=%d prev=%.2f",

--- a/internal/routerrules/sweep.go
+++ b/internal/routerrules/sweep.go
@@ -26,6 +26,17 @@ type SweepPoint struct {
 	// SevereRecall is recall over SevSevere classes — these should stay caught
 	// far longer than marginal ones.
 	SevereRecall float64
+
+	// MarginalPositives and SeverePositives are how many (class,
+	// expected-rule) pairs each recall was computed OVER.
+	//
+	// A recall of 1.0 means two different things — everything was caught, or
+	// there was nothing to catch — and only this count separates them. The
+	// severe-recall floor asserts perfection at every swept point, so without
+	// the population size a generator change that stopped planting severe
+	// classes would satisfy the floor with no severe class present.
+	MarginalPositives int
+	SeverePositives   int
 }
 
 // SweepAxes declares the grid to sweep. Each axis is varied independently
@@ -96,17 +107,17 @@ func scorePoint(ctx context.Context, cat *Catalog, seed int64, wm float64, ms in
 	m := scoreReport(rep, corpus)
 	pt := SweepPoint{
 		WatermarkPctile: wm, MinSupport: ms, Prevalence: prev,
-		Overall:        m.Overall,
-		MarginalRecall: severityRecall(rep, corpus, SevMarginal),
-		SevereRecall:   severityRecall(rep, corpus, SevSevere),
+		Overall: m.Overall,
 	}
+	pt.MarginalRecall, pt.MarginalPositives = severityRecall(rep, corpus, SevMarginal)
+	pt.SevereRecall, pt.SeverePositives = severityRecall(rep, corpus, SevSevere)
 	return pt, nil
 }
 
 // severityRecall computes recall restricted to classes of one planted severity:
 // of all (class, expected-rule) positive pairs at that severity, the fraction
 // the catalog actually fired.
-func severityRecall(rep *Report, corpus *BenchCorpus, sev PathologySeverity) float64 {
+func severityRecall(rep *Report, corpus *BenchCorpus, sev PathologySeverity) (recall float64, positives int) {
 	fired := map[string]map[string]struct{}{}
 	for _, f := range rep.Findings {
 		id := matchClassID(f, corpus)
@@ -136,9 +147,12 @@ func severityRecall(rep *Report, corpus *BenchCorpus, sev PathologySeverity) flo
 		}
 	}
 	if want == 0 {
-		return 1 // no positives at this severity: vacuously perfect.
+		// No positives at this severity. 1.0 would read as "everything was
+		// caught"; the caller has to be able to tell that apart, which is
+		// what the returned count is for.
+		return 1, 0
 	}
-	return float64(got) / float64(want)
+	return float64(got) / float64(want), want
 }
 
 // FormatSweepTable renders the sensitivity grid as an aligned text table.


### PR DESCRIPTION
Progresses #3182 — the gates that report success having examined nothing.

## Scans that passed on an empty input

Five `forbid-skip` arms and `forbid-chplan-fn-literal` exited 0 on a zero-file
pathspec, while their sibling `forbid-sql-raw` has always failed with "pathspec
matched zero files — the scan is broken, not the tree".

The guard now lives once, as `lib/gh.mjs`'s `lsFilesRequired`, and every scan
goes through it — invariant 15's rule that logic shared by two or more scripts
belongs in `lib/`. It guards the pathspec **set**, not each element, because a
set may legitimately name a pattern with no files today (`*.spec.js` beside
`*.spec.ts`) and still read a real corpus.

Verified in a synthetic empty repository: all seven scans now exit non-zero
where all seven previously passed. A `gh.test.mjs` case pins it, and fails when
the guard is neutralised.

## A property loop that verified zero plans

The four extended row-set property tests skip an iteration whose
pre-optimization plan does not execute, with no assertion that any iteration
ever got past the skip. They are the only tests in the tree that check the
optimizer preserves **results** rather than SQL text.

Adding the completion guard immediately caught one of them **already inert**:
`TestPropertyConstantFoldHeuristic_RowSetEquivalent` skipped all ten iterations
on `expected 4 destination arguments in Scan, not 1`. `runPlan` derived its
column count by parsing the SELECT list, which cannot see through `SELECT *` —
one projection in the text, four columns at scan time. It now asks the driver
via `rows.Columns()`, and the text parser that could not answer the question is
deleted.

So that test went from verifying zero plans to verifying ten, which is the point
of the guard rather than a side effect of it.

## A recall floor scored over an empty population

`severityRecall` returns 1.0 when a severity has no planted classes, which reads
identically to "everything was caught", and the regression floor asserts
perfection at every swept point. A generator change that stopped planting severe
classes would satisfy the floor with no severe class present. It now returns the
population size alongside the ratio, and the floor asserts the population first.
Zeroing that count fails eighteen grid points.

## A mirror pinned to a literal instead of its source

`TestSpillThresholdBytes_MatchesDefaultCapThreshold` says a bump to
`config.defaultCHQueryMaxMemory` "fails here", and compared against a
package-local literal — so the bump it names would have left it green. It now
reads `config.DefaultCHQueryMaxMemory`. `.go-arch-lint.yml` forbids engine
importing config and excludes `_test.go`, so the engine test is the one place
the two can meet. Bumping the default to 2 GiB now fails the test, as the
comment always promised.

## Still open on #3182

The Tempo compat differ's exemplar-count-only comparison, the LogQL leg's
missing anti-hollow guard, `TestAGPLOracleTagSetCoverage`'s hand-written prefix
list, the migration attestation's element-vs-node counting, `promrules.Parse`'s
leniency, `sortingkey_test`'s two-Go-constants comparison, and `bench-report`'s
tests. The issue stays open for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
