### PR TITLE
test: repair the test mechanisms that could not fail, and delete the dead code

### DIFF
--- a/.github/scripts/doc-counts.mjs
+++ b/.github/scripts/doc-counts.mjs
@@ -126,6 +126,7 @@ const CH_OPT_DOC = join(REPO, 'docs', 'clickhouse-optimizations.md');
 const SURFACE_INVENTORY_DIR = join(REPO, 'test', 'surface-parity', 'inventory');
 const REJECTION_CATALOGUE_DIR = join(REPO, 'test', 'rejection-parity', 'catalogue');
 const DIVERGENCE_CEILING = join(REPO, 'test', 'rejection-parity', 'divergence-ceiling.json');
+const SHAPES_GO = join(REPO, 'test', 'property', 'gen', 'shapes.go');
 
 // The dispatch mode that runs every registered scan; a legal CHECK value that is
 // deliberately not a registry entry. Mirrors `ALL` in forbid-skip.mjs.
@@ -599,6 +600,151 @@ function readWorkflows() {
     }));
 }
 
+// --- 8. property-shape roster -------------------------------------------
+//
+// docs/test-strategy.md's "Exact semantic-shape roster" enumerates every
+// stable ID test/property/gen/shapes.go publishes, grouped, with a per-group
+// count and a total. Nothing derived it, and it had drifted: the doc said 81
+// while the generator published 83, having gained promql.instant.label-replace
+// and promql.range.label-replace without the manifest following.
+//
+// A count alone would be the weaker gate — two compensating edits keep a total
+// right while naming the wrong shapes — so this asserts the SET. The doc's own
+// sentence licenses that reading: brace notation "denotes the exact listed
+// expansion, not an open-ended prefix".
+
+const SHAPE_ROSTER_HEADING = '### Exact semantic-shape roster';
+
+// liveShapeIDs reads the roster's source of truth: every
+// `<name> ShapeID = "<id>"` constant in test/property/gen/shapes.go.
+function liveShapeIDs(src) {
+  return [...src.matchAll(/ShapeID\s*=\s*"([^"]+)"/g)].map((m) => m[1]);
+}
+
+// expandBraceTerm expands one `a.{x,y}.{p,q}` term into its Cartesian product,
+// which is how the roster writes the instant-window family.
+function expandBraceTerm(term) {
+  let out = [''];
+  let rest = term;
+  while (rest.length > 0) {
+    const open = rest.indexOf('{');
+    if (open < 0) {
+      out = out.map((prefix) => prefix + rest);
+      break;
+    }
+    const close = rest.indexOf('}', open);
+    if (close < 0) {
+      out = out.map((prefix) => prefix + rest);
+      break;
+    }
+    const literal = rest.slice(0, open);
+    const alts = rest.slice(open + 1, close).split(',').filter((a) => a.length > 0);
+    out = out.flatMap((prefix) => alts.map((alt) => prefix + literal + alt));
+    rest = rest.slice(close + 1);
+  }
+  return out;
+}
+
+// braceTermsIn recovers the brace terms from one roster bullet.
+//
+// A term is written inside inline-code spans and a long one is split across
+// several of them to respect the line-length limit, so the spans have to be
+// rejoined — but only where the split is real, or two independent terms
+// separated by prose would fuse into one bogus Cartesian product. A split is
+// real in exactly two shapes: the accumulated text still has an unclosed brace,
+// or it ends in `.` and the next span opens a brace (the instant-window
+// family's `{a,b,c}.{d,e}` product). Prose outside the code spans is never
+// read, and a span with no brace is not a term.
+function braceTermsIn(chunk) {
+  const spans = [...chunk.matchAll(/`([^`]*)`/g)].map((m) => m[1].replace(/\s+/g, ''));
+  const unclosed = (t) => (t.match(/\{/g) || []).length > (t.match(/\}/g) || []).length;
+  const terms = [];
+  let cur = '';
+  for (const span of spans) {
+    if (cur === '') {
+      cur = span;
+    } else if (unclosed(cur) || (cur.endsWith('.') && span.startsWith('{'))) {
+      cur += span;
+    } else {
+      terms.push(cur);
+      cur = span;
+    }
+  }
+  if (cur !== '') terms.push(cur);
+  return terms.filter((t) => t.includes('{')).map((t) => t.replace(/\.+$/, ''));
+}
+
+// docShapeGroups parses the roster section into one entry per `- **Name — N.**`
+// bullet, carrying the stated count and the IDs its brace terms expand to.
+function docShapeGroups(src) {
+  const start = src.indexOf(SHAPE_ROSTER_HEADING);
+  if (start < 0) return { total: null, groups: [] };
+  const after = src.slice(start + SHAPE_ROSTER_HEADING.length);
+  const end = after.search(/\n#{2,3} /);
+  const section = end < 0 ? after : after.slice(0, end);
+
+  const totalMatch = section.match(/Its\s+(\d+)\s+stable\s+IDs/);
+  const total = totalMatch ? Number(totalMatch[1]) : null;
+
+  const groups = [];
+  for (const chunk of section.split(/\n- \*\*/).slice(1)) {
+    const head = chunk.match(/^([^—]+)—\s*(\d+)\.\*\*/);
+    if (!head) continue;
+    const ids = braceTermsIn(chunk).flatMap(expandBraceTerm);
+    groups.push({ name: head[1].trim(), stated: Number(head[2]), ids });
+  }
+  return { total, groups };
+}
+
+// assertShapeRoster compares the doc's expanded roster against the generator's
+// live IDs, both as a set and per stated group count.
+function assertShapeRoster() {
+  const live = liveShapeIDs(readFileSync(SHAPES_GO, 'utf8'));
+  const { total, groups } = docShapeGroups(readFileSync(TEST_STRATEGY_DOC, 'utf8'));
+  const docIDs = groups.flatMap((g) => g.ids);
+  log(
+    `property-shape roster (live): ${live.length} IDs in test/property/gen/shapes.go; ` +
+      `docs/test-strategy.md enumerates ${docIDs.length} across ${groups.length} groups`,
+  );
+
+  let ok = true;
+  if (total === null) {
+    error('doc-counts: docs/test-strategy.md states no "Its N stable IDs" total for the shape roster');
+    ok = false;
+  } else if (total !== live.length) {
+    error(
+      `doc-counts: docs/test-strategy.md says the roster has ${total} stable IDs, ` +
+        `test/property/gen/shapes.go publishes ${live.length}`,
+    );
+    ok = false;
+  }
+
+  for (const g of groups) {
+    if (g.ids.length !== g.stated) {
+      error(
+        `doc-counts: shape-roster group "${g.name}" states ${g.stated} but enumerates ${g.ids.length} IDs`,
+      );
+      ok = false;
+    }
+  }
+
+  const liveSet = new Set(live);
+  const docSet = new Set(docIDs);
+  for (const id of live) {
+    if (!docSet.has(id)) {
+      error(`doc-counts: shape ${id} is published by shapes.go and absent from the roster in docs/test-strategy.md`);
+      ok = false;
+    }
+  }
+  for (const id of docIDs) {
+    if (!liveSet.has(id)) {
+      error(`doc-counts: the roster in docs/test-strategy.md names ${id}, which shapes.go does not publish`);
+      ok = false;
+    }
+  }
+  return ok;
+}
+
 function runAssertions() {
   const forbidSrc = readFileSync(FORBID_SKIP_MJS, 'utf8');
   const { count: fsCount, names: fsNames } = countForbidSkipChecks(forbidSrc);
@@ -664,6 +810,8 @@ function runAssertions() {
     patterns: CHOPT_TOTAL_CLAIM_PATTERNS,
   });
 
+  const rosterOk = assertShapeRoster();
+
   const callers = forbidSkipCallers(readWorkflows());
   log(
     `forbid-skip workflow callers (live): ${callers.length} ` +
@@ -671,7 +819,10 @@ function runAssertions() {
   );
   const callersOk = assertForbidSkipCallers(fsNames, callers);
 
-  if (forbidOk && layerOk && parityOk && glanceOk && divergenceOk && callersOk && choptOptInOk && choptTotalOk) {
+  if (
+    forbidOk && layerOk && parityOk && glanceOk && divergenceOk &&
+    callersOk && choptOptInOk && choptTotalOk && rosterOk
+  ) {
     notice(
       `doc-counts: all doc-stated counts match source ` +
         `(forbid-skip=${fsCount}, test-layers=${layerCount}, ` +
@@ -680,6 +831,7 @@ function runAssertions() {
         `chopt=${chopt.optIn}/${chopt.total} opt-in-only, ` +
         `the coverage glance table matches the surface-parity ledger, ` +
         `shape-divergences=${divCount}, ` +
+        `the semantic-shape roster matches test/property/gen/shapes.go, ` +
         `${callers.length} workflow CHECK callers all name a live scan)`,
     );
     return 0;
@@ -1032,6 +1184,65 @@ function selfTest() {
   );
 
   check('real docs/coverage.md glance table matches test/surface-parity/inventory/', assertSurfaceParityGlance());
+
+  // 8. The shape roster is asserted as a SET, so the brace-term reader is what
+  // has to be trustworthy: it must rejoin a term the doc wrapped across code
+  // spans, expand a Cartesian product, and NOT fuse two independent terms that
+  // merely sit next to each other in one bullet.
+  check(
+    'brace expander expands a single group',
+    expandBraceTerm('a.{x,y,z}').join(',') === 'a.x,a.y,a.z',
+  );
+  check(
+    'brace expander expands a Cartesian product of two groups',
+    expandBraceTerm('a.{p,q}.{m,n}').join(',') === 'a.p.m,a.p.n,a.q.m,a.q.n',
+  );
+  check(
+    'brace-term reader rejoins a term the doc wrapped mid-list across code spans',
+    braceTermsIn('- **G — 3.** `a.{x,`\n  `y,z}`.').join(',') === 'a.{x,y,z}',
+  );
+  check(
+    'brace-term reader rejoins a Cartesian product split at the dot',
+    braceTermsIn('`a.{p,q}.`\n`{m,n}`').join(',') === 'a.{p,q}.{m,n}',
+  );
+  check(
+    'brace-term reader keeps two adjacent independent terms apart',
+    braceTermsIn('`a.{x,y}`; `b.{z}`').length === 2,
+  );
+  check(
+    'brace-term reader ignores a code span that is prose, not a term',
+    braceTermsIn('`a.{x,y}` where `duration-aggregate` is the average').length === 1,
+  );
+  const fakeRoster = [
+    '### Exact semantic-shape roster',
+    '',
+    'source of truth. Its 3 stable',
+    'IDs are grouped as follows:',
+    '',
+    '- **G1 — 2.** `a.{x,y}`.',
+    '- **G2 — 1.** `b.{z}`.',
+    '',
+    '## Next section',
+  ].join('\n');
+  const fakeGroups = docShapeGroups(fakeRoster);
+  check('roster reader reads the stated total', fakeGroups.total === 3);
+  check(
+    'roster reader reads each group and its IDs',
+    fakeGroups.groups.length === 2 &&
+      fakeGroups.groups[0].stated === 2 &&
+      fakeGroups.groups.flatMap((g) => g.ids).join(',') === 'a.x,a.y,b.z',
+  );
+  check(
+    'roster reader stops at the next heading rather than swallowing the rest of the doc',
+    !fakeGroups.groups.some((g) => g.name.includes('Next')),
+  );
+  const liveIDs = liveShapeIDs(readFileSync(SHAPES_GO, 'utf8'));
+  check('shapes.go reader found the live stable IDs', liveIDs.length > 0);
+  check(
+    'shapes.go reader returns the ID string, not the Go constant name',
+    liveIDs.every((id) => id.includes('.') && id === id.toLowerCase()),
+  );
+  check('real semantic-shape roster matches test/property/gen/shapes.go', assertShapeRoster());
 
   // 7. The shape-divergence count is a SECOND measurement, and the doc must
   //    state it rather than let the symbol-level zero stand in for it.

--- a/docs/router-rules.md
+++ b/docs/router-rules.md
@@ -37,11 +37,18 @@ confirm it by reading the shipped files.
   percentile cutoff) is **per-deployment** and resolved **at runtime from the
   database** (the deployment's own corpus aggregates) and/or the deployment's
   config. It is **never** a literal in the YAML or in Go.
-- Example generic rule: *"flag `route=A` queries whose `memory_usage` exceeds
-  `{memory_high_watermark}`"*, where `{memory_high_watermark}` is a **named
-  parameter** resolved per-deployment (a percentile of *this* deployment's own
-  `memory_usage` distribution). The file carries the **name** and the
-  **resolver kind**, never the number.
+- Example generic rule (`route_a_memory_near_cap`): *"flag `route=A` queries
+  whose `memory_usage` is at or above `{memory_near_cap}`"*, where
+  `{memory_near_cap}` is a **named parameter** resolved per-deployment (a
+  configured fraction of *this* deployment's own `query.max_memory_bytes`). The
+  file carries the **name** and the **resolver kind**, never the number.
+- A declared parameter that no rule reaches is a **load-time error**
+  (`validateEveryParamIsReached`), the dual of the dangling-`${param}` check.
+  Resolution walks the declared params, not the used ones, and each
+  corpus-derived param drives its own full aggregate pass — so an unreached one
+  costs a corpus scan per run and can never change a finding. Reachability is
+  transitive and includes a `finding` message placeholder, which is how a
+  MESSAGE-only param such as `{cerberus_reject_ratio}` stays legal.
 
 This mirrors the self-tuning generic-loop / local-constants split: the shipped
 catalog generalizes across all deployments; the numbers come from each

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -590,24 +590,22 @@ memo-hit and routing the request through plain route A instead, so the
 underlying premise ("route A still fails on this shape") gets honestly
 re-confirmed by real traffic rather than trusted forever.
 
-**The ordering bug `ObserveRouteAFailureAndMaybeBeginProbe` fixes.** The
+**Why `ObserveRouteAFailureAndMaybeBeginProbe` is one atomic step.** The
 re-validation path depends on a route-A dispatch actually failing again while
-the entry looks stale. A naive two-call sequence —
-`Observe(k, RouteA, OutcomeResourceFailure)` (which refreshes `createdAt`,
-un-staling the entry) followed by `BeginProbe(k)` (which admits only an
-`Unknown` entry) — loses exactly the request that should trigger the rescue:
-by the time `BeginProbe` looks, `Observe`'s own side effect has already made
-the entry look fresh again, so `BeginProbe`'s Unknown-only gate refuses it.
-The caller's actual HTTP request is then stuck on the very failure the memo
-already knows how to avoid, with no rescue, even though the memo has been
-confidently routing this shape to B for the entry's entire life.
-`ObserveRouteAFailureAndMaybeBeginProbe` closes the gap by combining
-record-and-decide into one critical section: it captures whether the entry
-WAS stale before the state transition, then decides admission on that
-pre-transition snapshot rather than the post-transition one. Callers on the
-route-A failure path (`retryOnRouteAResourceFailure`) MUST use this one atomic
-method — never the two separate calls — for a route-A resource-exhaustion
-failure.
+the entry looks stale. Recording that failure refreshes `createdAt`, which
+un-stales the entry — so an admission check that ran as a SEPARATE step
+afterwards would see a fresh `PreferB` entry and refuse, losing exactly the
+request that should have triggered the rescue. The caller's actual HTTP
+request would then be stuck on the very failure the memo already knows how to
+avoid, even though the memo has been confidently routing this shape to B for
+the entry's entire life. `ObserveRouteAFailureAndMaybeBeginProbe` holds the
+memo's mutex across both steps: it captures whether the entry WAS stale
+before the state transition, then decides admission on that pre-transition
+snapshot rather than the post-transition one. That snapshot is why the memo
+exposes no separate admission entry point for a route-A resource failure —
+this method is the only way route-A failure admission happens, so the
+record-then-admit sequence cannot be written any other way. The route-A
+failure path (`retryOnRouteAResourceFailure`) is its only production caller.
 
 ### Admission: one process-wide dispatch-token semaphore
 

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1036,12 +1036,13 @@ successfully.
 
 ### Exact semantic-shape roster
 
-`test/property/gen/shapes.go` is the executable source of truth. Its 81 stable
+`test/property/gen/shapes.go` is the executable source of truth. Its 83 stable
 IDs are grouped as follows (brace notation below denotes the exact listed
 expansion, not an open-ended prefix):
 
-- **PromQL instant — 5.** `promql.instant.{selector,sum,sum-by,rate,sum-rate}`.
-- **PromQL range — 3.** `promql.range.{selector,sum-by,rate}`.
+- **PromQL instant — 6.**
+  `promql.instant.{selector,sum,sum-by,rate,sum-rate,label-replace}`.
+- **PromQL range — 4.** `promql.range.{selector,sum-by,rate,label-replace}`.
 - **PromQL native histogram — 20.**
   `promql.native-histogram.{function.count,function.sum,function.avg,`
   `function.stddev,function.stdvar,fraction,selector,sum,sum-by,rate,increase,`

--- a/internal/chplan/grid_carrier.go
+++ b/internal/chplan/grid_carrier.go
@@ -182,20 +182,21 @@ func (r *RangeBucketFanout) AnchorGridDivides() bool { return !r.PeakIndependent
 
 // AnchorGridDivides: the native aggregate materialises one Array of N grid
 // points per (series, `le` rung), so its intermediate is linear in the grid
-// width exactly as RangeWindowGridNative's is. It is reported honestly even
-// though slicing never reaches this node.
+// width exactly as RangeWindowGridNative's is.
 //
-// TRUE here is the solver's LICENCE TO SHARD, so what keeps the honest answer
-// safe is that two independent refusals stop the plan before any threshold
-// reads it: the kind is deliberately absent from sliceInvariantKinds (no
-// slice-invariance proof has been argued for it), and internal/solver's
-// carrierGeometryOf reports it non-re-anchorable (ReanchorRange has no arm
-// that re-grids it). Neither is left as prose — both, and the routing outcome
-// they produce, are pinned by internal/solver's
-// TestRangeBucketGridNative_SlicingRefusedAtBothGates /
-// _NeverRoutesUnderAuto, which fail if either refusal is removed. Registering
-// this kind as slice-invariant therefore fails loudly rather than silently
-// handing the solver a licence nobody re-derived.
+// TRUE here is the solver's LICENCE TO SHARD, and that licence is LIVE: #2677
+// argued the stage-by-stage slice-invariance proof (recorded on this kind's
+// entry in sliceInvariantKinds — internal/chplan/sliceinvariant.go) and added
+// the re-gridding arm (reanchorRangeBucketGridNative, dispatched by
+// ReanchorRange), so a wide-window classic-histogram quantile that busts one
+// query's memory cap is time-sliced across K shards instead of having no
+// relief at all. Both mechanisms are load-bearing and admitted together or not
+// at all: the registry entry alone lets the whole-plan walk accept the plan
+// with nothing able to re-grid the carrier, and the reanchor arm alone is
+// never reached. internal/solver's
+// TestRangeBucketGridNative_SlicingAdmittedAtBothGates pins each separately
+// (along with this method's answer), so withdrawing either fails there naming
+// which one, rather than silently stranding the carrier back on route A.
 func (r *RangeBucketGridNative) AnchorGridDivides() bool { return true }
 
 // AnchorGridDivides: absent_over_time emits one row per anchor.

--- a/internal/chsql/fail_closed_guards_test.go
+++ b/internal/chsql/fail_closed_guards_test.go
@@ -1,0 +1,145 @@
+package chsql_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// searchTraceLimitScanTable is the spans table the SearchTraceLimit guard
+// fixtures scan. Named so the assertion below can look for it in the
+// emitted SQL: a guard that failed OPEN would render the input subtree,
+// and the input subtree is the only thing that puts this token in the
+// output.
+const searchTraceLimitScanTable = "otel_traces"
+
+func searchTraceLimitNode(traceLimit int64) *chplan.SearchTraceLimit {
+	return &chplan.SearchTraceLimit{
+		Input:           &chplan.Scan{Table: searchTraceLimitScanTable, Columns: []string{"TraceId", "Timestamp"}},
+		TraceIDColumn:   "TraceId",
+		TimestampColumn: "Timestamp",
+		TraceLimit:      traceLimit,
+	}
+}
+
+// TestEmitSearchTraceLimit_NonPositiveLimitFailsClosed pins that a
+// SearchTraceLimit carrying a non-positive TraceLimit is REJECTED rather
+// than emitted as its bare input.
+//
+// The top-N subquery is the only thing bounding /api/search's drain to N
+// traces. Emitting the input unchanged (the previous behaviour) silently
+// removed that bound and drained every trace matching the window — a
+// scan-amplification defect no assertion could observe, because the
+// emitter reported success. Failing closed matches every sibling guard in
+// the package (emitTopK, emitMetricsSecondStageTopK,
+// lagAdjacencyMatrixShapeCheck).
+func TestEmitSearchTraceLimit_NonPositiveLimitFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		limit int64
+	}{
+		{name: "zero limit", limit: 0},
+		{name: "negative limit", limit: -1},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, _, err := chsql.Emit(context.Background(), searchTraceLimitNode(tc.limit))
+			if err == nil {
+				t.Fatalf("Emit(SearchTraceLimit{TraceLimit: %d}) returned no error; it emitted:\n%s\n"+
+					"A non-positive trace limit must be rejected — emitting the input unchanged "+
+					"drops the top-N restriction and drains every matching trace.", tc.limit, sql)
+			}
+			if !errors.Is(err, chsql.ErrUnsupported) {
+				t.Errorf("error %v does not wrap chsql.ErrUnsupported; callers classify emit "+
+					"rejections by that sentinel", err)
+			}
+			// The fail-open shape returned the input subtree's SQL, which
+			// necessarily scans the spans table. Assert the table name is
+			// absent so restoring `return e.emitNode(n.Input)` fails here
+			// even if the emitter ever returned SQL alongside an error.
+			if strings.Contains(sql, searchTraceLimitScanTable) {
+				t.Errorf("rejected emit leaked the unbounded input scan of %q:\n%s",
+					searchTraceLimitScanTable, sql)
+			}
+		})
+	}
+}
+
+// TestEmitQueryExemplars_ZeroBoundRejected pins that a zero start or end
+// is rejected with a wrapped ErrUnsupported instead of being formatted
+// into the SQL as `0001-01-01 00:00:00.000000000` — a bound that reads as
+// a real window but is either unbounded below or empty by construction.
+//
+// The HTTP handler validates the range too
+// (internal/api/prom/exemplars.go), but the emitter is a public entry
+// point and must not depend on its caller for that.
+func TestEmitQueryExemplars_ZeroBoundRejected(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	valid := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	predicate := chsql.Eq(chsql.Col(s.MetricNameColumn), chsql.Lit("http_requests_total"))
+	// The zero time renders through Go's reference layout as this literal;
+	// asserting on it makes the test fail loudly if the guard is removed
+	// and the bound is silently formatted instead.
+	const zeroTimeLiteral = "0001-01-01 00:00:00.000000000"
+
+	cases := []struct {
+		name       string
+		start, end time.Time
+	}{
+		{name: "zero start", start: time.Time{}, end: valid},
+		{name: "zero end", start: valid, end: time.Time{}},
+		{name: "both zero", start: time.Time{}, end: time.Time{}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, args, _, err := chsql.EmitQueryExemplars(
+				context.Background(), s.GaugeTable, predicate, tc.start, tc.end, s,
+			)
+			if err == nil {
+				t.Fatalf("EmitQueryExemplars accepted a zero bound; it emitted:\n%s\nargs: %v", sql, args)
+			}
+			if !errors.Is(err, chsql.ErrUnsupported) {
+				t.Errorf("error %v does not wrap chsql.ErrUnsupported", err)
+			}
+			for _, a := range args {
+				if got, ok := a.(string); ok && got == zeroTimeLiteral {
+					t.Errorf("zero time was formatted into the bound args as %q", zeroTimeLiteral)
+				}
+			}
+		})
+	}
+
+	// The union entry point threads through the same builder, so it must
+	// reject identically rather than only on the single-arm path.
+	t.Run("union arm", func(t *testing.T) {
+		t.Parallel()
+
+		arms := []chsql.ExemplarArm{
+			{Table: s.GaugeTable, Predicate: predicate},
+			{Table: s.SumTable, Predicate: predicate},
+		}
+		if _, _, _, err := chsql.EmitQueryExemplarsUnion(
+			context.Background(), arms, time.Time{}, valid, s,
+		); !errors.Is(err, chsql.ErrUnsupported) {
+			t.Errorf("EmitQueryExemplarsUnion with a zero start: err = %v, want ErrUnsupported", err)
+		}
+	})
+}

--- a/internal/chsql/query_exemplars.go
+++ b/internal/chsql/query_exemplars.go
@@ -255,6 +255,17 @@ func queryExemplarsSelect(
 		err := fmt.Errorf("%w: schema.Metrics.TimestampColumn is empty", ErrUnsupported)
 		return nil, err
 	}
+	// A zero bound is rejected rather than formatted: dateTime64Frag would
+	// render Go's zero time as the literal `0001-01-01 00:00:00.000000000`,
+	// a silently-unbounded lower edge (or an empty-by-construction upper
+	// edge) that reads as a real window in the emitted SQL. The HTTP
+	// handler already rejects a missing/unparseable start or end
+	// (internal/api/prom/exemplars.go::handleQueryExemplars); this guard
+	// closes the same hole for any other caller of the emitter.
+	if start.IsZero() || end.IsZero() {
+		err := fmt.Errorf("%w: exemplars time range has a zero bound (start zero: %t, end zero: %t)", ErrUnsupported, start.IsZero(), end.IsZero())
+		return nil, err
+	}
 
 	// Inner SELECT — fans out via `arrayJoin(arrayEnumerate(...))` and
 	// applies all predicates ahead of the fan-out so the cross product
@@ -333,8 +344,10 @@ func queryExemplarsSelect(
 // section in fixtures across the codebase stays uniform: a string
 // "2026-01-01 00:00:00.000000000" followed by an int64 9.
 //
-// Zero `t` panics — callers must validate the time range before
-// reaching this emitter.
+// It formats whatever it is handed, including Go's zero time — the
+// bound is validated by its one caller, queryExemplarsSelect, which
+// rejects a zero start or end with ErrUnsupported before reaching here,
+// so this never renders `0001-01-01 00:00:00.000000000`.
 func dateTime64Frag(t time.Time) Frag {
 	return Call(
 		"toDateTime64",

--- a/internal/chsql/range_bucket_grid_native_bound.go
+++ b/internal/chsql/range_bucket_grid_native_bound.go
@@ -511,10 +511,11 @@ func bucketGridGroupCountGuardFrag(probeCount *QueryBuilder, numAnchors, maxRows
 // A real production deployment on v1.16.1 was hitting this guard's throwIf
 // repeatedly on an ordinary dashboard panel (shape `cerb:project;agg=3;rbf;rbn`,
 // `decision_reason=not-sliceable`) even though axis1 (#2651/#2653) had
-// already been recalibrated. At the time, `RangeBucketGridNative` was
-// deliberately absent from `chplan.IsSliceInvariant`'s registry — never
-// sliceable, by design — so a slicing fallback for `not-sliceable` was not an
-// available fix shape and the guard's own calibration was the only lever.
+// already been recalibrated. At the time — a premise that NO LONGER HOLDS,
+// see the next paragraph — `RangeBucketGridNative` was deliberately absent
+// from `chplan.IsSliceInvariant`'s registry — never sliceable, by design — so
+// a slicing fallback for `not-sliceable` was not an available fix shape and
+// the guard's own calibration was the only lever.
 //
 // That premise was INVERTED by #2677, which registered the kind slice-invariant
 // (`chplan/sliceinvariant.go`; the test that pinned the old refusal is now

--- a/internal/chsql/search_trace_limit.go
+++ b/internal/chsql/search_trace_limit.go
@@ -59,9 +59,12 @@ func (e *emitter) emitSearchTraceLimit(n *chplan.SearchTraceLimit) error {
 		return fmt.Errorf("%w: SearchTraceLimit column names unset", ErrUnsupported)
 	}
 	if n.TraceLimit <= 0 {
-		// Defensive: the lowering never builds the node with a non-positive
-		// limit. Emit the input unchanged rather than a degenerate LIMIT.
-		return e.emitNode(n.Input)
+		// The lowering gates node construction on `limit > 0`
+		// (internal/traceql/search_limit.go::stampSearchTraceLimit), so the
+		// only path here is a programmer error in a lowering or rewrite.
+		// Reject it: emitting the input unchanged would silently drop the
+		// top-N restriction and drain every matching trace in the window.
+		return fmt.Errorf("%w: SearchTraceLimit with non-positive TraceLimit=%d", ErrUnsupported, n.TraceLimit)
 	}
 
 	outerSub, err := e.subqueryFrag(n.Input)

--- a/internal/config/ch_connection.go
+++ b/internal/config/ch_connection.go
@@ -58,8 +58,6 @@ type chExtra struct {
 	rawHTTPURLPath     string
 	rawHTTPMaxConns    int
 	rawHTTPProxyURL    string
-	rawConnStrategy    string
-	singleAddr         bool
 }
 
 // keepAliveInputs groups the four already-parsed TCP-keepalive knobs so they
@@ -233,15 +231,13 @@ func chExtraFromEnv(v *viper.Viper) (chExtra, error) {
 	var out chExtra
 
 	// Multi-host address list. CERBERUS_CH_ADDR is comma-separated; trim each
-	// entry, drop empties, require at least one. A single host (the common
-	// case) yields a one-element slice and singleAddr=true (used to note the
-	// pointless round_robin-with-one-host combo).
+	// entry, drop empties, require at least one. A single host is the common
+	// case and yields a one-element slice.
 	addrs, err := parseAddrs(getString(v, envCHAddr))
 	if err != nil {
 		return chExtra{}, fmt.Errorf("%s: %w", envCHAddr, err)
 	}
 	out.Addrs = addrs
-	out.singleAddr = len(addrs) == 1
 
 	// Protocol enum.
 	switch proto := strings.ToLower(getString(v, envCHProtocol)); proto {
@@ -256,7 +252,6 @@ func chExtraFromEnv(v *viper.Viper) (chExtra, error) {
 
 	// Connection-open strategy enum.
 	strategy := strings.ToLower(getString(v, envCHConnOpenStrategy))
-	out.rawConnStrategy = strategy
 	switch strategy {
 	case chConnOpenInOrder:
 		out.ConnOpenStrategy = clickhouse.ConnOpenInOrder

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2028,22 +2028,26 @@ func queryMaxSamplesFromEnv(v *viper.Viper) (int64, error) {
 	return resolveQueryMaxSamples(n)
 }
 
-// defaultRBGNMaxRows / defaultRBGNMaxDensityUnits mirror
-// internal/chsql's own maxRangeBucketGridNativeRows (25,000,000) /
-// maxRangeBucketGridNativeDensityUnits (400,000,000) — kept as independent
-// constants, the same duplication defaultDeltaPrefixLookback's own doc
+// defaultRBGNMaxRows mirrors internal/chsql's own
+// maxRangeBucketGridNativeRows (25,000,000) — kept as an independent
+// constant, the same duplication defaultDeltaPrefixLookback's own doc
 // already establishes the precedent for (chsql may not import
-// internal/config; see .go-arch-lint.yml), so Config.RangeBucketGridNativeMaxRows
-// / Config.RangeBucketGridNativeMaxDensityUnits resolve to the SAME
-// real-ClickHouse-calibrated values chsql itself falls back to when
-// nothing threads a ctx override at all. See
+// internal/config; see .go-arch-lint.yml), so
+// Config.RangeBucketGridNativeMaxRows resolves to the SAME
+// real-ClickHouse-calibrated value chsql itself falls back to when nothing
+// threads a ctx override at all. See
 // internal/chsql/range_bucket_grid_native_bound.go's own calibration doc
-// for the real evidence grounding both numbers, and its "Operator
-// override" section for why raising either above these defaults forfeits
-// that evidence.
+// for the real evidence grounding the number, and its "Operator override"
+// section for why raising it above this default forfeits that evidence.
+//
+// The density axis has NO such mirrored default, deliberately: unlike rows,
+// resolveRBGNMaxDensityUnits derives the unset (0) case from
+// CERBERUS_CH_QUERY_MAX_MEMORY via rbgnDensityUnitsForMemory rather than
+// falling back to a fixed number. A defaultRBGNMaxDensityUnits constant sat
+// here claiming to be that fallback until #3188; nothing read it, and the
+// value it named (400,000,000) was not what an unset knob resolves to.
 const (
-	defaultRBGNMaxRows         int64 = 25_000_000
-	defaultRBGNMaxDensityUnits int64 = 400_000_000
+	defaultRBGNMaxRows int64 = 25_000_000
 
 	// rbgnDensityUnitsPerGiB is the density bound granted per GiB of
 	// CERBERUS_CH_QUERY_MAX_MEMORY, and rbgnDensityUnitsFloor is the bound a

--- a/internal/engine/cardinality_probe_wiring.go
+++ b/internal/engine/cardinality_probe_wiring.go
@@ -371,15 +371,20 @@ func cardinalityProbeEffectiveDistinctSeries(est chclient.CardinalityEstimate) u
 // ESTIMATE's granule-resolution upper bound for the SAME K-clamp arithmetic
 // planner.go already applies (solver.ScanEstimate.Rows' own doc) — while
 // Parts/Marks (EXPLAIN-ESTIMATE-only, unread by classify()) pass through
-// untouched. DistinctSeries is always set from the probe: base never
-// carries one (ScanEstimateAdvisor has no comparable per-series signal).
+// untouched.
+//
+// The distinct-series reading is deliberately NOT folded in. It has exactly
+// one consumer, maybeSeedPerRungPrior, which reads it off the
+// chclient.CardinalityEstimate directly and through
+// cardinalityProbeEffectiveDistinctSeries — the saturation-aware resolver a
+// raw copy would bypass. solver.ScanEstimate carried a DistinctSeries field
+// that this function wrote and nothing ever read (#3188).
 func mergeCardinalityEstimate(base *solver.ScanEstimate, est chclient.CardinalityEstimate) *solver.ScanEstimate {
 	merged := solver.ScanEstimate{}
 	if base != nil {
 		merged = *base
 	}
 	merged.Rows = est.Rows
-	merged.DistinctSeries = est.DistinctSeries
 	return &merged
 }
 

--- a/internal/engine/cardinality_probe_wiring_test.go
+++ b/internal/engine/cardinality_probe_wiring_test.go
@@ -138,11 +138,12 @@ func TestCardinalityProbeAdvisor_SkipsWhenRouteMemoHasVerdict(t *testing.T) {
 	key := cardinalityProbeTestKey()
 
 	memo := routememo.New(time.Hour)
-	memo.Observe(key, routememo.RouteA, routememo.OutcomeResourceFailure)
-	memo.Observe(key, routememo.RouteA, routememo.OutcomeResourceFailure)
-	release, ok := memo.BeginProbe(key)
+	for i := 0; i < routememo.MinCorroboratingFailures-1; i++ {
+		memo.Observe(key, routememo.RouteA, routememo.OutcomeResourceFailure)
+	}
+	release, ok, _ := memo.ObserveRouteAFailureAndMaybeBeginProbe(key)
 	if !ok {
-		t.Fatalf("BeginProbe declined admission for a corroborated key")
+		t.Fatalf("route memo declined probe admission for a corroborated key")
 	}
 	memo.Observe(key, routememo.RouteB, routememo.OutcomeSuccess)
 	release()

--- a/internal/engine/cardinality_probe_wiring_test.go
+++ b/internal/engine/cardinality_probe_wiring_test.go
@@ -98,16 +98,16 @@ func TestCardinalityProbeAdvisor_SkipsSecondProbeForSameShapeAndMetric(t *testin
 	baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
 
 	first := a.Advise(context.Background(), nil, plan, baseline, nil)
-	if first == nil || first.Rows != 500_000 || first.DistinctSeries != 40 {
-		t.Fatalf("first probe: got %+v, want Rows=500000, DistinctSeries=40", first)
+	if first == nil || first.Rows != 500_000 {
+		t.Fatalf("first probe: got %+v, want Rows=500000", first)
 	}
 	if probe.calls != 1 {
 		t.Fatalf("first probe issued %d round trips, want 1", probe.calls)
 	}
 
 	second := a.Advise(context.Background(), nil, plan, baseline, nil)
-	if second == nil || second.Rows != 500_000 || second.DistinctSeries != 40 {
-		t.Fatalf("second probe (cached): got %+v, want Rows=500000, DistinctSeries=40", second)
+	if second == nil || second.Rows != 500_000 {
+		t.Fatalf("second probe (cached): got %+v, want Rows=500000", second)
 	}
 	if probe.calls != 1 {
 		t.Fatalf("second probe for the SAME (shape, metric) issued %d round trips, want 1 (cache hit)", probe.calls)
@@ -351,8 +351,8 @@ func TestCardinalityProbeAdvisor_ProbesNewCarrierKinds(t *testing.T) {
 			baseline := cardinalityProbeTestBaseline(solver.ReasonRouted)
 
 			got := a.Advise(context.Background(), nil, plan, baseline, nil)
-			if got == nil || got.Rows != 500_000 || got.DistinctSeries != 40 {
-				t.Fatalf("%s: got %+v, want Rows=500000, DistinctSeries=40", name, got)
+			if got == nil || got.Rows != 500_000 {
+				t.Fatalf("%s: got %+v, want Rows=500000", name, got)
 			}
 			if probe.calls != 1 {
 				t.Fatalf("%s: issued %d round trips, want 1", name, probe.calls)
@@ -411,9 +411,6 @@ func TestCardinalityProbeAdvisor_MergesWithExistingEstimate(t *testing.T) {
 	}
 	if got.Rows != 900_000 {
 		t.Fatalf("got Rows=%d, want the REAL probe count (900000) to supersede the granule upper bound", got.Rows)
-	}
-	if got.DistinctSeries != 12 {
-		t.Fatalf("got DistinctSeries=%d, want 12", got.DistinctSeries)
 	}
 	if current.Rows != 500_000 {
 		t.Fatalf("merge must not mutate the caller's current estimate in place; got Rows=%d", current.Rows)

--- a/internal/engine/explain_estimate_wiring_test.go
+++ b/internal/engine/explain_estimate_wiring_test.go
@@ -147,11 +147,12 @@ func TestScanEstimateAdvisor_SkipsWhenRouteMemoHasVerdict(t *testing.T) {
 	key := estimateTestKey()
 
 	memo := routememo.New(time.Hour)
-	memo.Observe(key, routememo.RouteA, routememo.OutcomeResourceFailure)
-	memo.Observe(key, routememo.RouteA, routememo.OutcomeResourceFailure)
-	release, ok := memo.BeginProbe(key)
+	for i := 0; i < routememo.MinCorroboratingFailures-1; i++ {
+		memo.Observe(key, routememo.RouteA, routememo.OutcomeResourceFailure)
+	}
+	release, ok, _ := memo.ObserveRouteAFailureAndMaybeBeginProbe(key)
 	if !ok {
-		t.Fatalf("BeginProbe declined admission for a corroborated key")
+		t.Fatalf("route memo declined probe admission for a corroborated key")
 	}
 	memo.Observe(key, routememo.RouteB, routememo.OutcomeSuccess)
 	release()

--- a/internal/engine/route_memo_wiring.go
+++ b/internal/engine/route_memo_wiring.go
@@ -307,16 +307,16 @@ func (e *Engine) tryRouteMemoHit(
 // retried is true once Executor.Execute itself returns without a
 // pre-flight error — a cursor was opened, not that route B is known to have
 // succeeded. This retry IS the probe that decides the Key's very first
-// verdict (BeginProbe only ever admits an Unknown Key): a clean drain is
-// what CREATES a PreferB entry (Memo.Observe's OutcomeSuccess branch), so —
-// unlike a memo-hit, where the verdict already exists and a success needs
-// no re-confirmation — this dispatch's real outcome cannot be assumed and
-// must be reported from the caller's ACTUAL drain result, success or
-// failure alike. observeFn is that hook: the caller MUST call it exactly
-// once, with the drain error (nil on a clean finish), whenever retried is
-// true. Skipping it silently drops the one observation this probe exists to
-// make, leaving the Key permanently Unknown no matter how many times route A
-// goes on failing it.
+// verdict (first-probe admission only ever grants a token to an Unknown
+// Key): a clean drain is what CREATES a PreferB entry (Memo.Observe's
+// OutcomeSuccess branch), so — unlike a memo-hit, where the verdict already
+// exists and a success needs no re-confirmation — this dispatch's real
+// outcome cannot be assumed and must be reported from the caller's ACTUAL
+// drain result, success or failure alike. observeFn is that hook: the
+// caller MUST call it exactly once, with the drain error (nil on a clean
+// finish), whenever retried is true. Skipping it silently drops the one
+// observation this probe exists to make, leaving the Key permanently
+// Unknown no matter how many times route A goes on failing it.
 // responseShape is the dispatching adapter's engine.Meta.ResponseShape,
 // threaded for the same reason as on tryRouteMemoHit: this dispatch opens
 // route-B cursors, so it declares the shape through routeBExecCtx. It matters

--- a/internal/optimizer/constant_fold.go
+++ b/internal/optimizer/constant_fold.go
@@ -145,10 +145,11 @@ func foldNode(n chplan.Node, foldFn func(chplan.Expr) (chplan.Expr, bool)) (chpl
 //
 // Every chplan Expr kind that holds a child Expr must appear here or in
 // foldExprSingleChild — a missing case silently strands any pure-literal
-// subtree nested inside it unfolded. This mirrors projection_pushdown.go's
-// walkExpr, which documents the same exhaustiveness requirement for
-// column-reference discovery; the switches should be kept in lockstep over
-// the chplan Expr vocabulary.
+// subtree nested inside it unfolded. This mirrors chplan.InspectExpr (the
+// traversal projection_pushdown.go's stageColumns uses for
+// column-reference discovery), whose own exhaustiveness is ratcheted by
+// chplan's TestInspectExprExhaustive; the switches should be kept in
+// lockstep over the chplan Expr vocabulary.
 func foldExprWith(e chplan.Expr, foldBinary func(*chplan.Binary) (chplan.Expr, bool)) (chplan.Expr, bool) {
 	switch v := e.(type) {
 	case *chplan.Binary:

--- a/internal/optimizer/fold_property_test.go
+++ b/internal/optimizer/fold_property_test.go
@@ -3,11 +3,37 @@
 // The fold helpers (`foldIntInt`, `foldFloatFloat`) are the analyzer rule's
 // hot path: every pure-literal Binary subtree in a Filter predicate,
 // Project expression, or Aggregate group-by / arg expression flows through
-// them. They must be drop-in replacements for the Go-native operator on
-// the underlying scalar type — there is no other ground truth to compare
-// against. A divergence here would silently flip the row set of any plan
-// that contained a literal arithmetic subtree (`metric{} - 1` after a
+// them. A divergence here would silently flip the row set of any plan that
+// contained a literal arithmetic subtree (`metric{} - 1` after a
 // `LitInt - LitInt` fold, etc.).
+//
+// The INT oracle is arbitrary-precision, not the Go operator. This file used to
+// assert `foldIntInt(OpAdd, l, r) == l + r`, restating the implementation with
+// a second copy of the same Go operator (#3188). That form does catch a change
+// to foldIntInt itself, but it can only ever conclude "the fold agrees with
+// Go" — and agreeing with Go is not the requirement. Folding `LitInt op LitInt`
+// REPLACES arithmetic ClickHouse would otherwise have performed, so the fold is
+// correct only if it matches CLICKHOUSE. Over the overflow region that is a
+// substantive claim, and an oracle spelled `l + r` asserts it vacuously: it
+// reads as if wraparound had been verified when nothing about ClickHouse was
+// consulted.
+//
+// wrappedInt64 computes the exact result in math/big and reduces it into
+// int64's range, so it states the owed contract outright — ClickHouse Int64
+// arithmetic wraps two's-complement, it neither saturates nor throws — rather
+// than deferring to whatever Go happens to do.
+//
+// That the contract HOLDS against a real engine is settled where it can only be
+// settled, against ClickHouse itself:
+// test/property/int_fold_ch_agreement_test.go (build tag chdb) drives these
+// same operand pairs through the shipped ConstantFoldSemantic rule and through
+// chDB, and requires them to agree.
+//
+// The FLOAT oracle is still Go's own operator, and that is not the same
+// mistake: IEEE-754 double semantics are the contract, ClickHouse Float64
+// evaluates them, and Go evaluates the same hardware ones. There is no
+// higher-precision oracle for NaN / signed-zero / Inf propagation, and
+// math/big has no NaN or Inf at all.
 //
 // The audit at PR #375 Round 4 flagged `foldFloatFloat` at 0% line
 // coverage and `foldIntInt` at 21%. These property tests close that gap
@@ -38,6 +64,7 @@ package optimizer
 
 import (
 	"math"
+	"math/big"
 	"testing"
 
 	"pgregory.net/rapid"
@@ -46,17 +73,53 @@ import (
 )
 
 // arithIntOps enumerates the integer arithmetic ops the fold helper
-// supports. Each op must produce a *chplan.LitInt with the same value
-// as the native Go operator. `OpDiv` is handled separately so the
+// supports. Each must produce a *chplan.LitInt holding the value
+// wrappedInt64 derives independently. `OpDiv` is handled separately so the
 // property can guard against division-by-zero (the helper declines the
 // rewrite — returns `(nil, false)`).
-var arithIntOps = []struct {
-	op chplan.BinaryOp
-	fn func(a, b int64) int64
-}{
-	{chplan.OpAdd, func(a, b int64) int64 { return a + b }},
-	{chplan.OpSub, func(a, b int64) int64 { return a - b }},
-	{chplan.OpMul, func(a, b int64) int64 { return a * b }},
+var arithIntOps = []chplan.BinaryOp{chplan.OpAdd, chplan.OpSub, chplan.OpMul}
+
+// int64Bits is the width wrappedInt64 reduces into, and int64SignBit is the
+// bit whose value decides whether that reduction is a negative number in
+// two's-complement.
+const (
+	int64Bits    = 64
+	int64SignBit = int64Bits - 1
+)
+
+// wrappedInt64 is the independent oracle for foldIntInt's arithmetic: it
+// computes a op b EXACTLY in arbitrary precision and only then reduces the
+// result into int64, so it shares no arithmetic with the implementation.
+//
+// The reduction is modulo 2^64 with the high half reinterpreted as negative —
+// two's-complement wraparound, which is what ClickHouse's Int64 `+`/`-`/`*`
+// do (they neither saturate nor raise). Stating it this way means a fold that
+// saturated at MaxInt64, promoted to a wider type, or declined on overflow
+// would each be caught, where comparing against Go's own operator could catch
+// none of them.
+func wrappedInt64(op chplan.BinaryOp, a, b int64) int64 {
+	x := new(big.Int).SetInt64(a)
+	y := new(big.Int).SetInt64(b)
+	z := new(big.Int)
+	switch op {
+	case chplan.OpAdd:
+		z.Add(x, y)
+	case chplan.OpSub:
+		z.Sub(x, y)
+	case chplan.OpMul:
+		z.Mul(x, y)
+	default:
+		panic("wrappedInt64: " + string(op) + " is not an arithmetic op this oracle models")
+	}
+
+	modulus := new(big.Int).Lsh(big.NewInt(1), int64Bits)
+	// big.Int.Mod is Euclidean, so the result lands in [0, 2^64) whatever the
+	// sign of z — which is exactly the unsigned bit pattern to reinterpret.
+	z.Mod(z, modulus)
+	if z.Cmp(new(big.Int).Lsh(big.NewInt(1), int64SignBit)) >= 0 {
+		z.Sub(z, modulus)
+	}
+	return z.Int64()
 }
 
 // arithFloatOps mirrors arithIntOps for float64. `OpDiv` is again
@@ -159,24 +222,24 @@ func drawFloat64(t *rapid.T, label string) float64 {
 func TestFoldIntInt_Arithmetic(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range arithIntOps {
-		tc := tc
-		t.Run(string(tc.op), func(t *testing.T) {
+	for _, op := range arithIntOps {
+		t.Run(string(op), func(t *testing.T) {
 			t.Parallel()
 			rapid.Check(t, func(t *rapid.T) {
 				l := drawInt64(t, "l")
 				r := drawInt64(t, "r")
-				got, ok := foldIntInt(tc.op, l, r)
+				got, ok := foldIntInt(op, l, r)
 				if !ok {
-					t.Fatalf("foldIntInt(%v, %d, %d) declined the fold; expected a LitInt", tc.op, l, r)
+					t.Fatalf("foldIntInt(%v, %d, %d) declined the fold; expected a LitInt", op, l, r)
 				}
 				lit, isInt := got.(*chplan.LitInt)
 				if !isInt {
-					t.Fatalf("foldIntInt(%v, %d, %d) = %T; want *chplan.LitInt", tc.op, l, r, got)
+					t.Fatalf("foldIntInt(%v, %d, %d) = %T; want *chplan.LitInt", op, l, r, got)
 				}
-				want := tc.fn(l, r)
+				want := wrappedInt64(op, l, r)
 				if lit.V != want {
-					t.Fatalf("foldIntInt(%v, %d, %d) = %d; want %d", tc.op, l, r, lit.V, want)
+					t.Fatalf("foldIntInt(%v, %d, %d) = %d; want %d (exact big.Int result reduced "+
+						"into int64 two's-complement)", op, l, r, lit.V, want)
 				}
 			})
 		})
@@ -511,4 +574,105 @@ func floatEqualIEEE(a, b float64) bool {
 		return true
 	}
 	return a == b
+}
+
+// saturatingInt64 is a DELIBERATELY WRONG fold: it clamps at the int64
+// boundaries instead of wrapping. It exists only for the meta-test below.
+//
+// It is the most plausible way foldIntInt could actually be got wrong: a
+// well-meaning overflow guard.
+func saturatingInt64(op chplan.BinaryOp, a, b int64) int64 {
+	x := new(big.Int).SetInt64(a)
+	y := new(big.Int).SetInt64(b)
+	z := new(big.Int)
+	switch op {
+	case chplan.OpAdd:
+		z.Add(x, y)
+	case chplan.OpSub:
+		z.Sub(x, y)
+	case chplan.OpMul:
+		z.Mul(x, y)
+	default:
+		panic("saturatingInt64: unsupported op " + string(op))
+	}
+	if z.Cmp(big.NewInt(math.MaxInt64)) > 0 {
+		return math.MaxInt64
+	}
+	if z.Cmp(big.NewInt(math.MinInt64)) < 0 {
+		return math.MinInt64
+	}
+	return z.Int64()
+}
+
+// TestWrappedInt64OracleIsIndependent proves the oracle
+// TestFoldIntInt_Arithmetic compares against can actually reject a wrong fold.
+//
+// Two claims, and both are needed:
+//
+//   - On operands that do NOT overflow, the oracle agrees with the Go operator.
+//     Without this the oracle could be arbitrary and the property would fail on
+//     correct code.
+//   - On operands that DO overflow, the oracle disagrees with a saturating
+//     fold — the most plausible way this could actually be got wrong, a
+//     well-meaning overflow guard. An oracle that cannot separate wrapping from
+//     saturating is not an oracle for the thing this file claims to pin.
+func TestWrappedInt64OracleIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("agrees with the Go operator below overflow", func(t *testing.T) {
+		t.Parallel()
+		rapid.Check(t, func(t *rapid.T) {
+			// Half-width operands: no int64 product or sum can overflow.
+			l := int64(rapid.Int32().Draw(t, "l"))
+			r := int64(rapid.Int32().Draw(t, "r"))
+			for _, op := range arithIntOps {
+				var want int64
+				switch op {
+				case chplan.OpAdd:
+					want = l + r
+				case chplan.OpSub:
+					want = l - r
+				case chplan.OpMul:
+					want = l * r
+				}
+				if got := wrappedInt64(op, l, r); got != want {
+					t.Fatalf("wrappedInt64(%v, %d, %d) = %d; want %d — the oracle disagrees with "+
+						"the Go operator on operands that cannot overflow", op, l, r, got, want)
+				}
+			}
+		})
+	})
+
+	t.Run("rejects a saturating fold on overflow", func(t *testing.T) {
+		t.Parallel()
+		overflowing := []struct {
+			op   chplan.BinaryOp
+			l, r int64
+		}{
+			{chplan.OpAdd, math.MaxInt64, 1},
+			{chplan.OpSub, math.MinInt64, 1},
+			{chplan.OpMul, math.MaxInt64, 2},
+			{chplan.OpMul, math.MinInt64, -1},
+		}
+		for _, c := range overflowing {
+			wrapped := wrappedInt64(c.op, c.l, c.r)
+			saturated := saturatingInt64(c.op, c.l, c.r)
+			if wrapped == saturated {
+				t.Errorf("wrappedInt64(%v, %d, %d) = saturatingInt64(...) = %d — the oracle cannot "+
+					"tell a wrapping fold from a saturating one here, so the property it backs "+
+					"could not catch that regression", c.op, c.l, c.r, wrapped)
+			}
+			// And the real implementation is the wrapping one.
+			got, ok := foldIntInt(c.op, c.l, c.r)
+			if !ok {
+				t.Fatalf("foldIntInt(%v, %d, %d) declined an overflowing fold; ClickHouse Int64 "+
+					"arithmetic wraps rather than refusing", c.op, c.l, c.r)
+			}
+			lit, isInt := got.(*chplan.LitInt)
+			if !isInt || lit.V != wrapped {
+				t.Errorf("foldIntInt(%v, %d, %d) = %v; want the wrapped value %d",
+					c.op, c.l, c.r, got, wrapped)
+			}
+		}
+	})
 }

--- a/internal/optimizer/projection_pushdown.go
+++ b/internal/optimizer/projection_pushdown.go
@@ -509,6 +509,23 @@ func histogramQuantileColumns(h *chplan.HistogramQuantile) []string {
 // silently omitted Having and rangeWindowColumns silently omitted
 // TemporalityColumn and the fused Variants arms: a field added to a plan
 // node was eight places to remember, not one.
+//
+// The Expr traversal is [chplan.InspectExpr], and that choice is
+// correctness-critical rather than a convenience: an Expr kind the walk
+// does not descend into silently hides the columns its subtree reads,
+// ProjectionPushdown then prunes them off the Scan, and ClickHouse fails
+// outer-scope resolution with error 47 (UNKNOWN_IDENTIFIER). That exact
+// escape — FieldAccess.Source unwalked, so `| select(span.http.method)`'s
+// SpanAttributes carrier was pruned on the plain-filter /api/search arm —
+// 502'd Grafana's showcase select panel; see
+// internal/api/tempo/search_select_plain_filter_chdb_test.go for the
+// end-to-end pin. InspectExpr's switch is exhaustive over the sealed Expr
+// set and is ratcheted by chplan's TestInspectExprExhaustive, so a newly
+// added Expr kind cannot reintroduce that class here without failing CI in
+// chplan first. Passing a nil nodeVisit keeps the traversal Expr-only: the
+// plan subtree embedded in a ScalarSubquery / InSubquery is a SEPARATE
+// relation whose column reads are satisfied inside its own scope, not off
+// the Scan this rule narrows.
 func stageColumns(bare []string, roots ...chplan.Expr) []string {
 	seen := map[string]struct{}{}
 	for _, c := range bare {
@@ -518,7 +535,7 @@ func stageColumns(bare []string, roots ...chplan.Expr) []string {
 	}
 	collect := collectColumn(seen)
 	for _, r := range roots {
-		walkExpr(r, collect)
+		chplan.InspectExpr(r, collect)
 	}
 	return sortedColumnSet(seen)
 }
@@ -607,17 +624,20 @@ func predicateColumns(e chplan.Expr) []string {
 	return stageColumns(nil, e)
 }
 
-// collectColumn returns a walkExpr visitor that records every column
-// name an expression node reads into seen. Three node kinds carry one:
-// ColumnRef (by definition), NestedArrayExists, whose Column field
+// collectColumn returns a [chplan.InspectExpr] visitor that records every
+// column name an expression node reads into seen. Three node kinds carry
+// one: ColumnRef (by definition), NestedArrayExists, whose Column field
 // names the Nested carrier (e.g. `Events`) as a plain string rather
 // than a child ColumnRef, and BoundedTraceScope, whose TraceIDColumn is
 // read as the LHS of its `<TraceId> IN (...)` predicate (a bare
 // outer-scope column, not a child ColumnRef) — omitting it would let
 // ProjectionPushdown prune TraceId off the Scan beneath a gated leaf and
-// emit an UNKNOWN_IDENTIFIER (the failure mode walkExpr's own doc names).
-func collectColumn(seen map[string]struct{}) func(chplan.Expr) {
-	return func(sub chplan.Expr) {
+// emit an UNKNOWN_IDENTIFIER (the failure mode stageColumns' own doc
+// names). The visitor always returns true: every sub-expression of a
+// projection or predicate is evaluated on the Scan's row shape, so there
+// is no subtree whose column reads may be skipped.
+func collectColumn(seen map[string]struct{}) func(chplan.Expr) bool {
+	return func(sub chplan.Expr) bool {
 		switch v := sub.(type) {
 		case *chplan.ColumnRef:
 			seen[v.Name] = struct{}{}
@@ -626,6 +646,7 @@ func collectColumn(seen map[string]struct{}) func(chplan.Expr) {
 		case *chplan.BoundedTraceScope:
 			seen[v.TraceIDColumn] = struct{}{}
 		}
+		return true
 	}
 }
 
@@ -657,59 +678,4 @@ func unionSortedColumns(a, b []string) []string {
 // in projs, deduped and sorted for deterministic emission.
 func referencedColumns(projs []chplan.Projection) []string {
 	return stageColumns(nil, projectionExprs(projs)...)
-}
-
-// walkExpr visits e and every Expr reachable from it. Every chplan
-// Expr kind that holds child Exprs must appear here: a missing case
-// silently hides the columns the subtree reads, ProjectionPushdown
-// then prunes them from the Scan, and ClickHouse fails outer-scope
-// resolution with error 47 (UNKNOWN_IDENTIFIER). That exact escape —
-// FieldAccess.Source unwalked, so `| select(span.http.method)`'s
-// SpanAttributes carrier was pruned on the plain-filter /api/search
-// arm — 502'd Grafana's showcase select panel; see
-// internal/api/tempo/search_select_plain_filter_chdb_test.go for the
-// end-to-end pin. There's no chplan-side helper for this yet because
-// the optimizer is so far the only caller; if we add a second consumer
-// it should graduate into chplan.
-func walkExpr(e chplan.Expr, visit func(chplan.Expr)) {
-	if e == nil {
-		return
-	}
-	visit(e)
-	switch v := e.(type) {
-	case *chplan.Binary:
-		walkExpr(v.Left, visit)
-		walkExpr(v.Right, visit)
-	case *chplan.InList:
-		walkExpr(v.Left, visit)
-		for _, e := range v.List {
-			walkExpr(e, visit)
-		}
-	case *chplan.FuncCall:
-		for _, a := range v.Args {
-			walkExpr(a, visit)
-		}
-	case *chplan.MapAccess:
-		walkExpr(v.Map, visit)
-		walkExpr(v.Key, visit)
-	case *chplan.FieldAccess:
-		walkExpr(v.Source, visit)
-	case *chplan.Subscript:
-		walkExpr(v.Container, visit)
-		walkExpr(v.Key, visit)
-	case *chplan.Lambda:
-		walkExpr(v.Body, visit)
-	case *chplan.LabelJoin:
-		walkExpr(v.Map, visit)
-	case *chplan.LabelReplace:
-		walkExpr(v.Map, visit)
-	case *chplan.LineContent:
-		walkExpr(v.Source, visit)
-	case *chplan.MapWithoutEmptyValues:
-		walkExpr(v.Map, visit)
-	case *chplan.MapWithoutKeys:
-		walkExpr(v.Map, visit)
-	case *chplan.NestedArrayExists:
-		walkExpr(v.Value, visit)
-	}
 }

--- a/internal/optimizer/projection_pushdown_test.go
+++ b/internal/optimizer/projection_pushdown_test.go
@@ -248,3 +248,139 @@ func TestAggregateColumns_Having(t *testing.T) {
 		t.Errorf("aggregateColumns() = %v, want %v", got, want)
 	}
 }
+
+// --- Expr-traversal exhaustiveness: the columns a pruned Scan must keep.
+//
+// stageColumns delegates its Expr walk to chplan.InspectExpr precisely so
+// that the "an unwalked Expr kind hides the columns its subtree reads,
+// ProjectionPushdown prunes them, ClickHouse answers error 47" class cannot
+// reopen. The three tests below pin that contract behaviourally, one per
+// Expr kind whose children the optimizer's former hand-rolled walk did NOT
+// descend into (WindowExpr, InSubquery) plus the one whose embedded plan it
+// deliberately must NOT descend into (ScalarSubquery). Each is a real
+// pruning shape: the surviving projection supplies at least one OTHER
+// column, so the rule fires and produces a narrowed Scan.Columns — a set
+// the missing column is absent from unless the traversal reaches it.
+
+// TestProjectionPushdown_KeepsWindowExprColumns pins that a column read
+// only from inside a WindowExpr (its Args or its PartitionBy) survives the
+// narrowing. `max(TimeUnix) OVER (PARTITION BY MetricName)` reads both off
+// the Scan the rule is about to prune.
+func TestProjectionPushdown_KeepsWindowExprColumns(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "v"},
+			{
+				Expr: &chplan.WindowExpr{
+					Fn:          chplan.FnMax,
+					Args:        []chplan.Expr{&chplan.ColumnRef{Name: "TimeUnix"}},
+					PartitionBy: []chplan.Expr{&chplan.ColumnRef{Name: "MetricName"}},
+				},
+				Alias: "series_end",
+			},
+		},
+	}
+
+	out, changed := ProjectionPushdown{}.Apply(plan)
+	if !changed {
+		t.Fatal("ProjectionPushdown did not fire on Project(Scan)")
+	}
+	got := narrowedScanColumns(t, out)
+	want := []string{"MetricName", "TimeUnix", "Value"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("narrowed Scan.Columns = %v, want %v — a column read only inside a WindowExpr was pruned", got, want)
+	}
+}
+
+// TestProjectionPushdown_KeepsInSubqueryLeftColumn pins that the LHS of an
+// `<col> IN (<subquery>)` predicate survives the narrowing. The predicate
+// is evaluated on the narrowed Scan's row shape, so pruning TraceId off it
+// emits SQL ClickHouse rejects with UNKNOWN_IDENTIFIER.
+func TestProjectionPushdown_KeepsInSubqueryLeftColumn(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input: &chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_traces"},
+			Predicate: &chplan.InSubquery{
+				Left:     &chplan.ColumnRef{Name: "TraceId"},
+				Subquery: &chplan.Scan{Table: "otel_traces", Columns: []string{"TraceId"}},
+			},
+		},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "SpanName"}, Alias: "name"},
+		},
+	}
+
+	out, changed := ProjectionPushdown{}.Apply(plan)
+	if !changed {
+		t.Fatal("ProjectionPushdown did not fire on Project(Filter(Scan))")
+	}
+	got := narrowedScanColumns(t, out)
+	want := []string{"SpanName", "TraceId"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("narrowed Scan.Columns = %v, want %v — the IN-subquery's LHS column was pruned", got, want)
+	}
+}
+
+// TestProjectionPushdown_IgnoresScalarSubqueryPlanColumns pins the other
+// half of the boundary: InspectExpr is called WITHOUT a node visitor, so a
+// ScalarSubquery's embedded plan — a separate relation whose column reads
+// are satisfied in its own scope — contributes nothing to the outer Scan's
+// column set. Widening the traversal to InspectExprNodes would leak
+// `InnerOnly` (a column of a different table) into this Scan.
+func TestProjectionPushdown_IgnoresScalarSubqueryPlanColumns(t *testing.T) {
+	t.Parallel()
+
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Projections: []chplan.Projection{
+			{
+				Expr: &chplan.Binary{
+					Op:   chplan.OpDiv,
+					Left: &chplan.ColumnRef{Name: "Value"},
+					Right: &chplan.ScalarSubquery{
+						Input: &chplan.Project{
+							Input:       &chplan.Scan{Table: "otel_metrics_sum"},
+							Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: "InnerOnly"}}},
+						},
+					},
+				},
+				Alias: "ratio",
+			},
+		},
+	}
+
+	out, changed := ProjectionPushdown{}.Apply(plan)
+	if !changed {
+		t.Fatal("ProjectionPushdown did not fire on Project(Scan)")
+	}
+	got := narrowedScanColumns(t, out)
+	want := []string{"Value"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("narrowed Scan.Columns = %v, want %v — the ScalarSubquery's own relation leaked into the outer Scan", got, want)
+	}
+}
+
+// narrowedScanColumns digs the (single) Scan out of a rewritten Project
+// tree and returns its Columns. Fails the test if the shape is not the
+// Project(Scan) / Project(Filter(Scan)) the pushdown produces.
+func narrowedScanColumns(t *testing.T, n chplan.Node) []string {
+	t.Helper()
+	p, ok := n.(*chplan.Project)
+	if !ok {
+		t.Fatalf("expected *chplan.Project at the root, got %T", n)
+	}
+	inner := p.Input
+	if f, isFilter := inner.(*chplan.Filter); isFilter {
+		inner = f.Input
+	}
+	s, ok := inner.(*chplan.Scan)
+	if !ok {
+		t.Fatalf("expected a *chplan.Scan under the Project, got %T", inner)
+	}
+	return s.Columns
+}

--- a/internal/optimizer/property_test.go
+++ b/internal/optimizer/property_test.go
@@ -146,14 +146,12 @@ func TestPropertyOptimizerSemanticEquivalence(t *testing.T) {
 	ctx := context.Background()
 	opt := optimizer.Default()
 
+	dropBudget := n * maxDroppedPlansPerVerified
 	tried := 0
 	dropped := 0
+	var lastDropErr error
 	for tried < n {
 		plan := generatePlan(rng, 0)
-		if plan == nil {
-			dropped++
-			continue
-		}
 
 		gotPre, errPre := runPlan(ctx, db, plan)
 		if errPre != nil {
@@ -161,6 +159,14 @@ func TestPropertyOptimizerSemanticEquivalence(t *testing.T) {
 			// (e.g. a degenerate Projection list). Skip — this is
 			// not what the property checks.
 			dropped++
+			lastDropErr = errPre
+			if dropped > dropBudget {
+				t.Fatalf("drop budget exhausted: %d generated plans failed their PRE-optimizer "+
+					"run after verifying only %d of %d (budget %d = %d x maxDroppedPlansPerVerified). "+
+					"Emission is broken for the generated shapes, so the property was never checked; "+
+					"last drop error: %v",
+					dropped, tried, n, dropBudget, n, lastDropErr)
+			}
 			continue
 		}
 
@@ -184,9 +190,25 @@ func TestPropertyOptimizerSemanticEquivalence(t *testing.T) {
 	}
 }
 
-// generatePlan builds a random plan tree with bounded depth. Returns
-// nil to signal "skip this iteration" when the generator picks a shape
-// that's known-ill (empty projection list, etc.).
+// maxDroppedPlansPerVerified bounds the generator's drop budget as a
+// multiple of the plans the property actually verifies, so the bound
+// scales with -short instead of being a second magic number beside n.
+//
+// A drop is a generated plan whose PRE-optimizer run failed to execute —
+// a generator/emitter mismatch, not a property violation, so the
+// iteration is discarded rather than failed. Under a healthy generator
+// drops are rare (the `SELECT *` column-count bug that made every
+// wildcard plan drop was fixed in runPlan), so any run that discards
+// twice as many plans as it verifies is reporting a regression in
+// emission, not sampling noise. Without the budget that regression made
+// the loop spin forever — `tried` only advances on a successful pre-run —
+// and a test that hangs reports nothing at all.
+const maxDroppedPlansPerVerified = 2
+
+// generatePlan builds a random plan tree with bounded depth. It always
+// returns a plan: every arm bottoms out in a Scan, and the Project arm
+// falls back to its own input when the projection list comes out empty,
+// so callers never have to handle a nil node.
 //
 // Depth budget: at depth 0 the generator picks any node type; once
 // depth ≥ 3 it bottoms out into a Scan to keep trees small. This

--- a/internal/optimizer/rule_interaction_test.go
+++ b/internal/optimizer/rule_interaction_test.go
@@ -2,41 +2,66 @@ package optimizer_test
 
 // Rule × rule interaction matrix (Layer 4 § A).
 //
-// The optimizer ships 6 named rules across 3 batches:
+// The optimizer ships 8 TREE-REWRITING rules across 5 batches — the
+// complete Default() registration minus the two verify-only rules
+// excluded below:
 //
-//   - ConstantFoldSemantic (analyzer batch)
+//   - ConstantFoldSemantic, NormalizeScanTimeBound (analyzer batches)
 //   - ConstantFoldHeuristic (Once batch)
 //   - FilterFusion, FilterAggregateTranspose,
 //     FilterRangeWindowTranspose (predicate-pushdown FixedPoint batch)
 //   - ProjectionPushdown (projection FixedPoint batch)
+//   - FlattenVectorSetOp (set-op-linearize FixedPoint batch)
 //
-// C(6,2) = 15 unordered pairs. For each pair the goal is the same:
-// construct a plan where BOTH rules are applicable, run a Driver
-// that registers exactly those two rules (in either order), and
-// assert the final tree is identical regardless of registration
-// order. This catches commutation bugs: a pair where the rule
-// firing order changes the converged tree shape would be a hazard
-// for the Catalyst-style Batch driver (each FixedPoint batch picks
-// up rules in declared order and iterates).
+// Excluded, deliberately and not as a gap: RequireScanTimeBound and
+// RequireScanResourceBound. Both are verify-only — neither ever returns
+// changed=true; they read the node, panic on a contract violation, and
+// hand the tree back untouched. A rule that cannot change the tree cannot
+// change the CONVERGED tree in either registration order, so a commutation
+// assertion over one would hold for any implementation including a no-op:
+// it would be a test that cannot fail. What those two rules actually have
+// to say is pinned where it can fail — scan_time_bound_test.go and
+// scan_resource_bound_test.go assert the panic fires on a violating plan
+// and that a conforming plan comes back unchanged. The exclusion is
+// enforced rather than asserted in prose:
+// TestRuleInteractionMatrixCoversDefaultRules reads the live Default()
+// registration and fails if a rule is neither in the matrix nor in the
+// named verify-only set.
 //
-// FilterProjectTranspose and MVSubstitution were retired (2026-06);
-// the pairs that involved them are gone, so the pair numbering below
-// is non-contiguous against the original 28-pair enumeration.
+// C(8,2) = 28 unordered pairs, and every one of them is exercised.
+// TestRuleInteractionMatrix enumerates the pairs from the rule list itself
+// and fails on any pair with no registered plan, so "every pair" is a
+// derived fact rather than a claim in a comment. For each pair the goal is
+// the same: construct a plan where BOTH rules are applicable, run a Driver
+// that registers exactly those two rules (in either order), and assert the
+// final tree is identical regardless of registration order. This catches
+// commutation bugs: a pair where the rule firing order changes the
+// converged tree shape would be a hazard for the Catalyst-style Batch
+// driver (each FixedPoint batch picks up rules in declared order and
+// iterates).
 //
-// Strategy. Rather than reach for `RunWithRuleOrder` (which the
-// driver doesn't expose), each test wires two NewWithBatches
-// drivers — one with `[r1, r2]` and one with `[r2, r1]`. Both run
-// inside a single FixedPoint(100) batch so the iteration order
-// converges. The pair is "interaction-stable" iff
+// FilterProjectTranspose and MVSubstitution were retired (2026-06); the
+// pairs that involved them are gone.
+//
+// Strategy. Rather than reach for `RunWithRuleOrder` (which the driver
+// doesn't expose), each pair wires two NewWithBatches drivers — one with
+// `[r1, r2]` and one with `[r2, r1]`. Both run inside a single
+// FixedPoint(100) batch so the iteration order converges. The pair is
+// "interaction-stable" iff
 // Driver(r1, r2).Run(plan).Equal(Driver(r2, r1).Run(plan)).
 //
-// Note. Some pairs are conceptually trivial (e.g. ConstantFoldSemantic
-// + ProjectionPushdown — they touch disjoint plan slots). We still
-// pin every pair so future rule additions can't quietly break a
-// commutation property the codebase implicitly relies on.
+// Note. Some pairs are conceptually trivial (e.g. ConstantFoldSemantic +
+// ProjectionPushdown — they touch disjoint plan slots). We still pin every
+// pair so future rule additions can't quietly break a commutation property
+// the codebase implicitly relies on. That motivation is exactly why
+// FlattenVectorSetOp belongs here despite running alone in its own batch
+// today: it REPLACES a VectorSetOp with a NaryVectorSetOp, a node the other
+// rules' patterns no longer match, so it is the one rule whose firing order
+// can decide whether another rule ever sees a subtree at all.
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -44,26 +69,208 @@ import (
 	"github.com/tsouza/cerberus/internal/optimizer"
 )
 
+// The eight tree-rewriting rules, instantiated once so matrixRules and the
+// pairPlans keys name the same objects — a pairPlans key is built by
+// pairKey from these very values, which is what makes a key impossible to
+// mistype into a pair that does not exist.
+var (
+	ruleFoldSemantic   optimizer.Rule = optimizer.ConstantFoldSemantic{}
+	ruleFoldHeuristic  optimizer.Rule = optimizer.ConstantFoldHeuristic{}
+	ruleFilterFusion   optimizer.Rule = optimizer.FilterFusion{}
+	ruleAggTranspose   optimizer.Rule = optimizer.FilterAggregateTranspose()
+	ruleRWTranspose    optimizer.Rule = optimizer.FilterRangeWindowTranspose()
+	ruleProjPushdown   optimizer.Rule = optimizer.ProjectionPushdown{}
+	ruleNormalizeBound optimizer.Rule = optimizer.NormalizeScanTimeBound{}
+	ruleFlattenSetOp   optimizer.Rule = optimizer.FlattenVectorSetOp{}
+)
+
+// matrixRules is the tree-rewriting rule set the matrix enumerates pairs
+// over. TestRuleInteractionMatrixCoversDefaultRules pins it against the
+// live Default() registration, so a new rule cannot join production
+// without joining the matrix.
+func matrixRules() []optimizer.Rule {
+	return []optimizer.Rule{
+		ruleFoldSemantic,
+		ruleFoldHeuristic,
+		ruleFilterFusion,
+		ruleAggTranspose,
+		ruleRWTranspose,
+		ruleProjPushdown,
+		ruleNormalizeBound,
+		ruleFlattenSetOp,
+	}
+}
+
+// matrixVerifyOnlyRules names the Default() rules the matrix deliberately
+// does not pair, with the reason recorded in the file header: a rule that
+// never returns changed=true cannot make a converged tree order-dependent,
+// so a commutation assertion over it could not fail.
+func matrixVerifyOnlyRules() []string {
+	return []string{
+		optimizer.RequireScanTimeBound{}.Name(),
+		optimizer.RequireScanResourceBound{}.Name(),
+	}
+}
+
+// pairKey is the order-independent identity of an unordered rule pair.
+func pairKey(a, b optimizer.Rule) string {
+	names := []string{a.Name(), b.Name()}
+	sort.Strings(names)
+	return names[0] + " x " + names[1]
+}
+
+// firingRule wraps a Rule and counts the applications that actually
+// rewrote a node. It is what keeps the matrix from going hollow: a
+// commutation assertion over a plan neither rule can match holds
+// trivially, so every pair must first PROVE both of its rules fired on
+// the shared plan.
+type firingRule struct {
+	inner optimizer.Rule
+	fired int
+}
+
+func (r *firingRule) Name() string { return r.inner.Name() }
+
+func (r *firingRule) Apply(n chplan.Node) (chplan.Node, bool) {
+	out, changed := r.inner.Apply(n)
+	if changed {
+		r.fired++
+	}
+	return out, changed
+}
+
 // twoRuleConverge runs the plan through two drivers — one ordered
 // (a, b), one ordered (b, a) — and asserts the final trees are
 // `Equal`. Both drivers iterate to fixpoint (100 iterations), so any
 // commutation property of the pair surfaces as a tree-shape diff.
+//
+// Before comparing, it asserts that BOTH rules rewrote something in BOTH
+// orders. That is the pair's applicability precondition made checkable:
+// without it a plan that has drifted out of one rule's pattern (or a rule
+// whose pattern narrowed) would keep passing while silently testing
+// nothing. Requiring it in both orders rather than once also covers the
+// pairs where one rule only becomes applicable AFTER the other fires —
+// the fixpoint gets there from either starting order or the pair is not
+// interaction-stable to begin with.
 func twoRuleConverge(t *testing.T, label string, plan chplan.Node, a, b optimizer.Rule) {
 	t.Helper()
-	dAB := optimizer.NewWithBatches(optimizer.Batch{
-		Name:     "ab",
-		Strategy: optimizer.FixedPoint(100),
-		Rules:    []optimizer.Rule{a, b},
-	})
-	dBA := optimizer.NewWithBatches(optimizer.Batch{
-		Name:     "ba",
-		Strategy: optimizer.FixedPoint(100),
-		Rules:    []optimizer.Rule{b, a},
-	})
-	outAB := dAB.Run(context.Background(), plan)
-	outBA := dBA.Run(context.Background(), plan)
+	outAB := runOrdered(t, label, "(a, b)", plan, a, b)
+	outBA := runOrdered(t, label, "(b, a)", plan, b, a)
 	if !outAB.Equal(outBA) {
 		t.Fatalf("%s: order-dependent fixpoint\n--- (a, b) ---\n%#v\n--- (b, a) ---\n%#v", label, outAB, outBA)
+	}
+}
+
+// runOrdered runs plan through a single FixedPoint batch holding first
+// then second, in that declared order, and fails if either rule never
+// rewrote a node.
+func runOrdered(t *testing.T, label, order string, plan chplan.Node, first, second optimizer.Rule) chplan.Node {
+	t.Helper()
+	f := &firingRule{inner: first}
+	s := &firingRule{inner: second}
+	d := optimizer.NewWithBatches(optimizer.Batch{
+		Name:     "pair",
+		Strategy: optimizer.FixedPoint(100),
+		Rules:    []optimizer.Rule{f, s},
+	})
+	out := d.Run(context.Background(), plan)
+	for _, r := range []*firingRule{f, s} {
+		if r.fired == 0 {
+			t.Fatalf("%s %s: rule %q never rewrote a node — the pair's plan does not make both "+
+				"rules applicable, so the commutation assertion below would be vacuous",
+				label, order, r.Name())
+		}
+	}
+	return out
+}
+
+// TestRuleInteractionMatrix is the matrix itself: it enumerates every
+// unordered pair of matrixRules, looks the pair's shared plan shape up in
+// pairPlans, and asserts order-independent convergence. A pair with no
+// registered plan is a hard failure naming the pair — that is what makes
+// "every pair is covered" a checked property instead of a comment. The
+// reverse direction is checked too: a pairPlans entry that names no live
+// pair (a stale key left behind by a renamed or retired rule, or a pair
+// registered twice so that one entry overwrote another) fails.
+func TestRuleInteractionMatrix(t *testing.T) {
+	t.Parallel()
+
+	rules := matrixRules()
+	covered := map[string]bool{}
+	for i := 0; i < len(rules); i++ {
+		for j := i + 1; j < len(rules); j++ {
+			a, b := rules[i], rules[j]
+			key := pairKey(a, b)
+			if covered[key] {
+				t.Fatalf("duplicate rule in matrixRules: pair %q enumerated twice", key)
+			}
+			covered[key] = true
+
+			build, ok := pairPlans[key]
+			if !ok {
+				t.Errorf("no plan registered for rule pair %q — add a pairPlans entry whose "+
+					"plan makes BOTH rules applicable; do not drop the pair", key)
+				continue
+			}
+			t.Run(key, func(t *testing.T) {
+				t.Parallel()
+				twoRuleConverge(t, key, build(), a, b)
+			})
+		}
+	}
+
+	for key := range pairPlans {
+		if !covered[key] {
+			t.Errorf("pairPlans has entry %q that is not a pair of matrixRules — "+
+				"a rule was renamed or retired; fix the key or delete the entry", key)
+		}
+	}
+	if len(pairPlans) != len(covered) {
+		t.Errorf("pairPlans holds %d entries for %d pairs — two entries share a key and one "+
+			"overwrote the other", len(pairPlans), len(covered))
+	}
+}
+
+// TestRuleInteractionMatrixCoversDefaultRules pins the matrix's rule list
+// against the live Default() registration: every rule the production
+// driver runs is either paired by the matrix or named in the verify-only
+// exclusion set, and nothing in either list is absent from Default(). This
+// is the ratchet — registering a new rewriting rule in Default() without
+// enrolling it here fails the build rather than silently shrinking the
+// matrix's coverage.
+func TestRuleInteractionMatrixCoversDefaultRules(t *testing.T) {
+	t.Parallel()
+
+	registered := map[string]bool{}
+	for _, name := range optimizer.DefaultRuleNamesForTest() {
+		registered[name] = true
+	}
+
+	enrolled := map[string]bool{}
+	for _, r := range matrixRules() {
+		enrolled[r.Name()] = true
+		if !registered[r.Name()] {
+			t.Errorf("matrixRules enumerates %q, which Default() does not register — "+
+				"remove it from the matrix or re-register it", r.Name())
+		}
+	}
+	for _, name := range matrixVerifyOnlyRules() {
+		if enrolled[name] {
+			t.Errorf("%q is both paired and listed as verify-only — pick one", name)
+		}
+		enrolled[name] = true
+		if !registered[name] {
+			t.Errorf("verify-only exclusion names %q, which Default() does not register — "+
+				"drop the stale exclusion", name)
+		}
+	}
+
+	for name := range registered {
+		if !enrolled[name] {
+			t.Errorf("Default() registers %q, which the interaction matrix neither pairs nor "+
+				"excludes — add it to matrixRules (and a pairPlans entry per new pair), or, if it "+
+				"is verify-only, to matrixVerifyOnlyRules with the reason in the file header", name)
+		}
 	}
 }
 
@@ -76,317 +283,430 @@ func labelFilter(col, v string) chplan.Expr {
 	}
 }
 
-// --- Pair 1: ConstantFoldSemantic × ConstantFoldHeuristic.
-// `(1+2=3) AND X`: semantic folds the arithmetic to `true`, heuristic
-// then collapses `true AND X → X`. Order matters across the two but
-// in the same FixedPoint batch they converge.
-func TestRuleInteraction_ConstantFoldSemantic_x_Heuristic(t *testing.T) {
-	t.Parallel()
-	inner := labelFilter("MetricName", "up")
-	plan := &chplan.Filter{
-		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
-		Predicate: &chplan.Binary{
-			Op: chplan.OpAnd,
-			Left: &chplan.Binary{
-				Op:    chplan.OpEq,
-				Left:  &chplan.Binary{Op: chplan.OpAdd, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 2}},
-				Right: &chplan.LitInt{V: 3},
-			},
-			Right: inner,
-		},
-	}
-	twoRuleConverge(t, "semantic×heuristic", plan, optimizer.ConstantFoldSemantic{}, optimizer.ConstantFoldHeuristic{})
+// trueEq is a pure-literal tautology (`n = n`) — the shape
+// ConstantFoldSemantic folds to `true`.
+func trueEq(n int64) chplan.Expr {
+	return &chplan.Binary{Op: chplan.OpEq, Left: &chplan.LitInt{V: n}, Right: &chplan.LitInt{V: n}}
 }
 
-// --- Pair 2: ConstantFoldSemantic × FilterFusion.
-// Filter(Filter(scan, p1), 1=1) — semantic collapses `1=1 → true`;
-// fusion combines into a single Filter.
-func TestRuleInteraction_ConstantFoldSemantic_x_FilterFusion(t *testing.T) {
-	t.Parallel()
-	plan := &chplan.Filter{
-		Input: &chplan.Filter{
-			Input:     &chplan.Scan{Table: "otel_metrics_gauge"},
-			Predicate: labelFilter("MetricName", "up"),
-		},
-		Predicate: &chplan.Binary{
-			Op:    chplan.OpEq,
-			Left:  &chplan.LitInt{V: 1},
-			Right: &chplan.LitInt{V: 1},
+// sumAgg is the one-key / one-aggregate Aggregate shape the matrix's
+// aggregate-shaped plans share.
+func sumAgg(input chplan.Node, key string) *chplan.Aggregate {
+	return &chplan.Aggregate{
+		Input:   input,
+		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: key}},
+		AggFuncs: []chplan.AggFunc{
+			{Fn: chplan.FnSum, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
 		},
 	}
-	twoRuleConverge(t, "semantic×fusion", plan, optimizer.ConstantFoldSemantic{}, optimizer.FilterFusion{})
 }
 
-// --- Pair 4: ConstantFoldSemantic × FilterAggregateTranspose.
-func TestRuleInteraction_ConstantFoldSemantic_x_FilterAggregateTranspose(t *testing.T) {
-	t.Parallel()
-	plan := &chplan.Filter{
-		Input: &chplan.Aggregate{
-			Input:   &chplan.Scan{Table: "otel_metrics_gauge"},
-			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
-			AggFuncs: []chplan.AggFunc{
-				{Fn: chplan.FnSum, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
-			},
-		},
-		Predicate: &chplan.Binary{
-			Op:    chplan.OpAnd,
-			Left:  &chplan.Binary{Op: chplan.OpEq, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 1}},
-			Right: labelFilter("job", "api"),
-		},
-	}
-	twoRuleConverge(t, "semantic×agg-transpose", plan, optimizer.ConstantFoldSemantic{}, optimizer.FilterAggregateTranspose())
-}
-
-// --- Pair 5: ConstantFoldSemantic × FilterRangeWindowTranspose.
-func TestRuleInteraction_ConstantFoldSemantic_x_FilterRangeWindowTranspose(t *testing.T) {
-	t.Parallel()
-	scan := &chplan.Scan{Table: "otel_metrics_sum"}
-	rw := &chplan.RangeWindow{
-		Input:           scan,
+// rateWindow is the RangeWindow shape the matrix's window-shaped plans
+// share. It is an instant windowed-array leaf (OuterRange == 0, non-metrics
+// Input), so NormalizeScanTimeBound is applicable to it — which is what
+// lets one RangeWindow shape serve both the transpose pairs and the
+// scan-time-bound pairs.
+func rateWindow(input chplan.Node) *chplan.RangeWindow {
+	return &chplan.RangeWindow{
+		Input:           input,
 		Func:            "rate",
 		Range:           5 * time.Minute,
 		TimestampColumn: "TimeUnix",
 		ValueColumn:     "Value",
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
 	}
-	plan := &chplan.Filter{
-		Input: rw,
-		Predicate: &chplan.Binary{
-			Op:    chplan.OpAnd,
-			Left:  &chplan.Binary{Op: chplan.OpEq, Left: &chplan.LitInt{V: 2}, Right: &chplan.LitInt{V: 2}},
-			Right: labelFilter("Attributes", "irrelevant"), // bare column ref over passthrough
-		},
-	}
-	twoRuleConverge(t, "semantic×rw-transpose", plan, optimizer.ConstantFoldSemantic{}, optimizer.FilterRangeWindowTranspose())
 }
 
-// --- Pair 6: ConstantFoldSemantic × ProjectionPushdown.
-// Disjoint targets (expression slots vs Scan.Columns) but pin commutation.
-func TestRuleInteraction_ConstantFoldSemantic_x_ProjectionPushdown(t *testing.T) {
-	t.Parallel()
-	plan := &chplan.Project{
-		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
-		Projections: []chplan.Projection{
-			{
-				// `Value + 0` — semantic does NOT fold this (the right
-				// is a literal but the left is a ColumnRef); ProjectionPushdown
-				// still narrows the Scan to [Value].
-				Expr: &chplan.Binary{
-					Op:    chplan.OpAdd,
-					Left:  &chplan.ColumnRef{Name: "Value"},
-					Right: &chplan.LitFloat{V: 0},
+// setOp builds a canonical-column VectorSetOp. Every link of a chain uses
+// the same column names so FlattenVectorSetOp's same-shape guard is
+// satisfied and the chain actually linearises.
+func setOp(op chplan.VectorSetOpKind, l, r chplan.Node) *chplan.VectorSetOp {
+	return &chplan.VectorSetOp{
+		Left: l, Right: r, Op: op,
+		MetricNameColumn: "MetricName", AttributesColumn: "Attributes",
+		TimestampColumn: "TimeUnix", ValueColumn: "Value",
+	}
+}
+
+// orChain wraps arm in a two-link `or` chain — `((arm or b) or c)` — the
+// left-leaning shape FlattenVectorSetOp collapses into one N-ary node. The
+// pair's other rule fires inside `arm`, so both rules see the same tree and
+// the flatten's arm-freezing order is what is under test.
+func orChain(arm chplan.Node) chplan.Node {
+	return setOp(chplan.VectorSetOr,
+		setOp(chplan.VectorSetOr, arm, &chplan.Scan{Table: "b"}),
+		&chplan.Scan{Table: "c"})
+}
+
+// pairPlans maps a pairKey to a builder for the plan shape that makes BOTH
+// rules of the pair applicable. Keys are built by pairKey from the rule
+// values themselves, so a key always names a real pair.
+// TestRuleInteractionMatrix fails on any pair missing from here.
+var pairPlans = map[string]func() chplan.Node{
+	// ConstantFoldSemantic × ConstantFoldHeuristic.
+	// `(1+2=3) AND X`: semantic folds the arithmetic to `true`, heuristic
+	// then collapses `true AND X → X`.
+	pairKey(ruleFoldSemantic, ruleFoldHeuristic): func() chplan.Node {
+		return &chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Predicate: &chplan.Binary{
+				Op: chplan.OpAnd,
+				Left: &chplan.Binary{
+					Op:    chplan.OpEq,
+					Left:  &chplan.Binary{Op: chplan.OpAdd, Left: &chplan.LitInt{V: 1}, Right: &chplan.LitInt{V: 2}},
+					Right: &chplan.LitInt{V: 3},
 				},
-				Alias: "v_plus_zero",
+				Right: labelFilter("MetricName", "up"),
 			},
-		},
-	}
-	twoRuleConverge(t, "semantic×proj-pushdown", plan, optimizer.ConstantFoldSemantic{}, optimizer.ProjectionPushdown{})
-}
+		}
+	},
 
-// --- Pair 8: ConstantFoldHeuristic × FilterFusion.
-// Filter(Filter(scan, p1), true AND p2) — heuristic collapses `true AND p2 → p2`,
-// fusion merges. Either order should produce identical results.
-func TestRuleInteraction_ConstantFoldHeuristic_x_FilterFusion(t *testing.T) {
-	t.Parallel()
-	plan := &chplan.Filter{
-		Input: &chplan.Filter{
-			Input:     &chplan.Scan{Table: "otel_metrics_gauge"},
-			Predicate: labelFilter("MetricName", "up"),
-		},
-		Predicate: &chplan.Binary{
-			Op:    chplan.OpAnd,
-			Left:  &chplan.LitBool{V: true},
-			Right: labelFilter("job", "api"),
-		},
-	}
-	twoRuleConverge(t, "heuristic×fusion", plan, optimizer.ConstantFoldHeuristic{}, optimizer.FilterFusion{})
-}
-
-// --- Pair 10: ConstantFoldHeuristic × FilterAggregateTranspose.
-func TestRuleInteraction_ConstantFoldHeuristic_x_FilterAggregateTranspose(t *testing.T) {
-	t.Parallel()
-	plan := &chplan.Filter{
-		Input: &chplan.Aggregate{
-			Input:   &chplan.Scan{Table: "otel_metrics_gauge"},
-			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
-			AggFuncs: []chplan.AggFunc{
-				{Fn: chplan.FnSum, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
+	// ConstantFoldSemantic × FilterFusion.
+	// Filter(Filter(scan, p1), 1=1) — semantic collapses `1=1 → true`;
+	// fusion combines into a single Filter.
+	pairKey(ruleFoldSemantic, ruleFilterFusion): func() chplan.Node {
+		return &chplan.Filter{
+			Input: &chplan.Filter{
+				Input:     &chplan.Scan{Table: "otel_metrics_gauge"},
+				Predicate: labelFilter("MetricName", "up"),
 			},
-		},
-		Predicate: &chplan.Binary{
-			Op:    chplan.OpAnd,
-			Left:  &chplan.LitBool{V: true},
-			Right: labelFilter("job", "api"),
-		},
-	}
-	twoRuleConverge(t, "heuristic×agg-transpose", plan, optimizer.ConstantFoldHeuristic{}, optimizer.FilterAggregateTranspose())
-}
+			Predicate: trueEq(1),
+		}
+	},
 
-// --- Pair 11: ConstantFoldHeuristic × FilterRangeWindowTranspose.
-func TestRuleInteraction_ConstantFoldHeuristic_x_FilterRangeWindowTranspose(t *testing.T) {
-	t.Parallel()
-	rw := &chplan.RangeWindow{
-		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
-		Func:            "rate",
-		Range:           5 * time.Minute,
-		TimestampColumn: "TimeUnix",
-		ValueColumn:     "Value",
-		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
-	}
-	plan := &chplan.Filter{
-		Input: rw,
-		Predicate: &chplan.Binary{
-			Op:    chplan.OpAnd,
-			Left:  &chplan.LitBool{V: true},
-			Right: labelFilter("Attributes", "irrelevant"),
-		},
-	}
-	twoRuleConverge(t, "heuristic×rw-transpose", plan, optimizer.ConstantFoldHeuristic{}, optimizer.FilterRangeWindowTranspose())
-}
+	// ConstantFoldSemantic × FilterAggregateTranspose.
+	pairKey(ruleFoldSemantic, ruleAggTranspose): func() chplan.Node {
+		return &chplan.Filter{
+			Input: sumAgg(&chplan.Scan{Table: "otel_metrics_gauge"}, "job"),
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  trueEq(1),
+				Right: labelFilter("job", "api"),
+			},
+		}
+	},
 
-// --- Pair 12: ConstantFoldHeuristic × ProjectionPushdown.
-func TestRuleInteraction_ConstantFoldHeuristic_x_ProjectionPushdown(t *testing.T) {
-	t.Parallel()
-	plan := &chplan.Project{
-		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
-		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "v"},
-			{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "m"},
-		},
-	}
-	twoRuleConverge(t, "heuristic×proj-pushdown", plan, optimizer.ConstantFoldHeuristic{}, optimizer.ProjectionPushdown{})
-}
+	// ConstantFoldSemantic × FilterRangeWindowTranspose.
+	pairKey(ruleFoldSemantic, ruleRWTranspose): func() chplan.Node {
+		return &chplan.Filter{
+			Input: rateWindow(&chplan.Scan{Table: "otel_metrics_sum"}),
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  trueEq(2),
+				Right: labelFilter("Attributes", "irrelevant"), // bare column ref over passthrough
+			},
+		}
+	},
 
-// --- Pair 15: FilterFusion × FilterAggregateTranspose.
-func TestRuleInteraction_FilterFusion_x_FilterAggregateTranspose(t *testing.T) {
-	t.Parallel()
-	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
-	plan := &chplan.Filter{
-		Input: &chplan.Filter{
-			Input: &chplan.Aggregate{
-				Input:   scan,
-				GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
-				AggFuncs: []chplan.AggFunc{
-					{Fn: chplan.FnSum, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
+	// ConstantFoldSemantic × ProjectionPushdown.
+	// Disjoint targets (expression slots vs Scan.Columns) but pin
+	// commutation. `Value * (2 + 3)`: semantic folds the pure-literal
+	// `2 + 3` sub-expression to 5 while ProjectionPushdown narrows the
+	// Scan to [Value] — the scaling literal is deliberately a nested
+	// binary rather than a bare one, because semantic only folds a Binary
+	// whose BOTH operands are literals and a projection like `Value + 0`
+	// gives it nothing to do.
+	pairKey(ruleFoldSemantic, ruleProjPushdown): func() chplan.Node {
+		return &chplan.Project{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Projections: []chplan.Projection{
+				{
+					Expr: &chplan.Binary{
+						Op:   chplan.OpMul,
+						Left: &chplan.ColumnRef{Name: "Value"},
+						Right: &chplan.Binary{
+							Op:    chplan.OpAdd,
+							Left:  &chplan.LitInt{V: 2},
+							Right: &chplan.LitInt{V: 3},
+						},
+					},
+					Alias: "scaled",
 				},
+			},
+		}
+	},
+
+	// ConstantFoldSemantic × NormalizeScanTimeBound.
+	// The fold target sits in the RangeWindow's own input Filter, so both
+	// rules rewrite the same branch: normalize clones the RangeWindow to
+	// stamp InstantScanBounded, the fold rewrites the Filter underneath it.
+	pairKey(ruleFoldSemantic, ruleNormalizeBound): func() chplan.Node {
+		return rateWindow(&chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_metrics_sum"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  trueEq(3),
+				Right: labelFilter("MetricName", "up"),
+			},
+		})
+	},
+
+	// ConstantFoldSemantic × FlattenVectorSetOp.
+	pairKey(ruleFoldSemantic, ruleFlattenSetOp): func() chplan.Node {
+		return orChain(&chplan.Filter{
+			Input: &chplan.Scan{Table: "a"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  trueEq(1),
+				Right: labelFilter("MetricName", "up"),
+			},
+		})
+	},
+
+	// ConstantFoldHeuristic × FilterFusion.
+	// Filter(Filter(scan, p1), true AND p2) — heuristic collapses
+	// `true AND p2 → p2`, fusion merges.
+	pairKey(ruleFoldHeuristic, ruleFilterFusion): func() chplan.Node {
+		return &chplan.Filter{
+			Input: &chplan.Filter{
+				Input:     &chplan.Scan{Table: "otel_metrics_gauge"},
+				Predicate: labelFilter("MetricName", "up"),
+			},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  &chplan.LitBool{V: true},
+				Right: labelFilter("job", "api"),
+			},
+		}
+	},
+
+	// ConstantFoldHeuristic × FilterAggregateTranspose.
+	pairKey(ruleFoldHeuristic, ruleAggTranspose): func() chplan.Node {
+		return &chplan.Filter{
+			Input: sumAgg(&chplan.Scan{Table: "otel_metrics_gauge"}, "job"),
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  &chplan.LitBool{V: true},
+				Right: labelFilter("job", "api"),
+			},
+		}
+	},
+
+	// ConstantFoldHeuristic × FilterRangeWindowTranspose.
+	pairKey(ruleFoldHeuristic, ruleRWTranspose): func() chplan.Node {
+		return &chplan.Filter{
+			Input: rateWindow(&chplan.Scan{Table: "otel_metrics_sum"}),
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  &chplan.LitBool{V: true},
+				Right: labelFilter("Attributes", "irrelevant"),
+			},
+		}
+	},
+
+	// ConstantFoldHeuristic × ProjectionPushdown.
+	// The `true AND <p>` projection is what makes the heuristic
+	// applicable here; a projection list of bare ColumnRefs alone gives it
+	// nothing to collapse. Narrowing is unaffected either way — the
+	// surviving predicate reads the same column the unfolded one did.
+	pairKey(ruleFoldHeuristic, ruleProjPushdown): func() chplan.Node {
+		return &chplan.Project{
+			Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "v"},
+				{
+					Expr: &chplan.Binary{
+						Op:    chplan.OpAnd,
+						Left:  &chplan.LitBool{V: true},
+						Right: labelFilter("MetricName", "up"),
+					},
+					Alias: "is_up",
+				},
+			},
+		}
+	},
+
+	// ConstantFoldHeuristic × NormalizeScanTimeBound.
+	pairKey(ruleFoldHeuristic, ruleNormalizeBound): func() chplan.Node {
+		return rateWindow(&chplan.Filter{
+			Input: &chplan.Scan{Table: "otel_metrics_sum"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  &chplan.LitBool{V: true},
+				Right: labelFilter("MetricName", "up"),
+			},
+		})
+	},
+
+	// ConstantFoldHeuristic × FlattenVectorSetOp.
+	pairKey(ruleFoldHeuristic, ruleFlattenSetOp): func() chplan.Node {
+		return orChain(&chplan.Filter{
+			Input: &chplan.Scan{Table: "a"},
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpAnd,
+				Left:  &chplan.LitBool{V: true},
+				Right: labelFilter("MetricName", "up"),
+			},
+		})
+	},
+
+	// FilterFusion × FilterAggregateTranspose.
+	pairKey(ruleFilterFusion, ruleAggTranspose): func() chplan.Node {
+		return &chplan.Filter{
+			Input: &chplan.Filter{
+				Input:     sumAgg(&chplan.Scan{Table: "otel_metrics_gauge"}, "job"),
+				Predicate: labelFilter("job", "api"),
+			},
+			Predicate: labelFilter("job", "web"),
+		}
+	},
+
+	// FilterFusion × FilterRangeWindowTranspose.
+	pairKey(ruleFilterFusion, ruleRWTranspose): func() chplan.Node {
+		return &chplan.Filter{
+			Input: &chplan.Filter{
+				Input:     rateWindow(&chplan.Scan{Table: "otel_metrics_sum"}),
+				Predicate: labelFilter("Attributes", "v1"),
+			},
+			Predicate: labelFilter("Attributes", "v2"),
+		}
+	},
+
+	// FilterFusion × ProjectionPushdown.
+	// Disjoint shapes today (fusion fires on Filter(Filter), pushdown on
+	// Project(Scan)). Pin commutation as a forward guarantee.
+	pairKey(ruleFilterFusion, ruleProjPushdown): func() chplan.Node {
+		return &chplan.Filter{
+			Input: &chplan.Filter{
+				Input: &chplan.Project{
+					Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+					Projections: []chplan.Projection{
+						{Expr: &chplan.ColumnRef{Name: "MetricName"}},
+						{Expr: &chplan.ColumnRef{Name: "Value"}},
+					},
+				},
+				Predicate: labelFilter("MetricName", "up"),
+			},
+			Predicate: labelFilter("MetricName", "down"),
+		}
+	},
+
+	// FilterFusion × NormalizeScanTimeBound.
+	// The two adjacent Filters sit UNDER the RangeWindow, so fusion
+	// rewrites the subtree normalize is stamping the parent of.
+	pairKey(ruleFilterFusion, ruleNormalizeBound): func() chplan.Node {
+		return rateWindow(&chplan.Filter{
+			Input: &chplan.Filter{
+				Input:     &chplan.Scan{Table: "otel_metrics_sum"},
+				Predicate: labelFilter("MetricName", "up"),
 			},
 			Predicate: labelFilter("job", "api"),
-		},
-		Predicate: labelFilter("job", "web"),
-	}
-	twoRuleConverge(t, "fusion×agg-transpose", plan, optimizer.FilterFusion{}, optimizer.FilterAggregateTranspose())
-}
+		})
+	},
 
-// --- Pair 16: FilterFusion × FilterRangeWindowTranspose.
-func TestRuleInteraction_FilterFusion_x_FilterRangeWindowTranspose(t *testing.T) {
-	t.Parallel()
-	rw := &chplan.RangeWindow{
-		Input:           &chplan.Scan{Table: "otel_metrics_sum"},
-		Func:            "rate",
-		Range:           5 * time.Minute,
-		TimestampColumn: "TimeUnix",
-		ValueColumn:     "Value",
-		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
-	}
-	plan := &chplan.Filter{
-		Input: &chplan.Filter{
-			Input:     rw,
+	// FilterFusion × FlattenVectorSetOp.
+	pairKey(ruleFilterFusion, ruleFlattenSetOp): func() chplan.Node {
+		return orChain(&chplan.Filter{
+			Input: &chplan.Filter{
+				Input:     &chplan.Scan{Table: "a"},
+				Predicate: labelFilter("MetricName", "up"),
+			},
+			Predicate: labelFilter("job", "api"),
+		})
+	},
+
+	// FilterAggregateTranspose × FilterRangeWindowTranspose.
+	pairKey(ruleAggTranspose, ruleRWTranspose): func() chplan.Node {
+		return &chplan.Filter{
+			Input:     rateWindow(sumAgg(&chplan.Scan{Table: "otel_metrics_sum"}, "Attributes")),
 			Predicate: labelFilter("Attributes", "v1"),
-		},
-		Predicate: labelFilter("Attributes", "v2"),
-	}
-	twoRuleConverge(t, "fusion×rw-transpose", plan, optimizer.FilterFusion{}, optimizer.FilterRangeWindowTranspose())
-}
+		}
+	},
 
-// --- Pair 17: FilterFusion × ProjectionPushdown.
-// Disjoint shapes today (fusion fires on Filter(Filter), pushdown on
-// Project(Scan)). Pin commutation as a forward guarantee.
-func TestRuleInteraction_FilterFusion_x_ProjectionPushdown(t *testing.T) {
-	t.Parallel()
-	plan := &chplan.Filter{
-		Input: &chplan.Filter{
-			Input: &chplan.Project{
+	// FilterAggregateTranspose × ProjectionPushdown.
+	pairKey(ruleAggTranspose, ruleProjPushdown): func() chplan.Node {
+		return &chplan.Filter{
+			Input: sumAgg(&chplan.Project{
 				Input: &chplan.Scan{Table: "otel_metrics_gauge"},
-				Projections: []chplan.Projection{
-					{Expr: &chplan.ColumnRef{Name: "MetricName"}},
-					{Expr: &chplan.ColumnRef{Name: "Value"}},
-				},
-			},
-			Predicate: labelFilter("MetricName", "up"),
-		},
-		Predicate: labelFilter("MetricName", "down"),
-	}
-	twoRuleConverge(t, "fusion×proj-pushdown", plan, optimizer.FilterFusion{}, optimizer.ProjectionPushdown{})
-}
-
-// --- Pair 23: FilterAggregateTranspose × FilterRangeWindowTranspose.
-func TestRuleInteraction_FilterAggregateTranspose_x_FilterRangeWindowTranspose(t *testing.T) {
-	t.Parallel()
-	rw := &chplan.RangeWindow{
-		Input: &chplan.Aggregate{
-			Input:   &chplan.Scan{Table: "otel_metrics_sum"},
-			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
-			AggFuncs: []chplan.AggFunc{
-				{Fn: chplan.FnSum, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
-			},
-		},
-		Func:            "rate",
-		Range:           5 * time.Minute,
-		TimestampColumn: "TimeUnix",
-		ValueColumn:     "Value",
-		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
-	}
-	plan := &chplan.Filter{
-		Input:     rw,
-		Predicate: labelFilter("Attributes", "v1"),
-	}
-	twoRuleConverge(t, "agg-transpose×rw-transpose", plan, optimizer.FilterAggregateTranspose(), optimizer.FilterRangeWindowTranspose())
-}
-
-// --- Pair 24: FilterAggregateTranspose × ProjectionPushdown.
-func TestRuleInteraction_FilterAggregateTranspose_x_ProjectionPushdown(t *testing.T) {
-	t.Parallel()
-	scan := &chplan.Scan{Table: "otel_metrics_gauge"}
-	plan := &chplan.Filter{
-		Input: &chplan.Aggregate{
-			Input: &chplan.Project{
-				Input: scan,
 				Projections: []chplan.Projection{
 					{Expr: &chplan.ColumnRef{Name: "job"}},
 					{Expr: &chplan.ColumnRef{Name: "Value"}},
 				},
-			},
-			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "job"}},
-			AggFuncs: []chplan.AggFunc{
-				{Fn: chplan.FnSum, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}, Alias: "sum_value"},
-			},
-		},
-		Predicate: labelFilter("job", "api"),
-	}
-	twoRuleConverge(t, "agg-transpose×proj-pushdown", plan, optimizer.FilterAggregateTranspose(), optimizer.ProjectionPushdown{})
-}
+			}, "job"),
+			Predicate: labelFilter("job", "api"),
+		}
+	},
 
-// --- Pair 26: FilterRangeWindowTranspose × ProjectionPushdown.
-func TestRuleInteraction_FilterRangeWindowTranspose_x_ProjectionPushdown(t *testing.T) {
-	t.Parallel()
-	rw := &chplan.RangeWindow{
-		Input: &chplan.Project{
-			Input: &chplan.Scan{Table: "otel_metrics_sum"},
+	// FilterAggregateTranspose × NormalizeScanTimeBound.
+	// Filter(Aggregate(Scan)) sits under the instant windowed leaf, so the
+	// transpose rewrites inside the very node normalize stamps.
+	pairKey(ruleAggTranspose, ruleNormalizeBound): func() chplan.Node {
+		return rateWindow(&chplan.Filter{
+			Input:     sumAgg(&chplan.Scan{Table: "otel_metrics_sum"}, "Attributes"),
+			Predicate: labelFilter("Attributes", "v1"),
+		})
+	},
+
+	// FilterAggregateTranspose × FlattenVectorSetOp.
+	pairKey(ruleAggTranspose, ruleFlattenSetOp): func() chplan.Node {
+		return orChain(&chplan.Filter{
+			Input:     sumAgg(&chplan.Scan{Table: "a"}, "job"),
+			Predicate: labelFilter("job", "api"),
+		})
+	},
+
+	// FilterRangeWindowTranspose × ProjectionPushdown.
+	pairKey(ruleRWTranspose, ruleProjPushdown): func() chplan.Node {
+		return &chplan.Filter{
+			Input: rateWindow(&chplan.Project{
+				Input: &chplan.Scan{Table: "otel_metrics_sum"},
+				Projections: []chplan.Projection{
+					{Expr: &chplan.ColumnRef{Name: "Attributes"}},
+					{Expr: &chplan.ColumnRef{Name: "Value"}},
+					{Expr: &chplan.ColumnRef{Name: "TimeUnix"}},
+				},
+			}),
+			Predicate: labelFilter("Attributes", "v1"),
+		}
+	},
+
+	// FilterRangeWindowTranspose × NormalizeScanTimeBound.
+	// The head-on pair: both rules target the SAME RangeWindow node — the
+	// transpose rebuilds it with the pushed-down Filter as its Input, the
+	// normalize stamps it with InstantScanBounded. Either order must
+	// converge on a bound RangeWindow whose Filter has been pushed under
+	// it; a rebuild that dropped the stamp would show up here.
+	pairKey(ruleRWTranspose, ruleNormalizeBound): func() chplan.Node {
+		return &chplan.Filter{
+			Input:     rateWindow(&chplan.Scan{Table: "otel_metrics_sum"}),
+			Predicate: labelFilter("Attributes", "v1"),
+		}
+	},
+
+	// FilterRangeWindowTranspose × FlattenVectorSetOp.
+	pairKey(ruleRWTranspose, ruleFlattenSetOp): func() chplan.Node {
+		return orChain(&chplan.Filter{
+			Input:     rateWindow(&chplan.Scan{Table: "a"}),
+			Predicate: labelFilter("Attributes", "v1"),
+		})
+	},
+
+	// ProjectionPushdown × NormalizeScanTimeBound.
+	// RangeWindow(Scan) is simultaneously ProjectionPushdown's stage-node
+	// shape (4) — it narrows the Scan to the ts/value/group columns — and
+	// the instant windowed leaf normalize stamps.
+	pairKey(ruleProjPushdown, ruleNormalizeBound): func() chplan.Node {
+		return rateWindow(&chplan.Scan{Table: "otel_metrics_sum"})
+	},
+
+	// ProjectionPushdown × FlattenVectorSetOp.
+	pairKey(ruleProjPushdown, ruleFlattenSetOp): func() chplan.Node {
+		return orChain(&chplan.Project{
+			Input: &chplan.Scan{Table: "a"},
 			Projections: []chplan.Projection{
-				{Expr: &chplan.ColumnRef{Name: "Attributes"}},
+				{Expr: &chplan.ColumnRef{Name: "MetricName"}},
 				{Expr: &chplan.ColumnRef{Name: "Value"}},
-				{Expr: &chplan.ColumnRef{Name: "TimeUnix"}},
 			},
-		},
-		Func:            "rate",
-		Range:           5 * time.Minute,
-		TimestampColumn: "TimeUnix",
-		ValueColumn:     "Value",
-		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
-	}
-	plan := &chplan.Filter{
-		Input:     rw,
-		Predicate: labelFilter("Attributes", "v1"),
-	}
-	twoRuleConverge(t, "rw-transpose×proj-pushdown", plan, optimizer.FilterRangeWindowTranspose(), optimizer.ProjectionPushdown{})
+		})
+	},
+
+	// NormalizeScanTimeBound × FlattenVectorSetOp.
+	// A set-op arm that is itself an instant windowed leaf: the flatten
+	// freezes the arm into an N-ary node, normalize stamps the arm. Either
+	// order must produce a flattened chain whose RangeWindow arm is bound —
+	// an arm frozen BEFORE it was stamped, and then never revisited, would
+	// diverge here.
+	pairKey(ruleNormalizeBound, ruleFlattenSetOp): func() chplan.Node {
+		return orChain(rateWindow(&chplan.Scan{Table: "a"}))
+	},
 }

--- a/internal/optimizer/rule_registry_export_test.go
+++ b/internal/optimizer/rule_registry_export_test.go
@@ -1,0 +1,18 @@
+package optimizer
+
+// DefaultRuleNamesForTest returns the Name() of every rule Default()
+// registers, in batch-then-declaration order, to the external
+// optimizer_test package. Driver.batches is unexported and stays that way
+// — the rule-interaction matrix needs to prove it enumerates the SAME rule
+// set the production driver runs, and reading the registration through a
+// test-only accessor is how it does that without widening the Driver's
+// public surface.
+func DefaultRuleNamesForTest() []string {
+	var out []string
+	for _, b := range Default().batches {
+		for _, r := range b.Rules {
+			out = append(out, r.Name())
+		}
+	}
+	return out
+}

--- a/internal/optimizer/transpose_shared.go
+++ b/internal/optimizer/transpose_shared.go
@@ -16,18 +16,25 @@ import "github.com/tsouza/cerberus/internal/chplan"
 // shared implementation.
 func onlyReferencesPassthrough(e chplan.Expr, passthrough map[string]struct{}) bool {
 	ok := true
-	walkExpr(e, func(sub chplan.Expr) {
+	// Traversal is chplan.InspectExpr (exhaustive over the sealed Expr set,
+	// ratcheted by chplan's TestInspectExprExhaustive): a kind the walk
+	// missed would hide a ColumnRef and let this helper wrongly answer
+	// "safe to push through". The visitor never returns false — every
+	// sub-expression of the predicate is evaluated on the pushed-down row
+	// shape, so none of them may be skipped.
+	chplan.InspectExpr(e, func(sub chplan.Expr) bool {
 		cr, isCol := sub.(*chplan.ColumnRef)
 		if !isCol {
-			return
+			return true
 		}
 		if cr.Qualifier != "" {
 			ok = false
-			return
+			return true
 		}
 		if _, found := passthrough[cr.Name]; !found {
 			ok = false
 		}
+		return true
 	})
 	return ok
 }

--- a/internal/routememo/memo.go
+++ b/internal/routememo/memo.go
@@ -270,6 +270,16 @@ func (m *Memo) Lookup(k Key) (state LookupState, stale bool) {
 // dispatch finishes (success or failure). On denial, ok is false and
 // release is a no-op — callers must not call it, but it is safe to.
 func (m *Memo) AdmitDispatch() (release func(), ok bool) {
+	return m.tryReserveDispatchToken()
+}
+
+// tryReserveDispatchToken is the one place a dispatch token is taken from
+// the process-wide semaphore, shared by every admission path (AdmitDispatch
+// and both arms of ObserveRouteAFailureAndMaybeBeginProbe) so the
+// non-blocking, fall-back-to-route-A discipline cannot drift between them.
+// The token channel carries its own synchronization, so this is safe both
+// with and without m.mu held.
+func (m *Memo) tryReserveDispatchToken() (release func(), ok bool) {
 	select {
 	case m.dispatchTokens <- struct{}{}:
 		return m.releaseToken, true
@@ -282,63 +292,54 @@ func (m *Memo) releaseToken() { <-m.dispatchTokens }
 
 func noopRelease() {}
 
-// BeginProbe atomically checks probe-eligibility (corroboration met, not
-// under cluster-wide pressure) and reserves an AdmitDispatch token, inside
-// one critical section, for a route-A-failed Key that has never been
-// probed (Unknown, no verdict yet). It is the single-flight admission path
-// a caller uses right after observing route-A's Nth consecutive resource
-// failure. On success, release must be called exactly once when the probe
-// dispatch finishes.
-func (m *Memo) BeginProbe(k Key) (release func(), ok bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	now := m.now()
-	if m.pressure.countFresh(now, m.pressureWindow) > pressureFailureThreshold {
-		return noopRelease, false
-	}
+// admitProbeLocked is the FIRST-PROBE admission rule: a Key that has never
+// been probed (live, Unknown, no verdict yet) and whose consecutive route-A
+// resource failures have reached MinCorroboratingFailures earns a dispatch
+// token; anything else is refused. The caller must already hold m.mu and
+// must already have applied this failure's state transition, so the
+// corroboration count read here includes it.
+//
+// It deliberately does NOT cover the stale-PreferB re-validation rescue,
+// which is a different rule on a different snapshot (see
+// ObserveRouteAFailureAndMaybeBeginProbe): that arm admits a PreferB entry
+// on the basis of staleness captured BEFORE the state transition, precisely
+// the case this Unknown-only rule refuses.
+func (m *Memo) admitProbeLocked(k Key, now time.Time) (release func(), ok bool) {
 	v, live := m.getLiveLocked(k, now)
 	if !live || v.state != Unknown || v.corroboration < MinCorroboratingFailures {
 		return noopRelease, false
 	}
-	select {
-	case m.dispatchTokens <- struct{}{}:
-		return m.releaseToken, true
-	default:
-		return noopRelease, false
-	}
+	return m.tryReserveDispatchToken()
 }
 
 // ObserveRouteAFailureAndMaybeBeginProbe records a route-A resource-
 // exhaustion failure for k AND, in the SAME atomic step, decides whether
 // THIS failure earns an immediate rescue dispatch on route B — either
 // because it is the Nth consecutive failure on a fresh Unknown key (the
-// original first-probe admission BeginProbe alone already granted), or
-// because it is the failure a STALE PreferB entry's re-validation dispatch
-// produced.
+// first-probe rule, admitProbeLocked), or because it is the failure a STALE
+// PreferB entry's re-validation dispatch produced.
 //
-// The second case is why this method exists as one atomic operation rather
-// than two calls to the existing Observe + BeginProbe primitives. Lookup
-// correctly declines to memo-hit a stale PreferB verdict — the caller
-// routes through plain route A instead, "as if the Key were unknown", so
-// the verdict can be honestly re-confirmed by real traffic rather than
-// trusted forever. But if that route-A dispatch then fails for real (the
-// expected outcome, if the underlying premise still holds), a caller that
-// separately calls Observe(k, RouteA, OutcomeResourceFailure) — which
-// refreshes a PreferB entry's createdAt, un-staling it — and THEN calls
-// BeginProbe(k) finds BeginProbe's Unknown-only gate refuses: the entry no
-// longer LOOKS stale, because Observe already cleared that flag before
-// BeginProbe got to look at it. The caller's actual HTTP request is then
-// stuck on the very failure the memo already knows how to avoid, with no
-// rescue, even though the memo has been confidently routing this shape to
-// B for the entire life of the entry. Combining record-and-decide into one
-// critical section lets the admission check see staleness as it stood
-// BEFORE this call's own side effects, closing that gap.
+// The second case is why recording and deciding must happen inside ONE
+// critical section rather than as two steps. Lookup correctly declines to
+// memo-hit a stale PreferB verdict — the caller routes through plain route
+// A instead, "as if the Key were unknown", so the verdict can be honestly
+// re-confirmed by real traffic rather than trusted forever. But if that
+// route-A dispatch then fails for real (the expected outcome, if the
+// underlying premise still holds), recording that failure refreshes the
+// PreferB entry's createdAt, which un-stales it. An admission check that
+// ran AFTER the record would therefore see a fresh PreferB entry and refuse
+// — never the stale one that earned the rescue — leaving the caller's
+// actual HTTP request stuck on the very failure the memo already knows how
+// to avoid, even though the memo has been confidently routing this shape to
+// B for the entire life of the entry. Holding m.mu across both steps lets
+// admission decide on the staleness snapshot taken BEFORE this call's own
+// side effects, closing that gap.
 //
-// Callers MUST use this method — never a separate Observe(k, RouteA,
-// OutcomeResourceFailure) followed by BeginProbe(k) — for a route-A
-// resource-exhaustion failure. release must be called exactly once,
-// whenever ok is true, when the resulting probe/rescue dispatch finishes.
+// That snapshot is also why no separate exported admission entry point
+// exists: this method is the only way a route-A resource failure is
+// admitted, so the record-then-admit sequence cannot be written any other
+// way. release must be called exactly once, whenever ok is true, when the
+// resulting probe/rescue dispatch finishes.
 func (m *Memo) ObserveRouteAFailureAndMaybeBeginProbe(k Key) (release func(), ok, pressureDeclined bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -367,26 +368,14 @@ func (m *Memo) ObserveRouteAFailureAndMaybeBeginProbe(k Key) (release func(), ok
 	if wasStalePreferB {
 		// The re-validation rescue path: admit regardless of the (now
 		// refreshed, no longer "stale") post-transition state.
-		select {
-		case m.dispatchTokens <- struct{}{}:
-			return m.releaseToken, true, false
-		default:
-			return noopRelease, false, false
-		}
+		release, ok = m.tryReserveDispatchToken()
+		return release, ok, false
 	}
 
-	// The original first-probe path: admit only a fresh Unknown entry that
-	// has now reached the corroboration floor.
-	v, live = m.getLiveLocked(k, now)
-	if !live || v.state != Unknown || v.corroboration < MinCorroboratingFailures {
-		return noopRelease, false, false
-	}
-	select {
-	case m.dispatchTokens <- struct{}{}:
-		return m.releaseToken, true, false
-	default:
-		return noopRelease, false, false
-	}
+	// The first-probe path: admit only a fresh Unknown entry that has now
+	// reached the corroboration floor.
+	release, ok = m.admitProbeLocked(k, now)
+	return release, ok, false
 }
 
 // UnderPressure reports whether more than pressureFailureThreshold distinct

--- a/internal/routememo/memo_test.go
+++ b/internal/routememo/memo_test.go
@@ -39,6 +39,36 @@ func newTestMemo() (*Memo, *fakeClock) {
 	return m, clk
 }
 
+// admitFirstProbe drives k to the corroboration floor through the real
+// production admission path — MinCorroboratingFailures-1 plain route-A
+// resource failures, then the atomic record-and-admit call that contributes
+// the last one AND grants the probe token — and returns the admitted
+// probe's release. It t.Fatalf's if admission is declined, so a setup that
+// silently stopped being admit-eligible fails loudly here instead of
+// leaving the test's real assertion running against an un-probed key.
+func admitFirstProbe(t *testing.T, m *Memo, k Key) (release func()) {
+	t.Helper()
+	for i := 0; i < MinCorroboratingFailures-1; i++ {
+		m.Observe(k, RouteA, OutcomeResourceFailure)
+	}
+	release, ok, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k)
+	if !ok {
+		t.Fatalf("setup: probe admission declined for a key at the corroboration floor (%d consecutive route-A resource failures)", MinCorroboratingFailures)
+	}
+	return release
+}
+
+// buildPreferBEntry drives m through the corroborate → probe → succeed
+// sequence so k ends up a fresh, non-stale PreferB verdict — the shared
+// setup every test whose real assertion starts from an established verdict
+// uses.
+func buildPreferBEntry(t *testing.T, m *Memo, k Key) {
+	t.Helper()
+	release := admitFirstProbe(t, m, k)
+	m.Observe(k, RouteB, OutcomeSuccess)
+	release()
+}
+
 // --- Non-negotiable: retry fires only after corroboration, memoized once ---
 
 func TestCorroborationRequiresTwoConsecutiveFailuresNoInterveningSuccess(t *testing.T) {
@@ -46,14 +76,12 @@ func TestCorroborationRequiresTwoConsecutiveFailuresNoInterveningSuccess(t *test
 	k := testKey("A")
 
 	// A single failure must NOT make the key probe-eligible.
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	if _, ok := m.BeginProbe(k); ok {
+	if _, ok, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k); ok {
 		t.Fatalf("single resource failure must not grant probe eligibility")
 	}
 
 	// A second, consecutive failure DOES.
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, ok := m.BeginProbe(k)
+	release, ok, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k)
 	if !ok {
 		t.Fatalf("two consecutive resource failures must grant probe eligibility")
 	}
@@ -66,9 +94,8 @@ func TestInterveningSuccessResetsCorroboration(t *testing.T) {
 
 	m.Observe(k, RouteA, OutcomeResourceFailure)
 	m.Observe(k, RouteA, OutcomeSuccess) // resets
-	m.Observe(k, RouteA, OutcomeResourceFailure)
 
-	if _, ok := m.BeginProbe(k); ok {
+	if _, ok, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k); ok {
 		t.Fatalf("an intervening success must reset the corroboration counter — this failure is only the first since the reset")
 	}
 }
@@ -77,14 +104,7 @@ func TestSuccessfulRouteBRetryIsMemoizedAndSubsequentQueryRoutesDirectly(t *test
 	m, _ := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, ok := m.BeginProbe(k)
-	if !ok {
-		t.Fatalf("expected probe eligibility after corroboration")
-	}
-	m.Observe(k, RouteB, OutcomeSuccess)
-	release()
+	buildPreferBEntry(t, m, k)
 
 	state, stale := m.Lookup(k)
 	if state != PreferB || stale {
@@ -96,12 +116,7 @@ func TestFailedRouteBRetryIsMemoizedNegativelyAndNotRetriedAgain(t *testing.T) {
 	m, _ := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, ok := m.BeginProbe(k)
-	if !ok {
-		t.Fatalf("expected probe eligibility after corroboration")
-	}
+	release := admitFirstProbe(t, m, k)
 	m.Observe(k, RouteB, OutcomeResourceFailure)
 	release()
 
@@ -109,8 +124,9 @@ func TestFailedRouteBRetryIsMemoizedNegativelyAndNotRetriedAgain(t *testing.T) {
 	if state != BothFail {
 		t.Fatalf("Lookup(k) = %v, want BothFail", state)
 	}
-	// BothFail must never grant a second probe.
-	if _, ok := m.BeginProbe(k); ok {
+	// BothFail must never grant a second probe, however many further
+	// route-A failures the key accumulates.
+	if _, ok, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k); ok {
 		t.Fatalf("a bothFail key must never be re-probed")
 	}
 }
@@ -121,12 +137,7 @@ func TestNoEvidenceOutcomeNeverWritesMemoState(t *testing.T) {
 	m, _ := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, ok := m.BeginProbe(k)
-	if !ok {
-		t.Fatalf("expected probe eligibility")
-	}
+	release := admitFirstProbe(t, m, k)
 	// A route-B failure that is NOT a resource failure (e.g. a solver
 	// timeout classified upstream as NoEvidence) must not flip the entry to
 	// bothFail.
@@ -137,9 +148,14 @@ func TestNoEvidenceOutcomeNeverWritesMemoState(t *testing.T) {
 	if state != Unknown {
 		t.Fatalf("Lookup(k) = %v after a NoEvidence probe outcome, want Unknown (still probe-eligible)", state)
 	}
-	if _, ok := m.BeginProbe(k); !ok {
+	// The "future attempt" is the next route-A resource failure on this key:
+	// the entry is still Unknown at the corroboration floor, so it must be
+	// admitted again.
+	retryRelease, ok, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k)
+	if !ok {
 		t.Fatalf("a NoEvidence probe outcome must leave the key probe-eligible for a future attempt")
 	}
+	retryRelease()
 }
 
 // --- TTL / re-validation (Major-5) ---
@@ -148,11 +164,7 @@ func TestTTLExpiresFromCreationNotFromLookup(t *testing.T) {
 	m, clk := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, _ := m.BeginProbe(k)
-	m.Observe(k, RouteB, OutcomeSuccess)
-	release()
+	buildPreferBEntry(t, m, k)
 
 	// Repeated lookups before the TTL must NOT refresh the clock.
 	clk.advance(MemoEntryTTL - time.Second)
@@ -172,11 +184,7 @@ func TestReValidationAtMidpointSuccessDropsEntry(t *testing.T) {
 	m, clk := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, _ := m.BeginProbe(k)
-	m.Observe(k, RouteB, OutcomeSuccess)
-	release()
+	buildPreferBEntry(t, m, k)
 
 	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 	state, stale := m.Lookup(k)
@@ -200,17 +208,13 @@ func TestReValidationAtMidpointSuccessDropsEntry(t *testing.T) {
 // TestReValidationRescue_* below) — that method reuses this exact same
 // state transition internally. What this test does NOT cover is whether a
 // caller gets a RESCUE dispatch for the request that produced this
-// failure; see TestObserveThenBeginProbeSeparately_MissesStaleRescue and
-// TestReValidationRescue_AdmitsStalePreferBFailure for that half.
+// failure; see TestReValidationRescue_AdmitsStalePreferBFailure for that
+// half.
 func TestReValidationAtMidpointFailureRefreshesVerdictState(t *testing.T) {
 	m, clk := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, _ := m.BeginProbe(k)
-	m.Observe(k, RouteB, OutcomeSuccess)
-	release()
+	buildPreferBEntry(t, m, k)
 
 	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 	if state, stale := m.Lookup(k); state != PreferB || !stale {
@@ -229,53 +233,18 @@ func TestReValidationAtMidpointFailureRefreshesVerdictState(t *testing.T) {
 	}
 }
 
-// TestObserveThenBeginProbeSeparately_MissesStaleRescue documents the exact
-// ordering hazard ObserveRouteAFailureAndMaybeBeginProbe exists to close: a
-// caller that observes and admits as two SEPARATE calls can never rescue a
-// stale-PreferB re-validation failure, because Observe's own refresh of
-// createdAt un-stales the entry before BeginProbe (Unknown-only) ever looks
-// at it. This is a guard against "simplifying" the engine's call site back
-// to the two-call form — if this test ever starts passing with ok=true, the
-// atomic method has stopped being necessary or something has regressed the
-// separate calls' documented behavior.
-func TestObserveThenBeginProbeSeparately_MissesStaleRescue(t *testing.T) {
-	m, clk := newTestMemo()
-	k := testKey("A")
-
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, _ := m.BeginProbe(k)
-	m.Observe(k, RouteB, OutcomeSuccess)
-	release()
-
-	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
-	if state, stale := m.Lookup(k); state != PreferB || !stale {
-		t.Fatalf("expected stale PreferB at the midpoint, got (%v, %v)", state, stale)
-	}
-
-	// The two-call sequence: Observe refreshes (un-stales) the entry, THEN
-	// BeginProbe looks — and refuses, because state is PreferB, not Unknown.
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	_, ok := m.BeginProbe(k)
-	if ok {
-		t.Fatal("BeginProbe admitted after a separate Observe call — the ordering hazard this test documents no longer reproduces; if the two-call form is now safe, ObserveRouteAFailureAndMaybeBeginProbe may be unnecessary and this test's premise should be revisited")
-	}
-}
-
-// TestReValidationRescue_AdmitsStalePreferBFailure pins the actual fix: the
-// atomic method rescues the request that triggers a stale PreferB entry's
-// re-validation, using the SAME setup as
-// TestObserveThenBeginProbeSeparately_MissesStaleRescue to make the
-// before/after contrast direct.
+// TestReValidationRescue_AdmitsStalePreferBFailure pins the rescue half of
+// the re-validation protocol: the atomic method rescues the request that
+// triggers a stale PreferB entry's re-validation. Its counterpart,
+// TestReValidationAtMidpointFailureRefreshesVerdictState above, pins what
+// the plain Observe call does to the same entry's STATE — together they
+// cover both halves of "record the failure AND decide the rescue on the
+// pre-transition snapshot".
 func TestReValidationRescue_AdmitsStalePreferBFailure(t *testing.T) {
 	m, clk := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, _ := m.BeginProbe(k)
-	m.Observe(k, RouteB, OutcomeSuccess)
-	release()
+	buildPreferBEntry(t, m, k)
 
 	clk.advance(MemoEntryTTL/reValidationFraction + time.Second)
 	if state, stale := m.Lookup(k); state != PreferB || !stale {
@@ -305,11 +274,7 @@ func TestReValidationRescue_FreshPreferBNotAdmitted(t *testing.T) {
 	m, _ := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, _ := m.BeginProbe(k)
-	m.Observe(k, RouteB, OutcomeSuccess)
-	release()
+	buildPreferBEntry(t, m, k)
 
 	if state, stale := m.Lookup(k); state != PreferB || stale {
 		t.Fatalf("expected a fresh (non-stale) PreferB entry, got (%v, stale=%v)", state, stale)
@@ -321,36 +286,11 @@ func TestReValidationRescue_FreshPreferBNotAdmitted(t *testing.T) {
 	}
 }
 
-// TestReValidationRescue_UnknownKeyCorroborationStillWorks pins that the
-// atomic method preserves the ORIGINAL first-probe contract for a fresh
-// Unknown key — the case ObserveRouteAFailureAndMaybeBeginProbe replaces
-// Observe+BeginProbe for, not just the new stale-rescue case.
-func TestReValidationRescue_UnknownKeyCorroborationStillWorks(t *testing.T) {
-	m, _ := newTestMemo()
-	k := testKey("A")
-
-	release1, ok1, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k)
-	if ok1 {
-		t.Fatal("admitted on the FIRST failure — corroboration requires more than one")
-	}
-	if release1 != nil {
-		release1()
-	}
-
-	release2, ok2, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k)
-	if !ok2 {
-		t.Fatal("did not admit on the 2nd consecutive failure (minCorroboratingFailures)")
-	}
-	release2()
-}
-
 func TestBothFailHasNoReValidationAndExpiresAtPlainTTL(t *testing.T) {
 	m, clk := newTestMemo()
 	k := testKey("A")
 
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, _ := m.BeginProbe(k)
+	release := admitFirstProbe(t, m, k)
 	m.Observe(k, RouteB, OutcomeResourceFailure)
 	release()
 
@@ -454,11 +394,7 @@ func TestLRUTouchesOnCorroborationBumpAndStaleRevalidation(t *testing.T) {
 		m, clk := newTestMemo()
 
 		first := testKey("oldest")
-		m.Observe(first, RouteA, OutcomeResourceFailure)
-		m.Observe(first, RouteA, OutcomeResourceFailure)
-		release, _ := m.BeginProbe(first)
-		m.Observe(first, RouteB, OutcomeSuccess)
-		release()
+		buildPreferBEntry(t, m, first)
 
 		fillDistinctPreferB(m, MemoMaxEntries-1, func(i int) Key { return Key{RootKind: testKeyName(i)} })
 
@@ -515,9 +451,12 @@ func TestPressureDamperSuppressesBothActionAndLearning(t *testing.T) {
 	// otherwise-eligible key, and no write happens.
 	hot := testKey("hot")
 	m.Observe(hot, RouteA, OutcomeResourceFailure)
-	m.Observe(hot, RouteA, OutcomeResourceFailure)
-	if _, ok := m.BeginProbe(hot); ok {
-		t.Fatalf("BeginProbe must be refused while UnderPressure()")
+	_, ok, pressureDeclined := m.ObserveRouteAFailureAndMaybeBeginProbe(hot)
+	if ok {
+		t.Fatalf("probe admission must be refused while UnderPressure()")
+	}
+	if !pressureDeclined {
+		t.Fatalf("a refusal caused by cluster-wide pressure must report pressureDeclined=true")
 	}
 
 	m.mu.Lock()
@@ -599,7 +538,7 @@ func TestConcurrentLookupObserveAdmitDispatchIsRace_free(t *testing.T) {
 					release()
 				}
 			case 3:
-				if release, ok := m.BeginProbe(k); ok {
+				if release, ok, _ := m.ObserveRouteAFailureAndMaybeBeginProbe(k); ok {
 					m.Observe(k, RouteB, OutcomeSuccess)
 					release()
 				}
@@ -618,21 +557,6 @@ func TestConcurrentLookupObserveAdmitDispatchIsRace_free(t *testing.T) {
 }
 
 // --- SetEntryTTL / SetReValidationFraction: operator-configurable timing ---
-
-// buildPreferBEntry drives m through the corroborate → probe → succeed
-// sequence so k ends up a fresh, non-stale PreferB verdict — the shared
-// setup every re-validation/expiry timing test below starts from.
-func buildPreferBEntry(t *testing.T, m *Memo, k Key) {
-	t.Helper()
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	m.Observe(k, RouteA, OutcomeResourceFailure)
-	release, ok := m.BeginProbe(k)
-	if !ok {
-		t.Fatalf("expected probe eligibility after corroboration")
-	}
-	m.Observe(k, RouteB, OutcomeSuccess)
-	release()
-}
 
 // TestSetEntryTTLShortensExpiry proves SetEntryTTL actually changes
 // re-validation/expiry timing rather than being a purely cosmetic field: two

--- a/internal/routerrules/catalog/catalog.yaml
+++ b/internal/routerrules/catalog/catalog.yaml
@@ -85,16 +85,6 @@ params:
   # forgotten on the next geometry param — and where it empties a language's
   # population that language's partition key is simply absent, which skips the
   # rule for that language rather than firing it on everything.
-  - name: memory_high_watermark
-    kind: corpus_percentile
-    column: memory_usage
-    percentile:
-      ref: watermark_pctile                       # the fraction is itself a param ref
-    partition_by: [language]                      # one watermark per language
-    scope:
-      route: A
-      exit_status: ok                             # learn from the HEALTHY population only
-
   - name: fanout_route_b_floor
     kind: corpus_percentile
     column: fanout

--- a/internal/routerrules/effectiveness_test.go
+++ b/internal/routerrules/effectiveness_test.go
@@ -483,7 +483,7 @@ func TestEffectivenessParamsNonDegenerate(t *testing.T) {
 
 	// Partitioned watermarks must carry a positive value for every populated
 	// language bucket.
-	for _, name := range []string{"memory_high_watermark", "slow_duration_watermark", "d_high_watermark", "read_rows_high_watermark"} {
+	for _, name := range []string{"slow_duration_watermark", "d_high_watermark", "read_rows_high_watermark"} {
 		v, ok := env[name]
 		if !ok {
 			t.Errorf("%s not resolved", name)

--- a/internal/routerrules/eval.go
+++ b/internal/routerrules/eval.go
@@ -242,24 +242,38 @@ func parseEvidence(ev *Evidence) ([]evidenceExpr, error) {
 // sees concrete numbers. An unresolved placeholder is left as-is.
 func substituteMessage(msg string, groupKey map[string]string, env Env) string {
 	var sb strings.Builder
+	scanMessage(msg,
+		func(lit string) { sb.WriteString(lit) },
+		func(name string) { sb.WriteString(resolvePlaceholder(name, groupKey, env)) })
+	return sb.String()
+}
+
+// scanMessage walks a finding template, handing each literal run to lit and
+// each {name} placeholder to ph.
+//
+// substituteMessage renders those placeholders at report time;
+// validateEveryParamIsReached counts them as param references at load time. A
+// message is the only place a param can be reached without appearing in a
+// condition or a min_support ref, so the two must agree exactly on what a
+// placeholder is — hence one scanner rather than a second parser in validate.go
+// that could drift from this one.
+func scanMessage(msg string, lit func(string), ph func(name string)) {
 	for {
 		open := strings.IndexByte(msg, '{')
 		if open < 0 {
-			sb.WriteString(msg)
-			break
+			lit(msg)
+			return
 		}
-		close := strings.IndexByte(msg[open:], '}')
-		if close < 0 {
-			sb.WriteString(msg)
-			break
+		closing := strings.IndexByte(msg[open:], '}')
+		if closing < 0 {
+			lit(msg)
+			return
 		}
-		close += open
-		sb.WriteString(msg[:open])
-		name := msg[open+1 : close]
-		sb.WriteString(resolvePlaceholder(name, groupKey, env))
-		msg = msg[close+1:]
+		closing += open
+		lit(msg[:open])
+		ph(msg[open+1 : closing])
+		msg = msg[closing+1:]
 	}
-	return sb.String()
 }
 
 // unclassifiedLabel is what an absent classification reads as in a finding

--- a/internal/routerrules/resolve.go
+++ b/internal/routerrules/resolve.go
@@ -71,8 +71,10 @@ func NewParamResolver(cfg ConfigLookup, src CorpusSource) *ParamResolver {
 	return &ParamResolver{cfg: cfg, src: src}
 }
 
-// Resolve resolves every parameter referenced by the catalog (transitively)
-// into an Env. It fails closed on a dependency cycle, a missing config key, or a
+// Resolve resolves every parameter DECLARED by the catalog into an Env — not
+// only the ones the rules use. validateEveryParamIsReached makes the two sets
+// identical at load time, which is what stops this loop paying for a corpus
+// pass no rule can consume. It fails closed on a dependency cycle, a missing config key, or a
 // corpus read error.
 func (r *ParamResolver) Resolve(ctx context.Context, cat *Catalog) (Env, error) {
 	specs := make(map[string]ParamSpec, len(cat.Params))

--- a/internal/routerrules/validate.go
+++ b/internal/routerrules/validate.go
@@ -42,8 +42,80 @@ func Validate(cat *Catalog) error {
 	}
 
 	validateRules(cat, paramNames, specs, add)
+	validateEveryParamIsReached(cat, specs, add)
 
 	return errors.Join(errs...)
+}
+
+// validateEveryParamIsReached is the dual of the dangling-ref check: a declared
+// param that no rule reaches is rejected.
+//
+// It is not tidiness. ParamResolver.Resolve walks cat.Params, not the params
+// the rules actually use, and every corpus-kind param drives its own full
+// corpus pass. An unreached corpus param therefore costs a complete aggregate
+// scan on every run and can never influence a finding — waste no other check
+// could see, because the dangling-ref check only looks the other way (a rule
+// naming a param that does not exist).
+//
+// Reachability is transitive: a rule reaches the params in its condition and
+// its min_support, and each reached param reaches the params it refs (a
+// percentile's fraction, a config_scaled ref and scale_by). watermark_pctile is
+// reached that way; no rule names it directly.
+func validateEveryParamIsReached(cat *Catalog, specs map[string]ParamSpec, add func(string, ...any)) {
+	reached := map[string]struct{}{}
+
+	var reach func(name string)
+	reach = func(name string) {
+		if _, done := reached[name]; done {
+			return
+		}
+		spec, ok := specs[name]
+		if !ok {
+			return // undeclared: already reported as a dangling ref.
+		}
+		reached[name] = struct{}{}
+		if spec.Percentile != nil && spec.Percentile.Ref != "" {
+			reach(spec.Percentile.Ref)
+		}
+		if spec.Ref != "" {
+			reach(spec.Ref)
+		}
+		if spec.ScaleBy != "" {
+			reach(spec.ScaleBy)
+		}
+	}
+
+	for i := range cat.Rules {
+		r := &cat.Rules[i]
+		if r.MinSupport != nil && r.MinSupport.Ref != "" {
+			reach(r.MinSupport.Ref)
+		}
+		// A finding message reaches a param too: {cerberus_reject_ratio} is
+		// deliberately MESSAGE-only context and gates nothing. reach ignores a
+		// placeholder that is a group-key column rather than a param.
+		scanMessage(r.Finding, func(string) {}, reach)
+		cond, err := lowerPredicate(r.Condition)
+		if err != nil {
+			continue // a malformed condition is already reported by validateCondition.
+		}
+		refs := map[string]struct{}{}
+		cond.paramRefs(refs)
+		for name := range refs {
+			reach(name)
+		}
+	}
+
+	for i := range cat.Params {
+		name := cat.Params[i].Name
+		if name == "" {
+			continue // already reported by validateParams.
+		}
+		if _, ok := reached[name]; !ok {
+			add("param %q is declared but no rule reaches it: it is resolved on every "+
+				"run (a corpus param costs a full aggregate scan) and can never affect "+
+				"a finding", name)
+		}
+	}
 }
 
 // validateParams checks each param spec and returns the set of declared param

--- a/internal/routerrules/validate_test.go
+++ b/internal/routerrules/validate_test.go
@@ -402,3 +402,142 @@ func TestValidateHealthScope(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateRejectsUnreachedParam pins validateEveryParamIsReached, the dual
+// of the dangling-${param} check. ParamResolver.Resolve walks the DECLARED
+// params, not the used ones, and every corpus-kind param drives its own full
+// aggregate pass — so a param no rule reaches buys a corpus scan per run and
+// can never move a finding. memory_high_watermark sat in the shipped catalog in
+// exactly that state, and was the doc's headline example of the params
+// mechanism while gating nothing.
+//
+// The reached arms are asserted alongside the rejected one because each is a
+// distinct way a param is legitimately reached, and dropping any one of them
+// would turn this gate into a false positive that deletes a live param.
+func TestValidateRejectsUnreachedParam(t *testing.T) {
+	// mem_wm is declared and named by nothing: the memory_high_watermark shape.
+	const reachedByNothing = `
+apiVersion: routerrules.cerberus/v1
+catalogVersion: 1
+params:
+  - name: pctile
+    kind: config
+    key: router_rules.watermark_percentile
+  - name: support
+    kind: config
+    key: router_rules.min_class_support
+  - name: mem_wm
+    kind: corpus_percentile
+    column: memory_usage
+    percentile: { ref: pctile }
+    partition_by: [language]
+    scope: { route: A, exit_status: ok }
+rules:
+  - id: r1
+    severity: high
+    since: 1
+    status: active
+    group_by: [shape_id, language]
+    min_support: { ref: support }
+    condition:
+      all:
+        - { col: route, op: eq, enum: A }
+    finding: "x"
+`
+
+	// Same catalog, except the rule's condition carries a real ParamCmp leaf
+	// naming mem_wm.
+	const reachedByCondition = `
+apiVersion: routerrules.cerberus/v1
+catalogVersion: 1
+params:
+  - name: pctile
+    kind: config
+    key: router_rules.watermark_percentile
+  - name: support
+    kind: config
+    key: router_rules.min_class_support
+  - name: mem_wm
+    kind: corpus_percentile
+    column: memory_usage
+    percentile: { ref: pctile }
+    partition_by: [language]
+    scope: { route: A, exit_status: ok }
+rules:
+  - id: r1
+    severity: high
+    since: 1
+    status: active
+    group_by: [shape_id, language]
+    min_support: { ref: support }
+    condition:
+      all:
+        - { col: memory_usage, op: gte, param: mem_wm }
+    finding: "x"
+`
+
+	// A MESSAGE-only param gates nothing but is legitimately reached — the
+	// cerberus_reject_ratio shape. Without the message scan this arm would fail
+	// and the gate would delete a live param.
+	const reachedByMessage = `
+apiVersion: routerrules.cerberus/v1
+catalogVersion: 1
+params:
+  - name: pctile
+    kind: config
+    key: router_rules.watermark_percentile
+  - name: support
+    kind: config
+    key: router_rules.min_class_support
+  - name: mem_wm
+    kind: corpus_percentile
+    column: memory_usage
+    percentile: { ref: pctile }
+    partition_by: [language]
+    scope: { route: A, exit_status: ok }
+rules:
+  - id: r1
+    severity: high
+    since: 1
+    status: active
+    group_by: [shape_id, language]
+    min_support: { ref: support }
+    condition:
+      all:
+        - { col: route, op: eq, enum: A }
+    finding: "peaks at {mem_wm} for {shape_id}"
+`
+
+	t.Run("unreached param is rejected", func(t *testing.T) {
+		_, err := LoadCatalog([]byte(reachedByNothing))
+		if err == nil {
+			t.Fatal("expected load to fail: mem_wm is declared and reached by nothing")
+		}
+		if !strings.Contains(err.Error(), `param "mem_wm" is declared but no rule reaches it`) {
+			t.Fatalf("error %q should name the unreached param", err.Error())
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		yaml string
+	}{
+		{"a condition leaf reaches it", reachedByCondition},
+		{"a finding message placeholder reaches it", reachedByMessage},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := LoadCatalog([]byte(tc.yaml)); err != nil {
+				t.Fatalf("catalog should load: %v", err)
+			}
+		})
+	}
+
+	// pctile is reached only THROUGH mem_wm's percentile ref: reachability is
+	// transitive, or the gate would reject every fraction param in the shipped
+	// catalog.
+	t.Run("a param reached only transitively is accepted", func(t *testing.T) {
+		if _, err := LoadCatalog([]byte(reachedByCondition)); err != nil {
+			t.Fatalf("transitively reached pctile should load: %v", err)
+		}
+	})
+}

--- a/internal/schema/downsample_tier.go
+++ b/internal/schema/downsample_tier.go
@@ -87,9 +87,9 @@ const DownsampleTierGaugeTemporalitySentinel int64 = -1
 
 // DownsampleTierBucket is the tier's single supported aggregation bucket —
 // fixed, not operator-configurable (cerberus issue #2751's deliberate v1
-// scope decision). It mirrors the retired otel_metrics_sum_5m rollup's own
-// granularity (see the retired MetricsRollups' defaultOTelRollups doc),
-// chosen because it suits PromQL query_range's common 5-minute step. A
+// scope decision). It is five minutes because that suits PromQL
+// query_range's common 5-minute step — the same reason the retired
+// otel_metrics_sum_5m rollup registry, deleted in #3188, used it. A
 // configurable bucket size would multiply the routing-eligibility surface
 // (internal/promql/lower_strategy.go's resolution-aware eligibility check)
 // for marginal v1 benefit; a deployment needing a different granularity can

--- a/internal/schema/env_test.go
+++ b/internal/schema/env_test.go
@@ -32,9 +32,6 @@ func TestDefaultOTelMetricsFromEnv_Unset(t *testing.T) {
 	if got.MetricNameColumn != want.MetricNameColumn {
 		t.Errorf("MetricNameColumn drifted: got %q, want %q", got.MetricNameColumn, want.MetricNameColumn)
 	}
-	if len(got.MetricsRollups) != len(want.MetricsRollups) {
-		t.Errorf("MetricsRollups length drifted: got %d, want %d", len(got.MetricsRollups), len(want.MetricsRollups))
-	}
 }
 
 // TestDefaultOTelMetricsFromEnv_Overrides walks every overridable

--- a/internal/schema/otel.go
+++ b/internal/schema/otel.go
@@ -1,7 +1,5 @@
 package schema
 
-import "time"
-
 // Metrics describes how cerberus reads metrics from ClickHouse. The default
 // (returned by DefaultOTelMetrics) matches the OpenTelemetry ClickHouse
 // Exporter v0.x schema; users with custom layouts override individual
@@ -165,18 +163,6 @@ type Metrics struct {
 	// (`Exemplars.SpanId`, etc.).
 	ExemplarsColumn string
 
-	// MetricsRollups declares pre-aggregated rollup tables the
-	// operator has provisioned alongside the base metrics tables. The
-	// registry is the operator's contract: the listed tables are trusted
-	// to exist and carry the declared (Window, AggOp) semantics.
-	//
-	// NOTE: as of 2026-06 no optimizer rule consumes this registry — the
-	// MV-substitution rule that read it was retired (no rollup roadmap;
-	// it was a guaranteed no-op against the shipped schemas). The type
-	// and the default entries are retained as the schema-side contract a
-	// future rollup-substitution rule would re-consume.
-	MetricsRollups []Rollup
-
 	// DeltaPrefixTable names the AggregatingMergeTree table backing exact,
 	// retention-independent DELTA-temporality prefix-reconstruction
 	// (cerberus issue #2389). Unlike every other table name on this
@@ -233,95 +219,6 @@ type Metrics struct {
 	ExpHistogramSuffix string
 }
 
-// RollupAggOp enumerates the per-bucket reducer the operator
-// configured the upstream rollup table to compute. A rollup-substitution
-// rule would use this to check commutativity against the outer query's
-// aggregate (sum over sums is total sum; max over maxes is total max;
-// avg over avgs is NOT total avg without per-bucket weights, so an avg
-// rollup would be excluded). No optimizer rule consumes this today (see
-// MetricsRollups).
-type RollupAggOp string
-
-const (
-	// RollupAggSum names a rollup whose materialised column holds the
-	// per-bucket sum of the base table's value column. Commutes with
-	// outer `sum`.
-	RollupAggSum RollupAggOp = "sum"
-	// RollupAggCount names a rollup whose materialised column holds
-	// the per-bucket sample count. Commutes with outer `count` (and
-	// with outer `sum` when the per-bucket value is itself a count).
-	RollupAggCount RollupAggOp = "count"
-	// RollupAggMin names a rollup whose materialised column holds the
-	// per-bucket minimum. Commutes with outer `min`.
-	RollupAggMin RollupAggOp = "min"
-	// RollupAggMax names a rollup whose materialised column holds the
-	// per-bucket maximum. Commutes with outer `max`.
-	RollupAggMax RollupAggOp = "max"
-)
-
-// Rollup describes a single pre-aggregated rollup table in the OTel
-// metrics schema. A rollup-substitution rule would rewrite a
-// `RangeWindow(Scan(BaseTable))` to `RangeWindow(Scan(RollupTable))`
-// when the query's step + range + aggregate operator are compatible
-// with the rollup's window + commuting aggregate. No optimizer rule
-// consumes this today — the MV-substitution rule that did was retired in
-// 2026-06 (see MetricsRollups); the type stays as the schema-side
-// contract a future rule would re-consume.
-//
-// The rollup table is expected to expose:
-//
-//   - The same series-identity columns as the base table (the
-//     `Attributes` / `ResourceAttributes` / `ServiceName` columns are
-//     copied through unchanged by the upstream OTel exporter).
-//   - The same `TimestampColumn` aligned to the rollup window's
-//     boundary (e.g. `toStartOfFiveMinute(TimeUnix) AS TimeUnix`).
-//   - A `ValueColumn` carrying the pre-aggregated per-bucket value
-//     (e.g. `Sum` for an AggOp=sum rollup, `Max` for AggOp=max, …).
-//     The rule rewrites the `RangeWindow.ValueColumn` to this name
-//     before re-emitting SQL.
-type Rollup struct {
-	// BaseTable names the source `otel_metrics_*` table the rollup
-	// summarises (e.g. "otel_metrics_sum").
-	BaseTable string
-	// RollupTable names the materialised pre-aggregated table the
-	// upstream OTel exporter writes (e.g. "otel_metrics_sum_5m").
-	RollupTable string
-	// Window is the rollup's bucket size — every row in RollupTable
-	// represents one bucket of this width over the base table.
-	Window time.Duration
-	// AggOp is the per-bucket reducer the rollup applies to the base
-	// table's value column. Determines which outer aggregates can
-	// commute with the rollup.
-	AggOp RollupAggOp
-	// ValueColumn names the column on RollupTable that carries the
-	// pre-aggregated per-bucket value. Almost always upper-cased
-	// AggOp ("Sum" / "Count" / "Min" / "Max"). Stored explicitly so
-	// custom-named rollups can override the convention.
-	ValueColumn string
-}
-
-// Rollups returns the configured MetricsRollups list. Returned as a
-// dedicated accessor so future filtering (e.g. selecting candidates
-// for a given base table) can centralise here without touching every
-// caller.
-func (m Metrics) Rollups() []Rollup { return m.MetricsRollups }
-
-// RollupsFor returns the rollups whose BaseTable equals base. Order
-// is preserved from MetricsRollups. No optimizer rule consumes this
-// today (the MV-substitution rule that did was retired in 2026-06); a
-// future rollup-substitution rule that walks the slice in order should
-// have operators list the longest (coarsest) window first so it prefers
-// the rollup that strips the most data.
-func (m Metrics) RollupsFor(base string) []Rollup {
-	var out []Rollup
-	for _, r := range m.MetricsRollups {
-		if r.BaseTable == base {
-			out = append(out, r)
-		}
-	}
-	return out
-}
-
 // defaultDeltaPrefixTable / defaultDeltaPrefixBucketColumn /
 // defaultDeltaPrefixSumColumn are the default names for
 // Metrics.DeltaPrefixTable / DeltaPrefixBucketColumn / DeltaPrefixSumColumn
@@ -336,43 +233,6 @@ const (
 	defaultDeltaPrefixBucketColumn = "BucketStart"
 	defaultDeltaPrefixSumColumn    = "PartialSum"
 )
-
-// defaultOTelRollups returns the canonical OTel CH exporter rollups.
-// The upstream exporter only writes these tables when the operator
-// explicitly enables the rollup feature, so the default schema
-// advertises them — operators who haven't enabled rollups will simply
-// never have the rule fire (the substitution checks for the rollup
-// table existing logically via this registry; cerberus does not probe
-// CH's `system.tables`).
-//
-// Two canonical rollups ship in the default schema:
-//
-//   - `otel_metrics_sum_5m` — five-minute sum buckets. Suits PromQL
-//     `query_range` with 5-minute step.
-//   - `otel_metrics_sum_1h` — one-hour sum buckets. Suits long-range
-//     queries (24h, 7d) where five-minute resolution is overkill.
-//
-// Longest window first so a rollup-substitution rule walking the slice
-// in order (see RollupsFor) prefers the coarsest rollup that still
-// satisfies the query's step.
-func defaultOTelRollups() []Rollup {
-	return []Rollup{
-		{
-			BaseTable:   "otel_metrics_sum",
-			RollupTable: "otel_metrics_sum_1h",
-			Window:      time.Hour,
-			AggOp:       RollupAggSum,
-			ValueColumn: "Sum",
-		},
-		{
-			BaseTable:   "otel_metrics_sum",
-			RollupTable: "otel_metrics_sum_5m",
-			Window:      5 * time.Minute,
-			AggOp:       RollupAggSum,
-			ValueColumn: "Sum",
-		},
-	}
-}
 
 // DefaultOTelMetrics returns the schema produced by the upstream OTel
 // ClickHouse Exporter. Column names mirror the upstream
@@ -428,7 +288,6 @@ func DefaultOTelMetrics() Metrics {
 		// are deliberately left "" here — see their doc comments above.
 		// DefaultOTelMetricsFrom (internal/schema/env.go) populates them
 		// only when CERBERUS_SCHEMA_DELTA_PREFIX_ENABLED opts in.
-		MetricsRollups: defaultOTelRollups(),
 	}
 }
 

--- a/internal/schema/otel_test.go
+++ b/internal/schema/otel_test.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"testing"
-	"time"
 )
 
 // TestDefaultOTelMetricsPinsUpstreamColumns pins every column name
@@ -287,50 +286,6 @@ func TestHistogramCompanionColumn(t *testing.T) {
 					tc.input, col, tc.wantValueColumn)
 			}
 		})
-	}
-}
-
-// TestDefaultOTelMetricsRollups pins the canonical OTel sum rollups
-// the upstream exporter writes when rollup tables are enabled. No
-// optimizer rule consumes this registry today (the MV-substitution rule
-// that did was retired in 2026-06); the pin keeps the schema-side
-// contract stable for a future rollup-substitution rule.
-func TestDefaultOTelMetricsRollups(t *testing.T) {
-	t.Parallel()
-	m := DefaultOTelMetrics()
-
-	rollups := m.Rollups()
-	if len(rollups) == 0 {
-		t.Fatalf("DefaultOTelMetrics: expected at least the two canonical sum rollups; got none")
-	}
-
-	// The 1h rollup must come before 5m so a rollup-substitution rule
-	// walking the slice in order prefers the coarsest applicable window.
-	got1h := rollups[0]
-	if got1h.RollupTable != "otel_metrics_sum_1h" {
-		t.Errorf("first rollup: got RollupTable=%q, want otel_metrics_sum_1h (coarsest-first ordering broken)", got1h.RollupTable)
-	}
-	if got1h.Window != time.Hour {
-		t.Errorf("1h rollup Window: got %s, want 1h", got1h.Window)
-	}
-	if got1h.AggOp != RollupAggSum {
-		t.Errorf("1h rollup AggOp: got %q, want sum", got1h.AggOp)
-	}
-	if got1h.ValueColumn != "Sum" {
-		t.Errorf("1h rollup ValueColumn: got %q, want Sum", got1h.ValueColumn)
-	}
-	if got1h.BaseTable != m.SumTable {
-		t.Errorf("1h rollup BaseTable: got %q, want %q", got1h.BaseTable, m.SumTable)
-	}
-
-	// RollupsFor must filter by base table.
-	sumOnly := m.RollupsFor(m.SumTable)
-	if len(sumOnly) != 2 {
-		t.Errorf("RollupsFor(SumTable): expected 2 rollups, got %d", len(sumOnly))
-	}
-	gaugeOnly := m.RollupsFor(m.GaugeTable)
-	if len(gaugeOnly) != 0 {
-		t.Errorf("RollupsFor(GaugeTable): expected 0 rollups (no gauge rollups in default schema), got %d", len(gaugeOnly))
 	}
 }
 

--- a/internal/solver/decision.go
+++ b/internal/solver/decision.go
@@ -97,18 +97,6 @@ type ScanEstimate struct {
 	// probes ran for the same request (see its own mergeCardinalityEstimate
 	// doc).
 	Rows uint64
-
-	// DistinctSeries is the cardinality pre-probe's uniqUpTo(100)(...)
-	// read-out (issue #2788) — the number of distinct series backing the
-	// scan window, up to the uniqUpTo(100) cap (see chplan.FnUniqUpTo's own
-	// doc for the saturation behaviour above it). Zero when the cardinality
-	// pre-probe did not run (EXPLAIN ESTIMATE alone never populates this
-	// field — it has no comparable per-series signal). classify() does not
-	// read this field at all: it exists solely for
-	// internal/engine/cardinality_probe_wiring.go's own per-rung admission
-	// seeding, which needs the fan-out signal EXPLAIN ESTIMATE's row-only
-	// upper bound cannot provide.
-	DistinctSeries uint64
 }
 
 // Decision is the routing output. Slices are ordered oldest-first

--- a/internal/solver/planner.go
+++ b/internal/solver/planner.go
@@ -70,9 +70,6 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 		if !perRung && int64(sig.outerN)*sig.maxFanout < int64(minAnchorPairs) {
 			return notRouted(ReasonBelowThreshold).withGrid(sig, meta), false
 		}
-		if k < 2 {
-			return notRouted(ReasonBelowThreshold).withGrid(sig, meta), false
-		}
 		// Last, so a plan that was already below threshold keeps THAT reason
 		// and the shipped route-A analyzer's population does not shift
 		// underneath it: only plans that would genuinely have routed change
@@ -82,8 +79,9 @@ func (p *Planner) Plan(plan chplan.Node, meta RequestMeta) (*Decision, bool) {
 		}
 		return p.sliceAndDecide(plan, meta, sig, k, perRung)
 	}
-	// "sharded": thresholds drop to the floor — every eligible plan routes
-	// at K_min = 2 (k is already clamped to >= 2 by classify when upper >= 2).
+	// "sharded": thresholds drop to the floor — every eligible plan routes at
+	// K_min = minRouteBShards (classify clamps k to that floor whenever it
+	// reports eligible).
 
 	return p.sliceAndDecide(plan, meta, sig, k, false)
 }
@@ -347,19 +345,25 @@ func (p *Planner) classify(plan chplan.Node, meta RequestMeta) (sig signals, dec
 	if highBound < upper {
 		upper = highBound
 	}
-	lower := int64(2)
+	// If the high-D clamp ceiling fell below the floor there is no valid K —
+	// the documented high-D floor.
+	//
+	// Checked BEFORE the clamp below, which is what makes the floor
+	// structural: with upper >= minRouteBShards established here, kk is
+	// clamped up to minRouteBShards and then down to upper, so an ELIGIBLE
+	// classify can only ever return k >= minRouteBShards. Plan has no k <
+	// minRouteBShards arm because such an arm could never run — it had one,
+	// dead, until #3188.
+	if upper < minRouteBShards {
+		return sig, notRouted(ReasonHighD).withGrid(sig, meta), 0, false
+	}
+
 	kk := int64(n / p.Cfg.MinAnchorsPerSlice)
-	if kk < lower {
-		kk = lower
+	if kk < minRouteBShards {
+		kk = minRouteBShards
 	}
 	if kk > upper {
 		kk = upper
-	}
-
-	// If the high-D clamp ceiling fell below 2 there is no valid K — the
-	// documented high-D floor.
-	if upper < 2 {
-		return sig, notRouted(ReasonHighD).withGrid(sig, meta), 0, false
 	}
 	// (6) An end-phased nested grid is generated backward from its own End,
 	// so the slice quantum must preserve its phase — checked against the
@@ -868,6 +872,15 @@ type carrierGeometry struct {
 // than 0 because the samples ARE read — a zero would say the carrier touches no
 // data, which is StepGrid's answer, not this family's.
 const singlePassFanout = int64(1)
+
+// minRouteBShards is the smallest K a routed plan can carry. One shard is not
+// a shard: it re-runs the whole query as a single slice, paying route B's
+// coordination for exactly route A's scan. So a ceiling below it means there is
+// no valid K at all, and classify refuses (ReasonHighD) rather than routing.
+//
+// It is the floor for BOTH ends of classify's clamp, which is what lets Plan
+// and sliceAndDecide take k >= minRouteBShards as given.
+const minRouteBShards = int64(2)
 
 // minAnchorsForPerRungShard is the anchor count at or above which a per-rung
 // carrier (carrierGeometry.perRungIntermediate) is routed by ModeAuto without

--- a/internal/solver/planner_test.go
+++ b/internal/solver/planner_test.go
@@ -1254,3 +1254,83 @@ func TestPlan_NativeFanoutStillRoutes(t *testing.T) {
 		t.Fatalf("reason = %q, want %q", d.Reason, ReasonRouted)
 	}
 }
+
+// TestClassifyNeverReportsEligibleBelowTheShardFloor pins the invariant that
+// makes Plan's k-below-floor arm unnecessary rather than merely absent.
+//
+// Plan carried `if k < 2 { return notRouted(ReasonBelowThreshold) }` until
+// #3188. It could never run: classify clamps kk UP to minRouteBShards and only
+// then DOWN to upper, and refuses with ReasonHighD when upper is below the
+// floor, so every eligible classify already returns k >= minRouteBShards. A
+// branch that cannot execute is not a safety net — it reads as one while
+// pinning nothing, and it made the real floor look like it lived in Plan.
+//
+// The floor now lives in exactly one place, so this sweep is what guards it.
+// floorClamped counts the cases where the anchor-derived kk was itself below
+// the floor, i.e. where the clamp is the only thing keeping k legal; requiring
+// it to be non-zero is what stops this test passing over a sweep that never
+// reached the clamp at all.
+func TestClassifyNeverReportsEligibleBelowTheShardFloor(t *testing.T) {
+	t.Parallel()
+
+	// A sweep wide enough that MinAnchorsPerSlice ranges from far below the
+	// anchor count to far above it, which is the axis that drives kk below the
+	// floor.
+	steps := []time.Duration{15 * time.Second, time.Minute, 5 * time.Minute}
+	outers := []time.Duration{30 * time.Minute, time.Hour, 6 * time.Hour}
+	perSlice := []int{1, 4, 30, 240, 5000}
+
+	var eligible, floorClamped int
+	for _, step := range steps {
+		for _, outer := range outers {
+			for _, mps := range perSlice {
+				cfg := autoCfg()
+				cfg.MinAnchorsPerSlice = mps
+				p := &Planner{Cfg: cfg}
+
+				start := gridStart
+				end := start.Add(outer)
+				rw := &chplan.RangeWindow{
+					Input:           leafScan(),
+					Func:            "rate",
+					Range:           5 * time.Minute,
+					Step:            step,
+					OuterRange:      outer,
+					Start:           start,
+					End:             end,
+					TimestampColumn: "TimeUnix",
+					ValueColumn:     "Value",
+					GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+				}
+				plan := &chplan.Aggregate{
+					Input:    rw,
+					AggFuncs: []chplan.AggFunc{{Fn: chplan.FnSum, Args: []chplan.Expr{&chplan.ColumnRef{Name: "Value"}}}},
+				}
+				meta := RequestMeta{Lang: LangPromQL, Start: start, End: end, Step: step}
+
+				sig, _, k, ok := p.classify(plan, meta)
+				if !ok {
+					continue
+				}
+				eligible++
+				if k < minRouteBShards {
+					t.Errorf("classify(step=%s outer=%s minAnchorsPerSlice=%d) reported eligible with k=%d, "+
+						"below the minRouteBShards=%d floor — Plan and sliceAndDecide take that floor as given",
+						step, outer, mps, k, minRouteBShards)
+				}
+				if int64(sig.outerN/mps) < minRouteBShards {
+					floorClamped++
+				}
+			}
+		}
+	}
+
+	if eligible == 0 {
+		t.Fatal("no swept shape classified eligible: the sweep asserts nothing")
+	}
+	if floorClamped == 0 {
+		t.Fatalf("swept %d eligible shapes but none had an anchor-derived kk below the floor: "+
+			"the clamp this test exists to pin was never exercised", eligible)
+	}
+	t.Logf("swept %d eligible shapes, %d of them relying on the floor clamp", eligible, floorClamped)
+}

--- a/test/property/int_fold_ch_agreement_test.go
+++ b/test/property/int_fold_ch_agreement_test.go
@@ -1,0 +1,154 @@
+//go:build chdb
+
+// Layer 4 — the ClickHouse-agreement half of the int64 constant-fold property.
+//
+// # The gap this closes (#3188)
+//
+// internal/optimizer's TestFoldIntInt_Arithmetic asserts foldIntInt reproduces
+// two's-complement wraparound. It can only ever assert that against an oracle
+// living in the same process — originally Go's own operator (a restatement of
+// the implementation), now an arbitrary-precision reduction that at least
+// states the contract explicitly.
+//
+// Neither answers the question the fold actually owes an answer to. Folding
+// `LitInt op LitInt` at plan time REPLACES an arithmetic ClickHouse would
+// otherwise have performed itself. The fold is correct only if it computes
+// what ClickHouse would have computed. Whether Go's int64 semantics and
+// ClickHouse's Int64 semantics agree across the overflow region is a claim
+// about ClickHouse, and no in-process oracle can settle it — a suite that
+// compares Go against Go passes identically whether they agree or not.
+//
+// So this asks ClickHouse. The same operand pairs the unit property drives
+// through foldIntInt are evaluated by chDB as Int64 arithmetic, and the two
+// must match. If ClickHouse ever saturated, promoted, or threw where cerberus
+// wraps, the fold would be silently rewriting query results and this is the
+// only layer that would notice.
+//
+// Build-tagged chdb: it needs libchdb.so (`just chdb-install`).
+
+package property
+
+import (
+	"database/sql"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/optimizer"
+)
+
+// intFoldOps pairs each folded operator with its ClickHouse spelling. The
+// optimizer folds exactly these three for int64 (OpDiv declines, and OpMod /
+// OpPow are deliberately unfolded because Go and ClickHouse disagree on them).
+var intFoldOps = []struct {
+	op chplan.BinaryOp
+	ch string
+}{
+	{chplan.OpAdd, "+"},
+	{chplan.OpSub, "-"},
+	{chplan.OpMul, "*"},
+}
+
+// intFoldOperands are the pairs the agreement is checked over: the int64
+// boundaries where wrap-vs-saturate-vs-throw actually diverge, plus ordinary
+// values so a reader can see the check is not boundary-only.
+var intFoldOperands = [][2]int64{
+	{0, 0},
+	{1, -1},
+	{7, 6},
+	{-7, 6},
+	{math.MaxInt32, math.MaxInt32},
+	{math.MinInt32, math.MinInt32},
+	{math.MaxInt64, 1},
+	{math.MaxInt64, math.MaxInt64},
+	{math.MinInt64, 1},
+	{math.MinInt64, -1},
+	{math.MinInt64, math.MinInt64},
+	{math.MaxInt64, -1},
+	{math.MaxInt64, 2},
+	{math.MinInt64, 2},
+}
+
+// chInt64Arith evaluates `a op b` in ClickHouse with both operands pinned to
+// Int64, and reports whether ClickHouse produced a value at all.
+//
+// The casts are load-bearing. An unqualified integer literal is typed by its
+// magnitude, so ClickHouse would widen the expression to Int128 and compute a
+// non-wrapping result that says nothing about the Int64 arithmetic the fold
+// replaces.
+func chInt64Arith(t *testing.T, db *sql.DB, op string, a, b int64) (int64, bool) {
+	t.Helper()
+	q := fmt.Sprintf("SELECT toInt64(%d) %s toInt64(%d)", a, op, b)
+	var got int64
+	if err := db.QueryRow(q).Scan(&got); err != nil {
+		t.Logf("chDB refused %q: %v", q, err)
+		return 0, false
+	}
+	return got, true
+}
+
+// TestIntFoldAgreesWithClickHouse is the cross-engine half of the fold
+// property: for every folded operator and operand pair, ClickHouse's own Int64
+// arithmetic must equal what the optimizer folds to.
+func TestIntFoldAgreesWithClickHouse(t *testing.T) {
+	db := openChDB(t)
+
+	for _, o := range intFoldOps {
+		for _, pair := range intFoldOperands {
+			a, b := pair[0], pair[1]
+			name := fmt.Sprintf("%s/%d_%s_%d", o.op, a, o.ch, b)
+			t.Run(name, func(t *testing.T) {
+				chVal, ok := chInt64Arith(t, db, o.ch, a, b)
+				if !ok {
+					t.Fatalf("ClickHouse refused toInt64(%d) %s toInt64(%d), but the optimizer "+
+						"folds it to a literal — folding an expression the engine rejects "+
+						"turns a query error into a wrong answer", a, o.ch, b)
+				}
+
+				folded, ok := foldLiteralInts(o.op, a, b)
+				if !ok {
+					t.Fatalf("the optimizer declined to fold %d %s %d, which ClickHouse evaluates "+
+						"to %d", a, o.ch, b, chVal)
+				}
+				if folded != chVal {
+					t.Fatalf("fold(%d %s %d) = %d, ClickHouse says %d — the constant fold replaces "+
+						"arithmetic ClickHouse would otherwise do, so a disagreement here is a "+
+						"silently wrong query result", a, o.ch, b, folded, chVal)
+				}
+			})
+		}
+	}
+}
+
+// foldLiteralInts runs the SHIPPED ConstantFoldSemantic rule over a plan whose
+// projection is `a op b` with both operands int literals, and returns the
+// folded value.
+//
+// It drives the real rule rather than reaching for the private helper, so what
+// this test compares against ClickHouse is the same rewrite a production query
+// gets — including the walk that decides an expression is foldable at all.
+func foldLiteralInts(op chplan.BinaryOp, a, b int64) (int64, bool) {
+	plan := &chplan.Project{
+		Input: &chplan.Scan{Table: "t", Columns: []string{"v"}},
+		Projections: []chplan.Projection{{
+			Alias: "folded",
+			Expr: &chplan.Binary{
+				Op:    op,
+				Left:  &chplan.LitInt{V: a},
+				Right: &chplan.LitInt{V: b},
+			},
+		}},
+	}
+
+	out, _ := optimizer.ConstantFoldSemantic{}.Apply(plan)
+	proj, ok := out.(*chplan.Project)
+	if !ok || len(proj.Projections) != 1 {
+		return 0, false
+	}
+	lit, ok := proj.Projections[0].Expr.(*chplan.LitInt)
+	if !ok {
+		return 0, false
+	}
+	return lit.V, true
+}

--- a/test/regression/goleak_test.go
+++ b/test/regression/goleak_test.go
@@ -50,9 +50,18 @@ import (
 // stuck-WebSocket leaks this file names as its targets.
 //
 // t.Cleanup runs LIFO, so registering this FIRST makes it run LAST.
+//
+// The options are built HERE and captured, never inside the cleanup closure.
+// goleak.IgnoreCurrent snapshots the live goroutine set at OPTION-CREATION
+// time; building the options inside the closure takes that snapshot at
+// verification time, so every goroutine the test leaked is in the snapshot and
+// is ignored, and VerifyNone cannot fail for any reason. Call this as the first
+// statement of the test, before anything spawns a goroutine, so the baseline is
+// the inventory the test inherited rather than the one it created.
 func verifyNoLeaksAfterCleanup(t *testing.T) {
 	t.Helper()
-	t.Cleanup(func() { goleak.VerifyNone(t, goleakOpts()...) })
+	opts := goleakOpts()
+	t.Cleanup(func() { goleak.VerifyNone(t, opts...) })
 }
 
 // goleakOpts excludes the few intermittent goroutines that don't
@@ -66,14 +75,18 @@ func verifyNoLeaksAfterCleanup(t *testing.T) {
 // verifyNoLeaksAfterCleanup); with the ordering fixed the suite passes
 // without it. Do not re-add it: an entry that broad makes the detector
 // unable to fail for its stated targets.
+//
+// IgnoreCurrent must be evaluated before the test body runs — see
+// verifyNoLeaksAfterCleanup — which is why this returns options rather than
+// running the verification itself.
 func goleakOpts() []goleak.Option {
 	return []goleak.Option{
 		goleak.IgnoreTopFunction("net/http.(*Transport).getConn"),
 		goleak.IgnoreTopFunction("net/http.(*persistConn).readLoop"),
 		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
-		// Some tests use httptest.Server which spawns its own conn-tracking
-		// goroutines that linger briefly after Close — ignore the standard
-		// tail.
+		// Goroutines the test inherited from the ones that ran before it in
+		// this binary: another test's lingering conn-tracking tail is not this
+		// test's leak.
 		goleak.IgnoreCurrent(),
 	}
 }
@@ -559,5 +572,81 @@ func TestNoGoroutineLeak_RouteMemo(t *testing.T) {
 
 	if state, _ := m.Lookup(other); state != routememo.BothFail {
 		t.Fatalf("Lookup(other) = %v, want BothFail", state)
+	}
+}
+
+// recordingLeakT is a goleak.TestingT that records failure instead of failing
+// the surrounding test, so a test can assert that the leak detector DOES fire.
+type recordingLeakT struct {
+	mu     sync.Mutex
+	failed bool
+}
+
+func (r *recordingLeakT) Error(...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failed = true
+}
+
+// TestGoleakDetectorCanFail is the meta-test for the 14 leak tests above: it
+// proves the guard they all call actually reports a leaked goroutine.
+//
+// The whole suite was vacuous before this test existed. goleak.IgnoreCurrent
+// snapshots the live goroutine set when the OPTION is constructed, and
+// verifyNoLeaksAfterCleanup built its options inside the cleanup closure — so
+// the snapshot was taken at verification time, contained every goroutine the
+// test had leaked, and ignored all of them. A goroutine deliberately parked for
+// 30s passed all 14 tests.
+//
+// Both arms below run the identical leak against the identical options, and
+// differ only in WHEN the options are built. That is the entire mechanism, so
+// the "after" arm is asserted too: if goleak ever changed IgnoreCurrent to
+// snapshot lazily, the "after" arm would start failing and tell us the
+// ordering rule this file is built on no longer holds.
+func TestGoleakDetectorCanFail(t *testing.T) {
+	tests := []struct {
+		name string
+		// buildBeforeLeak mirrors verifyNoLeaksAfterCleanup: options are
+		// constructed before the test body spawns anything.
+		buildBeforeLeak bool
+		wantDetected    bool
+	}{
+		{name: "options built before the leak detect it", buildBeforeLeak: true, wantDetected: true},
+		{name: "options built after the leak ignore it", buildBeforeLeak: false, wantDetected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var opts []goleak.Option
+			if tc.buildBeforeLeak {
+				opts = goleakOpts()
+			}
+
+			// A goroutine that outlives the body, released only on cleanup so
+			// this test leaks nothing of its own.
+			release := make(chan struct{})
+			running := make(chan struct{})
+			t.Cleanup(func() { close(release) })
+			go func() {
+				close(running)
+				<-release
+			}()
+			<-running
+
+			if !tc.buildBeforeLeak {
+				opts = goleakOpts()
+			}
+
+			rec := &recordingLeakT{}
+			goleak.VerifyNone(rec, opts...)
+
+			rec.mu.Lock()
+			got := rec.failed
+			rec.mu.Unlock()
+			if got != tc.wantDetected {
+				t.Fatalf("leak detected = %v, want %v — the Layer 11 detector's "+
+					"IgnoreCurrent ordering no longer behaves as this file assumes", got, tc.wantDetected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Repairs test mechanisms that could not fail, and deletes the dead code the ACPR
(#3180) turned up. Every item was verified against the tree before it was
touched; the ones that did not reproduce are named as refuted rather than
"fixed".

Every fix carries a test that provably fails when the fix is neutralized, and
each neutralization was actually run — the output is in the commit that makes
the change.

The fixture half of #3188 is out of scope here: it is tracked per-case in #3183
and handled separately.

## The sharpest one: the whole Layer 11 leak suite was vacuous

The issue reported the 14 goroutine-leak tests asserting before
`httptest.Server.Close`. That ordering bug was already fixed by #3180. The suite
was still unable to fail, for a different reason.

`goleak.IgnoreCurrent` snapshots the live goroutine set at **option-construction**
time, and `verifyNoLeaksAfterCleanup` built its option slice *inside* the cleanup
closure. The snapshot was therefore taken at verification time, contained every
goroutine the test had just leaked, and ignored all of them.

Demonstrated: a goroutine deliberately parked in `time.Sleep` for 30s passed all
14 tests. With the options built when the guard is registered, the same leak
fails them. The `internal/poll.runtime_pollWait` ignore entry the issue asked
about **stays removed** — all 14 pass against a detector that can now fail.

## Other gates that reported success on absent evidence

- **The int64 fold property** compared `foldIntInt` against a second copy of the
  same Go operator. That catches a change to the fold, but can only conclude
  "the fold agrees with Go" — and agreeing with Go is not the requirement.
  Folding `LitInt op LitInt` *replaces* arithmetic ClickHouse would have done,
  so over the overflow region the interesting claim is about ClickHouse, and
  `l + r` asserts it vacuously. The in-process oracle is now an exact `math/big`
  computation reduced into int64, and the contract is confirmed against a real
  engine in `test/property/int_fold_ch_agreement_test.go` — the same operand
  pairs through the shipped `ConstantFoldSemantic` rule and through chDB. They
  agree at every int64 boundary; a saturating fold is rejected on 12 pairs.

  Note for reviewers: the `property` lane is a **green no-op on an ordinary PR**
  by design (it links `libchdb.so` and is segregated from the CGO-free required
  lane), so its green check here does not mean this test ran. It gates on
  merge-to-`main`, nightly, and release PRs. It was run locally against real
  chDB under CI's full tag set (`chdb,agpl_oracle,chdb_agpl_oracle`) — 42
  subtests, all passing.

- **The rule-interaction matrix** claimed to pin "every pair" and enumerated 6
  rules, omitting `FlattenVectorSetOp`. Pairs are now *derived* (C(8,2) = 28)
  and a second test reads `Default()`'s live registration, so an unpaired rule
  fails instead of being quietly absent. Requiring both rules to have actually
  fired, in both orders, exposed **two pre-existing pairs whose plans gave the
  fold rule nothing to fold** — tautological for 2 of the original 15 while the
  header claimed both rules applied.

- **`TestPropertyOptimizerSemanticEquivalence` hung instead of failing.** It
  advanced its counter only on a successful pre-run with no cap on drops, so a
  regression breaking emission for the generated shapes looped forever. A test
  that hangs reports nothing.

- **`ProjectionPushdown`'s `walkExpr`** had no `WindowExpr` / `InSubquery` /
  `ScalarSubquery` arm and its doc claimed no chplan-side helper existed. One
  does — `chplan.InspectExpr`, exhaustive by construction and ratcheted. A
  column read only inside an unwalked sub-expression gets pruned and ClickHouse
  answers error 47.

- **`doc-counts` now derives the semantic-shape roster.** It had already
  drifted: the doc claimed 81 stable IDs while `test/property/gen/shapes.go`
  publishes 83. The assertion compares the **set**, both directions, plus each
  group's integer, because a count alone survives two compensating edits.

- **`routerrules`: a declared param no rule reaches is now a load-time error.**
  Resolution walks the *declared* params, and each corpus param drives its own
  full aggregate pass, so an unreached one buys a corpus scan per run and can
  never move a finding. `memory_high_watermark` was in exactly that state while
  being the architecture doc's headline example of the params mechanism.

## Failing open, and comments that lied

- `emitSearchTraceLimit` answered a non-positive `TraceLimit` by emitting the
  input subtree unchanged — the whole unbounded scan, top-N silently gone —
  where every sibling guard returns `ErrUnsupported`.
- `dateTime64Frag`'s comment promised "Zero `t` panics". Nothing panicked; a
  zero time rendered as `0001-01-01 00:00:00.000000000`, which reads as a real
  window. The bound is now rejected where the emitter can actually return an
  error.
- `chplan`'s `RangeBucketGridNative.AnchorGridDivides` asserted the kind was
  "deliberately absent from `sliceInvariantKinds`" and non-re-anchorable, citing
  two tests that do not exist. #2677 registered the kind and added the reanchor
  arm, so the licence to shard the comment called inert is live. The **claim** is
  corrected, not just the citation.
- `singleAddr`'s comment claimed to drive a warning nothing emits.
  `defaultRBGNMaxDensityUnits`'s claimed to be the fallback an unset knob
  resolves to, when that case derives from `CERBERUS_CH_QUERY_MAX_MEMORY`.

## Dead code deleted

Each verified unreachable or unread first: `solver.Plan`'s `if k < 2` (the floor
check now runs *before* the clamp, making `k >= minRouteBShards` structural, with
a 45-shape sweep that fails if the clamp goes), `solver.ScanEstimate.DistinctSeries`,
`schema.Metrics.MetricsRollups` and its type/accessors, `chExtra.singleAddr` /
`rawConnStrategy`, `defaultRBGNMaxDensityUnits`, and `routememo.BeginProbe` —
an exported admission path with no production caller that both its own doc and
its replacement's told callers not to use. Deleting it makes the two-call
footgun unexpressible, and the duplicated admission rule collapses to one
`admitProbeLocked`.

## Filed rather than claimed

Verified, evidenced, out of scope for one PR: #3208, #3209, #3210, #3211, #3213.

Closes #3188
