### PR TITLE
fix(routerrules): make the calibration corpora match what production produces

### DIFF
--- a/docs/router-rules.md
+++ b/docs/router-rules.md
@@ -385,6 +385,17 @@ Flags:
 | `--validate-only`                | off       | load + validate the catalog, resolve nothing, exit |
 | `--experimental`                 | off       | also evaluate `status: experimental` rules         |
 
+`--since` windows on `event_time`, and means the same thing on both sources: the
+`chtable` source bounds the SELECT on the table's own `event_time`, and the
+`jsonl` source filters on the `event_time` the JSONL sink stamps on every line at
+write time — the same instant, from the same clock, that the CH-table sink binds
+to the column. A corpus line carrying no `event_time` at all predates that
+stamping and can be placed neither inside nor outside the window, so under
+`--since` it is REFUSED with the offending `file:line` rather than admitted:
+admitting it silently degrades the flag to a full-history scan while the operator
+believes a window applied. Without `--since` nothing is being windowed and such a
+line is read normally.
+
 The CLI exits non-zero only on an operational or validation error — **never on
 findings** (findings are the expected output). The conservative ClickHouse scan
 settings (single-threaded, deprioritised, read-only, row/byte/time-capped) make
@@ -407,6 +418,18 @@ The evaluator never branches on backend: a rule's condition lowers to a typed
 *same* AST, so the two backends produce identical findings. A `chdb`-tagged
 parity test seeds one fixture as JSONL and as a CH table and asserts the findings
 match.
+
+Identical findings requires identical GROUP KEYS, which is a narrower contract
+than it looks. `normalized_query_hash` is a `UInt64`: the CH path groups by
+`toString(normalized_query_hash)`, and the in-Go paths must render the same exact
+decimal. Widening the column to a `float64` first — the obvious way to share one
+numeric path across every column — rounds every value at or above 2^53 and
+collapses distinct hot shapes into one class, so the backends disagree about what
+a class even is while every individual rule still lowers from the same AST. A
+fixture cannot detect that below 2^53, where the two renderings agree; the
+benchmark's one hash-grouped class therefore sits at
+`17000000000000000001`/`...002`, adjacent values above 2^63, and the parity lane
+compares exact keys over the range a real hash occupies.
 
 ### Why parity-on-chDB is not enough: the strict-scan integration lane
 
@@ -470,18 +493,27 @@ deployment lacks — OOM / timeout / sample-budget / breaker / rejected clusters
 route-B failing cluster with non-zero `k_shards`, a route-B overshard-regret
 class, a high-fanout route-A class, and a high-geometry sub-population.
 
-Every fixture is constrained to states the production solver can actually reach,
-and `test/regression/router_corpus_seed_test.go` pins that: a `decision_reason` is
-a `solver.Reasons` member, the corpus-only `non-promql` token, or absent;
-`route == "B"` and the `routed` reason are the
-same event, and only a PromQL row carries a route or geometry at all —
-the router classifies nothing else, so on every other head those columns are
-absent rather than small. That last invariant is the load-bearing one. A fixture
-that fakes geometry onto a LogQL row makes a `cumulative_d >= p(cumulative_d)`
-leaf look selective, while on real data that language's whole geometry population
-is zero, the fitted percentile is zero, and the leaf matches every failing row it
-has. The fixtures also carry both populations — classified and unclassified — so
-neither the route-scoped rules nor the two non-PromQL heads go untested.
+The JSONL fixtures are constrained to states the production solver can actually
+reach, and `test/regression/router_corpus_seed_test.go` pins that with three
+invariants: a `decision_reason` is a `solver.Reasons` member, the corpus-only
+`non-promql` token, or absent; `route == "B"` and the `routed` reason are the
+same event; and only a PromQL row carries a route or geometry at all — the router
+classifies nothing else, so on every other head those columns are absent rather
+than small. That last invariant is the load-bearing one. A fixture that fakes
+geometry onto a LogQL row makes a `cumulative_d >= p(cumulative_d)` leaf look
+selective, while on real data that language's whole geometry population is zero,
+the fitted percentile is zero, and the leaf matches every failing row it has. The
+fixtures also carry both populations — classified and unclassified — so neither
+the route-scoped rules nor the two non-PromQL heads go untested.
+
+The GENERATED benchmark corpus is a separate population and is pinned separately,
+because that test globs `testdata/*.jsonl` and the benchmark corpus is built in
+Go and handed to the evaluator in memory, never touching a file. It is held to
+the first two invariants by `TestRouterBenchCorpusIsProducible` in the same file.
+It does not yet satisfy the third: it plants classified LogQL and TraceQL classes
+that a PromQL-gated solver cannot emit, which is tracked in issue #3204 —
+correcting them moves the labeled ground truth and the regression floors, so it
+is its own change rather than a fixture edit.
 
 It proves
 the catalog is **effective**, not just well-formed: default-lane tests assert that

--- a/internal/optcorpus/sink.go
+++ b/internal/optcorpus/sink.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 )
 
 // JSONLSink is the v1 durable sink: it appends each reconciled Row as one JSON
@@ -19,6 +20,23 @@ type JSONLSink struct {
 	mu sync.Mutex
 	f  *os.File
 	w  *bufio.Writer
+	// now is the write-time clock, overridable in tests. It stamps event_time
+	// on every line for the same reason CHTableSink.Write stamps the table's
+	// event_time column from time.Now(): the corpus keys recency on the
+	// reconcile instant, and a reader windowing the corpus (routerrules'
+	// --since) has nothing else to window on.
+	now func() time.Time
+}
+
+// jsonlRecord is the JSONL wire form: a Row plus the write-time event_time the
+// CH table carries as its first column. Row is embedded, so its fields stay
+// flattened into the same JSON object and the two sinks remain
+// column-for-column comparable — event_time is the field the table always had
+// and the JSONL form used to be missing, which silently made a reader's
+// event-time window a no-op over this file.
+type jsonlRecord struct {
+	EventTime int64 `json:"event_time"`
+	Row
 }
 
 // NewJSONLSink opens (creating if absent, appending if present) the JSONL
@@ -37,12 +55,18 @@ func NewJSONLSink(path string) (*JSONLSink, error) {
 	if err != nil {
 		return nil, fmt.Errorf("optcorpus: open sink %q: %w", path, err)
 	}
-	return &JSONLSink{f: f, w: bufio.NewWriter(f)}, nil
+	return &JSONLSink{f: f, w: bufio.NewWriter(f), now: time.Now}, nil
 }
 
 // Write appends each row as one JSON line and flushes so the corpus is durable
 // at interval granularity (a crash loses at most the in-flight buffer, not
 // already-flushed lines). An empty slice is a no-op.
+//
+// Every line carries event_time, stamped once per batch from the write-time
+// clock — the same instant, from the same source, that CHTableSink.Write binds
+// to the table's event_time column. Both sinks therefore date a row identically,
+// which is what lets a reader's event-time window mean the same thing over the
+// JSONL corpus as over the table.
 func (s *JSONLSink) Write(rows []Row) error {
 	if len(rows) == 0 {
 		return nil
@@ -50,8 +74,9 @@ func (s *JSONLSink) Write(rows []Row) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	enc := json.NewEncoder(s.w)
+	stamp := s.now().Unix()
 	for i := range rows {
-		if err := enc.Encode(rows[i]); err != nil {
+		if err := enc.Encode(jsonlRecord{EventTime: stamp, Row: rows[i]}); err != nil {
 			return fmt.Errorf("optcorpus: encode row: %w", err)
 		}
 	}

--- a/internal/optcorpus/sink_eventtime_test.go
+++ b/internal/optcorpus/sink_eventtime_test.go
@@ -1,0 +1,91 @@
+package optcorpus
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestJSONLSink_StampsEventTime pins that every JSONL corpus line carries the
+// write-time event_time, at the same instant and from the same clock that
+// CHTableSink.Write binds to the table's event_time column.
+//
+// It exists because the JSONL sink used to write no event_time at all. Nothing
+// noticed, because Row has no such field and the round-trip tests only compare
+// Row back to Row — but a corpus reader windowing on event_time (routerrules'
+// --since) then had nothing to window on, so the flag silently degraded to a
+// full-history scan on the DEFAULT source while the ClickHouse backend honoured
+// it. The two backends answered the same flag over different populations.
+func TestJSONLSink_StampsEventTime(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "corpus.jsonl")
+	sink, err := NewJSONLSink(path)
+	if err != nil {
+		t.Fatalf("NewJSONLSink: %v", err)
+	}
+	// A fixed clock, so the assertion is on the stamped value itself rather
+	// than on a tolerance window around wall-clock time.
+	stamp := time.Unix(1_700_000_000, 0).UTC()
+	sink.now = func() time.Time { return stamp }
+
+	rows := []Row{
+		{ShapeID: "prom:a", Language: "promql", NormalizedQueryHash: 1},
+		{ShapeID: "prom:b", Language: "promql", NormalizedQueryHash: 2},
+	}
+	if err := sink.Write(rows); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	n := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		// Decode into a map, not a struct: a struct with an EventTime field
+		// would deserialize a MISSING event_time to the zero value and pass,
+		// which is exactly the failure this test exists to catch.
+		var got map[string]any
+		if err := json.Unmarshal(line, &got); err != nil {
+			t.Fatalf("line %d is not valid JSON: %v", n+1, err)
+		}
+		raw, ok := got["event_time"]
+		if !ok {
+			t.Fatalf("line %d has no event_time field; a corpus line with no event time cannot be "+
+				"windowed by a reader, which is what made --since a silent no-op", n+1)
+		}
+		secs, ok := raw.(float64)
+		if !ok {
+			t.Fatalf("line %d event_time is %T, want a unix-seconds number", n+1, raw)
+		}
+		if int64(secs) != stamp.Unix() {
+			t.Errorf("line %d event_time = %d, want %d (the write-time clock)", n+1, int64(secs), stamp.Unix())
+		}
+		// The Row columns must still be flattened into the same object, or the
+		// JSONL form has stopped being column-for-column comparable with the table.
+		if got["shape_id"] != rows[n].ShapeID {
+			t.Errorf("line %d shape_id = %v, want %q", n+1, got["shape_id"], rows[n].ShapeID)
+		}
+		n++
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if n != len(rows) {
+		t.Fatalf("read %d lines, wrote %d rows", n, len(rows))
+	}
+}

--- a/internal/routerrules/benchmark.go
+++ b/internal/routerrules/benchmark.go
@@ -88,19 +88,18 @@ type BenchRow struct {
 func (r BenchRow) toCorpusRow() corpusRow {
 	return corpusRow{
 		numeric: map[string]float64{
-			"n_anchors":             r.NAnchors,
-			"fanout":                r.Fanout,
-			"cumulative_d":          r.CumulativeD,
-			"outer_range":           r.OuterRange,
-			"step":                  r.Step,
-			"k_shards":              r.KShards,
-			"read_rows":             r.ReadRows,
-			"read_bytes":            r.ReadBytes,
-			"query_duration_ms":     r.QueryDurationMS,
-			"memory_usage":          r.MemoryUsage,
-			"shards_observed":       r.ShardsObserved,
-			"parallelism":           r.Parallelism,
-			"normalized_query_hash": float64(r.NormalizedQueryHash),
+			"n_anchors":         r.NAnchors,
+			"fanout":            r.Fanout,
+			"cumulative_d":      r.CumulativeD,
+			"outer_range":       r.OuterRange,
+			"step":              r.Step,
+			"k_shards":          r.KShards,
+			"read_rows":         r.ReadRows,
+			"read_bytes":        r.ReadBytes,
+			"query_duration_ms": r.QueryDurationMS,
+			"memory_usage":      r.MemoryUsage,
+			"shards_observed":   r.ShardsObserved,
+			"parallelism":       r.Parallelism,
 		},
 		str: map[string]string{
 			"shape_id":              r.ShapeID,
@@ -108,7 +107,7 @@ func (r BenchRow) toCorpusRow() corpusRow {
 			"route":                 r.Route,
 			"decision_reason":       r.DecisionReason,
 			"exit_status":           r.ExitStatus,
-			"normalized_query_hash": formatNumeric(float64(r.NormalizedQueryHash)),
+			"normalized_query_hash": formatQueryHash(r.NormalizedQueryHash),
 		},
 	}
 }
@@ -357,7 +356,7 @@ func plantRouteBFloor(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
 				KShards:             k,
 				ShardsObserved:      k,
 				Parallelism:         benchRouteBParallelism,
-				DecisionReason:      "sliceable",
+				DecisionReason:      "routed",
 				ReadRows:            jitter(rng, healthyReadBase, healthyReadSpread),
 				ReadBytes:           jitter(rng, 1_000_000, 40_000_000),
 				QueryDurationMS:     jitter(rng, routeBFloorDurBase, routeBFloorDurSpread),
@@ -366,7 +365,7 @@ func plantRouteBFloor(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
 			})
 		}
 		bc.Classes = append(bc.Classes, LabeledClass{
-			ShapeID: shape, Language: lang, DecisionReason: "sliceable",
+			ShapeID: shape, Language: lang, DecisionReason: "routed",
 			QueryHash: hash, Expect: nil, Severity: SevHealthy,
 		})
 	}
@@ -487,7 +486,7 @@ func pathologyFailureSpecs() []pathologySpec {
 			severities: []PathologySeverity{SevSevere, SevMarginal},
 			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
 				return BenchRow{
-					Route: "A", ExitStatus: "oom", DecisionReason: "high-cardinality",
+					Route: "A", ExitStatus: "oom", DecisionReason: "high-D",
 					MemoryUsage: pick(sev, sevMemSevere, sevMemMarg),
 					CumulativeD: pick(sev, sevDSevere, sevDMarg),
 					NAnchors:    jitter(rng, 5, 20), Fanout: jitter(rng, 20, 40),
@@ -513,7 +512,7 @@ func pathologyFailureSpecs() []pathologySpec {
 			severities: []PathologySeverity{SevSevere, SevMarginal},
 			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
 				return BenchRow{
-					Route: "A", ExitStatus: "timeout", DecisionReason: "high-cardinality",
+					Route: "A", ExitStatus: "timeout", DecisionReason: "high-D",
 					QueryDurationMS: pick(sev, sevDurSevere, sevDurMarg),
 					CumulativeD:     pick(sev, sevDSevere, sevDMarg),
 					NAnchors:        jitter(rng, 5, 20), Fanout: jitter(rng, 20, 40),
@@ -566,7 +565,7 @@ func pathologyFailureSpecs() []pathologySpec {
 			severities: []PathologySeverity{SevSevere},
 			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
 				return BenchRow{
-					Route: "B", ExitStatus: "oom", DecisionReason: "not-sliceable",
+					Route: "B", ExitStatus: "oom", DecisionReason: "routed",
 					KShards: jitter(rng, 8, 32), CumulativeD: sevDSevere,
 					// The OOM cancels the fan-out, so only the resident wave ever
 					// reached ClickHouse: shards_observed falls short of k_shards.
@@ -592,7 +591,7 @@ func pathologyTailSpecs() []pathologySpec {
 			severities: []PathologySeverity{SevSevere},
 			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
 				return BenchRow{
-					Route: "B", ExitStatus: "ok", DecisionReason: "sliceable",
+					Route: "B", ExitStatus: "ok", DecisionReason: "routed",
 					Fanout: regretFanout, QueryDurationMS: regretDur, KShards: regretShards,
 					ShardsObserved: regretShards, Parallelism: benchRouteBParallelism,
 					CumulativeD: jitter(rng, healthyDBase, healthyDSpread),
@@ -695,7 +694,7 @@ func max(a, b int) int {
 // classID is a stable identifier for a labeled class across its group_by
 // dimensions, used to order classes and to look one up from a fired finding.
 func classID(c LabeledClass) string {
-	return c.Language + "|" + c.ShapeID + "|" + c.DecisionReason + "|" + formatNumeric(float64(c.QueryHash))
+	return c.Language + "|" + c.ShapeID + "|" + c.DecisionReason + "|" + formatQueryHash(c.QueryHash)
 }
 
 func sortBenchRows(rows []BenchRow) {

--- a/internal/routerrules/benchmark.go
+++ b/internal/routerrules/benchmark.go
@@ -176,6 +176,23 @@ const (
 	// to be scored as a false negative rather than vanishing entirely.
 	minPathologyClassRows = 1
 
+	// benchSlowHotHashBase is the hash base of prom:slow_hot, the ONE planted
+	// class whose rule (route_a_slow_hot_shape) groups by
+	// normalized_query_hash rather than shape_id. Its two severities sit at
+	// benchSlowHotHashBase+1 and +2 — 17000000000000000001 and ...002, two
+	// adjacent UInt64 values above 2^63.
+	//
+	// The value is deliberately huge rather than another 3xxxx like its
+	// siblings. normalized_query_hash is a UInt64 and a real hash is uniform
+	// over that whole range, but every fixture in this package used to sit
+	// below 2^53, where a float64 still holds an integer exactly. That is the
+	// only reason rendering the column through float64 went unnoticed: at
+	// these two values it collapses both classes onto "1.7e+19", so the
+	// benchmark's own ground truth would fold two distinct classes into one.
+	// Keeping the hash-grouped class up here is what makes the cross-backend
+	// parity lane compare exact keys over the range production actually uses.
+	benchSlowHotHashBase = 17_000_000_000_000_000_000
+
 	// benchMemoryHardCapBytes is the deployment query memory cap the benchmark
 	// scores at (query.max_memory_bytes), and benchMemoryNearCapFraction is the
 	// fraction of it route_a_memory_near_cap gates on. Their product is the
@@ -636,7 +653,7 @@ func pathologyTailSpecs() []pathologySpec {
 		// Slow hot shape (route A, in the per-language duration tail):
 		// route_a_slow_hot_shape only. Grouped by normalized_query_hash.
 		{
-			shape: "prom:slow_hot", lang: "promql", hashBase: 39000,
+			shape: "prom:slow_hot", lang: "promql", hashBase: benchSlowHotHashBase,
 			expect:     always("route_a_slow_hot_shape"),
 			severities: []PathologySeverity{SevSevere, SevMarginal},
 			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {

--- a/internal/routerrules/columns.go
+++ b/internal/routerrules/columns.go
@@ -1,6 +1,9 @@
 package routerrules
 
-import "sort"
+import (
+	"sort"
+	"strconv"
+)
 
 // CorpusTableName is the ClickHouse table the router corpus is written to. It is
 // re-declared here verbatim rather than imported from internal/optcorpus so this
@@ -242,6 +245,17 @@ var enumDomains = map[string]map[string]struct{}{
 		"non-promql",
 	),
 }
+
+// formatQueryHash renders a normalized_query_hash value as its group key. The
+// column is UInt64, and the ClickHouse backend groups by
+// toString(normalized_query_hash) — the exact decimal. Rendering it through a
+// generic float64 numeric formatter instead silently rounds every value at or
+// above 2^53, so distinct hot shapes collapse into a single class and the
+// backends stop agreeing on what a class even IS: 9007199254740993 comes back
+// as ...992, and 17000000000000000001 and ...002 both come back as "1.7e+19".
+// Formatting the uint64 directly is what keeps the JSONL, in-memory and
+// ClickHouse group keys identical across the whole domain of the column.
+func formatQueryHash(h uint64) string { return strconv.FormatUint(h, 10) }
 
 func setOf(xs ...string) map[string]struct{} {
 	m := make(map[string]struct{}, len(xs))

--- a/internal/routerrules/metrics.go
+++ b/internal/routerrules/metrics.go
@@ -176,7 +176,7 @@ func classMatchesFinding(c *LabeledClass, gk map[string]string) bool {
 	if v, ok := gk["decision_reason"]; ok && v != c.DecisionReason {
 		return false
 	}
-	if v, ok := gk["normalized_query_hash"]; ok && v != formatNumeric(float64(c.QueryHash)) {
+	if v, ok := gk["normalized_query_hash"]; ok && v != formatQueryHash(c.QueryHash) {
 		return false
 	}
 	// At least one identifying dimension (shape_id or query hash) must be present

--- a/internal/routerrules/parity_chdb_test.go
+++ b/internal/routerrules/parity_chdb_test.go
@@ -342,6 +342,20 @@ func seedParityTableFromRows(t *testing.T, db *sql.DB, rows []jsonlRow) {
 	}
 }
 
+// parityEventTime renders a seed row's event_time for the parity table. The
+// column is a non-nullable DateTime, and jsonlRow.EventTime is a pointer so an
+// ABSENT event_time stays distinguishable from a present zero (a row without
+// one cannot be windowed, so the JSONL source refuses it under --since). The
+// parity fixtures all carry an event_time; a row built from a BenchRow, which
+// has no event time at all, seeds the epoch — the parity assertions compare
+// findings, and no rule in the catalog reads this column.
+func parityEventTime(r jsonlRow) int64 {
+	if r.EventTime == nil {
+		return 0
+	}
+	return int64(*r.EventTime)
+}
+
 // parityRowTuple renders one VALUES tuple in the table's own column order. The
 // per-column literals are looked up by name, so adding a column to the corpus
 // table fails here loudly instead of shifting every later value one position left.
@@ -349,7 +363,7 @@ func parityRowTuple(t *testing.T, cols []chsql.ColumnDef, r jsonlRow) string {
 	t.Helper()
 
 	byName := map[string]string{
-		"event_time":            fmt.Sprintf("toDateTime(%d)", int64(r.EventTime)),
+		"event_time":            fmt.Sprintf("toDateTime(%d)", parityEventTime(r)),
 		"shape_id":              chLiteral(r.ShapeID),
 		"language":              chLiteral(r.Language),
 		"normalized_query_hash": strconv.FormatUint(r.NormalizedQueryHash, 10),

--- a/internal/routerrules/queryhash_groupkey_test.go
+++ b/internal/routerrules/queryhash_groupkey_test.go
@@ -1,0 +1,135 @@
+package routerrules
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+// normalized_query_hash is a UInt64 and a real hash is uniform over that whole
+// range, but a float64 holds an integer exactly only below 2^53. These are the
+// three measured collapse cases from issue #3189: the first value above the
+// float64 integer boundary, and an adjacent pair above 2^63 that both render
+// as "1.7e+19".
+const (
+	hashAtFloat64Boundary = uint64(9007199254740992)     // 2^53, still exact
+	hashPastFloat64Bound  = uint64(9007199254740993)     // 2^53+1, rounds down to 2^53
+	hashAbove2p63A        = uint64(17000000000000000001) // both render "1.7e+19"
+	hashAbove2p63B        = uint64(17000000000000000002)
+)
+
+// groupKeysByHash evaluates a match-everything rule grouped by
+// normalized_query_hash and returns the group keys, sorted.
+func groupKeysByHash(t *testing.T, src CorpusSource) []string {
+	t.Helper()
+	groups, err := src.EvalRule(context.Background(), RuleQuery{
+		Condition: &EnumCmp{Column: "language", Op: OpEq, Values: []string{"promql"}},
+		GroupBy:   []string{"normalized_query_hash"},
+		Env:       Env{},
+	})
+	if err != nil {
+		t.Fatalf("eval rule: %v", err)
+	}
+	keys := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if len(g.GroupKey) != 1 {
+			t.Fatalf("group key = %v, want exactly one column", g.GroupKey)
+		}
+		keys = append(keys, g.GroupKey[0])
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// wantHashKeys is the exact decimal rendering of each hash — the same string
+// the ClickHouse backend produces, which groups by
+// toString(normalized_query_hash).
+func wantHashKeys(hashes ...uint64) []string {
+	out := make([]string, 0, len(hashes))
+	for _, h := range hashes {
+		out = append(out, strconv.FormatUint(h, 10))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestQueryHashGroupKeysAreExactAboveFloat64Range pins that both in-Go corpus
+// backends key a class on the EXACT UInt64 hash, over the whole domain of the
+// column rather than the part of it a float64 happens to survive.
+//
+// Rendering the column through float64 — which both backends used to do —
+// silently rounds every value at or above 2^53, so two distinct hot shapes
+// collapse into a single class. The ClickHouse backend groups by
+// toString(normalized_query_hash) and never had the defect, so the two backends
+// produced DIFFERENT findings from the same corpus while docs/router-rules.md
+// claimed they produce identical ones.
+//
+// Every fixture in this package used to sit below 2^53, which is exactly why
+// the harness could not see it: the two renderings agree everywhere the corpus
+// was ever tested. These values are above it, in both directions that break —
+// past the float64 integer boundary, and past 2^63 where the int64 fast path in
+// a generic numeric formatter overflows and falls through to "1.7e+19".
+func TestQueryHashGroupKeysAreExactAboveFloat64Range(t *testing.T) {
+	t.Parallel()
+
+	hashes := []uint64{hashAtFloat64Boundary, hashPastFloat64Bound, hashAbove2p63A, hashAbove2p63B}
+	want := wantHashKeys(hashes...)
+
+	t.Run("jsonl", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "corpus.jsonl")
+		var buf []byte
+		for _, h := range hashes {
+			buf = append(buf, fmt.Sprintf(
+				`{"event_time":1,"shape_id":"prom:s","language":"promql","route":"A",`+
+					`"exit_status":"ok","normalized_query_hash":%d,"memory_usage":1}`+"\n", h,
+			)...)
+		}
+		if err := os.WriteFile(path, buf, 0o600); err != nil {
+			t.Fatalf("write corpus: %v", err)
+		}
+		assertHashKeys(t, groupKeysByHash(t, NewJSONLCorpusSource(path, 0)), want)
+	})
+
+	t.Run("in-memory", func(t *testing.T) {
+		t.Parallel()
+		rows := make([]BenchRow, 0, len(hashes))
+		for _, h := range hashes {
+			rows = append(rows, BenchRow{
+				ShapeID: "prom:s", Language: "promql", Route: "A", ExitStatus: "ok",
+				NormalizedQueryHash: h, MemoryUsage: 1,
+			})
+		}
+		assertHashKeys(t, groupKeysByHash(t, (&BenchCorpus{Rows: rows}).AsCorpusSource()), want)
+	})
+}
+
+func assertHashKeys(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d classes %v, want %d %v; distinct hashes collapsed into one class, so two "+
+			"hot shapes are reported as one", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("group key %d = %q, want %q; the key must be the exact decimal the ClickHouse "+
+				"backend's toString(normalized_query_hash) produces", i, got[i], want[i])
+		}
+	}
+}
+
+// TestFormatQueryHashIsExact pins the renderer itself at the boundary, so a
+// failure names the cause directly rather than through a collapsed class count.
+func TestFormatQueryHashIsExact(t *testing.T) {
+	t.Parallel()
+
+	for _, h := range []uint64{0, 1, hashAtFloat64Boundary, hashPastFloat64Bound, hashAbove2p63A, hashAbove2p63B, ^uint64(0)} {
+		if got, want := formatQueryHash(h), strconv.FormatUint(h, 10); got != want {
+			t.Errorf("formatQueryHash(%d) = %q, want %q", h, got, want)
+		}
+	}
+}

--- a/internal/routerrules/source.go
+++ b/internal/routerrules/source.go
@@ -87,23 +87,19 @@ type CorpusSource interface {
 // aggregator. Numeric columns are widened to float64 so a single comparison
 // path serves every numeric column; enum/group columns stay strings.
 type corpusRow struct {
-	eventTimeUnix float64
-	numeric       map[string]float64
-	str           map[string]string
+	numeric map[string]float64
+	str     map[string]string
 }
 
 func (r corpusRow) numericValue(col string) float64 { return r.numeric[col] }
 
 func (r corpusRow) enumValue(col string) string { return r.str[col] }
 
-func (r corpusRow) groupValue(col string) string {
-	if v, ok := r.str[col]; ok {
-		return v
-	}
-	// Group columns that are numeric (normalized_query_hash) render through the
-	// numeric map; format as an integer for a stable group key.
-	if v, ok := r.numeric[col]; ok {
-		return formatNumeric(v)
-	}
-	return ""
-}
+// groupValue returns the group key for a group column. Every group column
+// (shape_id, normalized_query_hash) is carried in str already rendered — the
+// hash by formatQueryHash, which matches the ClickHouse backend's
+// toString(normalized_query_hash) exactly. There is deliberately no fallback
+// through the float64 numeric map: that is the path that used to round every
+// hash at or above 2^53 into a neighbouring class, and reinstating it would
+// reintroduce the same silent collapse.
+func (r corpusRow) groupValue(col string) string { return r.str[col] }

--- a/internal/routerrules/source_jsonl.go
+++ b/internal/routerrules/source_jsonl.go
@@ -15,8 +15,9 @@ import (
 // jsonlCorpusSource reads the per-pod JSONL corpus (the default fallback sink)
 // and implements aggregation, percentiles, and rule evaluation in-Go. It needs
 // no ClickHouse, so the catalog is testable against a seeded fixture file. The
-// JSON shape matches optcorpus.Row (column-for-column with the CH table), plus
-// an optional event_time field for --since windowing.
+// JSON shape matches optcorpus.Row (column-for-column with the CH table),
+// including the event_time the JSONL sink stamps on every line, which is what
+// --since windows on.
 type jsonlCorpusSource struct {
 	path  string
 	since float64 // event_time floor (unix seconds); 0 disables windowing
@@ -30,47 +31,51 @@ func NewJSONLCorpusSource(path string, sinceUnix float64) CorpusSource {
 
 // jsonlRow mirrors optcorpus.Row's JSON tags plus event_time. Numeric corpus
 // columns are decoded as float64 so the in-Go matcher shares one comparison
-// path. event_time is optional (the JSONL sink may omit it; the CH table always
-// has it) and accepted as a unix-seconds number when present.
+// path.
+//
+// EventTime is a POINTER so an absent event_time is distinguishable from a
+// present zero. That distinction is load-bearing: every line the JSONL sink
+// writes carries event_time, so a line without one predates that stamping, and
+// a --since window cannot be honoured over it. Decoding into a plain float64
+// would collapse "undatable" into "dated 1970", which is what silently turned
+// --since into a no-op over the whole file.
 type jsonlRow struct {
-	EventTime           float64 `json:"event_time"`
-	ShapeID             string  `json:"shape_id"`
-	Language            string  `json:"language"`
-	NormalizedQueryHash uint64  `json:"normalized_query_hash"`
-	NAnchors            float64 `json:"n_anchors"`
-	Fanout              float64 `json:"fanout"`
-	CumulativeD         float64 `json:"cumulative_d"`
-	OuterRange          float64 `json:"outer_range"`
-	Step                float64 `json:"step"`
-	Route               string  `json:"route"`
-	KShards             float64 `json:"k_shards"`
-	DecisionReason      string  `json:"decision_reason"`
-	ReadRows            float64 `json:"read_rows"`
-	ReadBytes           float64 `json:"read_bytes"`
-	QueryDurationMS     float64 `json:"query_duration_ms"`
-	MemoryUsage         float64 `json:"memory_usage"`
-	ExitStatus          string  `json:"exit_status"`
-	ShardsObserved      float64 `json:"shards_observed"`
-	Parallelism         float64 `json:"parallelism"`
+	EventTime           *float64 `json:"event_time"`
+	ShapeID             string   `json:"shape_id"`
+	Language            string   `json:"language"`
+	NormalizedQueryHash uint64   `json:"normalized_query_hash"`
+	NAnchors            float64  `json:"n_anchors"`
+	Fanout              float64  `json:"fanout"`
+	CumulativeD         float64  `json:"cumulative_d"`
+	OuterRange          float64  `json:"outer_range"`
+	Step                float64  `json:"step"`
+	Route               string   `json:"route"`
+	KShards             float64  `json:"k_shards"`
+	DecisionReason      string   `json:"decision_reason"`
+	ReadRows            float64  `json:"read_rows"`
+	ReadBytes           float64  `json:"read_bytes"`
+	QueryDurationMS     float64  `json:"query_duration_ms"`
+	MemoryUsage         float64  `json:"memory_usage"`
+	ExitStatus          string   `json:"exit_status"`
+	ShardsObserved      float64  `json:"shards_observed"`
+	Parallelism         float64  `json:"parallelism"`
 }
 
 func (r jsonlRow) toCorpusRow() corpusRow {
 	return corpusRow{
-		eventTimeUnix: r.EventTime,
 		numeric: map[string]float64{
-			"n_anchors":             r.NAnchors,
-			"fanout":                r.Fanout,
-			"cumulative_d":          r.CumulativeD,
-			"outer_range":           r.OuterRange,
-			"step":                  r.Step,
-			"k_shards":              r.KShards,
-			"read_rows":             r.ReadRows,
-			"read_bytes":            r.ReadBytes,
-			"query_duration_ms":     r.QueryDurationMS,
-			"memory_usage":          r.MemoryUsage,
-			"shards_observed":       r.ShardsObserved,
-			"parallelism":           r.Parallelism,
-			"normalized_query_hash": float64(r.NormalizedQueryHash),
+			"n_anchors":         r.NAnchors,
+			"fanout":            r.Fanout,
+			"cumulative_d":      r.CumulativeD,
+			"outer_range":       r.OuterRange,
+			"step":              r.Step,
+			"k_shards":          r.KShards,
+			"read_rows":         r.ReadRows,
+			"read_bytes":        r.ReadBytes,
+			"query_duration_ms": r.QueryDurationMS,
+			"memory_usage":      r.MemoryUsage,
+			"shards_observed":   r.ShardsObserved,
+			"parallelism":       r.Parallelism,
 		},
 		str: map[string]string{
 			"shape_id":              r.ShapeID,
@@ -78,7 +83,7 @@ func (r jsonlRow) toCorpusRow() corpusRow {
 			"route":                 r.Route,
 			"decision_reason":       r.DecisionReason,
 			"exit_status":           r.ExitStatus,
-			"normalized_query_hash": formatNumeric(float64(r.NormalizedQueryHash)),
+			"normalized_query_hash": formatQueryHash(r.NormalizedQueryHash),
 		},
 	}
 }
@@ -108,17 +113,33 @@ func (s *jsonlCorpusSource) streamFile(path string, fn func(corpusRow) error) er
 
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, corpusScanInitial), corpusScanMax)
+	lineNo := 0
 	for sc.Scan() {
+		lineNo++
 		line := strings.TrimSpace(sc.Text())
 		if line == "" {
 			continue
 		}
 		var jr jsonlRow
 		if err := json.Unmarshal([]byte(line), &jr); err != nil {
-			return fmt.Errorf("routerrules: decode corpus line in %q: %w", path, err)
+			return fmt.Errorf("routerrules: decode corpus line %s: %w", corpusAt(path, lineNo), err)
 		}
-		if s.since > 0 && jr.EventTime > 0 && jr.EventTime < s.since {
-			continue
+		if s.since > 0 {
+			// An undatable row cannot be placed inside or outside the window,
+			// so it is refused rather than admitted. Admitting it is what made
+			// --since a silent no-op: the operator got findings over the whole
+			// file history while believing the window applied, and the
+			// ClickHouse backend — which windows in SQL on the table's own
+			// event_time — answered the same flag over a different population.
+			if jr.EventTime == nil {
+				return fmt.Errorf("routerrules: corpus line %s has no event_time, so --since cannot "+
+					"window it; this corpus predates event-time stamping — re-run without --since to "+
+					"scan the whole file, or roll the corpus file so new lines carry event_time",
+					corpusAt(path, lineNo))
+			}
+			if *jr.EventTime < s.since {
+				continue
+			}
 		}
 		if err := fn(jr.toCorpusRow()); err != nil {
 			return err
@@ -128,6 +149,12 @@ func (s *jsonlCorpusSource) streamFile(path string, fn func(corpusRow) error) er
 		return fmt.Errorf("routerrules: scan corpus %q: %w", path, err)
 	}
 	return nil
+}
+
+// corpusAt renders a corpus file position for an error message, so a bad line
+// in a multi-file corpus directory is locatable rather than merely reported.
+func corpusAt(path string, lineNo int) string {
+	return fmt.Sprintf("%s:%d", path, lineNo)
 }
 
 func (s *jsonlCorpusSource) files() ([]string, error) {

--- a/internal/routerrules/source_jsonl_since_test.go
+++ b/internal/routerrules/source_jsonl_since_test.go
@@ -1,0 +1,128 @@
+package routerrules
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sinceCorpusLine renders one JSONL corpus line. eventTime < 0 omits the
+// event_time field entirely, modelling a corpus written before the sink stamped
+// one.
+func sinceCorpusLine(shape string, eventTime, memory int64) string {
+	if eventTime < 0 {
+		return fmt.Sprintf(
+			`{"shape_id":%q,"language":"promql","route":"A","exit_status":"ok","memory_usage":%d}`,
+			shape, memory,
+		)
+	}
+	return fmt.Sprintf(
+		`{"event_time":%d,"shape_id":%q,"language":"promql","route":"A","exit_status":"ok","memory_usage":%d}`,
+		eventTime, shape, memory,
+	)
+}
+
+func writeSinceCorpus(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "corpus.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write corpus: %v", err)
+	}
+	return path
+}
+
+// maxOf aggregates memory_usage over whatever rows the source admitted, so the
+// assertion is on the POPULATION the window selected rather than on a row count
+// the source does not expose.
+func maxOf(t *testing.T, src CorpusSource) float64 {
+	t.Helper()
+	v, err := src.Aggregate(context.Background(), AggSpec{Column: "memory_usage", Agg: AggMax})
+	if err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+	return v.Scalar
+}
+
+// TestJSONLSinceWindowsOnEventTime pins that --since actually windows the JSONL
+// corpus. It used to be a silent no-op: the sink wrote no event_time, jsonlRow
+// decoded the absent field to 0, and the filter's `jr.EventTime > 0` guard then
+// admitted every row. An operator passing --since 720h got findings over the
+// whole file history while believing the window applied — and the ClickHouse
+// backend, which windows in SQL on the table's own event_time, answered the same
+// flag over a different population.
+//
+// The old row is the one with the LARGER memory_usage, so a source that ignores
+// the window reports the old row's value and fails. A source that applied the
+// window reports the recent row's.
+func TestJSONLSinceWindowsOnEventTime(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldEventTime    = 1_000
+		recentEventTime = 9_000
+		windowFloor     = 5_000
+		oldMemory       = 900
+		recentMemory    = 100
+	)
+	path := writeSinceCorpus(
+		t,
+		sinceCorpusLine("prom:old", oldEventTime, oldMemory),
+		sinceCorpusLine("prom:recent", recentEventTime, recentMemory),
+	)
+
+	if got := maxOf(t, NewJSONLCorpusSource(path, windowFloor)); got != recentMemory {
+		t.Errorf("max(memory_usage) with --since = %v, want %v; the pre-window row leaked into the "+
+			"result, so --since did not window the corpus", got, float64(recentMemory))
+	}
+
+	// The complement: with no window, the old row MUST be present. Without this
+	// half, a source that dropped every row would pass the assertion above.
+	if got := maxOf(t, NewJSONLCorpusSource(path, 0)); got != oldMemory {
+		t.Errorf("max(memory_usage) with no --since = %v, want %v; the unwindowed source must see "+
+			"the whole file", got, float64(oldMemory))
+	}
+}
+
+// TestJSONLSinceRefusesUndatableRow pins that a corpus line with no event_time
+// is REFUSED under --since rather than admitted. Such a row cannot be placed
+// inside or outside the window; admitting it is precisely what made the flag a
+// silent no-op, and silently dropping it would discard data just as quietly. It
+// is a corpus written before event-time stamping, and the operator is told so.
+func TestJSONLSinceRefusesUndatableRow(t *testing.T) {
+	t.Parallel()
+
+	const (
+		datedEventTime = 9_000
+		windowFloor    = 5_000
+	)
+	path := writeSinceCorpus(
+		t,
+		sinceCorpusLine("prom:dated", datedEventTime, 100),
+		sinceCorpusLine("prom:undated", -1, 900),
+	)
+
+	_, err := NewJSONLCorpusSource(path, windowFloor).
+		Aggregate(context.Background(), AggSpec{Column: "memory_usage", Agg: AggMax})
+	if err == nil {
+		t.Fatal("aggregating an undatable row under --since succeeded; the row can be placed neither " +
+			"inside nor outside the window, so admitting it silently reinstates the no-op")
+	}
+	if !strings.Contains(err.Error(), "event_time") {
+		t.Errorf("error %q does not name event_time; the operator cannot act on it", err)
+	}
+	// The position must be locatable: a multi-file corpus directory otherwise
+	// gives the operator no way to find the offending line.
+	if !strings.Contains(err.Error(), ":2") {
+		t.Errorf("error %q does not carry the offending line number", err)
+	}
+
+	// Without --since the same corpus is answerable: nothing is being windowed,
+	// so a missing event_time costs nothing and must not be an error.
+	if got := maxOf(t, NewJSONLCorpusSource(path, 0)); got != 900 {
+		t.Errorf("max(memory_usage) with no --since = %v, want 900; an undated row is only a problem "+
+			"when a window is being applied", got)
+	}
+}

--- a/test/regression/router_corpus_seed_test.go
+++ b/test/regression/router_corpus_seed_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/routerrules"
 	"github.com/tsouza/cerberus/internal/solver"
 )
 
@@ -184,4 +185,88 @@ func checkCorpusFixture(t *testing.T, path string, valid map[string]struct{}) (c
 		t.Fatalf("scan %s: %v", path, err)
 	}
 	return classified, unclassified
+}
+
+// TestRouterBenchCorpusIsProducible extends the reachable-states pin above from
+// the JSONL fixtures to the GENERATED benchmark corpus, which
+// TestRouterCorpusFixturesAreProducible never saw: it globs *.jsonl, and the
+// benchmark corpus is built in Go by routerrules.GenerateBenchCorpus and handed
+// straight to the evaluator through the in-memory seam, never touching a file.
+//
+// That gap is not hypothetical. The benchmark corpus used to plant
+// decision_reason tokens no production path can emit — "sliceable" on its
+// route-B rows and "high-cardinality" on its route-A OOM and timeout rows —
+// neither of which is a solver.Reasons member. Three catalog rules group by
+// decision_reason, so the regression floors, the sweep and the ClickHouse
+// parity lane all scored a corpus whose reason column was fiction, and the
+// route-B rows additionally claimed a refusal reason while carrying route B.
+//
+// Two of the three invariants documented on TestRouterCorpusFixturesAreProducible
+// are asserted here, both derived from the production consts rather than
+// restated:
+//
+//  1. decision_reason is a solver.Reasons member or the corpus-only non-PromQL
+//     token.
+//
+//  3. route == "B" iff decision_reason == solver.ReasonRouted.
+//
+// Invariant 2 (only PromQL rows carry a classification) is NOT asserted here,
+// and deliberately so rather than silently: the benchmark corpus plants
+// classified LogQL and TraceQL classes — route A with real geometry — which the
+// solver cannot produce, because solver.Classify is PromQL-gated. Making those
+// classes honest changes which rules can fire on them and therefore the labeled
+// ground truth and the regression floors, so it is its own change, tracked in
+// issue #3204. Asserting the two invariants that DO hold is what keeps the
+// remaining gap visible instead of letting the whole corpus go unpinned.
+func TestRouterBenchCorpusIsProducible(t *testing.T) {
+	t.Parallel()
+
+	corpus := routerrules.GenerateBenchCorpus(routerrules.BenchParams{})
+	if len(corpus.Rows) == 0 {
+		t.Fatal("benchmark corpus generated no rows — this pin would assert nothing")
+	}
+	if len(corpus.Classes) == 0 {
+		t.Fatal("benchmark corpus generated no labeled classes — this pin would assert nothing")
+	}
+
+	valid := validRouterDecisionReasons()
+
+	// Both sides of invariant 3 must be exercised, or a corpus that happened to
+	// contain only route-A rows would satisfy it vacuously.
+	var routeB, routeA int
+	for i, r := range corpus.Rows {
+		if _, ok := valid[r.DecisionReason]; !ok {
+			t.Errorf("bench row %d (%s/%s) has decision_reason %q, which is no token production can emit",
+				i, r.ShapeID, r.Language, r.DecisionReason)
+		}
+		if routed := r.DecisionReason == solver.ReasonRouted; (r.Route == "B") != routed {
+			t.Errorf("bench row %d (%s/%s) has route=%q with decision_reason=%q; route B and %q are the same event",
+				i, r.ShapeID, r.Language, r.Route, r.DecisionReason, solver.ReasonRouted)
+		}
+		switch r.Route {
+		case "B":
+			routeB++
+		case "A":
+			routeA++
+		}
+	}
+	if routeB == 0 {
+		t.Error("no route-B bench row — the route-B half of the routed-reason invariant is untested")
+	}
+	if routeA == 0 {
+		t.Error("no route-A bench row — the refusal half of the routed-reason invariant is untested")
+	}
+
+	// The labeled ground truth carries decision_reason too, and a finding is
+	// matched back to its class by that column: a class labeled with an
+	// unproducible reason scores rules against a class no row can belong to.
+	for i, c := range corpus.Classes {
+		if c.DecisionReason == "" {
+			continue // a class may group on shape_id alone
+		}
+		if _, ok := valid[c.DecisionReason]; !ok {
+			t.Errorf("bench class %d (%s/%s) has decision_reason %q, which is no token production can emit",
+				i, c.ShapeID, c.Language, c.DecisionReason)
+		}
+	}
 }


### PR DESCRIPTION
## What

The ACPR (#3180) found three defects in the router-rules calibration corpora
with one root cause: the corpus the tool reasons about did not match what
production produces, so its conclusions were drawn from a population that
cannot occur.

All three are verified against `main` before being fixed, and each fix is
pinned by a test that was watched failing with the fix neutralized.

Closes #3189

## 1. `normalized_query_hash` group keys rendered through `float64`

**Verified.** `source_jsonl.go:81` and `benchmark.go:111` rendered the key as
`formatNumeric(float64(hash))`. The column is `UInt64`, and `formatNumeric`
takes a `float64`, so:

```
9007199254740993      -> "9007199254740992"
17000000000000000001  -> "1.7e+19"
17000000000000000002  -> "1.7e+19"
```

Two further sites shared the defect and would have desynchronised from any
partial fix: `benchmark.go:698` (`classID`) and `metrics.go:179`, which match a
fired finding back to its labeled class.

**Fixed.** One `formatQueryHash` helper renders the `uint64` directly, used by
all four sites. The `float64` copy of the hash is gone from the numeric map, and
`groupValue`'s numeric fallback with it — that fallback was the lossy path, and
both group columns are carried in the string map already
(`normalized_query_hash` is `ColumnGroup`, and `validate.go:154,359` gate every
numeric path on `ColumnNumeric`, so it could never legitimately reach it).

**Pinned.** The issue is right that the existing fixtures cannot catch this:
every hash in `seed.jsonl` (11–111), `effectiveness.jsonl` (101–303) and the
benchmark (30000–40000) sits below 2^53, where both renderings agree.

`prom:slow_hot` — the one planted class whose rule groups by
`normalized_query_hash` rather than `shape_id` — moves to hash base
`17000000000000000000`, putting its two severity classes at `...001` and
`...002`. That flows into the `chdb`-tagged cross-backend parity lane
automatically, since it re-derives from `GenerateBenchCorpus`.

**Neutralization evidence.** With `formatQueryHash` reverted to `float64`,
`TestCrossBackendParityBenchmark` fails and prints the defect the issue
describes, in the harness that was supposed to catch it:

```
finding count differs: ch=26 mem=25
ch  = ... normalized_query_hash=17000000000000000001:6
          normalized_query_hash=17000000000000000002:10
mem = ... normalized_query_hash=1.7e+19:16
```

Two backends, one corpus, different findings — the merged class carries the
summed support. Restored, the lane passes.

Also failing under the same neutralization, and passing when restored:

- `TestQueryHashGroupKeysAreExactAboveFloat64Range` — four distinct hashes
  collapse to two classes on *both* in-Go backends.
- `TestFormatQueryHashIsExact` — names the cause directly.
- `TestMultiRuleInteraction`: `class promql/prom:slow_hot_severe fired [],
  expected exactly [route_a_slow_hot_shape]`.
- `TestRegressionFloorSaneRange`: `severe recall 0.947 below floor 1.000`.

## 2. Unreachable `decision_reason` tokens in the benchmark corpus

**Verified.** `sliceable` (`benchmark.go:360,369,595`) and `high-cardinality`
(`:490,516`) are in neither `enumDomains["decision_reason"]`
(`columns.go:209-244`) nor `solver.Reasons` (`decision.go:315`).

A fourth row had the same defect and is fixed with them, though the issue did
not name it: `benchmark.go:569` planted `not-sliceable` on a **route-B** row.
`solver/decision.go:202` states that "a true route sets `ReasonRouted`", so a
routed row carrying a structural-refusal reason is equally unproducible.

**Fixed.** Every route-B row now carries `routed`; the route-A heavy-`D`
failures carry `high-D`, which is what the solver emits when the K clamp floor
drove K below 2 — matching those specs' `CumulativeD: sevDSevere`. Only
`route_a_high_fanout_should_shard` conditions on `decision_reason`, and it also
requires `fanout >= fanout_route_b_floor` (70) while those rows sit at 20–40, so
no rule's firing set moves.

**Pinned.** `TestRouterBenchCorpusIsProducible` extends the existing
reachable-states pin from the JSONL fixtures to the generated corpus.
`TestRouterCorpusFixturesAreProducible` globs `testdata/*.jsonl`; the benchmark
corpus is built in Go and handed to the evaluator in memory, so the glob
structurally could not see it.

**Neutralization evidence.** Reverting the route-B token to `sliceable`:

```
bench row 106 (logql:routeb_healthy/logql) has decision_reason "sliceable",
  which is no token production can emit
bench row 106 ... has route="B" with decision_reason="sliceable";
  route B and "routed" are the same event
```

## 3. `--since` was a silent no-op on the default `jsonl` source

**Verified.** `optcorpus.Row` has no event time, `JSONLSink.Write` encoded the
`Row` directly, and `source_jsonl.go:120` read
`s.since > 0 && jr.EventTime > 0 && jr.EventTime < s.since` — so every real line
decoded to `EventTime == 0` and the guard never dropped anything. The CH source
enforces the window in SQL, so the two backends answered the same flag over
different populations.

`TestJSONLSinceWindowDropsOldRows` (`source_test.go:83`) passed throughout,
because its fixture `seed.jsonl` hand-authors `event_time` on every line. The
fixture was more capable than what the sink actually wrote — the same
corpus-versus-production mismatch as the other two findings, expressed in a test.

### Resolution chosen: make it WORK

The issue offers WORK or REFUSE. I chose **work**, because the asymmetry was not
a missing capability but a missing field: `CHTableSink.Write`
(`chtable.go:557`) already stamps the table's `event_time` from `time.Now()` at
the reconcile instant, and the JSONL sink is documented as a column-for-column
swap for it. Refusing would have left the *documented default source* unable to
honour a documented flag, and left the two sinks disagreeing about whether a
corpus row has a date — the very divergence the issue is about. Giving the sink
the same stamp makes both sinks date a row identically and costs one field.

`Row` itself is unchanged: `CorpusColumns()` documents that `event_time` is
"stamped per batch rather than read off a Row", so the JSONL sink encodes a
`jsonlRecord` that embeds `Row` and adds the stamp, keeping the JSON flat.

One case cannot be made to work: a line written *before* this change carries no
`event_time`. It can be placed neither inside nor outside the window, so under
`--since` it is **refused** with the offending `file:line` — loudly, not
silently dropped and not silently admitted. Without `--since` nothing is being
windowed and it reads normally. `jsonlRow.EventTime` is a pointer so absent stays
distinguishable from a present zero.

**Neutralization evidence.**

- Sink stops stamping → `TestJSONLSink_StampsEventTime`: `line 1 has no
  event_time field`. It decodes into a `map`, not a struct, because a struct
  with an `EventTime` field deserializes a *missing* field to the zero value and
  would pass.
- Filter admits undatable rows again → `TestJSONLSinceRefusesUndatableRow`:
  `aggregating an undatable row under --since succeeded`.
- `TestJSONLSinceWindowsOnEventTime` asserts both directions, so a source that
  dropped every row cannot pass it.

## Docs

`docs/router-rules.md` stated both claims the issue names, more broadly than the
code supported:

- "the two backends produce identical findings" omitted that this requires
  identical **group keys**, which is where the breach was. The doc now names the
  `toString(normalized_query_hash)` contract and why a fixture below 2^53 cannot
  detect a breach of it.
- "Every fixture is constrained to states the production solver can actually
  reach" cited a test that only globs `testdata/*.jsonl`. The doc now separates
  the two populations and states the remaining gap rather than claiming it.
- `--since` is now documented as meaning the same thing on both sources, with
  the refusal behaviour.

## Filed, not deferred

**#3204** — the benchmark corpus plants 236 rows across 5 shapes with LogQL and
TraceQL classifications a PromQL-gated solver cannot emit (measured, table in
the issue). This is the third invariant of the reachable-states pin. It is not
fixed here because making those classes honest gives them an empty route and
zero geometry, at which point every rule gated on `route: A` stops firing on
them — so the labeled ground truth and the generated regression floors move with
it. `TestRouterBenchCorpusIsProducible` asserts the two invariants that do hold
and documents the exclusion inline, so the gap stays visible instead of leaving
the whole corpus unpinned.

## Verification

- `go test ./internal/routerrules/ ./internal/optcorpus/ ./test/regression/` —
  green.
- `go test -tags chdb -run TestCrossBackendParity ./internal/routerrules/` —
  green (libchdb installed locally), and red under neutralization as shown above.
- `node .github/scripts/forbid-sql-raw.mjs` — no raw SQL token writes.
- `markdownlint-cli2 docs/router-rules.md` — 0 errors.
- No golden artefact is stale: the hash-base change alters no checked-in
  baseline, and the benchmark corpus is generated at test time.
