### PR TITLE
docs(chopt): state the tag-group label-op conclusion instead of citing a tracker

### DIFF
--- a/internal/chopt/registry.go
+++ b/internal/chopt/registry.go
@@ -1860,11 +1860,37 @@ const (
 	// is a documented follow-up, see below) onto grouping by a deduplicated
 	// UInt64 id (timeSeriesTagsToGroup(Attributes)) instead of the raw
 	// Map(String,String) Attributes column, rehydrating Attributes via
-	// timeSeriesGroupToTags only in the wrapping output projection (cerberus
-	// issue #2750 — the grouping-keys-only slice of the tag-group family; label
-	// ops (by/without/label_replace/label_join/group_left via the purpose-built
-	// tag functions) are the second half of that staging and are still
-	// outstanding, tracked on cerberus issue #3195).
+	// timeSeriesGroupToTags only in the wrapping output projection.
+	//
+	// GROUPING KEYS ARE THE WHOLE FEATURE. The label ops the tag-group family
+	// also offers — by / without / label_replace / label_join / group_left
+	// through the purpose-built tag functions — are deliberately NOT part of
+	// it, and that exclusion is a conclusion rather than a staging note. They
+	// are unsound at the sites that would want them, for the same reason the SITE
+	// CHOICE below explains at length: timeSeriesTagsToGroup and
+	// timeSeriesGroupToTags are STATEFUL, backed by a per-query
+	// ContextTimeSeriesTagsCollector, so a group id means nothing outside the
+	// single query execution that produced it. Every label op reaches range
+	// mode, range mode is what the solver's route B shards, and route B
+	// concatenates K per-shard cursors in Go without re-aggregating on any key
+	// the shards produced — so a group id would have to cross a shard boundary
+	// to survive, which it cannot. Applying them would need a per-shard
+	// rehydration story that does not exist, and inventing one to chase an
+	// unmeasured win is not a trade this registry makes.
+	//
+	// The performance case is closed too, and by measurement rather than by
+	// argument — see PAYING-SITE SEARCH CLOSED, PERMANENT NEGATIVE below,
+	// which re-ran the real-ClickHouse A/B against the strongest multi-stage
+	// candidate in the codebase and found the group id paid once per SIDE
+	// rather than once per QUERY. A label-op conversion would extend a
+	// mechanism already measured negative at every site tried.
+	//
+	// So there is nothing outstanding to pick up. This paragraph used to say
+	// the label ops were "still outstanding, tracked on" an issue — first
+	// #2750, then #3195 — while the block below already recorded the search
+	// as permanently closed. Two citations rotted into closed issues before
+	// the contradiction was noticed, which is the argument for stating the
+	// conclusion here instead of pointing at a tracker.
 	//
 	// SITE CHOICE: guardNameDropCollision is the single most self-contained
 	// grouping site in the pipeline that groups on the raw Attributes Map —


### PR DESCRIPTION
`FeatureTSGridTagGroups` described its label-op half as "still outstanding,
tracked on" an issue. Two things were wrong with that, and they compound.

Closes #3195

## The citation had rotted twice

It pointed at **#2750**, which is closed. #3195 was filed to say so, and the
citation was then re-pointed at **#3195** — which this PR closes. Re-pointing it
a third time would rot again the moment that issue closed. Invariant 3 wants an
open issue behind a deferral marker; the honest resolution is that there is no
deferral to track.

## The declaration contradicted itself

A few hundred lines below, the same declaration already carries a section
headed **PAYING-SITE SEARCH CLOSED, PERMANENT NEGATIVE**, recording that #2880
re-ran the real-ClickHouse A/B methodology against the strongest multi-stage
candidate in the codebase — `vector_join.go`'s `CardOneToOne` shape — and found
the group id is paid **once per SIDE, not once per QUERY**, so no downstream
reuse amortizes it. It states `AutoSelect` stays false *permanently, not
pending further investigation*.

So the header said work was outstanding while the body said the search was
closed. That is the paradox class, not a stale link.

## What the comment says now

The label ops are excluded as a **conclusion**, with two independent reasons
recorded because either alone settles it:

1. **Soundness.** `timeSeriesTagsToGroup` / `timeSeriesGroupToTags` are
   stateful, backed by a per-query `ContextTimeSeriesTagsCollector`, so a group
   id means nothing outside the execution that produced it. Every label op
   (`by` / `without` / `label_replace` / `label_join` / `group_left`) reaches
   range mode; range mode is what the solver's route B shards; route B
   concatenates K per-shard cursors in Go **without re-aggregating** on any key
   the shards produced. A group id would have to cross a shard boundary to
   survive, and it cannot. This is the same argument the existing SITE CHOICE
   paragraph already makes for why the shipped slice picked an instant-mode-only
   site.
2. **Measured performance.** Already documented below; a label-op conversion
   would extend a mechanism measured negative at every site tried.

## Why not implement the label ops instead

That is the issue's other "Done when", and I considered it. A sound version
would have to be confined to sites that structurally cannot reach route B —
the criterion the shipped grouping-keys slice already used. That is a narrow
slice of the label-op surface, and the registry's own measurements say the
mechanism does not pay even at the sites chosen *because* they looked most
favourable. Building it to satisfy a backlog entry, against a documented
measured negative, is not a trade worth making.

No behaviour change; comment only. `internal/chopt` tests pass.
