### PR TITLE
refactor: pin the unpinned mirrors, and seed every emitter from its context

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -829,6 +829,23 @@ what actually runs.
   - Exit: `0` consistent (or self-test green), `1` on any drift.
   - The CHECK-arm count here is the source of truth for the "N checks"
     claim in `docs/forbid-skip.md`, asserted live by `doc-counts.mjs`.
+- **`chdb-version-sync.mjs`** — `ci.yml`, the `forbid-skip` job's chDB
+  substrate pin gate. The `libchdb.so` every chdb-tagged lane runs on is
+  pinned in three places that must agree: `versions.yaml`'s `chdb_substrate`,
+  `just/chdb.just`'s `CHDB_VERSION` (the chdb-core release tag the installer
+  downloads), and every `actions/cache` key of the form
+  `libchdb-<os>-<arch>-<tag>` across `.github/workflows`. Nothing read them
+  against each other, and the cache keys sat under a comment claiming they
+  were derived. They were nine hand-typed copies in front of an installer that
+  SKIPS when the file already exists, so a bump that missed one restored the
+  old engine and the recipe declined to replace it — the lane kept running on
+  the previous ClickHouse while the repository believed it had moved (issue
+  #3186). The gate also fails when it finds no cache key at all, so the scan
+  cannot report success after silently stopping matching.
+  - Args: `--self-test` pins each assertion by proving it FAILS on a
+    deliberate mismatch (run as a CI step before the gate); no args runs the
+    gate over the tree.
+  - Exit: `0` consistent (or self-test green), `1` on any drift.
 - **`doc-refs.mjs`** — `ci.yml`, the `doc-to-code reference check` step in
   the `lint` job. The GATE that keeps prose docs honest about the code they
   cite: greps `docs/**/*.md` for inline `(internal|cmd|test|deploy)/<path>.go`

--- a/.github/scripts/chdb-version-sync.mjs
+++ b/.github/scripts/chdb-version-sync.mjs
@@ -1,0 +1,269 @@
+// chdb-version-sync.mjs - the chDB substrate version-consistency gate.
+//
+// The libchdb.so build every chdb-tagged lane runs on is pinned in three
+// places that MUST agree, and nothing read any of them against the others:
+//
+//   - versions.yaml `chdb_substrate`   the single source of truth (major.minor)
+//   - just/chdb.just `CHDB_VERSION`    the chdb-core release tag the installer
+//                                      downloads (e.g. "v26.5.0")
+//   - .github/workflows/*.yml          every `actions/cache` key of the form
+//                                      `libchdb-<os>-<arch>-<tag>`
+//
+// The cache keys sat under a comment claiming the key "is pinned to the
+// recipe's CHDB_VERSION so a version bump busts the cache automatically".
+// It is not: they are nine hand-typed copies of the tag in front of an
+// INSTALLER THAT SKIPS WHEN THE FILE ALREADY EXISTS. Bumping CHDB_VERSION
+// without editing all nine restores the OLD libchdb.so from cache, the
+// idempotent recipe then declines to replace it, and every chdb-tagged lane
+// silently keeps running on the previous engine while the repo believes it
+// moved (cerberus issue #3186).
+//
+// This gate asserts:
+//
+//   (a) just/chdb.just CHDB_VERSION parses as a `vMAJOR.MINOR.PATCH` tag and
+//       its major.minor equals versions.yaml chdb_substrate. chdb-core release
+//       tags track the ClickHouse version directly, so the two are the same
+//       number written two ways; nothing bound them before.
+//   (b) EVERY `libchdb-…` cache key across .github/workflows carries exactly
+//       that CHDB_VERSION tag. A key that names any other tag fails, and so
+//       does a workflow that caches /usr/local/lib/libchdb.so under a key
+//       shape this reader does not recognise — an unreadable key is a key
+//       this gate cannot pin, which is the same hazard as a wrong one.
+//   (c) at least one such cache key exists. The scan's own pathspec is the
+//       thing most likely to silently stop matching; a zero-key run reports
+//       success while checking nothing, so it fails instead.
+//
+// Dependency-light by design (node: builtins only), matching the other
+// .github/scripts/*.mjs modules.
+//
+// Invocation:
+//   node .github/scripts/chdb-version-sync.mjs              run the gate
+//   node .github/scripts/chdb-version-sync.mjs --self-test  pin the logic
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// ---------------------------------------------------------------------------
+// readers
+// ---------------------------------------------------------------------------
+
+// versions.yaml is read with the same flat `key: "value"` scanner
+// clickhouse-version-sync.mjs uses (the file is intentionally flat, and a YAML
+// dependency is not worth it for one key).
+export function readChdbSubstrate(text) {
+  const m = /^chdb_substrate:\s*"?([0-9]+\.[0-9]+)"?/m.exec(text);
+  return m ? m[1] : null;
+}
+
+// just/chdb.just's `CHDB_VERSION := "v26.5.0"` assignment.
+export function readChdbVersion(text) {
+  const m = /^CHDB_VERSION\s*:=\s*"([^"]+)"/m.exec(text);
+  return m ? m[1] : null;
+}
+
+// Every libchdb cache key in one workflow file, as { line, key } records.
+// The reader is deliberately two-pronged: it collects keys that MATCH the
+// expected `libchdb-<...>-<tag>` shape, and separately flags any
+// actions/cache step whose `path:` is the libchdb install path but whose key
+// this reader could not parse — see check (b).
+export function readLibchdbCacheKeys(text) {
+  const keys = [];
+  const unreadable = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*path:\s*\/usr\/local\/lib\/libchdb\.so\s*$/.test(line)) {
+      // The key line is conventionally the next non-blank line of the same
+      // `with:` block. Look ahead a short, bounded distance.
+      let found = null;
+      for (let j = i + 1; j < Math.min(i + 5, lines.length); j++) {
+        const km = /^\s*key:\s*(.+?)\s*$/.exec(lines[j]);
+        if (km) {
+          found = { line: j + 1, key: km[1] };
+          break;
+        }
+      }
+      if (found) keys.push(found);
+      else unreadable.push({ line: i + 1, key: null });
+    }
+  }
+  return { keys, unreadable };
+}
+
+// The version tag a `libchdb-${{ runner.os }}-${{ runner.arch }}-v26.5.0`
+// cache key pins, or null when the key is not of that shape.
+export function tagFromCacheKey(key) {
+  const m = /^libchdb-.*-(v[0-9]+\.[0-9]+\.[0-9]+)$/.exec(key);
+  return m ? m[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// the gate
+// ---------------------------------------------------------------------------
+
+// runChecks(sources) -> { failures, notes }. Pure over already-read strings so
+// the self-test can drive it with fixtures. `sources.workflows` is a map of
+// file name -> file text.
+export function runChecks(sources) {
+  const failures = [];
+  const notes = [];
+
+  const substrate = readChdbSubstrate(sources.versionsYaml);
+  const version = readChdbVersion(sources.chdbJust);
+
+  if (!substrate) failures.push('versions.yaml: chdb_substrate is missing or unparseable');
+  if (!version) failures.push('just/chdb.just: CHDB_VERSION is missing or unparseable');
+
+  // (a) CHDB_VERSION major.minor == chdb_substrate.
+  if (substrate && version) {
+    const m = /^v([0-9]+)\.([0-9]+)\.[0-9]+$/.exec(version);
+    if (!m) {
+      failures.push(`(a) just/chdb.just CHDB_VERSION "${version}" is not a vMAJOR.MINOR.PATCH chdb-core tag`);
+    } else if (`${m[1]}.${m[2]}` !== substrate) {
+      failures.push(
+        `(a) just/chdb.just CHDB_VERSION ${version} != versions.yaml chdb_substrate ${substrate} — ` +
+          `the chdb-core release tag tracks the ClickHouse version, so these are one number written two ways`,
+      );
+    } else {
+      notes.push(`(a) CHDB_VERSION ${version} == chdb_substrate ${substrate}`);
+    }
+  }
+
+  // (b) + (c) every libchdb cache key carries that same tag, and there is at
+  // least one to check.
+  let total = 0;
+  for (const [name, text] of Object.entries(sources.workflows)) {
+    const { keys, unreadable } = readLibchdbCacheKeys(text);
+    for (const u of unreadable) {
+      failures.push(`(b) ${name}:${u.line} caches libchdb.so with no key this gate can read`);
+    }
+    for (const k of keys) {
+      total++;
+      const tag = tagFromCacheKey(k.key);
+      if (!tag) {
+        failures.push(
+          `(b) ${name}:${k.line} libchdb cache key "${k.key}" is not of the form ` +
+            `libchdb-<...>-vMAJOR.MINOR.PATCH, so its pinned engine version cannot be checked`,
+        );
+      } else if (version && tag !== version) {
+        failures.push(
+          `(b) ${name}:${k.line} libchdb cache key pins ${tag} but just/chdb.just CHDB_VERSION is ${version} — ` +
+            `the install recipe SKIPS when the file already exists, so a stale key silently keeps the old engine`,
+        );
+      }
+    }
+  }
+  if (total === 0) {
+    failures.push(
+      '(c) no libchdb cache key was found in .github/workflows — either the caching was removed ' +
+        'or this scan stopped matching; a zero-key run checks nothing and must not report success',
+    );
+  } else if (failures.length === 0) {
+    notes.push(`(b) all ${total} libchdb cache key(s) pin ${version}`);
+  }
+
+  return { failures, notes };
+}
+
+// ---------------------------------------------------------------------------
+// self-test - pins each assertion by proving it FAILS on a deliberate mismatch
+// ---------------------------------------------------------------------------
+
+const OK_WORKFLOW = `jobs:
+  x:
+    steps:
+      - uses: actions/cache@v6
+        with:
+          path: /usr/local/lib/libchdb.so
+          key: libchdb-\${{ runner.os }}-\${{ runner.arch }}-v26.5.0
+`;
+
+function selfTest() {
+  const base = {
+    versionsYaml: 'chdb_substrate: "26.5"\n',
+    chdbJust: 'CHDB_VERSION := "v26.5.0"\n',
+    workflows: { 'a.yml': OK_WORKFLOW },
+  };
+
+  const cases = [
+    ['the repository as it stands passes', base, 0],
+    [
+      '(a) a CHDB_VERSION whose minor drifts from chdb_substrate fails',
+      { ...base, chdbJust: 'CHDB_VERSION := "v26.7.0"\n' },
+      1,
+    ],
+    [
+      '(a) a CHDB_VERSION that is not a release tag fails',
+      { ...base, chdbJust: 'CHDB_VERSION := "latest"\n' },
+      1,
+    ],
+    [
+      '(b) a cache key naming a different tag fails',
+      { ...base, workflows: { 'a.yml': OK_WORKFLOW.replace('v26.5.0', 'v26.4.0') } },
+      1,
+    ],
+    [
+      '(b) a cache key shape this gate cannot read fails',
+      { ...base, workflows: { 'a.yml': OK_WORKFLOW.replace(/key:.*/, 'key: libchdb-whatever') } },
+      1,
+    ],
+    [
+      '(b) caching libchdb.so with no key at all fails',
+      {
+        ...base,
+        workflows: { 'a.yml': OK_WORKFLOW.split('\n').filter((l) => !l.includes('key:')).join('\n') },
+      },
+      1,
+    ],
+    ['(c) finding no cache key at all fails', { ...base, workflows: { 'a.yml': 'jobs:\n' } }, 1],
+  ];
+
+  let bad = 0;
+  for (const [name, sources, wantFailures] of cases) {
+    const { failures } = runChecks(sources);
+    const got = failures.length === 0 ? 0 : 1;
+    if (got !== wantFailures) {
+      bad++;
+      console.error(`::error::self-test: ${name} — expected ${wantFailures ? 'failure' : 'success'}, got: ${failures.join('; ') || 'success'}`);
+    } else {
+      console.log(`self-test OK: ${name}`);
+    }
+  }
+  if (bad > 0) process.exit(1);
+  console.log('chdb-version-sync self-test: all assertions pinned.');
+}
+
+// ---------------------------------------------------------------------------
+// entry point
+// ---------------------------------------------------------------------------
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    selfTest();
+    return;
+  }
+
+  const workflowsDir = join(repoRoot, '.github', 'workflows');
+  const workflows = {};
+  for (const f of readdirSync(workflowsDir)) {
+    if (f.endsWith('.yml') || f.endsWith('.yaml')) {
+      workflows[`.github/workflows/${f}`] = readFileSync(join(workflowsDir, f), 'utf8');
+    }
+  }
+
+  const { failures, notes } = runChecks({
+    versionsYaml: readFileSync(join(repoRoot, 'versions.yaml'), 'utf8'),
+    chdbJust: readFileSync(join(repoRoot, 'just', 'chdb.just'), 'utf8'),
+    workflows,
+  });
+
+  for (const n of notes) console.log(`::notice::chdb-version-sync: ${n}`);
+  for (const f of failures) console.error(`::error::chdb-version-sync: ${f}`);
+  if (failures.length > 0) process.exit(1);
+  console.log('chdb-version-sync: the chDB substrate pin agrees everywhere.');
+}
+
+main();

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -249,8 +249,11 @@ jobs:
       # Cache the pinned libchdb.so so the install step is a no-op cache
       # hit on the common path (the recipe is idempotent — it skips the
       # download when the file already exists at CHDB_INSTALL_PATH). The
-      # key is pinned to the recipe's CHDB_VERSION so a version bump busts
-      # the cache automatically.
+      # key names the recipe's CHDB_VERSION explicitly. It is NOT derived:
+      # .github/scripts/chdb-version-sync.mjs is what keeps every copy equal
+      # to the recipe, because the install step SKIPS when the file already
+      # exists, so a key left behind on a bump silently restores the old
+      # engine and keeps it.
       - name: Cache libchdb.so
         uses: actions/cache@v6
         with:
@@ -701,7 +704,9 @@ jobs:
       # and that fixed setup cost would eat much of the wall-clock the split is
       # buying. The recipe is idempotent — it skips the download when the file
       # is already at CHDB_INSTALL_PATH — so a cache hit makes the next step a
-      # no-op. Key pinned to the recipe's CHDB_VERSION so a bump busts it.
+      # no-op. The key names the recipe's CHDB_VERSION explicitly; it is not
+      # derived, and .github/scripts/chdb-version-sync.mjs is what keeps the
+      # two equal.
       - name: Cache libchdb.so
         uses: actions/cache@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,6 +815,19 @@ jobs:
         run: node .github/scripts/clickhouse-version-sync.mjs --self-test
       - name: ClickHouse version-sync gate
         run: node .github/scripts/clickhouse-version-sync.mjs
+      # chDB substrate pin gate. The libchdb.so every chdb-tagged lane runs
+      # on is pinned in three places — versions.yaml chdb_substrate,
+      # just/chdb.just CHDB_VERSION, and every actions/cache libchdb key —
+      # and nothing read them against each other. The install recipe is
+      # idempotent, so a cache key left on the old tag restores the previous
+      # engine and the recipe declines to replace it: the bump appears to
+      # land while every lane keeps running on the old ClickHouse. The
+      # `--self-test` run proves each assertion still FAILS on a deliberate
+      # mismatch — see .github/scripts/README.md.
+      - name: chDB version-sync self-test
+        run: node .github/scripts/chdb-version-sync.mjs --self-test
+      - name: chDB version-sync gate
+        run: node .github/scripts/chdb-version-sync.mjs
       # Assert-from-source doc-count gate. Doc prose states integer counts
       # that DESCRIBE source structures ("N forbid-skip checks", "N-layer
       # test map"); those literals rot the moment the structure grows. This

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -178,6 +178,12 @@ components:
   # activation-proof assertion. Consumed by test/perf/smoke and
   # internal/api/prom's real-CH integration lanes (issue #2487).
   chopttest:      { in: chopttest }
+  # Turns a resolved chopt.EnabledSet into the two things the query stack is
+  # configured with from it — the promql.RangeLowerers dispatch table and the
+  # capability-decided half of engine.SettingsRules. Exists so cmd/cerberus's
+  # boot path and internal/chopttest's real-CH activation harness compose them
+  # from ONE function instead of two reviewed copies (issue #3186).
+  choptwire:      { in: choptwire }
   sealedscan:     { in: sealedscan }
   dispatchscan:   { in: dispatchscan }
   testsql:        { in: testsql }
@@ -567,6 +573,14 @@ deps:
   chopttest:
     mayDependOn:
       - chclient
+      - promql
+      - engine
+      - choptwire
+  # choptwire composes the boot-resolved capability set onto the query stack:
+  # the promql lowering table and the engine settings rules. Those two are its
+  # whole dependency set.
+  choptwire:
+    mayDependOn:
       - promql
       - engine
   # api-reqctx resolves the per-request query budget and threads it onto

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -33,6 +33,7 @@ import (
 	tempogrpc "github.com/tsouza/cerberus/internal/api/tempo/grpc"
 	"github.com/tsouza/cerberus/internal/chclient"
 	"github.com/tsouza/cerberus/internal/chopt"
+	"github.com/tsouza/cerberus/internal/choptwire"
 	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/config"
 	"github.com/tsouza/cerberus/internal/engine"
@@ -1058,331 +1059,15 @@ func (a queryLogQuerierAdapter) QueryLogActuals(ctx context.Context, since time.
 	return out, nil
 }
 
-// nativeRangeLowerers builds the BOOT-WIRED polymorphic lowering dispatch table
-// for the ClickHouse-native timeSeries*ToGrid family from the resolved
-// optimization EnabledSet. The feature/version decision is made HERE, ONCE, at
-// boot (optSet was produced by the single boot-time version probe in
-// resolveCHOptimizations) and is the ONLY place the feature is read: each field
-// is wired to a CONCRETE non-nil strategy —
-//
-//	rate      = enabled ? NativeRateLowerer{Fallback: rateFallback} : rateFallback
-//	increase  = enabled ? NativeIncreaseLowerer{Fallback: increaseFallback} : increaseFallback
-//	delta     = enabled ? NativeDeltaLowerer{Fallback: deltaFallback} : deltaFallback
-//	  // where rateFallback/increaseFallback/deltaFallback are each
-//	  // fixedAccumEnabled ? FixedAccumulator*Lowerer{Fallback: Fanout*Lowerer{}} : Fanout*Lowerer{}
-//	staleness = enabled ? NativeStalenessLowerer{Fallback: FanoutStalenessLowerer{}} : FanoutStalenessLowerer{}
-//	changes   = enabled ? NativeChangesLowerer{Fallback: changesFallback} : changesFallback
-//	resets    = enabled ? NativeResetsLowerer{Fallback: resetsFallback} : resetsFallback
-//	irate     = enabled ? NativeIrateLowerer{Fallback: irateFallback} : irateFallback
-//	idelta    = enabled ? NativeIdeltaLowerer{Fallback: ideltaFallback} : ideltaFallback
-//	  // where changesFallback/resetsFallback/irateFallback/ideltaFallback are each
-//	  // laginframeEnabled ? LagAdjacency*Lowerer{Fallback: Fanout*Lowerer{}} : Fanout*Lowerer{}
-//	deriv     = enabled ? NativeDerivLowerer{Fallback: FanoutDerivLowerer{}} : FanoutDerivLowerer{}
-//	predict   = enabled ? NativePredictLinearLowerer{Fallback: FanoutPredictLinearLowerer{}} : FanoutPredictLinearLowerer{}
-//	classicHq = enabled ? NativeClassicHistogramWindowLowerer{Fallback: Fanout…{}} : Fanout…{}
-//	rankWalk  = enabled ? NativeQuantileRankWalkLowerer{} : FanoutQuantileRankWalkLowerer{}
-//	lastOverTime = enabled ? NativeLastOverTimeLowerer{Fallback: FanoutLastOverTimeLowerer{}} : FanoutLastOverTimeLowerer{}
-//	  // downsampleTierEnabled ? DownsampleTier{Irate,Idelta,LastOverTime}Lowerer{Fallback: <above>} : <above> unchanged
-//	overTime  = sortedSlabEnabled ? SortedSlabOverTimeLowerer{Fallback: FanoutOverTimeLowerer{}} : FanoutOverTimeLowerer{}
-//
-// rankWalk (quantile_prom_histogram) is not a timeSeries*ToGrid member — it
-// wraps ClickHouse's separate quantilePrometheusHistogram aggregate (floor
-// 25.10) — and carries no embedded Fallback because it has no shape-based
-// fallback to embed (see promql.QuantileRankWalkLowerer's own doc); it is
-// resolved here, in this same table, only because RangeLowerers is the one
-// seam every classic-histogram-quantile lowering already threads.
-//
-// overTime (sum_over_time/avg_over_time, issue #2761) is likewise not a
-// timeSeries*ToGrid member and carries no native competitor, but unlike
-// rankWalk it DOES embed a Fallback (the plain fan-out) — its sorted-slab
-// decomposition is a shape-gated SQL rewrite with its own eligibility guard
-// (sortedSlabOverTimeEligible), the same posture fixed_accumulator_extrapolated
-// has for rate/increase/delta, not an always-applicable aggregate swap like
-// rankWalk's.
-//
-// The fan-out impl is the concrete DEFAULT (never nil), and the native impl
-// embeds it as the fallback for shapes it cannot handle. The features are
-// independent, so the table composes per-function — native rate can be on while
-// native staleness / changes / resets / deriv / predict_linear are off, and vice
-// versa (the whole family shares the 25.9 floor, but each member is probed and
-// resolved on its own). The per-query
-// lowering then
-// dispatches through this table as a plain interface method call: NO
-// feature/version read, NO nil/presence check.
-//
-// ts_grid_recollapse is the one NON-independent knob: it defers the
-// label-shaping tower past the native rate grid, so it only means anything
-// inside the ts_grid_range branch. The registry has no inter-feature dependency
-// mechanism, so that narrowing is expressed HERE — reading it only where a
-// native rate lowerer is being built makes "recollapse without a native grid"
-// unrepresentable rather than merely unlikely.
-//
-// laginframe_adjacency (issue #2759) is a second non-independent knob, but in
-// the opposite direction from recollapse: it narrows changes/resets/irate/
-// idelta's FALLBACK (the arm a shape-ineligible or sub-25.9 server lands on),
-// not their native arm. It was irate/idelta's ONLY non-fan-out strategy until
-// issue #2746 gave them their own native timeSeriesInstantRateToGrid /
-// timeSeriesInstantDeltaToGrid competitor, so all four of changes / resets /
-// irate / idelta now share the identical three-tier Native{Fallback:
-// LagAdjacency{Fallback: Fanout{}}} composition. Unlike every ts_grid_*
-// feature it carries no version floor (chopt.AlwaysAvailable) and no
-// experimental-setting gate, so it composes with the version-gated native
-// features purely via which Fallback each Native*Lowerer embeds.
-//
-// fixed_accumulator_extrapolated (issue #2760) is laginframe_adjacency's own
-// sibling for the extrapolated family: it narrows rate/increase/delta's
-// FALLBACK the same way — delta gained its own native ts_grid_delta
-// competitor (issue #2745), so as of that feature all three of rate /
-// increase / delta share the identical three-tier
-// Native{Fallback: FixedAccumulator{Fallback: Fanout{}}} composition. Same
-// AlwaysAvailable floor, same no-experimental-setting posture, same "narrows
-// the fallback, never competes with the native arm" shape.
-//
-// ts_grid_instant (issue #2748) narrows the NATIVE arm itself rather than the
-// fallback — the opposite direction from recollapse/laginframe/fixed-
-// accumulator above. Each of rate/changes/resets/deriv/predict_linear's
-// Native*Lowerer gains an Instant field, set to tsGridInstant ONLY inside
-// that same function's own "matrix feature enabled" branch, so the instant
-// arm can never fire for a function whose matrix arm is off. increase() and
-// delta() are out of scope (see chopt.FeatureTSGridInstant's own doc) and
-// carry no Instant field.
-//
-// ts_grid_group_array (issue #2749) is a third non-swappable emission-detail
-// bit, mirroring VectorAgg's own posture: it lives on RangeLowerers itself
-// (promql.RangeLowerers.NativeGroupArray) rather than on any single
-// Native*Lowerer, and is set unconditionally below because rate/increase/
-// delta's fanout lowering reads it directly off the SAME chplan.RangeWindow
-// node regardless of which of those three functions' own Native /
-// FixedAccumulator / Fanout tiers produced it.
+// nativeRangeLowerers builds the boot-wired polymorphic lowering dispatch
+// table for the ClickHouse-native timeSeries*ToGrid family from the resolved
+// optimization EnabledSet. The formula itself lives in internal/choptwire,
+// which internal/chopttest wires the real-ClickHouse activation tests through,
+// so the table those lanes validate is literally the one the binary boots
+// with — see that package's doc for the whole composition and why it is not
+// written here (cerberus issue #3186).
 func nativeRangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
-	var l promql.RangeLowerers
-	// arg_and_max_fusion (issue #2764) is a plain emission-detail bit, not
-	// a swappable strategy — see RangeLowerers.ArgAndMaxFusion's own doc.
-	// It feeds BOTH the VectorJoin site (read directly off this table by
-	// internal/promql/binary.go) and the RangeLWR site (its own copy on
-	// FanoutStalenessLowerer below, threaded either directly or as the
-	// native staleness lowerer's embedded Fallback).
-	argAndMaxFusion := optSet.Has(chopt.FeatureArgAndMaxFusion)
-	l.ArgAndMaxFusion = argAndMaxFusion
-	// ts_grid_vector_agg (issue #2763) is a pure narrowing of ts_grid_range,
-	// but — unlike ts_grid_recollapse — it lives on RangeLowerers itself
-	// rather than on NativeRateLowerer (or any single Native*Lowerer),
-	// because lowerAggregate consults it at a LATER lowering stage than any
-	// range-function Lowerer: only after a range function has already
-	// lowered its input, and only when that input turns out to be a
-	// *chplan.RangeWindowGridNative. Setting it unconditionally here (never
-	// nested inside `if optSet.Has(chopt.FeatureTSGridRange)`) is therefore
-	// safe rather than a narrowing gap: the field is inert whenever no
-	// native grid node exists for lowerAggregate to fold into.
-	l.VectorAgg = optSet.Has(chopt.FeatureTSGridVectorAgg)
-	// ts_grid_group_array (issue #2749) is, like VectorAgg immediately
-	// above, a plain narrowing bit rather than a per-function Lowerer swap:
-	// it never changes WHICH of rate/increase/delta's own Native /
-	// FixedAccumulator / Fanout tiers fires, only how that tier's array-fold
-	// fallback assembles its per-series sample array. Set unconditionally
-	// here for the same reason VectorAgg is — it lives on RangeLowerers
-	// itself, not on any single Native*Lowerer.
-	l.NativeGroupArray = optSet.Has(chopt.FeatureTSGridGroupArray)
-	// ts_grid_instant (issue #2748) is a pure narrowing of each of
-	// rate/changes/resets/deriv/predict_linear's own matrix feature — it is
-	// consulted ONLY inside each function's own "matrix feature enabled"
-	// branch below, exactly like ts_grid_recollapse narrows ts_grid_range,
-	// so it can never make a Native*Lowerer's instant arm reachable on its
-	// own.
-	tsGridInstant := optSet.Has(chopt.FeatureTSGridInstant)
-	// fixed_accumulator_extrapolated (issue #2760) layers BENEATH
-	// rate/increase/delta's own native ts_grid strategy, exactly like
-	// laginframe_adjacency layers inside changes/resets below: it is the
-	// improved fan-out a shape-ineligible, sub-25.9, or temporality-bearing
-	// window falls back to, never a competitor to the native path.
-	var rateFallback promql.RateLowerer = promql.FanoutRateLowerer{}
-	var increaseFallback promql.IncreaseLowerer = promql.FanoutIncreaseLowerer{}
-	var deltaFallback promql.DeltaLowerer = promql.FanoutDeltaLowerer{}
-	if optSet.Has(chopt.FeatureFixedAccumulatorExtrapolated) {
-		rateFallback = promql.FixedAccumulatorRateLowerer{Fallback: rateFallback}
-		increaseFallback = promql.FixedAccumulatorIncreaseLowerer{Fallback: increaseFallback}
-		deltaFallback = promql.FixedAccumulatorDeltaLowerer{Fallback: deltaFallback}
-	}
-	if optSet.Has(chopt.FeatureTSGridRange) {
-		l.Rate = promql.NativeRateLowerer{
-			Fallback:   rateFallback,
-			Recollapse: optSet.Has(chopt.FeatureTSGridRecollapse),
-			Instant:    tsGridInstant,
-		}
-	} else {
-		l.Rate = rateFallback
-	}
-	if optSet.Has(chopt.FeatureTSGridIncrease) {
-		l.Increase = promql.NativeIncreaseLowerer{Fallback: increaseFallback}
-	} else {
-		l.Increase = increaseFallback
-	}
-	if optSet.Has(chopt.FeatureTSGridResample) {
-		l.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{ArgAndMaxFusion: argAndMaxFusion}}
-	} else {
-		l.Staleness = promql.FanoutStalenessLowerer{ArgAndMaxFusion: argAndMaxFusion}
-	}
-	// laginframe_adjacency (issue #2759) layers BENEATH changes/resets' own
-	// native ts_grid strategy, exactly like ts_grid_recollapse layers inside
-	// ts_grid_range above: it is the improved fan-out a shape-ineligible or
-	// sub-25.9 server falls back to, never a competitor to the native path.
-	var changesFallback promql.ChangesLowerer = promql.FanoutChangesLowerer{}
-	var resetsFallback promql.ResetsLowerer = promql.FanoutResetsLowerer{}
-	if optSet.Has(chopt.FeatureLagInFrameAdjacency) {
-		changesFallback = promql.LagAdjacencyChangesLowerer{Fallback: changesFallback}
-		resetsFallback = promql.LagAdjacencyResetsLowerer{Fallback: resetsFallback}
-	}
-	if optSet.Has(chopt.FeatureTSGridChanges) {
-		l.Changes = promql.NativeChangesLowerer{Fallback: changesFallback, Instant: tsGridInstant}
-	} else {
-		l.Changes = changesFallback
-	}
-	if optSet.Has(chopt.FeatureTSGridResets) {
-		l.Resets = promql.NativeResetsLowerer{Fallback: resetsFallback, Instant: tsGridInstant}
-	} else {
-		l.Resets = resetsFallback
-	}
-	// irate/idelta gained their own native timeSeries*ToGrid member
-	// (timeSeriesInstantRateToGrid / timeSeriesInstantDeltaToGrid, cerberus
-	// issue #2746): laginframe_adjacency now layers BENEATH that native
-	// strategy exactly like it does for changes/resets above, rather than
-	// being their only non-fan-out strategy the way issue #2759 originally
-	// left it.
-	var irateFallback promql.IrateLowerer = promql.FanoutIrateLowerer{}
-	var ideltaFallback promql.IdeltaLowerer = promql.FanoutIdeltaLowerer{}
-	if optSet.Has(chopt.FeatureLagInFrameAdjacency) {
-		irateFallback = promql.LagAdjacencyIrateLowerer{Fallback: irateFallback}
-		ideltaFallback = promql.LagAdjacencyIdeltaLowerer{Fallback: ideltaFallback}
-	}
-	if optSet.Has(chopt.FeatureTSGridIrate) {
-		l.Irate = promql.NativeIrateLowerer{Fallback: irateFallback}
-	} else {
-		l.Irate = irateFallback
-	}
-	if optSet.Has(chopt.FeatureTSGridIdelta) {
-		l.Idelta = promql.NativeIdeltaLowerer{Fallback: ideltaFallback}
-	} else {
-		l.Idelta = ideltaFallback
-	}
-	if optSet.Has(chopt.FeatureTSGridDeriv) {
-		l.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}, Instant: tsGridInstant}
-	} else {
-		l.Deriv = promql.FanoutDerivLowerer{}
-	}
-	if optSet.Has(chopt.FeatureTSGridPredictLinear) {
-		l.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}, Instant: tsGridInstant}
-	} else {
-		l.PredictLinear = promql.FanoutPredictLinearLowerer{}
-	}
-	if optSet.Has(chopt.FeatureTSGridDelta) {
-		l.Delta = promql.NativeDeltaLowerer{Fallback: deltaFallback}
-	} else {
-		l.Delta = deltaFallback
-	}
-	// The anchor-injection window-slide mechanism (#2408 follow-up, #2493)
-	// was removed by #2511's root-cause investigation: its anchor-injection
-	// UNION structurally requires the per-series canonical-bound subquery to
-	// be inlined into BOTH UNION arms (real rows' JOIN and the sentinel
-	// arm's FROM), and this codebase's chsql architecture only single-
-	// evaluates a genuinely scalar CTE (QueryBuilder.WithScalar) — a
-	// relational CTE re-inlines, and re-scans, at every reference
-	// (QueryBuilder.With's own doc). Real EXPLAIN PLAN / EXPLAIN PIPELINE
-	// evidence against chDB confirmed 3 independent ReadFromMergeTree scans
-	// of the base table for one window-slide query where the fan-out needs
-	// one, plus the shared LIMIT+throwIf resource-bound pattern doubling
-	// whatever that count is — the real root cause of the ~5x-more-bytes
-	// regression #2511 measured. No fix avoids this without either
-	// reintroducing the O(rows^2)-per-series blow-up an earlier review
-	// already rejected, or a per-row scalar-map lookup against thousands of
-	// series (unvalidated and very likely slower still). Combined with the
-	// mechanism's own real-world win being marginal at the modal dashboard
-	// shape (1.12x at 5m/1m, per #2408's own Task-1 spike), fan-out is kept
-	// as the sole classic-histogram range-window path below the native
-	// rate ladder.
-	if optSet.Has(chopt.FeatureTSGridHistogram) {
-		l.ClassicHistogram = promql.NativeClassicHistogramWindowLowerer{
-			Fallback: promql.FanoutClassicHistogramWindowLowerer{},
-		}
-	} else {
-		l.ClassicHistogram = promql.FanoutClassicHistogramWindowLowerer{}
-	}
-	// quantile_prom_histogram has no shape-based fallback (see
-	// promql.QuantileRankWalkLowerer's own doc), so the native strategy is
-	// wired directly with no embedded Fallback field.
-	if optSet.Has(chopt.FeatureQuantilePromHistogram) {
-		l.QuantileRankWalk = promql.NativeQuantileRankWalkLowerer{}
-	} else {
-		l.QuantileRankWalk = promql.FanoutQuantileRankWalkLowerer{}
-	}
-	// ts_grid_last_over_time rides the SAME native strategy shape as every
-	// other independent family member (Native{Fallback: Fanout{}}) — it has
-	// no narrowing/narrowed sibling knob of its own (no recollapse-style
-	// dependent, no laginframe/fixed-accumulator-style improved fallback).
-	if optSet.Has(chopt.FeatureTSGridLastOverTime) {
-		l.LastOverTime = promql.NativeLastOverTimeLowerer{Fallback: promql.FanoutLastOverTimeLowerer{}}
-	} else {
-		l.LastOverTime = promql.FanoutLastOverTimeLowerer{}
-	}
-	// downsample_tier (cerberus issue #2751) WRAPS whatever irate/idelta/
-	// last_over_time strategy was just resolved above — it is a genuinely
-	// different mechanism (an operator-provisioned, pre-populated table, not
-	// a stateless read-time function swap over the raw table), so it sits
-	// as an outer layer: an eligible shape routes to the tier, everything
-	// else falls through to the family's own best-available raw-scan
-	// strategy (native/laginframe/fanout) unchanged. See
-	// chopt.FeatureDownsampleTier's own doc for why rate()/increase()/
-	// delta() have no such wrapping at all.
-	if optSet.Has(chopt.FeatureDownsampleTier) {
-		l.Irate = promql.DownsampleTierIrateLowerer{Fallback: l.Irate}
-		l.Idelta = promql.DownsampleTierIdeltaLowerer{Fallback: l.Idelta}
-		l.LastOverTime = promql.DownsampleTierLastOverTimeLowerer{Fallback: l.LastOverTime}
-	}
-	// sorted_slab_over_time (issue #2761, widened to first_over_time /
-	// stddev_over_time / stdvar_over_time / mad_over_time by issue #2804)
-	// has no native timeSeries*ToGrid competitor: this whole function set's
-	// only non-fan-out arm is the sorted-slab decomposition itself, so it is
-	// wired directly with no embedded native layer above it (mirroring
-	// quantile_prom_histogram's posture just above, though this strategy
-	// DOES still embed its own Fallback — the plain fan-out — the way
-	// fixed_accumulator_extrapolated does for rate/increase/delta). One
-	// lowerer wiring covers the whole set: which PromQL function names
-	// reach it at all is decided upstream, purely by AST dispatch, in
-	// internal/promql/lower.go's `lowerRangeVectorCallFanout` switch — see
-	// that switch's own doc for why last_over_time deliberately never
-	// reaches this lowerer despite sharing its shape-eligibility check.
-	if optSet.Has(chopt.FeatureSortedSlabOverTime) {
-		l.OverTime = promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}}
-	} else {
-		l.OverTime = promql.FanoutOverTimeLowerer{}
-	}
-	// classic_bucket_merge_summap (issue #2756) has no version floor to
-	// probe. #2817 closed its original correctness blocker; issue #2923's
-	// real-ClickHouse re-measurement against the resulting (post-#2817)
-	// construction then found its real cost within ~1% of the fold's, not
-	// the estimated ~50x win — so AutoSelect stays false, a measured
-	// negative result rather than an open question. See
-	// promql.NativeClassicBucketMergeLowerer's own doc and
-	// classic_bucket_merge_summap.go's header.
-	if optSet.Has(chopt.FeatureClassicBucketMergeSumMap) {
-		l.ClassicBucketMerge = promql.NativeClassicBucketMergeLowerer{
-			Fallback: promql.FanoutClassicBucketMergeLowerer{},
-		}
-	} else {
-		l.ClassicBucketMerge = promql.FanoutClassicBucketMergeLowerer{}
-	}
-	// exp_histogram_merge_summap (issue #2757) has no version floor to
-	// probe, but ships AutoSelect: false: it now covers every shape —
-	// instant AND range mode (cerberus issue #3027), any by()/without()
-	// grouping (#2865), SUM or AVG fold (#2866) — each with its own
-	// real-ClickHouse-calibrated budget guard rather than a reuse of the
-	// classic fold's rows-dominated one — see
-	// promql.NativeExpHistogramMergeLowerer's own doc.
-	if optSet.Has(chopt.FeatureExpHistogramMergeSumMap) {
-		l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{}
-	} else {
-		l.ExpHistogramMerge = promql.FanoutExpHistogramMergeLowerer{}
-	}
-	return l
+	return choptwire.RangeLowerers(optSet)
 }
 
 // newLokiHandler builds the Loki head's handler with its limiters, version,
@@ -1479,21 +1164,17 @@ func newLokiHandler(client *chclient.Client, cfg config.Config, optSet chopt.Ena
 // of which head runs the query. Shared by all three heads' engines so the
 // rules flip uniformly.
 func settingsRules(cfg config.Config, set chopt.EnabledSet) engine.SettingsRules {
-	return engine.SettingsRules{
-		OptimizeAggregationInOrder: set.Has(chopt.FeatureAggregationInOrder),
-		ConditionCache:             set.Has(chopt.FeatureConditionCache),
-		JoinSpill:                  set.Has(chopt.FeatureJoinSpill),
-		TraceIDBitmapFilter:        set.Has(chopt.FeatureTraceIDBitmapFilter),
-		LogCommentShape:            cfg.LogCommentShape,
-		ResultCache:                set.Has(chopt.FeatureResultCache),
-		ResultCacheIngestLag:       cfg.ResultCacheIngestLag,
-		ResultCacheTTL:             cfg.ResultCacheTTL,
-		LazyMaterialization:        set.Has(chopt.FeatureLazyMaterialization),
-		QueryWorkload:              cfg.CHQueryWorkload,
-		Metrics:                    cfg.Schema,
-		Traces:                     cfg.Traces,
-		Logs:                       cfg.Logs,
-	}
+	// The capability-decided fields come from the one composition
+	// internal/chopttest also wires the real-ClickHouse activation tests
+	// through, so those lanes validate this table rather than a copy of it
+	// (cerberus issue #3186). Only the OPERATOR-configured knobs — which are
+	// read off config.Config, not off the EnabledSet — are overlaid here.
+	rules := choptwire.SettingsRules(set, cfg.Schema, cfg.Traces, cfg.Logs)
+	rules.LogCommentShape = cfg.LogCommentShape
+	rules.ResultCacheIngestLag = cfg.ResultCacheIngestLag
+	rules.ResultCacheTTL = cfg.ResultCacheTTL
+	rules.QueryWorkload = cfg.CHQueryWorkload
+	return rules
 }
 
 // viewRefreshStateInfo reads system.view_refreshes for one (database, view)

--- a/internal/actuals/config.go
+++ b/internal/actuals/config.go
@@ -78,7 +78,7 @@ type Config struct {
 	// MinObservations (CERBERUS_QUERY_ACTUALS_MIN_OBSERVATIONS) is the
 	// corroboration floor before a shape's drift verdict is trusted at all —
 	// mirroring internal/engine's own perRungEvidenceMinObservations /
-	// routememo's minCorroboratingFailures: a single anomalous actual must
+	// routememo's MinCorroboratingFailures: a single anomalous actual must
 	// never, by itself, flip a shape's verdict. This is the anti-autotune
 	// bound on OBSERVATION COUNT; EMAAlpha below is the matching bound on
 	// per-observation INFLUENCE.
@@ -97,7 +97,7 @@ type Config struct {
 
 	// EntryTTL (CERBERUS_QUERY_ACTUALS_ENTRY_TTL) bounds how long a shape's
 	// tracked state is trusted before it ages out — mirroring
-	// routememo.memoEntryTTL / the per-rung admission learner's
+	// routememo.MemoEntryTTL / the per-rung admission learner's
 	// perRungEvidenceTTL: a shape's real cardinality can grow, and a verdict
 	// computed against a stale window must not silently suppress recalibration
 	// forever once that has happened.
@@ -145,7 +145,7 @@ const (
 	defaultDriftUpperRatio = 3.0
 
 	// defaultMinObservations mirrors internal/engine's own
-	// perRungEvidenceMinObservations and routememo's minCorroboratingFailures
+	// perRungEvidenceMinObservations and routememo's MinCorroboratingFailures
 	// (both 2): a single observation is never enough evidence to flip a
 	// shape's advisory verdict.
 	defaultMinObservations = 2
@@ -158,7 +158,7 @@ const (
 	// requires.
 	defaultEMAAlpha = 0.2
 
-	// defaultEntryTTL mirrors routememo.memoEntryTTL / the per-rung admission
+	// defaultEntryTTL mirrors routememo.MemoEntryTTL / the per-rung admission
 	// learner's perRungEvidenceTTL (both 30m).
 	defaultEntryTTL = 30 * time.Minute
 

--- a/internal/chopttest/doc.go
+++ b/internal/chopttest/doc.go
@@ -21,11 +21,16 @@
 // boot (docker-compose / e2e / compose-smoke, none of which assert a
 // specific native family actually activated) — issue #2487.
 //
-// BuildRangeLowerers is a deliberate, reviewed duplicate of
-// nativeRangeLowerers's dispatch-table formula, not an import (it cannot be
-// one). Keeping the two in lockstep is a reviewer-discipline concern, the
-// same way nightlyClassicHistogramLowerer's own doc comment already flags
-// for the one field it duplicates.
+// BuildRangeLowerers and BuildSettingsRules are thin delegators to
+// internal/choptwire, the package cmd/cerberus's own boot path composes both
+// tables from. They used to be reviewed DUPLICATES of that formula, on the
+// stated grounds that an unexported `package main` function cannot be
+// imported — true of the function, false of the formula, which depends only
+// on chopt, promql and engine and so always belonged in an importable
+// package. While they were copies, every real-CH activation lane validated
+// the copy rather than the production wiring, so a feature wired in one and
+// forgotten in the other passed every activation test and shipped inert
+// (cerberus issue #3186).
 //
 // AssertNativeFunctionFired is the activation-proof half: an HTTP 200 alone
 // is indistinguishable from a silent fall-back to the fan-out path, so it

--- a/internal/chopttest/range_lowerers.go
+++ b/internal/chopttest/range_lowerers.go
@@ -2,223 +2,27 @@ package chopttest
 
 import (
 	"github.com/tsouza/cerberus/internal/chopt"
+	"github.com/tsouza/cerberus/internal/choptwire"
 	"github.com/tsouza/cerberus/internal/promql"
 )
 
 // This file carries no build tag on purpose: BuildRangeLowerers depends only
 // on chopt and promql, and the untagged unit lane's solver-decision ratchet
-// (test/perf/solver_decision_ratchet_test.go) consumes it as THE one
-// test-side copy of cmd/cerberus's nativeRangeLowerers composition, instead
-// of carrying a third hand-rolled mirror of it. The rest of this package
-// stays behind the integration tag because it needs a live ClickHouse.
+// (test/perf/solver_decision_ratchet_test.go) consumes it. The rest of this
+// package stays behind the integration tag because it needs a live
+// ClickHouse.
 
 // BuildRangeLowerers builds the FULL promql.RangeLowerers dispatch table from
-// set, field-for-field identical to cmd/cerberus/main.go's own
-// nativeRangeLowerers — see that function's doc comment for the formula
-// (a feature-gated native impl always embeds the NEXT link as its own
-// Fallback, never the bare fan-out impl directly). It duplicates that
-// function's body rather than importing it: nativeRangeLowerers is
-// unexported in `package main` (cmd/cerberus) and so cannot be imported by
-// any test package. Recollapse tracks chopt.FeatureTSGridRecollapse exactly
-// as main.go's does.
+// set. It is the SAME function cmd/cerberus's boot path calls — both delegate
+// to internal/choptwire.Build — so a real-ClickHouse activation test wired
+// through here is exercising the production table, not a copy of it.
+//
+// It used to be a reviewed duplicate of cmd/cerberus's own unexported
+// nativeRangeLowerers, on the stated grounds that an unexported `package main`
+// function cannot be imported. That was true of the function and false of the
+// formula: it depends only on chopt and promql and so always belonged in an
+// importable package. Every real-CH activation lane therefore validated the
+// copy while the binary booted the original (cerberus issue #3186).
 func BuildRangeLowerers(set chopt.EnabledSet) promql.RangeLowerers {
-	var l promql.RangeLowerers
-
-	// arg_and_max_fusion is a plain emission-detail bit, not a swappable
-	// strategy (RangeLowerers.ArgAndMaxFusion's own doc) — mirrors
-	// cmd/cerberus/main.go's nativeRangeLowerers exactly. It feeds both the
-	// VectorJoin site (read directly off this table) and the RangeLWR site
-	// via FanoutStalenessLowerer below.
-	argAndMaxFusion := set.Has(chopt.FeatureArgAndMaxFusion)
-	l.ArgAndMaxFusion = argAndMaxFusion
-
-	// ts_grid_vector_agg lives on RangeLowerers itself (never nested inside
-	// a `set.Has(chopt.FeatureTSGridRange)` branch) — mirrors
-	// cmd/cerberus/main.go's nativeRangeLowerers exactly; see
-	// promql.RangeLowerers.VectorAgg's own doc for why.
-	l.VectorAgg = set.Has(chopt.FeatureTSGridVectorAgg)
-
-	// ts_grid_group_array is, like VectorAgg immediately above, a plain
-	// narrowing bit rather than a per-function Lowerer swap — mirrors
-	// cmd/cerberus/main.go's nativeRangeLowerers exactly (cerberus issue
-	// #2749).
-	l.NativeGroupArray = set.Has(chopt.FeatureTSGridGroupArray)
-
-	// ts_grid_instant is NOT part of AllNativeOptimizations (new 26.5 floor,
-	// AutoSelect=false — see chopt.FeatureTSGridInstant's own doc), the same
-	// posture quantile_prom_histogram / ts_grid_last_over_time already take
-	// below: callers who want it activated resolve it explicitly against a
-	// >= 26.5 server and pass the resulting set here. It is a pure narrowing
-	// of each of rate/changes/resets/deriv/predict_linear's own matrix
-	// feature (never independently reachable), mirroring
-	// cmd/cerberus/main.go's nativeRangeLowerers exactly.
-	tsGridInstant := set.Has(chopt.FeatureTSGridInstant)
-
-	// fixed_accumulator_extrapolated layers BENEATH rate/increase/delta's own
-	// native ts_grid strategy, exactly like laginframe_adjacency layers
-	// inside irate/idelta below — mirrors cmd/cerberus/main.go's
-	// nativeRangeLowerers exactly (cerberus issue #2760).
-	var rateFallback promql.RateLowerer = promql.FanoutRateLowerer{}
-	var increaseFallback promql.IncreaseLowerer = promql.FanoutIncreaseLowerer{}
-	var deltaFallback promql.DeltaLowerer = promql.FanoutDeltaLowerer{}
-	if set.Has(chopt.FeatureFixedAccumulatorExtrapolated) {
-		rateFallback = promql.FixedAccumulatorRateLowerer{Fallback: rateFallback}
-		increaseFallback = promql.FixedAccumulatorIncreaseLowerer{Fallback: increaseFallback}
-		deltaFallback = promql.FixedAccumulatorDeltaLowerer{Fallback: deltaFallback}
-	}
-	if set.Has(chopt.FeatureTSGridRange) {
-		l.Rate = promql.NativeRateLowerer{
-			Fallback:   rateFallback,
-			Recollapse: set.Has(chopt.FeatureTSGridRecollapse),
-			Instant:    tsGridInstant,
-		}
-	} else {
-		l.Rate = rateFallback
-	}
-	if set.Has(chopt.FeatureTSGridIncrease) {
-		l.Increase = promql.NativeIncreaseLowerer{Fallback: increaseFallback}
-	} else {
-		l.Increase = increaseFallback
-	}
-	if set.Has(chopt.FeatureTSGridResample) {
-		l.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{ArgAndMaxFusion: argAndMaxFusion}}
-	} else {
-		l.Staleness = promql.FanoutStalenessLowerer{ArgAndMaxFusion: argAndMaxFusion}
-	}
-
-	// changes/resets: laginframe_adjacency layers BENEATH their own native
-	// ts_grid strategy, exactly like it does for irate/idelta below —
-	// mirrors cmd/cerberus/main.go's nativeRangeLowerers exactly (cerberus
-	// issue #2759).
-	var changesFallback promql.ChangesLowerer = promql.FanoutChangesLowerer{}
-	var resetsFallback promql.ResetsLowerer = promql.FanoutResetsLowerer{}
-	if set.Has(chopt.FeatureLagInFrameAdjacency) {
-		changesFallback = promql.LagAdjacencyChangesLowerer{Fallback: changesFallback}
-		resetsFallback = promql.LagAdjacencyResetsLowerer{Fallback: resetsFallback}
-	}
-	if set.Has(chopt.FeatureTSGridChanges) {
-		l.Changes = promql.NativeChangesLowerer{Fallback: changesFallback, Instant: tsGridInstant}
-	} else {
-		l.Changes = changesFallback
-	}
-	if set.Has(chopt.FeatureTSGridResets) {
-		l.Resets = promql.NativeResetsLowerer{Fallback: resetsFallback, Instant: tsGridInstant}
-	} else {
-		l.Resets = resetsFallback
-	}
-	if set.Has(chopt.FeatureTSGridDeriv) {
-		l.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}, Instant: tsGridInstant}
-	} else {
-		l.Deriv = promql.FanoutDerivLowerer{}
-	}
-	if set.Has(chopt.FeatureTSGridPredictLinear) {
-		l.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}, Instant: tsGridInstant}
-	} else {
-		l.PredictLinear = promql.FanoutPredictLinearLowerer{}
-	}
-	if set.Has(chopt.FeatureTSGridDelta) {
-		l.Delta = promql.NativeDeltaLowerer{Fallback: deltaFallback}
-	} else {
-		l.Delta = deltaFallback
-	}
-
-	// irate/idelta: laginframe_adjacency layers BENEATH their own native
-	// ts_grid strategy, mirroring cmd/cerberus's own nativeRangeLowerers
-	// (cerberus issue #2746).
-	var irateFallback promql.IrateLowerer = promql.FanoutIrateLowerer{}
-	var ideltaFallback promql.IdeltaLowerer = promql.FanoutIdeltaLowerer{}
-	if set.Has(chopt.FeatureLagInFrameAdjacency) {
-		irateFallback = promql.LagAdjacencyIrateLowerer{Fallback: irateFallback}
-		ideltaFallback = promql.LagAdjacencyIdeltaLowerer{Fallback: ideltaFallback}
-	}
-	if set.Has(chopt.FeatureTSGridIrate) {
-		l.Irate = promql.NativeIrateLowerer{Fallback: irateFallback}
-	} else {
-		l.Irate = irateFallback
-	}
-	if set.Has(chopt.FeatureTSGridIdelta) {
-		l.Idelta = promql.NativeIdeltaLowerer{Fallback: ideltaFallback}
-	} else {
-		l.Idelta = ideltaFallback
-	}
-
-	// The anchor-injection window-slide mechanism was removed by #2511's
-	// root-cause investigation (structural over-read, see main.go's
-	// nativeRangeLowerers doc) — fan-out is the sole fallback below the
-	// rate-only native ladder.
-	if set.Has(chopt.FeatureTSGridHistogram) {
-		l.ClassicHistogram = promql.NativeClassicHistogramWindowLowerer{Fallback: promql.FanoutClassicHistogramWindowLowerer{}}
-	} else {
-		l.ClassicHistogram = promql.FanoutClassicHistogramWindowLowerer{}
-	}
-
-	// quantile_prom_histogram is NOT part of AllNativeOptimizations (floor
-	// 25.10, above the 25.9-alpine substrate most callers of this function
-	// probe against under Enforcing mode — listing it there would fail every
-	// such caller loudly rather than silently degrading). Callers that want
-	// it activated resolve it explicitly against a >= 25.10 server and pass
-	// the resulting set here; this branch only ever fires for those callers.
-	if set.Has(chopt.FeatureQuantilePromHistogram) {
-		l.QuantileRankWalk = promql.NativeQuantileRankWalkLowerer{}
-	} else {
-		l.QuantileRankWalk = promql.FanoutQuantileRankWalkLowerer{}
-	}
-
-	// ts_grid_last_over_time is NOT part of AllNativeOptimizations (floor
-	// 26.6, above the 25.9-alpine substrate most callers of this function
-	// probe against under Enforcing mode — listing it there would fail every
-	// such caller loudly rather than silently degrading). Callers that want
-	// it activated resolve it explicitly against a >= 26.6 server and pass
-	// the resulting set here; this branch only ever fires for those callers.
-	if set.Has(chopt.FeatureTSGridLastOverTime) {
-		l.LastOverTime = promql.NativeLastOverTimeLowerer{Fallback: promql.FanoutLastOverTimeLowerer{}}
-	} else {
-		l.LastOverTime = promql.FanoutLastOverTimeLowerer{}
-	}
-
-	// downsample_tier WRAPS whichever irate/idelta/last_over_time strategy
-	// was just resolved above — mirrors cmd/cerberus/main.go's
-	// nativeRangeLowerers exactly (cerberus issue #2751). rate()/increase()/
-	// delta() have no such wrapping (chopt.FeatureDownsampleTier's own doc).
-	if set.Has(chopt.FeatureDownsampleTier) {
-		l.Irate = promql.DownsampleTierIrateLowerer{Fallback: l.Irate}
-		l.Idelta = promql.DownsampleTierIdeltaLowerer{Fallback: l.Idelta}
-		l.LastOverTime = promql.DownsampleTierLastOverTimeLowerer{Fallback: l.LastOverTime}
-	}
-
-	// sorted_slab_over_time (issue #2761, widened by issue #2804) has no
-	// native timeSeries*ToGrid competitor of its own — it is wired directly
-	// with its plain fan-out as its own embedded Fallback, mirroring
-	// cmd/cerberus/main.go's nativeRangeLowerers exactly.
-	if set.Has(chopt.FeatureSortedSlabOverTime) {
-		l.OverTime = promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}}
-	} else {
-		l.OverTime = promql.FanoutOverTimeLowerer{}
-	}
-
-	// classic_bucket_merge_summap has no version floor to probe — mirrors
-	// cmd/cerberus/main.go's nativeRangeLowerers exactly (cerberus issue
-	// #2756; AutoSelect stays false per #2923's measured negative result,
-	// see classic_bucket_merge_summap.go's header). Concrete fan-out impl
-	// when the feature is off; this field is never nil on the lowering
-	// path (promql.RangeLowerers.ClassicBucketMerge's own doc), so leaving
-	// it unset here would panic any test exercising a classic-bucket-merge
-	// shape rather than merely leaving the feature inert.
-	if set.Has(chopt.FeatureClassicBucketMergeSumMap) {
-		l.ClassicBucketMerge = promql.NativeClassicBucketMergeLowerer{Fallback: promql.FanoutClassicBucketMergeLowerer{}}
-	} else {
-		l.ClassicBucketMerge = promql.FanoutClassicBucketMergeLowerer{}
-	}
-
-	// exp_histogram_merge_summap has no version floor to probe either —
-	// mirrors cmd/cerberus/main.go's nativeRangeLowerers exactly (cerberus
-	// issue #2757). Same never-nil contract as ClassicBucketMerge above
-	// (promql.RangeLowerers.ExpHistogramMerge's own doc).
-	if set.Has(chopt.FeatureExpHistogramMergeSumMap) {
-		l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{}
-	} else {
-		l.ExpHistogramMerge = promql.FanoutExpHistogramMergeLowerer{}
-	}
-
-	return l
+	return choptwire.RangeLowerers(set)
 }

--- a/internal/chopttest/settings.go
+++ b/internal/chopttest/settings.go
@@ -4,6 +4,7 @@ package chopttest
 
 import (
 	"github.com/tsouza/cerberus/internal/chopt"
+	"github.com/tsouza/cerberus/internal/choptwire"
 	"github.com/tsouza/cerberus/internal/engine"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -11,9 +12,10 @@ import (
 // BuildSettingsRules builds the per-query engine.SettingsRules an integration
 // test's mounted handler must carry to behave the way a real deployment's
 // does, from a resolved chopt.EnabledSet (ResolveEnabledSet). It is the
-// SettingsRules-axis sibling of BuildRangeLowerers, and mirrors
-// cmd/cerberus/main.go's own settingsRules field-for-field for every rule the
-// EnabledSet decides.
+// SettingsRules-axis sibling of BuildRangeLowerers, and — like it — is the
+// SAME function cmd/cerberus's boot path calls rather than a mirror of it:
+// both delegate to internal/choptwire.SettingsRules, which cmd overlays its
+// operator-configured knobs onto (cerberus issue #3186).
 //
 // Why this exists: prom.New / tempo.New leave Engine.Settings at its zero
 // value, which applies NOTHING — every SettingsRules mechanism
@@ -42,15 +44,5 @@ import (
 // cache repeat costs almost nothing and would silently hollow out a max-of-N
 // memory measurement.
 func BuildSettingsRules(set chopt.EnabledSet, metrics schema.Metrics, traces schema.Traces, logs schema.Logs) engine.SettingsRules {
-	return engine.SettingsRules{
-		OptimizeAggregationInOrder: set.Has(chopt.FeatureAggregationInOrder),
-		ConditionCache:             set.Has(chopt.FeatureConditionCache),
-		JoinSpill:                  set.Has(chopt.FeatureJoinSpill),
-		TraceIDBitmapFilter:        set.Has(chopt.FeatureTraceIDBitmapFilter),
-		ResultCache:                set.Has(chopt.FeatureResultCache),
-		LazyMaterialization:        set.Has(chopt.FeatureLazyMaterialization),
-		Metrics:                    metrics,
-		Traces:                     traces,
-		Logs:                       logs,
-	}
+	return choptwire.SettingsRules(set, metrics, traces, logs)
 }

--- a/internal/choptwire/choptwire.go
+++ b/internal/choptwire/choptwire.go
@@ -160,6 +160,23 @@ func RangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 	// so it can never make a Native*Lowerer's instant arm reachable on its
 	// own.
 	tsGridInstant := optSet.Has(chopt.FeatureTSGridInstant)
+	extrapolatedLowerers(&l, optSet, argAndMaxFusion, tsGridInstant)
+	adjacencyLowerers(&l, optSet, tsGridInstant)
+	gridScalarLowerers(&l, optSet, tsGridInstant)
+	histogramLowerers(&l, optSet)
+	// downsample_tier WRAPS strategies the calls above resolved, and
+	// sorted_slab_over_time is independent of every one of them, so this
+	// pair runs last.
+	downsampleAndSlabLowerers(&l, optSet)
+	return l
+}
+
+// extrapolatedLowerers resolves rate / increase / delta / staleness — the
+// family whose three fallbacks share the fixed_accumulator_extrapolated
+// narrowing. delta is resolved here rather than beside deriv and
+// predict_linear because deltaFallback is built here and has no other
+// consumer.
+func extrapolatedLowerers(l *promql.RangeLowerers, optSet chopt.EnabledSet, argAndMaxFusion, tsGridInstant bool) {
 	// fixed_accumulator_extrapolated (issue #2760) layers BENEATH
 	// rate/increase/delta's own native ts_grid strategy, exactly like
 	// laginframe_adjacency layers inside changes/resets below: it is the
@@ -192,6 +209,16 @@ func RangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 	} else {
 		l.Staleness = promql.FanoutStalenessLowerer{ArgAndMaxFusion: argAndMaxFusion}
 	}
+	if optSet.Has(chopt.FeatureTSGridDelta) {
+		l.Delta = promql.NativeDeltaLowerer{Fallback: deltaFallback}
+	} else {
+		l.Delta = deltaFallback
+	}
+}
+
+// adjacencyLowerers resolves changes / resets / irate / idelta — the four
+// whose fallbacks share the laginframe_adjacency narrowing.
+func adjacencyLowerers(l *promql.RangeLowerers, optSet chopt.EnabledSet, tsGridInstant bool) {
 	// laginframe_adjacency (issue #2759) layers BENEATH changes/resets' own
 	// native ts_grid strategy, exactly like ts_grid_recollapse layers inside
 	// ts_grid_range above: it is the improved fan-out a shape-ineligible or
@@ -234,6 +261,11 @@ func RangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 	} else {
 		l.Idelta = ideltaFallback
 	}
+}
+
+// gridScalarLowerers resolves deriv and predict_linear, the two ts_grid
+// members whose fallback is the plain fan-out with no narrowing beneath it.
+func gridScalarLowerers(l *promql.RangeLowerers, optSet chopt.EnabledSet, tsGridInstant bool) {
 	if optSet.Has(chopt.FeatureTSGridDeriv) {
 		l.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}, Instant: tsGridInstant}
 	} else {
@@ -244,11 +276,12 @@ func RangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 	} else {
 		l.PredictLinear = promql.FanoutPredictLinearLowerer{}
 	}
-	if optSet.Has(chopt.FeatureTSGridDelta) {
-		l.Delta = promql.NativeDeltaLowerer{Fallback: deltaFallback}
-	} else {
-		l.Delta = deltaFallback
-	}
+}
+
+// histogramLowerers resolves the histogram-shaped strategies: the classic
+// histogram range window, the quantile rank walk, last_over_time, and the two
+// bucket-merge families.
+func histogramLowerers(l *promql.RangeLowerers, optSet chopt.EnabledSet) {
 	// The anchor-injection window-slide mechanism (#2408 follow-up, #2493)
 	// was removed by #2511's root-cause investigation: its anchor-injection
 	// UNION structurally requires the per-series canonical-bound subquery to
@@ -293,6 +326,40 @@ func RangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 	} else {
 		l.LastOverTime = promql.FanoutLastOverTimeLowerer{}
 	}
+	// classic_bucket_merge_summap (issue #2756) has no version floor to
+	// probe. #2817 closed its original correctness blocker; issue #2923's
+	// real-ClickHouse re-measurement against the resulting (post-#2817)
+	// construction then found its real cost within ~1% of the fold's, not
+	// the estimated ~50x win — so AutoSelect stays false, a measured
+	// negative result rather than an open question. See
+	// promql.NativeClassicBucketMergeLowerer's own doc and
+	// classic_bucket_merge_summap.go's header.
+	if optSet.Has(chopt.FeatureClassicBucketMergeSumMap) {
+		l.ClassicBucketMerge = promql.NativeClassicBucketMergeLowerer{
+			Fallback: promql.FanoutClassicBucketMergeLowerer{},
+		}
+	} else {
+		l.ClassicBucketMerge = promql.FanoutClassicBucketMergeLowerer{}
+	}
+	// exp_histogram_merge_summap (issue #2757) has no version floor to
+	// probe, but ships AutoSelect: false: it now covers every shape —
+	// instant AND range mode (cerberus issue #3027), any by()/without()
+	// grouping (#2865), SUM or AVG fold (#2866) — each with its own
+	// real-ClickHouse-calibrated budget guard rather than a reuse of the
+	// classic fold's rows-dominated one — see
+	// promql.NativeExpHistogramMergeLowerer's own doc.
+	if optSet.Has(chopt.FeatureExpHistogramMergeSumMap) {
+		l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{}
+	} else {
+		l.ExpHistogramMerge = promql.FanoutExpHistogramMergeLowerer{}
+	}
+}
+
+// downsampleAndSlabLowerers applies the two resolutions that must come after
+// the rest: downsample_tier WRAPS whichever irate / idelta / last_over_time
+// strategy was already resolved, and sorted_slab_over_time resolves over_time
+// on its own.
+func downsampleAndSlabLowerers(l *promql.RangeLowerers, optSet chopt.EnabledSet) {
 	// downsample_tier (cerberus issue #2751) WRAPS whatever irate/idelta/
 	// last_over_time strategy was just resolved above — it is a genuinely
 	// different mechanism (an operator-provisioned, pre-populated table, not
@@ -325,34 +392,6 @@ func RangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
 	} else {
 		l.OverTime = promql.FanoutOverTimeLowerer{}
 	}
-	// classic_bucket_merge_summap (issue #2756) has no version floor to
-	// probe. #2817 closed its original correctness blocker; issue #2923's
-	// real-ClickHouse re-measurement against the resulting (post-#2817)
-	// construction then found its real cost within ~1% of the fold's, not
-	// the estimated ~50x win — so AutoSelect stays false, a measured
-	// negative result rather than an open question. See
-	// promql.NativeClassicBucketMergeLowerer's own doc and
-	// classic_bucket_merge_summap.go's header.
-	if optSet.Has(chopt.FeatureClassicBucketMergeSumMap) {
-		l.ClassicBucketMerge = promql.NativeClassicBucketMergeLowerer{
-			Fallback: promql.FanoutClassicBucketMergeLowerer{},
-		}
-	} else {
-		l.ClassicBucketMerge = promql.FanoutClassicBucketMergeLowerer{}
-	}
-	// exp_histogram_merge_summap (issue #2757) has no version floor to
-	// probe, but ships AutoSelect: false: it now covers every shape —
-	// instant AND range mode (cerberus issue #3027), any by()/without()
-	// grouping (#2865), SUM or AVG fold (#2866) — each with its own
-	// real-ClickHouse-calibrated budget guard rather than a reuse of the
-	// classic fold's rows-dominated one — see
-	// promql.NativeExpHistogramMergeLowerer's own doc.
-	if optSet.Has(chopt.FeatureExpHistogramMergeSumMap) {
-		l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{}
-	} else {
-		l.ExpHistogramMerge = promql.FanoutExpHistogramMergeLowerer{}
-	}
-	return l
 }
 
 // SettingsRules builds the CAPABILITY-decided half of the per-query

--- a/internal/choptwire/choptwire.go
+++ b/internal/choptwire/choptwire.go
@@ -1,0 +1,389 @@
+// Package choptwire turns a resolved ClickHouse-optimization EnabledSet into
+// the two things the query stack is configured with from it: the polymorphic
+// PromQL range-lowering dispatch table, and the per-query engine settings
+// rules.
+//
+// It exists because both compositions have exactly two callers that must
+// agree and could not share code: cmd/cerberus's boot path, where they are
+// `package main` and therefore unimportable, and internal/chopttest, which
+// every real-ClickHouse activation test wires its handler through. The test
+// side carried reviewed COPIES of both formulas, so the perf smoke and
+// nightly lanes, the solver-decision ratchet and the API integration tests
+// all validated the copies rather than the production wiring: a feature
+// wired in one and forgotten in the other passed every activation test and
+// shipped inert, which is precisely the failure those lanes exist to prevent
+// (cerberus issue #3186).
+//
+// Only the CAPABILITY-decided fields live here. The operator-configured ones
+// cmd/cerberus reads off config.Config — the log-comment shape, the
+// result-cache ingest lag and TTL, the query workload — are not capability
+// decisions, so they are overlaid by the caller that has a config to read
+// them from rather than being given a hidden default here.
+package choptwire
+
+import (
+	"github.com/tsouza/cerberus/internal/chopt"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// RangeLowerers builds the BOOT-WIRED polymorphic lowering dispatch table
+// for the ClickHouse-native timeSeries*ToGrid family from the resolved
+// optimization EnabledSet. The feature/version decision is made HERE, ONCE, at
+// boot (optSet was produced by the single boot-time version probe in
+// resolveCHOptimizations) and is the ONLY place the feature is read: each field
+// is wired to a CONCRETE non-nil strategy —
+//
+//	rate      = enabled ? NativeRateLowerer{Fallback: rateFallback} : rateFallback
+//	increase  = enabled ? NativeIncreaseLowerer{Fallback: increaseFallback} : increaseFallback
+//	delta     = enabled ? NativeDeltaLowerer{Fallback: deltaFallback} : deltaFallback
+//	  // where rateFallback/increaseFallback/deltaFallback are each
+//	  // fixedAccumEnabled ? FixedAccumulator*Lowerer{Fallback: Fanout*Lowerer{}} : Fanout*Lowerer{}
+//	staleness = enabled ? NativeStalenessLowerer{Fallback: FanoutStalenessLowerer{}} : FanoutStalenessLowerer{}
+//	changes   = enabled ? NativeChangesLowerer{Fallback: changesFallback} : changesFallback
+//	resets    = enabled ? NativeResetsLowerer{Fallback: resetsFallback} : resetsFallback
+//	irate     = enabled ? NativeIrateLowerer{Fallback: irateFallback} : irateFallback
+//	idelta    = enabled ? NativeIdeltaLowerer{Fallback: ideltaFallback} : ideltaFallback
+//	  // where changesFallback/resetsFallback/irateFallback/ideltaFallback are each
+//	  // laginframeEnabled ? LagAdjacency*Lowerer{Fallback: Fanout*Lowerer{}} : Fanout*Lowerer{}
+//	deriv     = enabled ? NativeDerivLowerer{Fallback: FanoutDerivLowerer{}} : FanoutDerivLowerer{}
+//	predict   = enabled ? NativePredictLinearLowerer{Fallback: FanoutPredictLinearLowerer{}} : FanoutPredictLinearLowerer{}
+//	classicHq = enabled ? NativeClassicHistogramWindowLowerer{Fallback: Fanout…{}} : Fanout…{}
+//	rankWalk  = enabled ? NativeQuantileRankWalkLowerer{} : FanoutQuantileRankWalkLowerer{}
+//	lastOverTime = enabled ? NativeLastOverTimeLowerer{Fallback: FanoutLastOverTimeLowerer{}} : FanoutLastOverTimeLowerer{}
+//	  // downsampleTierEnabled ? DownsampleTier{Irate,Idelta,LastOverTime}Lowerer{Fallback: <above>} : <above> unchanged
+//	overTime  = sortedSlabEnabled ? SortedSlabOverTimeLowerer{Fallback: FanoutOverTimeLowerer{}} : FanoutOverTimeLowerer{}
+//
+// rankWalk (quantile_prom_histogram) is not a timeSeries*ToGrid member — it
+// wraps ClickHouse's separate quantilePrometheusHistogram aggregate (floor
+// 25.10) — and carries no embedded Fallback because it has no shape-based
+// fallback to embed (see promql.QuantileRankWalkLowerer's own doc); it is
+// resolved here, in this same table, only because RangeLowerers is the one
+// seam every classic-histogram-quantile lowering already threads.
+//
+// overTime (sum_over_time/avg_over_time, issue #2761) is likewise not a
+// timeSeries*ToGrid member and carries no native competitor, but unlike
+// rankWalk it DOES embed a Fallback (the plain fan-out) — its sorted-slab
+// decomposition is a shape-gated SQL rewrite with its own eligibility guard
+// (sortedSlabOverTimeEligible), the same posture fixed_accumulator_extrapolated
+// has for rate/increase/delta, not an always-applicable aggregate swap like
+// rankWalk's.
+//
+// The fan-out impl is the concrete DEFAULT (never nil), and the native impl
+// embeds it as the fallback for shapes it cannot handle. The features are
+// independent, so the table composes per-function — native rate can be on while
+// native staleness / changes / resets / deriv / predict_linear are off, and vice
+// versa (the whole family shares the 25.9 floor, but each member is probed and
+// resolved on its own). The per-query
+// lowering then
+// dispatches through this table as a plain interface method call: NO
+// feature/version read, NO nil/presence check.
+//
+// ts_grid_recollapse is the one NON-independent knob: it defers the
+// label-shaping tower past the native rate grid, so it only means anything
+// inside the ts_grid_range branch. The registry has no inter-feature dependency
+// mechanism, so that narrowing is expressed HERE — reading it only where a
+// native rate lowerer is being built makes "recollapse without a native grid"
+// unrepresentable rather than merely unlikely.
+//
+// laginframe_adjacency (issue #2759) is a second non-independent knob, but in
+// the opposite direction from recollapse: it narrows changes/resets/irate/
+// idelta's FALLBACK (the arm a shape-ineligible or sub-25.9 server lands on),
+// not their native arm. It was irate/idelta's ONLY non-fan-out strategy until
+// issue #2746 gave them their own native timeSeriesInstantRateToGrid /
+// timeSeriesInstantDeltaToGrid competitor, so all four of changes / resets /
+// irate / idelta now share the identical three-tier Native{Fallback:
+// LagAdjacency{Fallback: Fanout{}}} composition. Unlike every ts_grid_*
+// feature it carries no version floor (chopt.AlwaysAvailable) and no
+// experimental-setting gate, so it composes with the version-gated native
+// features purely via which Fallback each Native*Lowerer embeds.
+//
+// fixed_accumulator_extrapolated (issue #2760) is laginframe_adjacency's own
+// sibling for the extrapolated family: it narrows rate/increase/delta's
+// FALLBACK the same way — delta gained its own native ts_grid_delta
+// competitor (issue #2745), so as of that feature all three of rate /
+// increase / delta share the identical three-tier
+// Native{Fallback: FixedAccumulator{Fallback: Fanout{}}} composition. Same
+// AlwaysAvailable floor, same no-experimental-setting posture, same "narrows
+// the fallback, never competes with the native arm" shape.
+//
+// ts_grid_instant (issue #2748) narrows the NATIVE arm itself rather than the
+// fallback — the opposite direction from recollapse/laginframe/fixed-
+// accumulator above. Each of rate/changes/resets/deriv/predict_linear's
+// Native*Lowerer gains an Instant field, set to tsGridInstant ONLY inside
+// that same function's own "matrix feature enabled" branch, so the instant
+// arm can never fire for a function whose matrix arm is off. increase() and
+// delta() are out of scope (see chopt.FeatureTSGridInstant's own doc) and
+// carry no Instant field.
+//
+// ts_grid_group_array (issue #2749) is a third non-swappable emission-detail
+// bit, mirroring VectorAgg's own posture: it lives on RangeLowerers itself
+// (promql.RangeLowerers.NativeGroupArray) rather than on any single
+// Native*Lowerer, and is set unconditionally below because rate/increase/
+// delta's fanout lowering reads it directly off the SAME chplan.RangeWindow
+// node regardless of which of those three functions' own Native /
+// FixedAccumulator / Fanout tiers produced it.
+func RangeLowerers(optSet chopt.EnabledSet) promql.RangeLowerers {
+	var l promql.RangeLowerers
+	// arg_and_max_fusion (issue #2764) is a plain emission-detail bit, not
+	// a swappable strategy — see RangeLowerers.ArgAndMaxFusion's own doc.
+	// It feeds BOTH the VectorJoin site (read directly off this table by
+	// internal/promql/binary.go) and the RangeLWR site (its own copy on
+	// FanoutStalenessLowerer below, threaded either directly or as the
+	// native staleness lowerer's embedded Fallback).
+	argAndMaxFusion := optSet.Has(chopt.FeatureArgAndMaxFusion)
+	l.ArgAndMaxFusion = argAndMaxFusion
+	// ts_grid_vector_agg (issue #2763) is a pure narrowing of ts_grid_range,
+	// but — unlike ts_grid_recollapse — it lives on RangeLowerers itself
+	// rather than on NativeRateLowerer (or any single Native*Lowerer),
+	// because lowerAggregate consults it at a LATER lowering stage than any
+	// range-function Lowerer: only after a range function has already
+	// lowered its input, and only when that input turns out to be a
+	// *chplan.RangeWindowGridNative. Setting it unconditionally here (never
+	// nested inside `if optSet.Has(chopt.FeatureTSGridRange)`) is therefore
+	// safe rather than a narrowing gap: the field is inert whenever no
+	// native grid node exists for lowerAggregate to fold into.
+	l.VectorAgg = optSet.Has(chopt.FeatureTSGridVectorAgg)
+	// ts_grid_group_array (issue #2749) is, like VectorAgg immediately
+	// above, a plain narrowing bit rather than a per-function Lowerer swap:
+	// it never changes WHICH of rate/increase/delta's own Native /
+	// FixedAccumulator / Fanout tiers fires, only how that tier's array-fold
+	// fallback assembles its per-series sample array. Set unconditionally
+	// here for the same reason VectorAgg is — it lives on RangeLowerers
+	// itself, not on any single Native*Lowerer.
+	l.NativeGroupArray = optSet.Has(chopt.FeatureTSGridGroupArray)
+	// ts_grid_instant (issue #2748) is a pure narrowing of each of
+	// rate/changes/resets/deriv/predict_linear's own matrix feature — it is
+	// consulted ONLY inside each function's own "matrix feature enabled"
+	// branch below, exactly like ts_grid_recollapse narrows ts_grid_range,
+	// so it can never make a Native*Lowerer's instant arm reachable on its
+	// own.
+	tsGridInstant := optSet.Has(chopt.FeatureTSGridInstant)
+	// fixed_accumulator_extrapolated (issue #2760) layers BENEATH
+	// rate/increase/delta's own native ts_grid strategy, exactly like
+	// laginframe_adjacency layers inside changes/resets below: it is the
+	// improved fan-out a shape-ineligible, sub-25.9, or temporality-bearing
+	// window falls back to, never a competitor to the native path.
+	var rateFallback promql.RateLowerer = promql.FanoutRateLowerer{}
+	var increaseFallback promql.IncreaseLowerer = promql.FanoutIncreaseLowerer{}
+	var deltaFallback promql.DeltaLowerer = promql.FanoutDeltaLowerer{}
+	if optSet.Has(chopt.FeatureFixedAccumulatorExtrapolated) {
+		rateFallback = promql.FixedAccumulatorRateLowerer{Fallback: rateFallback}
+		increaseFallback = promql.FixedAccumulatorIncreaseLowerer{Fallback: increaseFallback}
+		deltaFallback = promql.FixedAccumulatorDeltaLowerer{Fallback: deltaFallback}
+	}
+	if optSet.Has(chopt.FeatureTSGridRange) {
+		l.Rate = promql.NativeRateLowerer{
+			Fallback:   rateFallback,
+			Recollapse: optSet.Has(chopt.FeatureTSGridRecollapse),
+			Instant:    tsGridInstant,
+		}
+	} else {
+		l.Rate = rateFallback
+	}
+	if optSet.Has(chopt.FeatureTSGridIncrease) {
+		l.Increase = promql.NativeIncreaseLowerer{Fallback: increaseFallback}
+	} else {
+		l.Increase = increaseFallback
+	}
+	if optSet.Has(chopt.FeatureTSGridResample) {
+		l.Staleness = promql.NativeStalenessLowerer{Fallback: promql.FanoutStalenessLowerer{ArgAndMaxFusion: argAndMaxFusion}}
+	} else {
+		l.Staleness = promql.FanoutStalenessLowerer{ArgAndMaxFusion: argAndMaxFusion}
+	}
+	// laginframe_adjacency (issue #2759) layers BENEATH changes/resets' own
+	// native ts_grid strategy, exactly like ts_grid_recollapse layers inside
+	// ts_grid_range above: it is the improved fan-out a shape-ineligible or
+	// sub-25.9 server falls back to, never a competitor to the native path.
+	var changesFallback promql.ChangesLowerer = promql.FanoutChangesLowerer{}
+	var resetsFallback promql.ResetsLowerer = promql.FanoutResetsLowerer{}
+	if optSet.Has(chopt.FeatureLagInFrameAdjacency) {
+		changesFallback = promql.LagAdjacencyChangesLowerer{Fallback: changesFallback}
+		resetsFallback = promql.LagAdjacencyResetsLowerer{Fallback: resetsFallback}
+	}
+	if optSet.Has(chopt.FeatureTSGridChanges) {
+		l.Changes = promql.NativeChangesLowerer{Fallback: changesFallback, Instant: tsGridInstant}
+	} else {
+		l.Changes = changesFallback
+	}
+	if optSet.Has(chopt.FeatureTSGridResets) {
+		l.Resets = promql.NativeResetsLowerer{Fallback: resetsFallback, Instant: tsGridInstant}
+	} else {
+		l.Resets = resetsFallback
+	}
+	// irate/idelta gained their own native timeSeries*ToGrid member
+	// (timeSeriesInstantRateToGrid / timeSeriesInstantDeltaToGrid, cerberus
+	// issue #2746): laginframe_adjacency now layers BENEATH that native
+	// strategy exactly like it does for changes/resets above, rather than
+	// being their only non-fan-out strategy the way issue #2759 originally
+	// left it.
+	var irateFallback promql.IrateLowerer = promql.FanoutIrateLowerer{}
+	var ideltaFallback promql.IdeltaLowerer = promql.FanoutIdeltaLowerer{}
+	if optSet.Has(chopt.FeatureLagInFrameAdjacency) {
+		irateFallback = promql.LagAdjacencyIrateLowerer{Fallback: irateFallback}
+		ideltaFallback = promql.LagAdjacencyIdeltaLowerer{Fallback: ideltaFallback}
+	}
+	if optSet.Has(chopt.FeatureTSGridIrate) {
+		l.Irate = promql.NativeIrateLowerer{Fallback: irateFallback}
+	} else {
+		l.Irate = irateFallback
+	}
+	if optSet.Has(chopt.FeatureTSGridIdelta) {
+		l.Idelta = promql.NativeIdeltaLowerer{Fallback: ideltaFallback}
+	} else {
+		l.Idelta = ideltaFallback
+	}
+	if optSet.Has(chopt.FeatureTSGridDeriv) {
+		l.Deriv = promql.NativeDerivLowerer{Fallback: promql.FanoutDerivLowerer{}, Instant: tsGridInstant}
+	} else {
+		l.Deriv = promql.FanoutDerivLowerer{}
+	}
+	if optSet.Has(chopt.FeatureTSGridPredictLinear) {
+		l.PredictLinear = promql.NativePredictLinearLowerer{Fallback: promql.FanoutPredictLinearLowerer{}, Instant: tsGridInstant}
+	} else {
+		l.PredictLinear = promql.FanoutPredictLinearLowerer{}
+	}
+	if optSet.Has(chopt.FeatureTSGridDelta) {
+		l.Delta = promql.NativeDeltaLowerer{Fallback: deltaFallback}
+	} else {
+		l.Delta = deltaFallback
+	}
+	// The anchor-injection window-slide mechanism (#2408 follow-up, #2493)
+	// was removed by #2511's root-cause investigation: its anchor-injection
+	// UNION structurally requires the per-series canonical-bound subquery to
+	// be inlined into BOTH UNION arms (real rows' JOIN and the sentinel
+	// arm's FROM), and this codebase's chsql architecture only single-
+	// evaluates a genuinely scalar CTE (QueryBuilder.WithScalar) — a
+	// relational CTE re-inlines, and re-scans, at every reference
+	// (QueryBuilder.With's own doc). Real EXPLAIN PLAN / EXPLAIN PIPELINE
+	// evidence against chDB confirmed 3 independent ReadFromMergeTree scans
+	// of the base table for one window-slide query where the fan-out needs
+	// one, plus the shared LIMIT+throwIf resource-bound pattern doubling
+	// whatever that count is — the real root cause of the ~5x-more-bytes
+	// regression #2511 measured. No fix avoids this without either
+	// reintroducing the O(rows^2)-per-series blow-up an earlier review
+	// already rejected, or a per-row scalar-map lookup against thousands of
+	// series (unvalidated and very likely slower still). Combined with the
+	// mechanism's own real-world win being marginal at the modal dashboard
+	// shape (1.12x at 5m/1m, per #2408's own Task-1 spike), fan-out is kept
+	// as the sole classic-histogram range-window path below the native
+	// rate ladder.
+	if optSet.Has(chopt.FeatureTSGridHistogram) {
+		l.ClassicHistogram = promql.NativeClassicHistogramWindowLowerer{
+			Fallback: promql.FanoutClassicHistogramWindowLowerer{},
+		}
+	} else {
+		l.ClassicHistogram = promql.FanoutClassicHistogramWindowLowerer{}
+	}
+	// quantile_prom_histogram has no shape-based fallback (see
+	// promql.QuantileRankWalkLowerer's own doc), so the native strategy is
+	// wired directly with no embedded Fallback field.
+	if optSet.Has(chopt.FeatureQuantilePromHistogram) {
+		l.QuantileRankWalk = promql.NativeQuantileRankWalkLowerer{}
+	} else {
+		l.QuantileRankWalk = promql.FanoutQuantileRankWalkLowerer{}
+	}
+	// ts_grid_last_over_time rides the SAME native strategy shape as every
+	// other independent family member (Native{Fallback: Fanout{}}) — it has
+	// no narrowing/narrowed sibling knob of its own (no recollapse-style
+	// dependent, no laginframe/fixed-accumulator-style improved fallback).
+	if optSet.Has(chopt.FeatureTSGridLastOverTime) {
+		l.LastOverTime = promql.NativeLastOverTimeLowerer{Fallback: promql.FanoutLastOverTimeLowerer{}}
+	} else {
+		l.LastOverTime = promql.FanoutLastOverTimeLowerer{}
+	}
+	// downsample_tier (cerberus issue #2751) WRAPS whatever irate/idelta/
+	// last_over_time strategy was just resolved above — it is a genuinely
+	// different mechanism (an operator-provisioned, pre-populated table, not
+	// a stateless read-time function swap over the raw table), so it sits
+	// as an outer layer: an eligible shape routes to the tier, everything
+	// else falls through to the family's own best-available raw-scan
+	// strategy (native/laginframe/fanout) unchanged. See
+	// chopt.FeatureDownsampleTier's own doc for why rate()/increase()/
+	// delta() have no such wrapping at all.
+	if optSet.Has(chopt.FeatureDownsampleTier) {
+		l.Irate = promql.DownsampleTierIrateLowerer{Fallback: l.Irate}
+		l.Idelta = promql.DownsampleTierIdeltaLowerer{Fallback: l.Idelta}
+		l.LastOverTime = promql.DownsampleTierLastOverTimeLowerer{Fallback: l.LastOverTime}
+	}
+	// sorted_slab_over_time (issue #2761, widened to first_over_time /
+	// stddev_over_time / stdvar_over_time / mad_over_time by issue #2804)
+	// has no native timeSeries*ToGrid competitor: this whole function set's
+	// only non-fan-out arm is the sorted-slab decomposition itself, so it is
+	// wired directly with no embedded native layer above it (mirroring
+	// quantile_prom_histogram's posture just above, though this strategy
+	// DOES still embed its own Fallback — the plain fan-out — the way
+	// fixed_accumulator_extrapolated does for rate/increase/delta). One
+	// lowerer wiring covers the whole set: which PromQL function names
+	// reach it at all is decided upstream, purely by AST dispatch, in
+	// internal/promql/lower.go's `lowerRangeVectorCallFanout` switch — see
+	// that switch's own doc for why last_over_time deliberately never
+	// reaches this lowerer despite sharing its shape-eligibility check.
+	if optSet.Has(chopt.FeatureSortedSlabOverTime) {
+		l.OverTime = promql.SortedSlabOverTimeLowerer{Fallback: promql.FanoutOverTimeLowerer{}}
+	} else {
+		l.OverTime = promql.FanoutOverTimeLowerer{}
+	}
+	// classic_bucket_merge_summap (issue #2756) has no version floor to
+	// probe. #2817 closed its original correctness blocker; issue #2923's
+	// real-ClickHouse re-measurement against the resulting (post-#2817)
+	// construction then found its real cost within ~1% of the fold's, not
+	// the estimated ~50x win — so AutoSelect stays false, a measured
+	// negative result rather than an open question. See
+	// promql.NativeClassicBucketMergeLowerer's own doc and
+	// classic_bucket_merge_summap.go's header.
+	if optSet.Has(chopt.FeatureClassicBucketMergeSumMap) {
+		l.ClassicBucketMerge = promql.NativeClassicBucketMergeLowerer{
+			Fallback: promql.FanoutClassicBucketMergeLowerer{},
+		}
+	} else {
+		l.ClassicBucketMerge = promql.FanoutClassicBucketMergeLowerer{}
+	}
+	// exp_histogram_merge_summap (issue #2757) has no version floor to
+	// probe, but ships AutoSelect: false: it now covers every shape —
+	// instant AND range mode (cerberus issue #3027), any by()/without()
+	// grouping (#2865), SUM or AVG fold (#2866) — each with its own
+	// real-ClickHouse-calibrated budget guard rather than a reuse of the
+	// classic fold's rows-dominated one — see
+	// promql.NativeExpHistogramMergeLowerer's own doc.
+	if optSet.Has(chopt.FeatureExpHistogramMergeSumMap) {
+		l.ExpHistogramMerge = promql.NativeExpHistogramMergeLowerer{}
+	} else {
+		l.ExpHistogramMerge = promql.FanoutExpHistogramMergeLowerer{}
+	}
+	return l
+}
+
+// SettingsRules builds the CAPABILITY-decided half of the per-query
+// engine.SettingsRules from a resolved EnabledSet, plus the three schema
+// instances the eligibility checks need to map a scanned table name to its
+// sort-key prefix (passing the zero value would silently make the
+// aggregation-in-order and trace-id-bitmap-filter rules unable to fire).
+//
+// The OPERATOR-configured fields are deliberately absent: LogCommentShape,
+// ResultCacheIngestLag, ResultCacheTTL and QueryWorkload come off
+// config.Config, not off the EnabledSet, so the caller that has a config
+// overlays them on the returned value. A caller without one — an integration
+// test — leaves them at their zero values rather than inheriting a hidden
+// default it never asked for.
+//
+// Note on ResultCache: it rides the EnabledSet faithfully, but a set resolved
+// without chclient.ProbeResultCacheCapability keeps result_cache out by
+// construction (chopt's RequiresResultCacheCapability gate reads Capability's
+// conservative zero value). A caller that measures per-query cost must assert
+// that for itself — a served-from-cache repeat costs almost nothing and would
+// silently hollow out a max-of-N memory measurement.
+func SettingsRules(set chopt.EnabledSet, metrics schema.Metrics, traces schema.Traces, logs schema.Logs) engine.SettingsRules {
+	return engine.SettingsRules{
+		OptimizeAggregationInOrder: set.Has(chopt.FeatureAggregationInOrder),
+		ConditionCache:             set.Has(chopt.FeatureConditionCache),
+		JoinSpill:                  set.Has(chopt.FeatureJoinSpill),
+		TraceIDBitmapFilter:        set.Has(chopt.FeatureTraceIDBitmapFilter),
+		ResultCache:                set.Has(chopt.FeatureResultCache),
+		LazyMaterialization:        set.Has(chopt.FeatureLazyMaterialization),
+		Metrics:                    metrics,
+		Traces:                     traces,
+		Logs:                       logs,
+	}
+}

--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -40,6 +40,24 @@ type Builder struct {
 	// byte-identical SQL.
 	attrStrategies AttrStrategies
 
+	// env is the emitter this Builder is rendering inside, or nil for a
+	// free-standing Builder (an ad-hoc query, a test). It exists for ONE
+	// purpose: chplan.ScalarSubquery and chplan.InSubquery embed a whole
+	// plan subtree that has to be rendered through an emitter of its own,
+	// and that sub-emitter must inherit the outer emission's ctx-seeded
+	// bounds and strategies plus its CTE-name counter. Before this field
+	// those two sites built a bare `&emitter{}`, so a rate() over a DELTA
+	// counter inside scalar(...) read the metric's whole retention, a
+	// JSON-typed attribute column rendered Map syntax, and a nested
+	// structural closure re-emitted `_struct_closure_1` inside a statement
+	// that already used it — ClickHouse error 49 (cerberus issue #3186).
+	//
+	// It rides the same path attrStrategies already does: stamped onto a
+	// QueryBuilder by emitSelect and handed to each Builder that renders
+	// it. nil is the ordinary free-standing case and keeps the previous
+	// behaviour exactly.
+	env *emitter
+
 	// err is the first error Expr encountered while rendering into this
 	// Builder, first-error-wins. It exists because Frag has no error
 	// return (`func(b *Builder)`), so an expression embedded via a
@@ -592,7 +610,7 @@ func (b *Builder) exprScalarSubquery(s *chplan.ScalarSubquery) error {
 	if s.Input == nil {
 		return fmt.Errorf("%w: chplan.ScalarSubquery has nil Input", ErrUnsupported)
 	}
-	e := &emitter{}
+	e := b.subEmitter()
 	if err := e.emitSubquery(s.Input); err != nil {
 		return err
 	}
@@ -616,7 +634,7 @@ func (b *Builder) exprInSubquery(v *chplan.InSubquery) error {
 	if v.Subquery == nil {
 		return fmt.Errorf("%w: chplan.InSubquery has nil Subquery", ErrUnsupported)
 	}
-	e := &emitter{}
+	e := b.subEmitter()
 	if err := e.emitSubquery(v.Subquery); err != nil {
 		return err
 	}
@@ -3235,6 +3253,13 @@ type QueryBuilder struct {
 	// strategies throughout without each node's lowering/emit code having
 	// to know about it.
 	attrStrategies AttrStrategies
+
+	// env is the emitter this statement is being rendered inside, threaded
+	// onto every Builder that renders it so an embedded ScalarSubquery /
+	// InSubquery can derive its sub-emitter from the outer emission rather
+	// than from a bare zero value — see Builder.env (cerberus issue #3186).
+	// nil for every QueryBuilder built outside an emitter.
+	env *emitter
 }
 
 // WithAttrStrategies sets the AttrStrategies this QueryBuilder's Build /
@@ -3497,14 +3522,20 @@ func (s *QueryBuilder) LimitBy(exprs ...Frag) *QueryBuilder {
 func (s *QueryBuilder) Frag() Frag {
 	return func(b *Builder) {
 		b.sb.WriteByte('(')
+		// env rides the same swap as attrStrategies: a QueryBuilder that
+		// carries its own emitter (emitSelect stamped one on it) renders
+		// its embedded subqueries inside THAT emission, and the parent's
+		// is restored afterwards. A QueryBuilder with neither keeps
+		// inheriting the parent Builder's, exactly as before.
+		prevStrategies, prevEnv := b.attrStrategies, b.env
 		if s.attrStrategies != nil {
-			prev := b.attrStrategies
 			b.attrStrategies = s.attrStrategies
-			s.writeInto(b)
-			b.attrStrategies = prev
-		} else {
-			s.writeInto(b)
 		}
+		if s.env != nil {
+			b.env = s.env
+		}
+		s.writeInto(b)
+		b.attrStrategies, b.env = prevStrategies, prevEnv
 		b.sb.WriteByte(')')
 	}
 }
@@ -3536,6 +3567,7 @@ func (s *QueryBuilder) BuildCounted() (sql string, args []any, physicalScans int
 // every non-chsql caller already depends on.
 func (s *QueryBuilder) subquerySQL() (string, []any, error) {
 	b := NewBuilderWithAttrStrategies(s.attrStrategies)
+	b.env = s.env
 	s.writeInto(b)
 	s.lastPhysicalScans = b.physicalScans
 	return b.Build()

--- a/internal/chsql/emit.go
+++ b/internal/chsql/emit.go
@@ -162,23 +162,8 @@ func EmitCounted(ctx context.Context, n chplan.Node) (sql string, args []any, ph
 	// node past the canonicalising projection — cannot emit SQL that splits one
 	// series across two Map key orders.
 	n = chplan.CanonicalizeSeriesIdentityKeys(n, attributeMapColumns)
-	e := &emitter{
-		spansTable:             spansTable,
-		ctxSpansTable:          spansTable,
-		deltaPrefixLookbackNS:  deltaPrefixLookbackFromCtx(ctx).Nanoseconds(),
-		deltaPrefixReadEnabled: deltaPrefixReadEnabledFromCtx(ctx),
-
-		rangeBucketFanoutMaxRows: rangeBucketFanoutMaxRowsFromCtx(ctx),
-		rangeLWRFanoutMaxRows:    rangeLWRFanoutMaxRowsFromCtx(ctx),
-		rateWindowFanoutMaxRows:  rateWindowFanoutMaxRowsFromCtx(ctx),
-
-		rangeBucketGridNativeMaxRows:         rangeBucketGridNativeMaxRowsFromCtx(ctx),
-		rangeBucketGridNativeMaxDensityUnits: rangeBucketGridNativeMaxDensityUnitsFromCtx(ctx),
-
-		emittedSQLMaxBytes: maxEmittedSQLBytesFromCtx(ctx),
-		rootPlan:           n,
-		attrStrategies:     attrStrategiesFromCtx(ctx),
-	}
+	e := newEmitter(ctx)
+	e.rootPlan = n
 	// Collapse a structure-tab plan's repeated top-N trace-id gates onto one
 	// single-evaluation scalar binding hoisted to the outermost statement
 	// (#1672). No-op — returns nil, leaves the tree untouched — for every
@@ -403,14 +388,96 @@ type emitter struct {
 	// renders as a subquery of the outer one, and CH would bind the
 	// inner arm CTE in the outer scope. One counter across both
 	// emitters keeps every name in a single statement distinct.
-	cteSeq int
+	// It is a POINTER so a sub-emitter (sub, below) shares the outer
+	// emission's counter rather than restarting at 0: a ScalarSubquery /
+	// InSubquery renders its plan through its own emitter, but the SQL it
+	// produces is spliced into the SAME statement, where a repeated
+	// `_struct_closure_1` is ClickHouse error 49 — the exact collision this
+	// counter exists to prevent (cerberus issue #3186). nil is the ordinary
+	// zero value; nextCTESeq allocates on first use so an emitter built
+	// without newEmitter still hands out unique names within itself.
+	cteSeq *int
+}
+
+// newEmitter seeds an emitter from the emit context: the spans table under
+// resource-bound enforcement, the delta-prefix lookback and read gate, the
+// three sample-fanout ceilings, RangeBucketGridNative's two, the emitted-SQL
+// byte ceiling, and the resolved attribute-map strategies.
+//
+// It is the ONLY constructor any production emission path uses. Four sites
+// used to build a bare `&emitter{}` instead — exprScalarSubquery,
+// exprInSubquery, EmitMetricsExemplars and EmitCompareRootLeg — and each
+// therefore discarded every one of those bounds: a rate() over a DELTA
+// counter inside scalar(...) read the metric's whole retention because a
+// zero deltaPrefixLookbackNS is the explicit "no lower bound" opt-out, a
+// JSON-typed attribute column rendered Map syntax and failed at query time,
+// and the operator's CERBERUS_CH_* overrides did not apply (cerberus issue
+// #3186).
+//
+// rootPlan is NOT seeded here: it is the whole plan a top-level Emit was
+// started on, stamped by that caller so an emitted-SQL-size rejection can
+// name the composition the USER wrote. A sub-emitter has no such plan of its
+// own and leaves it nil, exactly as before.
+func newEmitter(ctx context.Context) *emitter {
+	spansTable := spansTableFromCtx(ctx)
+	return &emitter{
+		spansTable:             spansTable,
+		ctxSpansTable:          spansTable,
+		deltaPrefixLookbackNS:  deltaPrefixLookbackFromCtx(ctx).Nanoseconds(),
+		deltaPrefixReadEnabled: deltaPrefixReadEnabledFromCtx(ctx),
+
+		rangeBucketFanoutMaxRows: rangeBucketFanoutMaxRowsFromCtx(ctx),
+		rangeLWRFanoutMaxRows:    rangeLWRFanoutMaxRowsFromCtx(ctx),
+		rateWindowFanoutMaxRows:  rateWindowFanoutMaxRowsFromCtx(ctx),
+
+		rangeBucketGridNativeMaxRows:         rangeBucketGridNativeMaxRowsFromCtx(ctx),
+		rangeBucketGridNativeMaxDensityUnits: rangeBucketGridNativeMaxDensityUnitsFromCtx(ctx),
+
+		emittedSQLMaxBytes: maxEmittedSQLBytesFromCtx(ctx),
+		attrStrategies:     attrStrategiesFromCtx(ctx),
+		cteSeq:             new(int),
+	}
 }
 
 // nextCTESeq returns the next unique CTE sequence number, advancing the
 // counter.
 func (e *emitter) nextCTESeq() int {
-	e.cteSeq++
-	return e.cteSeq
+	if e.cteSeq == nil {
+		e.cteSeq = new(int)
+	}
+	*e.cteSeq++
+	return *e.cteSeq
+}
+
+// sub returns a fresh emitter for a plan subtree that renders into its own
+// buffer but belongs to THIS emission: it carries every ctx-seeded bound and
+// strategy over and SHARES the CTE-name counter, so names stay unique across
+// the whole statement the two halves are spliced into.
+//
+// rootPlan is deliberately not carried: it names the composition the user
+// wrote for an emitted-SQL-size rejection, and a subtree is not that
+// composition.
+func (e *emitter) sub() *emitter {
+	if e.cteSeq == nil {
+		e.cteSeq = new(int)
+	}
+	return &emitter{
+		spansTable:             e.spansTable,
+		ctxSpansTable:          e.ctxSpansTable,
+		deltaPrefixLookbackNS:  e.deltaPrefixLookbackNS,
+		deltaPrefixReadEnabled: e.deltaPrefixReadEnabled,
+
+		rangeBucketFanoutMaxRows: e.rangeBucketFanoutMaxRows,
+		rangeLWRFanoutMaxRows:    e.rangeLWRFanoutMaxRows,
+		rateWindowFanoutMaxRows:  e.rateWindowFanoutMaxRows,
+
+		rangeBucketGridNativeMaxRows:         e.rangeBucketGridNativeMaxRows,
+		rangeBucketGridNativeMaxDensityUnits: e.rangeBucketGridNativeMaxDensityUnits,
+
+		emittedSQLMaxBytes: e.emittedSQLMaxBytes,
+		attrStrategies:     e.attrStrategies,
+		cteSeq:             e.cteSeq,
+	}
 }
 
 // emitNode writes a `SELECT ...` statement for n into e.b.
@@ -520,4 +587,19 @@ func (e *emitter) emitSubquery(n chplan.Node) error {
 	}
 	e.b.WriteByte(')')
 	return nil
+}
+
+// subEmitter returns the emitter a chplan.ScalarSubquery / chplan.InSubquery
+// embedded in this Builder renders its plan subtree through: a sub-emitter of
+// the emission this Builder belongs to, so the subtree inherits its
+// ctx-seeded bounds and strategies and shares its CTE-name counter.
+//
+// A free-standing Builder — an ad-hoc query composed outside any emitter, or
+// a test — has no emission to inherit from and gets a bare emitter, which is
+// exactly what every such site got before this existed.
+func (b *Builder) subEmitter() *emitter {
+	if b.env != nil {
+		return b.env.sub()
+	}
+	return &emitter{}
 }

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -90,6 +90,7 @@ func (e *emitter) subqueryFrag(n chplan.Node) (Frag, error) {
 // pattern.
 func (e *emitter) emitSelect(sb *QueryBuilder) error {
 	sb.attrStrategies = e.attrStrategies
+	sb.env = e
 	sql, args, err := sb.subquerySQL()
 	if err != nil {
 		return err
@@ -264,6 +265,7 @@ func (e *emitter) emitUnionAll(u *chplan.UnionAll) error {
 		arms[i] = f
 	}
 	b := NewBuilder()
+	b.env = e
 	UnionAll(arms...)(b)
 	return e.splice(b)
 }

--- a/internal/chsql/emitter_context_inheritance_test.go
+++ b/internal/chsql/emitter_context_inheritance_test.go
@@ -1,0 +1,296 @@
+package chsql
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// The four production sites that used to build a bare `&emitter{}` — the two
+// Expr-embedded subquery renderers here, plus EmitMetricsExemplars and
+// EmitCompareRootLeg — each discarded every ctx-carried bound and strategy
+// chsql.Emit seeds. These tests pin that they inherit them now (cerberus
+// issue #3186). Each one is written against OBSERVABLE SQL rather than
+// against the emitter's fields, so it fails if the plumbing is removed even
+// if the fields survive.
+
+const inheritanceAttrColumn = "ResourceAttributes"
+
+func jsonAttrStrategies() AttrStrategies {
+	return AttrStrategies{inheritanceAttrColumn: AttrStrategyJSON}
+}
+
+// attrReadScan is a Scan projecting one attribute-map key read, the smallest
+// plan whose SQL differs between AttrStrategyMap and AttrStrategyJSON.
+func attrReadScan(table string) chplan.Node {
+	return &chplan.Project{
+		Input: &chplan.Scan{Table: table},
+		Projections: []chplan.Projection{{
+			Expr: &chplan.MapAccess{
+				Map: &chplan.ColumnRef{Name: inheritanceAttrColumn},
+				Key: &chplan.LitString{V: "k"},
+			},
+			Alias: "attr",
+		}},
+	}
+}
+
+// renderedAsJSON reports whether sql carries the JSON dynamic-subcolumn read
+// shape rather than the Map subscript. The two are mutually exclusive for the
+// same access, so this is a faithful "which strategy rendered it" question.
+func renderedAsJSON(sql string) bool {
+	return strings.Contains(sql, "coalesce(`"+inheritanceAttrColumn+"`.")
+}
+
+// TestScalarSubqueryInheritsAttrStrategies pins that a chplan.ScalarSubquery
+// renders its embedded plan inside the OUTER emission. Before this, the site
+// built a bare emitter, so the subtree rendered Map syntax against a
+// JSON-typed column and failed at query time.
+func TestScalarSubqueryInheritsAttrStrategies(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_metrics_sum"},
+		Projections: []chplan.Projection{{
+			Expr:  &chplan.ScalarSubquery{Input: attrReadScan("otel_metrics_sum")},
+			Alias: "scalar",
+		}},
+	}
+
+	ctx := WithAttrStrategies(context.Background(), jsonAttrStrategies())
+	sql, _, err := Emit(ctx, plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !renderedAsJSON(sql) {
+		t.Fatalf("the scalar subquery rendered Map syntax against a JSON-typed column:\n%s", sql)
+	}
+}
+
+// TestInSubqueryInheritsAttrStrategies is the same pin for chplan.InSubquery,
+// the other Expr slot that embeds a whole plan subtree.
+func TestInSubqueryInheritsAttrStrategies(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Filter{
+		Input: &chplan.Scan{Table: "otel_metrics_sum"},
+		Predicate: &chplan.InSubquery{
+			Left:     &chplan.ColumnRef{Name: "MetricName"},
+			Subquery: attrReadScan("otel_metrics_sum"),
+		},
+	}
+
+	ctx := WithAttrStrategies(context.Background(), jsonAttrStrategies())
+	sql, _, err := Emit(ctx, plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !renderedAsJSON(sql) {
+		t.Fatalf("the IN subquery rendered Map syntax against a JSON-typed column:\n%s", sql)
+	}
+}
+
+// TestEmbeddedSubqueryStrategiesAreScopedToTheEmission is the negative half:
+// with no strategies on the ctx, the same plans render the Map subscript. It
+// is what proves the two tests above assert a real switch rather than a shape
+// the emitter produces unconditionally.
+func TestEmbeddedSubqueryStrategiesAreScopedToTheEmission(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_metrics_sum"},
+		Projections: []chplan.Projection{{
+			Expr:  &chplan.ScalarSubquery{Input: attrReadScan("otel_metrics_sum")},
+			Alias: "scalar",
+		}},
+	}
+
+	sql, _, err := Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if renderedAsJSON(sql) {
+		t.Fatalf("a plain emission rendered the JSON shape with no strategies on the ctx:\n%s", sql)
+	}
+}
+
+// TestSubEmitterSharesTheCTECounter pins the second half of the same bug: a
+// sub-emitter renders into its own buffer but its SQL is spliced into the
+// SAME statement, so a restarted CTE counter re-emits a name the outer
+// statement already bound — ClickHouse error 49, the exact collision the
+// counter exists to prevent.
+func TestSubEmitterSharesTheCTECounter(t *testing.T) {
+	t.Parallel()
+
+	e := newEmitter(context.Background())
+	if got := e.nextCTESeq(); got != 1 {
+		t.Fatalf("first CTE sequence = %d, want 1", got)
+	}
+	sub := e.sub()
+	if got := sub.nextCTESeq(); got != 2 {
+		t.Fatalf("sub-emitter restarted the CTE counter at %d, want 2", got)
+	}
+	if got := e.nextCTESeq(); got != 3 {
+		t.Fatalf("the outer emitter did not see the sub-emitter's advance: got %d, want 3", got)
+	}
+}
+
+// TestSubEmitterCarriesEveryContextSeededBound pins that sub() forwards every
+// ctx-seeded field, so adding a bound to newEmitter and forgetting it here
+// cannot silently leave subqueries unbounded.
+func TestSubEmitterCarriesEveryContextSeededBound(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithAttrStrategies(context.Background(), jsonAttrStrategies())
+	ctx = WithSpansTable(ctx, "custom_spans")
+	e := newEmitter(ctx)
+	sub := e.sub()
+
+	for _, c := range []struct {
+		name      string
+		got, want any
+	}{
+		{"spansTable", sub.spansTable, e.spansTable},
+		{"ctxSpansTable", sub.ctxSpansTable, e.ctxSpansTable},
+		{"deltaPrefixLookbackNS", sub.deltaPrefixLookbackNS, e.deltaPrefixLookbackNS},
+		{"deltaPrefixReadEnabled", sub.deltaPrefixReadEnabled, e.deltaPrefixReadEnabled},
+		{"rangeBucketFanoutMaxRows", sub.rangeBucketFanoutMaxRows, e.rangeBucketFanoutMaxRows},
+		{"rangeLWRFanoutMaxRows", sub.rangeLWRFanoutMaxRows, e.rangeLWRFanoutMaxRows},
+		{"rateWindowFanoutMaxRows", sub.rateWindowFanoutMaxRows, e.rateWindowFanoutMaxRows},
+		{"rangeBucketGridNativeMaxRows", sub.rangeBucketGridNativeMaxRows, e.rangeBucketGridNativeMaxRows},
+		{"rangeBucketGridNativeMaxDensityUnits", sub.rangeBucketGridNativeMaxDensityUnits, e.rangeBucketGridNativeMaxDensityUnits},
+		{"emittedSQLMaxBytes", sub.emittedSQLMaxBytes, e.emittedSQLMaxBytes},
+	} {
+		if c.got != c.want {
+			t.Errorf("sub-emitter %s = %v, outer emitter has %v", c.name, c.got, c.want)
+		}
+	}
+	if sub.deltaPrefixLookbackNS == 0 {
+		t.Error("deltaPrefixLookbackNS is 0, the explicit \"no lower bound\" value — the default was not seeded")
+	}
+	if len(sub.attrStrategies) != len(e.attrStrategies) {
+		t.Errorf("sub-emitter attrStrategies = %v, outer emitter has %v", sub.attrStrategies, e.attrStrategies)
+	}
+}
+
+// TestEmitMetricsExemplarsInheritsAttrStrategies pins the third of the four
+// sites. The exemplars statement is built here and executed directly by the
+// Tempo handlers, so it never flows through Emit — which is exactly why its
+// emitter has to be seeded from the ctx itself rather than left bare.
+func TestEmitMetricsExemplarsInheritsAttrStrategies(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	attrRead := &chplan.MapAccess{
+		Map: &chplan.ColumnRef{Name: inheritanceAttrColumn},
+		Key: &chplan.LitString{V: "k"},
+	}
+	m := &chplan.MetricsAggregate{
+		Op:             chplan.MetricsOpRate,
+		GroupBy:        []chplan.Expr{attrRead},
+		GroupByAliases: []string{"attr"},
+		ValueAlias:     "Value",
+		Inner:          &chplan.Scan{Table: "otel_traces"},
+	}
+	rw := &chplan.RangeWindow{
+		Input:           m,
+		Step:            time.Minute,
+		Range:           time.Minute,
+		Start:           start,
+		End:             end,
+		TimestampColumn: "Timestamp",
+	}
+
+	ctx := WithAttrStrategies(context.Background(), jsonAttrStrategies())
+	sql, _, _, err := EmitMetricsExemplars(ctx, rw, m, "TraceId", "SpanId", 0, "")
+	if err != nil {
+		t.Fatalf("EmitMetricsExemplars: %v", err)
+	}
+	if !renderedAsJSON(sql) {
+		t.Fatalf("the exemplars statement rendered Map syntax against a JSON-typed column:\n%s", sql)
+	}
+
+	plain, _, _, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 0, "")
+	if err != nil {
+		t.Fatalf("EmitMetricsExemplars (no strategies): %v", err)
+	}
+	if renderedAsJSON(plain) {
+		t.Fatalf("the exemplars statement rendered the JSON shape with no strategies on the ctx:\n%s", plain)
+	}
+}
+
+// TestEmitCompareRootLegInheritsAttrStrategies pins the fourth site. The
+// compare root leg is rendered outside Emit so a caller can run it on its
+// own, and it too built a bare emitter.
+func TestEmitCompareRootLegInheritsAttrStrategies(t *testing.T) {
+	t.Parallel()
+
+	m := &chplan.MetricsCompare{
+		Selection: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  &chplan.ColumnRef{Name: "StatusCode"},
+			Right: &chplan.LitString{V: "Error"},
+		},
+		TopN: 10,
+		Pairs: &chplan.FuncCall{Fn: chplan.FnArray, Args: []chplan.Expr{
+			&chplan.FuncCall{Fn: chplan.FnTuple, Args: []chplan.Expr{
+				&chplan.LitString{V: "name"},
+				&chplan.ColumnRef{Name: "SpanName"},
+			}},
+		}},
+		SelAlias:      "is_selection",
+		AttrAlias:     "attr",
+		ValAlias:      "val",
+		ValueAlias:    "Value",
+		Inner:         &chplan.Scan{Table: "otel_traces"},
+		TraceIDColumn: "TraceId",
+		RootLookup: &chplan.Aggregate{
+			Input: &chplan.Filter{
+				Input: &chplan.Scan{Table: "otel_traces"},
+				Predicate: &chplan.Binary{
+					Op:    chplan.OpEq,
+					Left:  &chplan.ColumnRef{Name: "ParentSpanId"},
+					Right: &chplan.LitString{V: ""},
+				},
+			},
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "TraceId"}},
+			AggFuncs: []chplan.AggFunc{{
+				Fn: chplan.FnAny,
+				Args: []chplan.Expr{&chplan.MapAccess{
+					Map: &chplan.ColumnRef{Name: inheritanceAttrColumn},
+					Key: &chplan.LitString{V: "k"},
+				}},
+				Alias: "__root_attr",
+			}},
+		},
+	}
+	rw := &chplan.RangeWindow{
+		Input:           m,
+		Range:           time.Minute,
+		Step:            time.Minute,
+		Start:           time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		End:             time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC),
+		TimestampColumn: "Timestamp",
+	}
+
+	ctx := WithAttrStrategies(context.Background(), jsonAttrStrategies())
+	sql, _, _, err := EmitCompareRootLeg(ctx, rw)
+	if err != nil {
+		t.Fatalf("EmitCompareRootLeg: %v", err)
+	}
+	if !renderedAsJSON(sql) {
+		t.Fatalf("the compare root leg rendered Map syntax against a JSON-typed column:\n%s", sql)
+	}
+
+	plain, _, _, err := EmitCompareRootLeg(context.Background(), rw)
+	if err != nil {
+		t.Fatalf("EmitCompareRootLeg (no strategies): %v", err)
+	}
+	if renderedAsJSON(plain) {
+		t.Fatalf("the compare root leg rendered the JSON shape with no strategies on the ctx:\n%s", plain)
+	}
+}

--- a/internal/chsql/exemplars.go
+++ b/internal/chsql/exemplars.go
@@ -78,7 +78,15 @@ func EmitMetricsExemplars(
 		return "", nil, 0, err
 	}
 
-	e := &emitter{spansTable: spansTable}
+	// Seeded from the emit context exactly as chsql.Emit's own emitter is:
+	// this statement is built here and executed directly by the Tempo
+	// handlers, so it never flows through Emit, and a bare emitter would
+	// discard every ctx-carried bound and strategy — a JSON-typed attribute
+	// column would render Map syntax and fail at query time (issue #3186).
+	// spansTable stays explicit because the caller resolves it, and the
+	// handler ctx is not always engine-threaded with WithSpansTable.
+	e := newEmitter(ctx)
+	e.spansTable = spansTable
 	if err := e.emitMetricsExemplars(rw, m, traceIDCol, spanIDCol, maxPerSeries, spansTable); err != nil {
 		span.RecordError(err)
 		return "", nil, 0, err

--- a/internal/chsql/fnresolution.go
+++ b/internal/chsql/fnresolution.go
@@ -288,3 +288,39 @@ func resolveAggFuncName(af chplan.AggFunc) (string, error) {
 	}
 	return name, nil
 }
+
+// arrayReduceParametricFrag renders ClickHouse's
+// `arrayReduce('<fn>(<params…>)', <arr>)` — the way a PARAMETRIC aggregate
+// (one carrying its own parameter list, like `quantileExactInclusive(phi)`)
+// is applied to an array expression rather than to a column.
+//
+// The aggregate's ClickHouse NAME is resolved through fnResolutions, the one
+// table that owns every plan symbol's ClickHouse spelling. Before this helper
+// the two `quantileExactInclusive` call sites in range_window.go retyped that
+// name and glued the parameter onto it with `+`, so the table's own entry and
+// the emitted token were two unpinned copies of one name, and a ClickHouse
+// function token was being assembled by string concatenation outside
+// builder.go.
+//
+// The spec is composed as a typed Call Frag and rendered once, then quoted
+// through InlineLit: arrayReduce takes the aggregate as a STRING argument, so
+// at the outer call site the rendered text is data, not SQL structure. Every
+// parameter must therefore render as an inline literal — a `?`-bound
+// parameter inside the quoted spec would bind at the wrong nesting level, so
+// one is rejected here rather than emitted.
+func arrayReduceParametricFrag(fn chplan.Fn, params []Frag, arr Frag) (Frag, error) {
+	name, render, err := resolveFn(fn)
+	if err != nil {
+		return nil, err
+	}
+	if render != nil {
+		return nil, fmt.Errorf("%w: chplan.Fn %q resolves via a render hook, "+
+			"which has no parametric-aggregate spelling", ErrUnsupported, fn)
+	}
+	spec, args := Render(Call(name, params...))
+	if len(args) != 0 {
+		return nil, fmt.Errorf("%w: the parametric-aggregate spec for chplan.Fn %q bound %d "+
+			"positional argument(s); its parameters must render as inline literals", ErrUnsupported, fn, len(args))
+	}
+	return Call("arrayReduce", InlineLit(spec), arr), nil
+}

--- a/internal/chsql/fnresolution_parametric_test.go
+++ b/internal/chsql/fnresolution_parametric_test.go
@@ -1,0 +1,90 @@
+package chsql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestArrayReduceParametricFragTakesItsNameFromTheResolutionTable pins the
+// parametric-aggregate spec to fnResolutions rather than to a name retyped at
+// the emitter. `want` is DERIVED from the table entry, so renaming
+// fnResolutions[chplan.FnQuantile] without the emitter following fails here —
+// which is the drift this helper exists to make impossible (issue #3186).
+func TestArrayReduceParametricFragTakesItsNameFromTheResolutionTable(t *testing.T) {
+	t.Parallel()
+
+	name, render, err := resolveFn(chplan.FnQuantile)
+	if err != nil {
+		t.Fatalf("resolveFn(FnQuantile): %v", err)
+	}
+	if render != nil {
+		t.Fatalf("FnQuantile resolves via a render hook; the parametric spelling has no name to take")
+	}
+
+	f, err := arrayReduceParametricFrag(chplan.FnQuantile, []Frag{InlineLit(0.5)}, BareIdent("window_vals"))
+	if err != nil {
+		t.Fatalf("arrayReduceParametricFrag: %v", err)
+	}
+	sql, args := Render(f)
+	if len(args) != 0 {
+		t.Fatalf("parametric spec bound %d positional args, want 0: %v", len(args), args)
+	}
+
+	want := "arrayReduce('" + name + "(0.5)', window_vals)"
+	if sql != want {
+		t.Fatalf("rendered spec\n got: %s\nwant: %s", sql, want)
+	}
+}
+
+// TestMedianOverArrayFragRendersThroughTheResolvedName is the same pin for
+// mad_over_time's median, whose phi is a compiled-in 0.5 rather than a plan
+// scalar. It also fixes the exact SQL both mad_over_time medians emit, so a
+// silent change to the median spelling is caught here and not only in a
+// TXTAR golden.
+func TestMedianOverArrayFragRendersThroughTheResolvedName(t *testing.T) {
+	t.Parallel()
+
+	name, _, err := resolveFn(chplan.FnQuantile)
+	if err != nil {
+		t.Fatalf("resolveFn(FnQuantile): %v", err)
+	}
+	f, err := medianOverArrayFrag(BareIdent("window_vals"))
+	if err != nil {
+		t.Fatalf("medianOverArrayFrag: %v", err)
+	}
+	sql, _ := Render(f)
+	want := "arrayReduce('" + name + "(0.5)', window_vals)"
+	if sql != want {
+		t.Fatalf("median frag\n got: %s\nwant: %s", sql, want)
+	}
+}
+
+// TestArrayReduceParametricFragRejectsABoundParameter pins the fail-closed
+// arm: a parameter that renders as a `?` placeholder would bind at the outer
+// statement's nesting level while its text sits inside a quoted string, so the
+// spec must be refused rather than emitted.
+func TestArrayReduceParametricFragRejectsABoundParameter(t *testing.T) {
+	t.Parallel()
+
+	_, err := arrayReduceParametricFrag(chplan.FnQuantile, []Frag{Lit(0.5)}, BareIdent("window_vals"))
+	if err == nil {
+		t.Fatal("a `?`-bound parameter was accepted into a quoted aggregate spec")
+	}
+	if !strings.Contains(err.Error(), "inline literals") {
+		t.Fatalf("rejection does not explain the constraint: %v", err)
+	}
+}
+
+// TestArrayReduceParametricFragRejectsAnUnresolvedFn pins the other
+// fail-closed arm: an Fn with no fnResolutions entry must not render an empty
+// or raw aggregate name.
+func TestArrayReduceParametricFragRejectsAnUnresolvedFn(t *testing.T) {
+	t.Parallel()
+
+	_, err := arrayReduceParametricFrag(chplan.Fn("no_such_fn"), []Frag{InlineLit(0.5)}, BareIdent("v"))
+	if err == nil {
+		t.Fatal("an unresolved chplan.Fn produced a parametric aggregate spec")
+	}
+}

--- a/internal/chsql/fnresolution_parametric_test.go
+++ b/internal/chsql/fnresolution_parametric_test.go
@@ -79,11 +79,14 @@ func TestArrayReduceParametricFragRejectsABoundParameter(t *testing.T) {
 
 // TestArrayReduceParametricFragRejectsAnUnresolvedFn pins the other
 // fail-closed arm: an Fn with no fnResolutions entry must not render an empty
-// or raw aggregate name.
+// or raw aggregate name. The zero value is the one such Fn that can be
+// written without a raw literal, which forbid-chplan-fn-literal forbids and
+// resolveFn's own doc names as the case it fails closed on.
 func TestArrayReduceParametricFragRejectsAnUnresolvedFn(t *testing.T) {
 	t.Parallel()
 
-	_, err := arrayReduceParametricFrag(chplan.Fn("no_such_fn"), []Frag{InlineLit(0.5)}, BareIdent("v"))
+	var unresolved chplan.Fn
+	_, err := arrayReduceParametricFrag(unresolved, []Frag{InlineLit(0.5)}, BareIdent("v"))
 	if err == nil {
 		t.Fatal("an unresolved chplan.Fn produced a parametric aggregate spec")
 	}

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -845,10 +845,12 @@ func EmitCompareRootLeg(ctx context.Context, r *chplan.RangeWindow) (string, []a
 		return fail(fmt.Errorf("%w: MetricsCompare.RootLookup is nil (no root leg to render)", ErrUnsupported))
 	}
 
-	e := &emitter{
-		spansTable:    spansTable,
-		ctxSpansTable: spansTable,
-	}
+	// Seeded from the emit context exactly as chsql.Emit's own emitter is —
+	// this leg is rendered outside Emit, and a bare emitter would discard
+	// every ctx-carried bound and strategy (issue #3186). spansTable and
+	// ctxSpansTable are already read off ctx by newEmitter; they are the
+	// same value spansTableFromCtx returned above.
+	e := newEmitter(ctx)
 	windowed, bound, err := e.compareWindowedScanBound(rw, m, rangeNS)
 	if err != nil {
 		return fail(err)

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -5529,6 +5529,7 @@ func (e *emitter) collectGroupByFrags(group []chplan.Expr) ([]Frag, error) {
 		// straight into GroupBy must not silently mis-render against a
 		// JSON-typed column.
 		sub := NewBuilderWithAttrStrategies(e.attrStrategies)
+		sub.env = e
 		if err := sub.Expr(g); err != nil {
 			return nil, err
 		}

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -2928,13 +2928,20 @@ func overTimeArrayValueFrag(fn string, vals Frag) (Frag, error) {
 		// applied twice: once over window_vals for the inner median, once
 		// over the absolute deviations. Empty windows are dropped by the
 		// shared outer WHERE length(window_vals) >= 1 below.
-		med := medianOverArrayFrag(vals)
+		med, err := medianOverArrayFrag(vals)
+		if err != nil {
+			return nil, err
+		}
 		devs := Call(
 			"arrayMap",
 			Lambda1("x", Call("abs", Sub(BareIdent("x"), med))),
 			vals,
 		)
-		inner = nonEmptyWindowOrNaNFrag(vals, medianOverArrayFrag(devs))
+		devMed, err := medianOverArrayFrag(devs)
+		if err != nil {
+			return nil, err
+		}
+		inner = nonEmptyWindowOrNaNFrag(vals, devMed)
 	case "stddev_over_time":
 		// Empty window → drop the series (Prom returns no sample).
 		// We mirror with NaN; the engine layer treats NaN as "drop"
@@ -3017,9 +3024,9 @@ func varPopTwoPassFrag(vals Frag) Frag {
 // this replaced, whose unwrapped sum silently rebound into the
 // subtraction (mad_over_time_even_window.txtar pins the correct
 // result).
-func medianOverArrayFrag(arr Frag) Frag {
+func medianOverArrayFrag(arr Frag) (Frag, error) {
 	const medianPhi = 0.5
-	return Call("arrayReduce", InlineLit("quantileExactInclusive("+formatFloat(medianPhi)+")"), arr)
+	return arrayReduceParametricFrag(chplan.FnQuantile, []Frag{InlineLit(medianPhi)}, arr)
 }
 
 // emitRangeWindowTsOfOverTime emits SQL for the experimental timestamp
@@ -3734,14 +3741,18 @@ func (e *emitter) emitRangeWindowQuantileOverTime(r *chplan.RangeWindow) error {
 	}
 	phi := r.Scalars[0]
 	// arrayReduce('quantileExactInclusive(<phi>)', window_vals) — the
-	// literal-phi path; the aggregate name carries phi inline (formatFloat
-	// keeps it stable across driver float formatting), so it rides
-	// InlineLit as a single quoted string. Empty window drops the series
-	// (nan).
+	// literal-phi path; the aggregate name carries phi inline, so it rides
+	// InlineLit as a single quoted string. The name itself comes from the
+	// FnQuantile resolution entry via arrayReduceParametricFrag rather than
+	// being retyped here. Empty window drops the series (nan).
+	q, err := arrayReduceParametricFrag(chplan.FnQuantile, []Frag{InlineLit(phi)}, BareIdent("window_vals"))
+	if err != nil {
+		return err
+	}
 	frag := Call(
 		"if",
 		Gt(Call("length", BareIdent("window_vals")), InlineLit(int64(0))),
-		Call("arrayReduce", InlineLit("quantileExactInclusive("+formatFloat(phi)+")"), BareIdent("window_vals")),
+		q,
 		BareIdent("nan"),
 	)
 	return e.emitWindowedArray(r, frag, 1)

--- a/internal/chsqltest/harness.go
+++ b/internal/chsqltest/harness.go
@@ -87,28 +87,3 @@ func isolatedDBName(testName string) string {
 	}
 	return fmt.Sprintf("%s_%d", b.String(), isolatedDBSeq.Add(1))
 }
-
-// MetricsSeedDDL renders the OTel-CH metric-table shape internal/chsql's chDB
-// round-trip tests seed. It is ONE definition rather than a copy per test file
-// because the read path decides which columns a selector projects, and a
-// column added there has to reach every seed at once: `ServiceName` was added
-// to the selector's label projection and eight identical inline CREATEs each
-// had to learn about it, which is exactly the drift a shared renderer removes.
-// A ninth seed that never adopted it — a hand-rolled three-column
-// `otel_metrics_sum` — is what #2074 was.
-//
-// `ResourceAttributes` and `ServiceName` carry DEFAULTs so the tests' explicit
-// INSERT column lists stay short — the read path only needs them to RESOLVE,
-// not to be populated.
-func MetricsSeedDDL(table string) string {
-	return fmt.Sprintf(`
-CREATE OR REPLACE TABLE %s (
-    MetricName String,
-    Attributes Map(String, String),
-    ResourceAttributes Map(String, String) DEFAULT map(),
-    ServiceName LowCardinality(String) DEFAULT '',
-    TimeUnix DateTime64(9),
-    Value Float64
-) ENGINE = MergeTree ORDER BY (MetricName, Attributes, TimeUnix);
-`, table)
-}

--- a/internal/chsqltest/seed_ddl.go
+++ b/internal/chsqltest/seed_ddl.go
@@ -1,0 +1,62 @@
+package chsqltest
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// metricsSeedTimestampKeyFn is the ClickHouse function the OTel-CH metrics
+// ORDER BY wraps its timestamp key element in. It is the one part of the
+// sorting key internal/schema cannot hand back as a bare column name —
+// Metrics.SortingKeyPrefix stops at the first function-wrapped element by
+// contract, because a wrapped element can never be a GROUP BY prefix — so it
+// is named here, next to the only renderer that needs it, rather than being
+// re-derived from DDL text. See internal/schema/sortingkey.go for the tuple
+// this completes.
+const metricsSeedTimestampKeyFn = "toUnixTimestamp64Nano"
+
+// MetricsSeedDDL renders the OTel-CH metric-table shape internal/chsql's chDB
+// round-trip tests seed. It is ONE definition rather than a copy per test file
+// because the read path decides which columns a selector projects, and a
+// column added there has to reach every seed at once: `ServiceName` was added
+// to the selector's label projection and eight identical inline CREATEs each
+// had to learn about it, which is exactly the drift a shared renderer removes.
+// A ninth seed that never adopted it — a hand-rolled three-column
+// `otel_metrics_sum` — is what #2074 was.
+//
+// `ResourceAttributes` and `ServiceName` carry DEFAULTs so the tests' explicit
+// INSERT column lists stay short — the read path only needs them to RESOLVE,
+// not to be populated.
+//
+// The ORDER BY is DERIVED from internal/schema rather than typed here. It was
+// typed here, as `(MetricName, Attributes, TimeUnix)`, while every real
+// cerberus metrics table is ordered by
+// `(MetricName, Attributes, ServiceName, toUnixTimestamp64Nano(TimeUnix))` —
+// so every chDB round-trip in internal/chsql exercised PREWHERE promotion and
+// sort-prefix ordering against a physical key the emitter is not written for
+// (cerberus issue #3186). Deriving it means the seed cannot drift from the
+// shape chsql's own TableShape registry reports for these tables, because both
+// read the same schema.Metrics column fields.
+func MetricsSeedDDL(table string) string {
+	m := schema.DefaultOTelMetrics()
+	sortKey := append(m.SortingKeyPrefix(), fmt.Sprintf("%s(%s)", metricsSeedTimestampKeyFn, m.TimestampColumn))
+	return fmt.Sprintf(`
+CREATE OR REPLACE TABLE %s (
+    %s String,
+    %s Map(String, String),
+    %s Map(String, String) DEFAULT map(),
+    %s LowCardinality(String) DEFAULT '',
+    %s DateTime64(9),
+    %s Float64
+) ENGINE = MergeTree ORDER BY (%s);
+`, table,
+		m.MetricNameColumn,
+		m.AttributesColumn,
+		m.ResourceAttributesColumn,
+		m.ServiceNameColumn,
+		m.TimestampColumn,
+		m.ValueColumn,
+		strings.Join(sortKey, ", "))
+}

--- a/internal/chsqltest/seed_ddl_test.go
+++ b/internal/chsqltest/seed_ddl_test.go
@@ -1,0 +1,63 @@
+package chsqltest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestMetricsSeedDDLOrdersLikeARealMetricsTable pins the seed's ORDER BY to
+// the sorting key every real cerberus metrics table carries. The seed used to
+// declare `(MetricName, Attributes, TimeUnix)` — dropping ServiceName and the
+// function-wrapped timestamp key — so every chDB round-trip in internal/chsql
+// validated PREWHERE promotion and sort-prefix ordering against a physical key
+// the emitter is not written for (cerberus issue #3186).
+func TestMetricsSeedDDLOrdersLikeARealMetricsTable(t *testing.T) {
+	t.Parallel()
+
+	m := schema.DefaultOTelMetrics()
+	ddl := MetricsSeedDDL(m.SumTable)
+
+	open := strings.LastIndex(ddl, "ORDER BY (")
+	if open < 0 {
+		t.Fatalf("seed DDL declares no ORDER BY:\n%s", ddl)
+	}
+	tail := ddl[open+len("ORDER BY ("):]
+	// The tuple's own closing paren is the one immediately before the
+	// statement terminator; the last key element is itself function-wrapped,
+	// so a plain "first )" would cut the tuple short.
+	closeIdx := strings.Index(tail, ");")
+	if closeIdx < 0 {
+		t.Fatalf("seed DDL's ORDER BY tuple is unterminated:\n%s", ddl)
+	}
+	got := strings.TrimSpace(tail[:closeIdx])
+
+	want := strings.Join(append(m.SortingKeyPrefix(), metricsSeedTimestampKeyFn+"("+m.TimestampColumn+")"), ", ")
+	if got != want {
+		t.Fatalf("seed ORDER BY\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestMetricsSeedDDLNamesEveryColumnFromSchema pins the column names too: a
+// schema override that renames a column must not leave the seed declaring the
+// old name, which would make the round-trip tests silently seed a table the
+// emitter cannot read.
+func TestMetricsSeedDDLNamesEveryColumnFromSchema(t *testing.T) {
+	t.Parallel()
+
+	m := schema.DefaultOTelMetrics()
+	ddl := MetricsSeedDDL(m.SumTable)
+	for _, col := range []string{
+		m.MetricNameColumn,
+		m.AttributesColumn,
+		m.ResourceAttributesColumn,
+		m.ServiceNameColumn,
+		m.TimestampColumn,
+		m.ValueColumn,
+	} {
+		if !strings.Contains(ddl, col) {
+			t.Errorf("seed DDL never declares schema column %q:\n%s", col, ddl)
+		}
+	}
+}

--- a/internal/engine/per_rung_admission.go
+++ b/internal/engine/per_rung_admission.go
@@ -50,7 +50,7 @@ import (
 // only once evidence says the shape does not need it.
 
 // perRungEvidenceMinObservations mirrors routememo's own
-// minCorroboratingFailures: a single clean-and-cheap drain cannot, by
+// MinCorroboratingFailures: a single clean-and-cheap drain cannot, by
 // itself, teach the learner anything — a low-traffic blip or an
 // unrepresentative first sample must not flip a shape's verdict alone.
 const perRungEvidenceMinObservations = 2
@@ -70,7 +70,7 @@ const perRungEvidenceMinObservations = 2
 const perRungCheapRowsPerAnchor = 20
 
 // perRungEvidenceTTL bounds how long a learned verdict is trusted, mirroring
-// routememo's own memoEntryTTL (30m): a metric's real cardinality can grow
+// routememo's own MemoEntryTTL (30m): a metric's real cardinality can grow
 // (a new label value, a service scaling out), and a verdict computed against
 // yesterday's shape must not silently suppress predictive routing forever
 // once that has happened. An observation older than this resets the state as
@@ -78,7 +78,7 @@ const perRungCheapRowsPerAnchor = 20
 // default, not a fresh strike against the shape.
 const perRungEvidenceTTL = 30 * time.Minute
 
-// perRungLearnerCapacity mirrors routememo's own memoMaxEntries: a bound
+// perRungLearnerCapacity mirrors routememo's own MemoMaxEntries: a bound
 // resident size so unbounded key cardinality cannot grow this cache without
 // limit. Eviction here is coarser than routememo's true LRU (any single
 // entry may be evicted once at capacity, not necessarily the oldest) because

--- a/internal/engine/per_rung_mirrored_defaults_test.go
+++ b/internal/engine/per_rung_mirrored_defaults_test.go
@@ -1,0 +1,34 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/routememo"
+)
+
+// TestPerRungDefaultsMirrorRouteMemo pins the three per-rung learner
+// constants that document themselves as mirroring internal/routememo's own
+// against those constants directly. The learner is a second, independent
+// application of one calibration decision — how much evidence is enough, how
+// long it stays trusted, how many keys stay resident — so without this the
+// two sides are free to drift while both comments still claim they agree
+// (cerberus issue #3186). It follows internal/downsampletier's
+// TestResourceCapsMatchDeltaPrefix, the pattern already established here.
+func TestPerRungDefaultsMirrorRouteMemo(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range []struct {
+		name      string
+		got, want any
+		mirrors   string
+	}{
+		{"perRungEvidenceMinObservations", perRungEvidenceMinObservations, routememo.MinCorroboratingFailures, "routememo.MinCorroboratingFailures"},
+		{"perRungEvidenceTTL", perRungEvidenceTTL, routememo.MemoEntryTTL, "routememo.MemoEntryTTL"},
+		{"perRungLearnerCapacity", perRungLearnerCapacity, routememo.MemoMaxEntries, "routememo.MemoMaxEntries"},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %v; %s is %v — the two carry one rationale and must stay identical",
+				c.name, c.got, c.mirrors, c.want)
+		}
+	}
+}

--- a/internal/engine/route_memo_wiring_test.go
+++ b/internal/engine/route_memo_wiring_test.go
@@ -469,7 +469,7 @@ func TestRetryOnRouteAResourceFailure_RecordsProbeDeclineReasons(t *testing.T) {
 		seed := memoWiringNotRoutedDecision(t)
 		before := routeMemoHitSkippedByReason(t, reader)[telemetry.RouteMemoDeclineProbeNotAdmitted]
 		// First resource failure on a fresh Unknown key: corroboration=1,
-		// below minCorroboratingFailures — ObserveRouteAFailureAndMaybeBeginProbe
+		// below MinCorroboratingFailures — ObserveRouteAFailureAndMaybeBeginProbe
 		// itself refuses, for a reason OTHER than cluster-wide pressure.
 		if _, _, _, _, retried := eng.retryOnRouteAResourceFailure(t.Context(), "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil); retried {
 			t.Fatal("retried on the first route-A resource failure")
@@ -719,7 +719,7 @@ func TestTryRouteMemoHit_StaleVerdictFallsBackToCaller(t *testing.T) {
 	d := eng.deriveRouteMemoDispatch(plan, seed, fixedNow)
 	memo.Observe(d.key, routememo.RouteB, routememo.OutcomeSuccess)
 
-	// Advance past the re-validation midpoint (memoEntryTTL/2) without
+	// Advance past the re-validation midpoint (MemoEntryTTL/2) without
 	// crossing the TTL itself.
 	memo.SetNowForTest(func() time.Time { return fixedNow.Add(20 * time.Minute) })
 
@@ -848,7 +848,7 @@ func TestTryRouteMemoHit_MidDrainResourceFailure_ObserveViaClassify(t *testing.T
 
 // TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration pins the A->B
 // retry's core contract: a route-A resource failure alone is NOT enough —
-// it takes minCorroboratingFailures consecutive failures with no
+// it takes MinCorroboratingFailures consecutive failures with no
 // intervening success before a probe (retry) is admitted.
 func TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration(t *testing.T) {
 	t.Parallel()
@@ -869,7 +869,7 @@ func TestRetryOnRouteAResourceFailure_ProbesAfterCorroboration(t *testing.T) {
 	}
 
 	// Second consecutive resource failure, same key, no intervening
-	// success: corroboration=2 (the default minCorroboratingFailures) —
+	// success: corroboration=2 (the default MinCorroboratingFailures) —
 	// NOW a probe is admitted and route B dispatches.
 	cur, info, usedDecision, observeFn, retried := eng.retryOnRouteAResourceFailure(ctx, "promql", memoWiringResponseShape, plan, seed, nil, chclient.ErrMemoryLimitExceeded, 0, nil)
 	if !retried {

--- a/internal/routememo/memo.go
+++ b/internal/routememo/memo.go
@@ -53,22 +53,29 @@ const (
 )
 
 // Named, meaning-bearing constants — see docs/solver.md for the full
-// rationale of each. memoEntryTTL and reValidationFraction are DEFAULT
+// rationale of each. MemoEntryTTL and reValidationFraction are DEFAULT
 // values only: New seeds them into the per-Memo entryTTL /
 // reValidationFraction fields, which SetEntryTTL / SetReValidationFraction
 // can override per instance without changing New's signature.
 const (
-	// memoMaxEntries bounds the memo's resident size. A bounded LRU evicts
+	// MemoMaxEntries bounds the memo's resident size. A bounded LRU evicts
 	// the least-recently-touched entry once this is exceeded, so the memo
-	// cannot grow without bound under high key cardinality.
-	memoMaxEntries = 4096
+	// cannot grow without bound under high key cardinality. Exported for the
+	// same reason MinCorroboratingFailures below is: internal/engine's
+	// per-rung learner documents its own capacity as mirroring this one, and
+	// an unexported constant cannot be pinned against from there, which left
+	// the two copies free to drift (cerberus issue #3186).
+	MemoMaxEntries = 4096
 
-	// memoEntryTTL is the default for how long any verdict is trusted at
+	// MemoEntryTTL is the default for how long any verdict is trusted at
 	// all, counted from creation. It is never refreshed by a lookup, nor by
 	// a plain confirming route-A success on an Unknown/bookkeeping entry —
 	// only a route-A ResourceFailure against a PreferB entry (the stale
-	// re-validation path) or a fresh route-B Observe restamps it.
-	memoEntryTTL = 30 * time.Minute
+	// re-validation path) or a fresh route-B Observe restamps it. Exported
+	// for the same cross-package pinning reason as MemoMaxEntries above:
+	// internal/engine's perRungEvidenceTTL and internal/actuals's own
+	// EntryTTL default both document themselves as mirroring this value.
+	MemoEntryTTL = 30 * time.Minute
 
 	// reValidationFraction is the default divisor that places
 	// re-validation at the TTL midpoint — a fixed relationship to entryTTL
@@ -172,7 +179,7 @@ type Memo struct {
 	pressure       *pressureTracker
 
 	// entryTTL and reValidationFraction are seeded from the package-level
-	// defaults (memoEntryTTL, reValidationFraction) inside New and are
+	// defaults (MemoEntryTTL, reValidationFraction) inside New and are
 	// mutable only through the SetEntryTTL / SetReValidationFraction
 	// setters below, so New's signature and default behaviour for every
 	// existing caller stay unchanged.
@@ -194,14 +201,14 @@ func New(pressureWindow time.Duration) *Memo {
 		dispatchTokens:       make(chan struct{}, maxConcurrentRoutedDispatches),
 		pressureWindow:       pressureWindow,
 		pressure:             newPressureTracker(),
-		entryTTL:             memoEntryTTL,
+		entryTTL:             MemoEntryTTL,
 		reValidationFraction: reValidationFraction,
 		now:                  time.Now,
 	}
 }
 
 // SetEntryTTL overrides how long a recorded verdict is trusted before it
-// ages out, replacing the memoEntryTTL default. A non-positive ttl is a
+// ages out, replacing the MemoEntryTTL default. A non-positive ttl is a
 // no-op: zero or negative would make every verdict expire the instant it is
 // written (getLiveLocked's expiry check trips immediately), silently
 // disabling the memo rather than tuning it, so a misconfigured operator
@@ -539,7 +546,7 @@ func (m *Memo) touchLRULocked(k Key) {
 }
 
 func (m *Memo) evictIfNeededLocked() {
-	for len(m.entries) > memoMaxEntries {
+	for len(m.entries) > MemoMaxEntries {
 		front := m.lruList.Front()
 		if front == nil {
 			return

--- a/internal/routememo/memo_test.go
+++ b/internal/routememo/memo_test.go
@@ -155,16 +155,16 @@ func TestTTLExpiresFromCreationNotFromLookup(t *testing.T) {
 	release()
 
 	// Repeated lookups before the TTL must NOT refresh the clock.
-	clk.advance(memoEntryTTL - time.Second)
+	clk.advance(MemoEntryTTL - time.Second)
 	for i := 0; i < 5; i++ {
 		if state, _ := m.Lookup(k); state != PreferB {
 			t.Fatalf("expected PreferB to still be live just under the TTL, got %v", state)
 		}
 	}
 
-	clk.advance(2 * time.Second) // now past memoEntryTTL from creation
+	clk.advance(2 * time.Second) // now past MemoEntryTTL from creation
 	if state, _ := m.Lookup(k); state != Unknown {
-		t.Fatalf("expected the entry to have expired at memoEntryTTL from CREATION, got %v", state)
+		t.Fatalf("expected the entry to have expired at MemoEntryTTL from CREATION, got %v", state)
 	}
 }
 
@@ -178,7 +178,7 @@ func TestReValidationAtMidpointSuccessDropsEntry(t *testing.T) {
 	m.Observe(k, RouteB, OutcomeSuccess)
 	release()
 
-	clk.advance(memoEntryTTL/reValidationFraction + time.Second)
+	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 	state, stale := m.Lookup(k)
 	if state != PreferB || !stale {
 		t.Fatalf("Lookup(k) at the re-validation midpoint = (%v, stale=%v), want (PreferB, stale=true)", state, stale)
@@ -212,7 +212,7 @@ func TestReValidationAtMidpointFailureRefreshesVerdictState(t *testing.T) {
 	m.Observe(k, RouteB, OutcomeSuccess)
 	release()
 
-	clk.advance(memoEntryTTL/reValidationFraction + time.Second)
+	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 	if state, stale := m.Lookup(k); state != PreferB || !stale {
 		t.Fatalf("expected stale PreferB at the midpoint, got (%v, %v)", state, stale)
 	}
@@ -223,7 +223,7 @@ func TestReValidationAtMidpointFailureRefreshesVerdictState(t *testing.T) {
 	}
 
 	// And the refreshed clock means it survives well past the ORIGINAL TTL.
-	clk.advance(memoEntryTTL - 2*time.Second)
+	clk.advance(MemoEntryTTL - 2*time.Second)
 	if state, _ := m.Lookup(k); state != PreferB {
 		t.Fatalf("expected the refreshed entry to still be live, got %v", state)
 	}
@@ -248,7 +248,7 @@ func TestObserveThenBeginProbeSeparately_MissesStaleRescue(t *testing.T) {
 	m.Observe(k, RouteB, OutcomeSuccess)
 	release()
 
-	clk.advance(memoEntryTTL/reValidationFraction + time.Second)
+	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 	if state, stale := m.Lookup(k); state != PreferB || !stale {
 		t.Fatalf("expected stale PreferB at the midpoint, got (%v, %v)", state, stale)
 	}
@@ -277,7 +277,7 @@ func TestReValidationRescue_AdmitsStalePreferBFailure(t *testing.T) {
 	m.Observe(k, RouteB, OutcomeSuccess)
 	release()
 
-	clk.advance(memoEntryTTL/reValidationFraction + time.Second)
+	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 	if state, stale := m.Lookup(k); state != PreferB || !stale {
 		t.Fatalf("expected stale PreferB at the midpoint, got (%v, %v)", state, stale)
 	}
@@ -354,15 +354,15 @@ func TestBothFailHasNoReValidationAndExpiresAtPlainTTL(t *testing.T) {
 	m.Observe(k, RouteB, OutcomeResourceFailure)
 	release()
 
-	clk.advance(memoEntryTTL/reValidationFraction + time.Second)
+	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 	// No re-validation staleness concept applies to bothFail.
 	if state, stale := m.Lookup(k); state != BothFail || stale {
 		t.Fatalf("bothFail at the PreferB re-validation midpoint = (%v, stale=%v), want (BothFail, false)", state, stale)
 	}
 
-	clk.advance(memoEntryTTL / reValidationFraction)
+	clk.advance(MemoEntryTTL / reValidationFraction)
 	if state, _ := m.Lookup(k); state != Unknown {
-		t.Fatalf("expected bothFail to expire at plain memoEntryTTL, got %v", state)
+		t.Fatalf("expected bothFail to expire at plain MemoEntryTTL, got %v", state)
 	}
 }
 
@@ -382,14 +382,14 @@ func fillDistinctPreferB(m *Memo, n int, keyAt func(i int) Key) {
 func TestLRUEvictionBoundsMemoSize(t *testing.T) {
 	m, _ := newTestMemo()
 
-	fillDistinctPreferB(m, memoMaxEntries+10, func(i int) Key { return Key{RootKind: testKeyName(i)} })
+	fillDistinctPreferB(m, MemoMaxEntries+10, func(i int) Key { return Key{RootKind: testKeyName(i)} })
 
 	stats := m.Stats()
-	if stats.Entries > memoMaxEntries {
-		t.Fatalf("memo grew to %d entries, want <= %d", stats.Entries, memoMaxEntries)
+	if stats.Entries > MemoMaxEntries {
+		t.Fatalf("memo grew to %d entries, want <= %d", stats.Entries, MemoMaxEntries)
 	}
 	if stats.Entries == 0 {
-		t.Fatalf("memo evicted everything; want the most recent memoMaxEntries to survive")
+		t.Fatalf("memo evicted everything; want the most recent MemoMaxEntries to survive")
 	}
 }
 
@@ -401,7 +401,7 @@ func TestLRUEvictsLeastRecentlyTouchedFirst(t *testing.T) {
 
 	// Fill the memo past capacity with distinct keys, never touching
 	// `first` again.
-	fillDistinctPreferB(m, memoMaxEntries, func(i int) Key { return Key{RootKind: testKeyName(i)} })
+	fillDistinctPreferB(m, MemoMaxEntries, func(i int) Key { return Key{RootKind: testKeyName(i)} })
 
 	m.mu.Lock()
 	_, stillPresent := m.entries[first]
@@ -416,7 +416,7 @@ func TestLRUEvictsLeastRecentlyTouchedFirst(t *testing.T) {
 // observeRouteAResourceFailureLocked — bumping corroboration on a live
 // Unknown entry, and refreshing a stale PreferB entry on re-validation —
 // both count as a touch for LRU purposes, matching the "least-recently-
-// touched" eviction policy documented at memoMaxEntries. Each subtest fills
+// touched" eviction policy documented at MemoMaxEntries. Each subtest fills
 // the memo to exactly capacity, re-touches `first` via the transition under
 // test, then adds ONE more distinct key to force a single eviction: if the
 // transition touched the LRU, `first` moved off the front and something
@@ -431,7 +431,7 @@ func TestLRUTouchesOnCorroborationBumpAndStaleRevalidation(t *testing.T) {
 
 		// Fill up to (but not past) capacity with distinct keys, all touched
 		// AFTER `first`'s creation.
-		fillDistinctPreferB(m, memoMaxEntries-1, func(i int) Key { return Key{RootKind: testKeyName(i)} })
+		fillDistinctPreferB(m, MemoMaxEntries-1, func(i int) Key { return Key{RootKind: testKeyName(i)} })
 
 		// Re-touch `first` via a second route-A failure (bumps corroboration,
 		// capped at minCorroboratingFailures) — now the MOST recently
@@ -460,9 +460,9 @@ func TestLRUTouchesOnCorroborationBumpAndStaleRevalidation(t *testing.T) {
 		m.Observe(first, RouteB, OutcomeSuccess)
 		release()
 
-		fillDistinctPreferB(m, memoMaxEntries-1, func(i int) Key { return Key{RootKind: testKeyName(i)} })
+		fillDistinctPreferB(m, MemoMaxEntries-1, func(i int) Key { return Key{RootKind: testKeyName(i)} })
 
-		clk.advance(memoEntryTTL/reValidationFraction + time.Second)
+		clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 		if state, stale := m.Lookup(first); state != PreferB || !stale {
 			t.Fatalf("expected stale PreferB at the midpoint, got (%v, %v)", state, stale)
 		}
@@ -657,7 +657,7 @@ func TestSetEntryTTLShortensExpiry(t *testing.T) {
 	buildPreferBEntry(t, shortened, k)
 
 	// Past the shortened TTL but far short of the package default
-	// (memoEntryTTL == 30m), so only the shortened Memo should have aged out.
+	// (MemoEntryTTL == 30m), so only the shortened Memo should have aged out.
 	clk.advance(shortTTL + time.Second)
 
 	if state, _ := shortened.Lookup(k); state != Unknown {
@@ -683,13 +683,13 @@ func TestSetReValidationFractionShortensReValidationWindow(t *testing.T) {
 	baseline.SetNowForTest(clk.now)
 	buildPreferBEntry(t, baseline, k)
 
-	const fasterFraction = 10 // midpoint at memoEntryTTL/10, versus the package default's /2
+	const fasterFraction = 10 // midpoint at MemoEntryTTL/10, versus the package default's /2
 	fasterReval := New(testPressureWindow)
 	fasterReval.SetNowForTest(clk.now)
 	fasterReval.SetReValidationFraction(fasterFraction)
 	buildPreferBEntry(t, fasterReval, k)
 
-	clk.advance(memoEntryTTL/fasterFraction + time.Second)
+	clk.advance(MemoEntryTTL/fasterFraction + time.Second)
 
 	if state, stale := fasterReval.Lookup(k); state != PreferB || !stale {
 		t.Fatalf("configured-fraction memo Lookup = (%v, stale=%v), want (PreferB, stale=true)", state, stale)
@@ -710,8 +710,8 @@ func TestSetEntryTTLAndSetReValidationFractionNoOpOnNonPositiveInput(t *testing.
 
 	for _, ttl := range []time.Duration{0, -time.Minute} {
 		m.SetEntryTTL(ttl)
-		if m.entryTTL != memoEntryTTL {
-			t.Fatalf("SetEntryTTL(%s) must no-op, got entryTTL=%s want default %s", ttl, m.entryTTL, memoEntryTTL)
+		if m.entryTTL != MemoEntryTTL {
+			t.Fatalf("SetEntryTTL(%s) must no-op, got entryTTL=%s want default %s", ttl, m.entryTTL, MemoEntryTTL)
 		}
 	}
 

--- a/internal/routememo/mirrored_defaults_test.go
+++ b/internal/routememo/mirrored_defaults_test.go
@@ -1,0 +1,35 @@
+package routememo
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/actuals"
+)
+
+// TestMirroredDefaultsMatchActuals pins the three constants this package
+// documents as mirroring internal/actuals's own defaults against those
+// defaults themselves. Each is a second, independent implementation of one
+// calibration decision — routememo is a pure leaf and must not import
+// internal/actuals outside a test (.go-arch-lint.yml) — so without this the
+// two sides are free to drift while both comments still claim they agree.
+// It follows internal/downsampletier's TestResourceCapsMatchDeltaPrefix,
+// the pattern already established for exactly this shape (issue #3186).
+func TestMirroredDefaultsMatchActuals(t *testing.T) {
+	t.Parallel()
+
+	def := actuals.DefaultConfig()
+	for _, c := range []struct {
+		name       string
+		got, want  any
+		mirrorDocs string
+	}{
+		{"magnitudeEMAAlpha", magnitudeEMAAlpha, def.EMAAlpha, "actuals.Config.EMAAlpha"},
+		{"MemoEntryTTL", MemoEntryTTL, def.EntryTTL, "actuals.Config.EntryTTL"},
+		{"MinCorroboratingFailures", MinCorroboratingFailures, def.MinObservations, "actuals.Config.MinObservations"},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %v; %s defaults to %v — the two carry one rationale and must stay identical",
+				c.name, c.got, c.mirrorDocs, c.want)
+		}
+	}
+}

--- a/internal/routememo/pressure.go
+++ b/internal/routememo/pressure.go
@@ -35,10 +35,10 @@ type pressureTracker struct {
 }
 
 // pressureTrackerMaxEntries bounds the tracker's resident size independently
-// of the time-based prune in countFresh. Reuses memoMaxEntries's rationale
+// of the time-based prune in countFresh. Reuses MemoMaxEntries's rationale
 // verbatim: the same order-of-magnitude bound on distinct in-flight Key
 // cardinality this process is sized for, not a fresh number to justify.
-const pressureTrackerMaxEntries = memoMaxEntries
+const pressureTrackerMaxEntries = MemoMaxEntries
 
 func newPressureTracker() *pressureTracker {
 	return &pressureTracker{

--- a/test/coverage-floor/internal__choptwire.json
+++ b/test/coverage-floor/internal__choptwire.json
@@ -1,0 +1,3 @@
+{
+  "internal/choptwire": 83.1
+}


### PR DESCRIPTION
Nine values and one whole function were duplicated across the tree with nothing
pinning the copies together. Each fix either makes one side derive from the
other, or pins them with a test that fails on drift — following
`TestResourceCapsMatchDeltaPrefix`, the pattern this repository already had for
exactly this shape.

Closes #3186

## The duplicate that mattered most

`chopttest.BuildRangeLowerers` was a ~130-line reviewed copy of
`cmd/cerberus.nativeRangeLowerers`, and `BuildSettingsRules` the same for
`settingsRules`. Every real-ClickHouse activation test — the perf smoke and
nightly lanes, the solver-decision ratchet, the API integration tests —
therefore validated the copies while the binary booted the originals.

The copy's own doc said it "cannot be" an import. That was true of the
function, which is unexported in `package main`, and false of the formula: it
depends only on chopt, promql and engine. `internal/choptwire` now owns both
compositions and both sides call it. Only the operator-configured settings
fields — log-comment shape, result-cache lag and TTL, query workload — are
overlaid by cmd, because they come off `config.Config` rather than the
`EnabledSet`.

**Evidence the lanes now watch production:** deleting the `ts_grid_delta`
branch from the shared table fails `TestSolverDecisionRatchet`. Deleting it
from `cmd/cerberus/main.go` used to fail nothing.

## The four bare emitters

`exprScalarSubquery`, `exprInSubquery`, `EmitMetricsExemplars` and
`EmitCompareRootLeg` built a bare `&emitter{}` instead of the one `Emit`
constructs, so each discarded every ctx-carried bound and strategy. All four
consequences the issue named are real and are fixed:

- a `rate()` over a DELTA counter inside `scalar(...)` rendered its prefix scan
  with `deltaPrefixLookbackNS == 0`, the documented explicit "no lower bound"
  opt-out, so it read the metric's entire retention regardless of
  `CERBERUS_DELTA_PREFIX_LOOKBACK`;
- a JSON-typed attribute column rendered Map syntax and failed at query time on
  the exemplars and compare-root-leg statements;
- `cteSeq` restarted at 0, so a TraceQL `InSubquery` containing a structural
  join re-emitted `_struct_closure_1` inside a statement that already used it —
  ClickHouse error 49, the exact collision the counter exists to prevent;
- operator overrides for the fan-out ceilings and for
  `CERBERUS_CH_MAX_EMITTED_SQL_BYTES` did not apply.

`newEmitter(ctx)` is now the single constructor. The two Expr-embedded subquery
renderers have no ctx of their own, so the emitter rides down the same path
`attrStrategies` already travelled — `emitSelect` stamps it on the
`QueryBuilder`, which hands it to each `Builder` — and derives a sub-emitter
that shares the CTE counter by pointer. A free-standing `Builder` still gets a
bare emitter, which is what every such site had before.

Each of the four is pinned by a test asserting observable SQL, and each of
those tests fails when its own fix is reverted.

## The metrics round-trip seed

`chsqltest.MetricsSeedDDL` declared `ORDER BY (MetricName, Attributes,
TimeUnix)`. Every real cerberus metrics table is `ORDER BY (MetricName,
Attributes, ServiceName, toUnixTimestamp64Nano(TimeUnix))`, so every chDB
round-trip in `internal/chsql` exercised PREWHERE promotion and sort-prefix
ordering against a physical key `orderedConjuncts` is not written for.

The seed now derives both its column names and its whole sorting key from
`internal/schema` — the same fields chsql's `TableShape` registry reads — and
the renderer moves out of the chdb-tagged harness so its pins run in the
ordinary unit lane. The full chdb-tagged `internal/chsql` suite passes on the
corrected key, as does the tempo chDB test that seeds through it.

## The chDB substrate pin

The `libchdb.so` every chdb-tagged lane runs on was pinned in three places with
nothing reading them against each other: `versions.yaml`'s `chdb_substrate`,
`just/chdb.just`'s `CHDB_VERSION`, and nine hand-typed `actions/cache` keys
sitting under a comment claiming they were derived from the recipe.

They are not derived, and the failure is silent rather than loud: the install
step SKIPS when `libchdb.so` already exists, so a bump that misses a cache key
restores the previous engine, the recipe declines to replace it, and the lane
keeps running on the old ClickHouse while the repository believes it moved.

`chdb-version-sync.mjs` asserts `CHDB_VERSION`'s major.minor equals
`chdb_substrate` and that every libchdb cache key names that exact tag. It also
fails when it finds no cache key at all, so the scan cannot pass by having
stopped matching. Bumping `CHDB_VERSION` alone on the real tree produces all
ten failures; its `--self-test` proves each assertion fails on a deliberate
mismatch. The two workflow comments that claimed the cache busts automatically
now say what actually keeps the copies equal.

## The parametric-aggregate name

Two sites in `range_window.go` built a ClickHouse parametric-aggregate spec by
gluing `"quantileExactInclusive("` to a formatted float — retyping the name
`fnResolutions` already owns for `chplan.FnQuantile`, and assembling a
ClickHouse function token by string concatenation outside `builder.go`.

`arrayReduceParametricFrag` composes the spec as a typed `Call` Frag off the
resolved name, renders it once and quotes it through `InlineLit`, failing
closed on an unresolved Fn, a render-hook Fn, and a parameter that would render
as a bound placeholder inside the quoted string. Emitted SQL is byte-identical,
so the goldens are unchanged. **Evidence:** renaming the table entry moves the
emitted SQL — the promql goldens fail — while the new tests, which derive their
expectation from the table, keep passing.

## The mirrored calibration constants

`magnitudeEMAAlpha`, `MemoEntryTTL`, `MinCorroboratingFailures`,
`perRungEvidenceTTL`, `perRungEvidenceMinObservations` and
`perRungLearnerCapacity` are six copies of three calibration decisions. Every
comment claimed the mirror; nothing enforced it. Two tests now pin them.
`memoEntryTTL` and `memoMaxEntries` are exported for the same cross-package
reason `MinCorroboratingFailures` already was: an unexported constant cannot be
pinned against from the package that documents itself as mirroring it. Comments
citing the old lowercase spellings are corrected to names that exist.

## Verified against the issue, not assumed

The Helm chart's ClickHouse image tag — the one pin `clickhouse-version-sync.mjs`
did not read — is fixed by #3196, which adds check (g) for it. It is not
duplicated here.

`deltaprefix` / `downsampletier` needed no change: the issue lists their caps
only as the pattern the others should follow.
