### PR TITLE
fix(traceql): an unscoped attribute read is not a numeric expression

### DIFF
--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -2255,8 +2255,19 @@ func isNumericExpr(expr chplan.Expr) bool {
 		return isArithmeticOp(b.Op)
 	}
 	switch v := expr.(type) {
-	case *chplan.LitInt, *chplan.LitFloat, *chplan.FuncCall:
+	case *chplan.LitInt, *chplan.LitFloat:
 		return true
+	case *chplan.FuncCall:
+		// An UNSCOPED attribute read is itself a FuncCall — the
+		// `if(mapContains(span,'k'), span['k'], resource['k'])`
+		// span-then-resource coalesce unscopedAttributeExpr builds — and it
+		// is String-valued, exactly like the scoped FieldAccess it stands in
+		// for. Answering "numeric" for it made `{ .duration = "slow" }`
+		// coerce both sides through toFloat64OrNull, so the string compare
+		// became NULL = 'slow' and the query matched nothing where reference
+		// Tempo matches the span. Every other FuncCall reaching an operand
+		// position here is a numeric helper or arithmetic.
+		return !isAttributeRead(v)
 	case *chplan.FieldAccess:
 		return v.MaterializedColumnNumeric
 	}

--- a/internal/traceql/unscoped_attr_numeric_test.go
+++ b/internal/traceql/unscoped_attr_numeric_test.go
@@ -1,0 +1,130 @@
+package traceql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/traceql/ast"
+)
+
+// lowerQuerySQL lowers q and renders it, so these assertions read the SQL a
+// deployment would actually send rather than an intermediate the emitter is
+// still free to change.
+func lowerQuerySQL(t *testing.T, q string) string {
+	t.Helper()
+	root, err := ast.Parse(q)
+	if err != nil {
+		t.Fatalf("parse %s: %v", q, err)
+	}
+	plan, err := Lower(t.Context(), root, schema.DefaultOTelTraces())
+	if err != nil {
+		t.Fatalf("lower %s: %v", q, err)
+	}
+	sql, _, err := chsql.Emit(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("emit %s: %v", q, err)
+	}
+	return sql
+}
+
+// TestUnscopedAttributeIsNotNumericByShape pins the discrimination that a
+// regression erased: an UNSCOPED attribute read lowers to a FuncCall (the
+// `if(mapContains(span,'k'), span['k'], resource['k'])` span-then-resource
+// coalesce), and isNumericExpr answered "numeric" for every FuncCall. That
+// made `{ .duration = "slow" }` coerce BOTH sides through toFloat64OrNull, so
+// a string compare became NULL = 'slow' and matched nothing where reference
+// Tempo matches the span.
+//
+// The cases below are deliberately paired: the same unscoped attribute must
+// NOT coerce against a string and MUST coerce against a number, so neither
+// assertion can pass by the emitter simply never coercing (or always doing
+// so).
+func TestUnscopedAttributeIsNotNumericByShape(t *testing.T) {
+	t.Parallel()
+
+	const coercion = "toFloat64OrNull"
+	for _, c := range []struct {
+		name       string
+		query      string
+		wantCoerce bool
+		why        string
+	}{
+		{
+			name:  "string compare against an attribute named like a numeric intrinsic",
+			query: `{ .duration = "slow" }`,
+			why:   "`.duration` is an ATTRIBUTE, not the duration intrinsic; comparing it to a string is a string compare",
+		},
+		{
+			name:  "string compare against a plain unscoped attribute",
+			query: `{ .status = "degraded" }`,
+			why:   "attribute equality is label-matcher semantics, never numeric",
+		},
+		{
+			name:       "ordering compare against a numeric literal",
+			query:      `{ .timeout >= 100 }`,
+			wantCoerce: true,
+			why:        "the numeric literal peer is what carries numeric intent",
+		},
+		{
+			name:       "equality against a numeric literal",
+			query:      `{ .retries = 3 }`,
+			wantCoerce: true,
+			why:        "a numeric literal peer carries numeric intent under equality too",
+		},
+		{
+			name:       "ordering compare between two unscoped attributes",
+			query:      `{ .a > .b }`,
+			wantCoerce: true,
+			why:        "two bare attribute reads under an ORDERING compare carry numeric intent; a raw compare would be lexicographic",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			sql := lowerQuerySQL(t, c.query)
+			got := strings.Contains(sql, coercion)
+			if got != c.wantCoerce {
+				verb := "coerced"
+				if c.wantCoerce {
+					verb = "did NOT coerce"
+				}
+				t.Fatalf("%s %s through %s, but %s\n%s", c.query, verb, coercion, c.why, sql)
+			}
+		})
+	}
+}
+
+// TestIsNumericExprRejectsTheUnscopedAttributeShape asserts the predicate
+// directly, so the classification is pinned even if a future lowering stops
+// routing this shape through a comparison.
+func TestIsNumericExprRejectsTheUnscopedAttributeShape(t *testing.T) {
+	t.Parallel()
+
+	unscoped := &chplan.FuncCall{
+		Fn: chplan.FnIf,
+		Args: []chplan.Expr{
+			&chplan.FuncCall{Fn: chplan.FnMapContainsKey, Args: []chplan.Expr{
+				&chplan.ColumnRef{Name: "SpanAttributes"}, &chplan.LitString{V: "k"},
+			}},
+			&chplan.FieldAccess{Source: &chplan.ColumnRef{Name: "SpanAttributes"}, Path: "k"},
+			&chplan.FieldAccess{Source: &chplan.ColumnRef{Name: "ResourceAttributes"}, Path: "k"},
+		},
+	}
+	if isNumericExpr(unscoped) {
+		t.Fatal("the unscoped span-then-resource attribute read is String-valued; classifying it numeric coerces string compares to NULL")
+	}
+	if !isAttributeRead(unscoped) {
+		t.Fatal("the fixture is not the shape isAttributeRead recognises, so the test above proves nothing")
+	}
+
+	// A FuncCall that is NOT an attribute read stays numeric, so the fix
+	// narrows the classification rather than deleting it.
+	other := &chplan.FuncCall{Fn: chplan.FnToFloat64OrNull, Args: []chplan.Expr{
+		&chplan.FieldAccess{Source: &chplan.ColumnRef{Name: "SpanAttributes"}, Path: "k"},
+	}}
+	if !isNumericExpr(other) {
+		t.Fatal("a non-attribute-read FuncCall must still classify as numeric")
+	}
+}

--- a/internal/traceql/unscoped_attr_numeric_test.go
+++ b/internal/traceql/unscoped_attr_numeric_test.go
@@ -128,3 +128,45 @@ func TestIsNumericExprRejectsTheUnscopedAttributeShape(t *testing.T) {
 		t.Fatal("a non-attribute-read FuncCall must still classify as numeric")
 	}
 }
+
+// TestIsAttributeReadRequiresBothCoalesceArms pins the conjunction in
+// isAttributeRead's FuncCall arm: BOTH branches of the span-then-resource
+// coalesce must themselves be attribute reads. A half-matching FnIf — one arm
+// an attribute read, the other any other expression — is not the shape
+// unscopedAttributeExpr builds, and treating it as one would extend the
+// "bare attribute" numeric intent to a call this lowering never produced.
+//
+// The `&&` between the two arm checks survived mutation to `||` because every
+// existing case supplied two attribute reads or none. These cases supply
+// exactly one, on each side in turn, so the operator is pinned in both
+// directions.
+func TestIsAttributeReadRequiresBothCoalesceArms(t *testing.T) {
+	t.Parallel()
+
+	attr := func() chplan.Expr {
+		return &chplan.FieldAccess{Source: &chplan.ColumnRef{Name: "SpanAttributes"}, Path: "k"}
+	}
+	notAttr := func() chplan.Expr { return &chplan.LitString{V: "not an attribute read"} }
+	contains := &chplan.FuncCall{Fn: chplan.FnMapContainsKey, Args: []chplan.Expr{
+		&chplan.ColumnRef{Name: "SpanAttributes"}, &chplan.LitString{V: "k"},
+	}}
+
+	for _, c := range []struct {
+		name      string
+		then, els chplan.Expr
+		want      bool
+	}{
+		{"both arms are attribute reads", attr(), attr(), true},
+		{"only the then-arm is an attribute read", attr(), notAttr(), false},
+		{"only the else-arm is an attribute read", notAttr(), attr(), false},
+		{"neither arm is an attribute read", notAttr(), notAttr(), false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			e := &chplan.FuncCall{Fn: chplan.FnIf, Args: []chplan.Expr{contains, c.then, c.els}}
+			if got := isAttributeRead(e); got != c.want {
+				t.Fatalf("isAttributeRead(%s) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}

--- a/test/perf/cardinality-baseline/traceql/edge_attr_dotted_duration_collision.json
+++ b/test/perf/cardinality-baseline/traceql/edge_attr_dotted_duration_collision.json
@@ -1,8 +1,8 @@
 {
   "fixture": "traceql/edge_attr_dotted_duration_collision",
-  "fan_factor": 0,
-  "scan_rows": 0,
-  "peak_intermediate": 0,
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/traceql/edge_attr_dotted_name_collision.json
+++ b/test/perf/cardinality-baseline/traceql/edge_attr_dotted_name_collision.json
@@ -1,8 +1,8 @@
 {
   "fixture": "traceql/edge_attr_dotted_name_collision",
-  "fan_factor": 0,
-  "scan_rows": 0,
-  "peak_intermediate": 0,
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/traceql/edge_attr_dotted_status_collision.json
+++ b/test/perf/cardinality-baseline/traceql/edge_attr_dotted_status_collision.json
@@ -1,8 +1,8 @@
 {
   "fixture": "traceql/edge_attr_dotted_status_collision",
-  "fan_factor": 0,
-  "scan_rows": 0,
-  "peak_intermediate": 0,
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,

--- a/test/perf/cardinality-baseline/traceql/span_attr_default.json
+++ b/test/perf/cardinality-baseline/traceql/span_attr_default.json
@@ -1,8 +1,8 @@
 {
   "fixture": "traceql/span_attr_default",
-  "fan_factor": 0,
-  "scan_rows": 0,
-  "peak_intermediate": 0,
+  "fan_factor": 1,
+  "scan_rows": 1,
+  "peak_intermediate": 1,
   "has_cross_join": false,
   "has_array_join": false,
   "has_recursive_cte": false,

--- a/test/spec/traceql/edge_attr_dotted_duration_collision.txtar
+++ b/test/spec/traceql/edge_attr_dotted_duration_collision.txtar
@@ -6,7 +6,7 @@
 [2] string = "duration"
 [3] string = "slow"
 -- sql --
-SELECT * FROM `otel_traces` WHERE (if(mapContains(`SpanAttributes`, ?), toFloat64OrNull(`SpanAttributes`[?]), toFloat64OrNull(`ResourceAttributes`[?])) = ?)
+SELECT * FROM `otel_traces` WHERE (if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], `ResourceAttributes`[?]) = ?)
 -- seed --
 CREATE TABLE otel_traces (
     Duration UInt64,
@@ -17,7 +17,9 @@ INSERT INTO otel_traces (Duration) VALUES
     (20000000),
     (30000000);
 -- expected_rows --
-[]
+[
+  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 10000000]
+]
 -- chplan --
-Filter predicate=(FnIf(FnMapContainsKey(SpanAttributes, "duration"), FnToFloat64OrNull(SpanAttributes["duration"]), FnToFloat64OrNull(ResourceAttributes["duration"])) = "slow")
+Filter predicate=(FnIf(FnMapContainsKey(SpanAttributes, "duration"), SpanAttributes["duration"], ResourceAttributes["duration"]) = "slow")
   Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_dotted_name_collision.txtar
+++ b/test/spec/traceql/edge_attr_dotted_name_collision.txtar
@@ -6,7 +6,7 @@
 [2] string = "name"
 [3] string = "checkout"
 -- sql --
-SELECT * FROM `otel_traces` WHERE (if(mapContains(`SpanAttributes`, ?), toFloat64OrNull(`SpanAttributes`[?]), toFloat64OrNull(`ResourceAttributes`[?])) = ?)
+SELECT * FROM `otel_traces` WHERE (if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], `ResourceAttributes`[?]) = ?)
 -- seed --
 CREATE TABLE otel_traces (
     Duration UInt64,
@@ -18,7 +18,9 @@ INSERT INTO otel_traces (Duration, SpanName) VALUES
     (20000000, 'billing-span'),
     (30000000, 'other-span');
 -- expected_rows --
-[]
+[
+  ["checkout-span", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 10000000]
+]
 -- chplan --
-Filter predicate=(FnIf(FnMapContainsKey(SpanAttributes, "name"), FnToFloat64OrNull(SpanAttributes["name"]), FnToFloat64OrNull(ResourceAttributes["name"])) = "checkout")
+Filter predicate=(FnIf(FnMapContainsKey(SpanAttributes, "name"), SpanAttributes["name"], ResourceAttributes["name"]) = "checkout")
   Scan(otel_traces)

--- a/test/spec/traceql/edge_attr_dotted_status_collision.txtar
+++ b/test/spec/traceql/edge_attr_dotted_status_collision.txtar
@@ -6,7 +6,7 @@
 [2] string = "status"
 [3] string = "degraded"
 -- sql --
-SELECT * FROM `otel_traces` WHERE (if(mapContains(`SpanAttributes`, ?), toFloat64OrNull(`SpanAttributes`[?]), toFloat64OrNull(`ResourceAttributes`[?])) = ?)
+SELECT * FROM `otel_traces` WHERE (if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], `ResourceAttributes`[?]) = ?)
 -- seed --
 CREATE TABLE otel_traces (
     Duration UInt64,
@@ -18,7 +18,9 @@ INSERT INTO otel_traces (Duration, StatusCode) VALUES
     (20000000, 'Ok'),
     (30000000, 'Ok');
 -- expected_rows --
-[]
+[
+  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 10000000]
+]
 -- chplan --
-Filter predicate=(FnIf(FnMapContainsKey(SpanAttributes, "status"), FnToFloat64OrNull(SpanAttributes["status"]), FnToFloat64OrNull(ResourceAttributes["status"])) = "degraded")
+Filter predicate=(FnIf(FnMapContainsKey(SpanAttributes, "status"), SpanAttributes["status"], ResourceAttributes["status"]) = "degraded")
   Scan(otel_traces)

--- a/test/spec/traceql/span_attr_default.txtar
+++ b/test/spec/traceql/span_attr_default.txtar
@@ -1,7 +1,7 @@
 -- query.traceql --
 { .http.method = "GET" }
 -- sql --
-SELECT * FROM `otel_traces` WHERE (if(mapContains(`SpanAttributes`, ?), toFloat64OrNull(`SpanAttributes`[?]), toFloat64OrNull(`ResourceAttributes`[?])) = ?)
+SELECT * FROM `otel_traces` WHERE (if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], `ResourceAttributes`[?]) = ?)
 -- args --
 [0] string = "http.method"
 [1] string = "http.method"
@@ -14,7 +14,9 @@ CREATE TABLE otel_traces (
 ) ENGINE = MergeTree ORDER BY _idx;
 INSERT INTO otel_traces (_idx) VALUES (0), (1);
 -- expected_rows --
-[]
+[
+  ["", {"__cerberus_parentSpanID": "", "__cerberus_spanID": "", "__cerberus_traceID": ""}, "1970-01-01T00:00:00Z", 0]
+]
 -- chplan --
-Filter predicate=(FnIf(FnMapContainsKey(SpanAttributes, "http.method"), FnToFloat64OrNull(SpanAttributes["http.method"]), FnToFloat64OrNull(ResourceAttributes["http.method"])) = "GET")
+Filter predicate=(FnIf(FnMapContainsKey(SpanAttributes, "http.method"), SpanAttributes["http.method"], ResourceAttributes["http.method"]) = "GET")
   Scan(otel_traces)


### PR DESCRIPTION
A wrong-answer regression on `main`, found by the release perf gate rather than
by any correctness test — because the correctness fixture had been regenerated
to record the wrong answer.

Refs #3183

## The bug

`isNumericExpr` answered "numeric" for every `*chplan.FuncCall`. That was true
while an unscoped attribute lowered to a bare `FieldAccess`, and stopped being
true when #3180 gave it the span-then-resource coalesce shape:

```
if(mapContains(SpanAttributes,'k'), SpanAttributes['k'], ResourceAttributes['k'])
```

which is itself a `FuncCall`. So from that commit on, **every unscoped
attribute compared against a string coerced both sides through
`toFloat64OrNull`**, turning the comparison into `NULL = 'slow'` — which
matches nothing, where reference Tempo matches the span.

`{ .duration = "slow" }` is the sharpest case: an attribute whose *name*
collides with a numeric intrinsic it is not. The parser gets this right
(`Intrinsic=none` for the dotted spelling); the coercion decision did not.

## How it reached `main` unnoticed

The fixture that exists to pin exactly this collision recorded the wrong
answer instead of catching it. In #3180 the goldens were regenerated and
`test/spec/traceql/edge_attr_dotted_duration_collision.txtar` moved:

```
-[["", {...}, "1970-01-01T00:00:00Z", 10000000]]     # 1 matching span
+[]                                                   # nothing matches
```

against a seed that still holds a span whose `duration` attribute is
`'slow'`. The cardinality baseline followed it from `scan_rows: 1` to `0`.
That is why `TestReleasePerfRegression` is red against `v1.20.0` on `main`
today — the perf gate noticed a correctness regression the correctness lane
had been taught to accept.

This is precisely the "fixtures that pin the divergence instead of catching
it" class catalogued in #3188, and the `.duration` case is one of the
unscoped-attribute fixtures #3183 lists.

## Blast radius: this is not an edge case

All four fixtures the fix moves lost their matching row in that same
regeneration, and the fourth is the ordinary shape:

| fixture | query | rows before #3180 | rows on `main` |
|---|---|---|---|
| `span_attr_default` | `{ .http.method = "GET" }` | 1 | 0 |
| `edge_attr_dotted_name_collision` | `{ .name = "checkout" }` | 1 | 0 |
| `edge_attr_dotted_status_collision` | `{ .status = "degraded" }` | 1 | 0 |
| `edge_attr_dotted_duration_collision` | `{ .duration = "slow" }` | 1 | 0 |

`{ .http.method = "GET" }` is the everyday unscoped-attribute equality, not a
collision edge case. **Any TraceQL query comparing an unscoped attribute to a
string has returned zero spans since #3180 merged**, and every correctness
lane was green throughout, because the expected rows had been regenerated to
match the broken output.

## The fix

`isNumericExpr` now excludes the shape `isAttributeRead` already recognises.
The classification narrows rather than disappearing — all three routes to
numeric intent still fire:

- a numeric literal peer (`{ .timeout >= 100 }`, `{ .retries = 3 }`);
- an arithmetic operand;
- an ordering comparison between two attribute reads (`{ .a > .b }`), where a
  raw compare would be lexicographic.

Four fixtures change. The other 26 carrying `toFloat64OrNull` do not.

## Evidence

The test pairs each case against its opposite — the same unscoped attribute
must NOT coerce against a string and MUST coerce against a number — so neither
half can pass by the emitter simply never coercing, or always coercing. A
second test asserts the predicate directly and checks that a non-attribute-read
`FuncCall` still classifies as numeric, so the narrowing is pinned as a
narrowing.

Reverting the one-line narrowing fails both tests, on both arms.

## Goldens

Four TXTAR fixtures and the cardinality baseline are regenerated through
`update-golden.yml` (`traceql` and `cardinality` shards), never by hand. The
v1.20.0 release baseline is **not** touched: the fix restores `scan_rows` to
the `1` that baseline already records, which is the whole point — a release
baseline moves only with a legitimate re-cut, never in a fix PR.
