### PR TITLE
fix(routerrules): give the benchmark corpus the shape production records

### DIFF
--- a/docs/router-rules.md
+++ b/docs/router-rules.md
@@ -516,11 +516,25 @@ the route-scoped rules nor the two non-PromQL heads go untested.
 The GENERATED benchmark corpus is a separate population and is pinned separately,
 because that test globs `testdata/*.jsonl` and the benchmark corpus is built in
 Go and handed to the evaluator in memory, never touching a file. It is held to
-the first two invariants by `TestRouterBenchCorpusIsProducible` in the same file.
-It does not yet satisfy the third: it plants classified LogQL and TraceQL classes
-that a PromQL-gated solver cannot emit, which is tracked in issue #3204 —
-correcting them moves the labeled ground truth and the regression floors, so it
-is its own change rather than a fixture edit.
+all three invariants by `TestRouterBenchCorpusIsProducible` in the same file,
+through the same `classified()` helper, and to a stricter form of the second: the
+generator writes every row itself, so a non-PromQL row must name its absent
+classification with the `non-promql` token rather than leaving the reason blank.
+`unclassifyNonPromQL` in `benchmark.go` is the single writer of `route`,
+`decision_reason` and the geometry columns on a LogQL or TraceQL row, applied as
+one post-pass over the finished corpus so a new pathology spec on those heads
+cannot opt out of it.
+
+That constrains what the benchmark can label. Route B is a Solver outcome, so the
+route-B fan-out floor is seeded on PromQL alone; a route-A pathology is planted on
+PromQL, where "route A" is a claim a classified head can make; and the two
+non-PromQL pathology classes expect only the detectors that gate on `exit_status`
+— `failure_cluster_by_reason` on a LogQL timeout, `cerberus_side_rejection_pressure`
+on a TraceQL breaker trip. Every route- or geometry-gated rule is absent from
+those labels structurally, not by tuning: an unclassified row matches neither
+route token, and `d_high_watermark` is a geometry percentile restricted to
+classified rows and partitioned by language, so those heads have no partition key
+and the rule is never evaluated for them at all.
 
 It proves
 the catalog is **effective**, not just well-formed: default-lane tests assert that
@@ -579,8 +593,12 @@ labels grounded in real incident outcomes, which this corpus does not have.
   numbers belong — the shipped catalog stays number-free; the floors live in
   test code). The overall recall/precision floors hold at nominal prevalence;
   severe-recall is floored at 1.0 across the whole grid including off-nominal
-  prevalence. Adversarial corpora (monochrome-healthy, distribution-shifted
-  across seeds) and a multi-rule-interaction test guard the edges.
+  prevalence. Every evaluated rule must also carry at least one labeled class:
+  the per-rule F1 check skips a rule with no labeled positives and the scorecard
+  omits it entirely, so without that assertion a rule the corpus stopped planting
+  a pathology for would leave every floor green while detecting nothing.
+  Adversarial corpora (monochrome-healthy, distribution-shifted across seeds) and
+  a multi-rule-interaction test guard the edges.
 - `cerberus route-rules benchmark` runs the whole thing from the CLI: it scores the
   embedded catalog over the generated corpus and prints the metric table, no
   corpus file required (`--seed`, `--min-support`, and `--param` tune it). The

--- a/internal/routerrules/benchmark.go
+++ b/internal/routerrules/benchmark.go
@@ -287,9 +287,17 @@ const (
 	routeBFloorDurSpread = 400.0
 )
 
+// benchClassifiedLang is the one head the router classifies. Solver.Classify is
+// PromQL-gated, so a PromQL row is the only row that can carry a route, a
+// decision reason drawn from the solver's own vocabulary, or any non-zero solver
+// geometry. Every other head is rewritten to the unclassified shape by
+// unclassifyNonPromQL, and the generator tests membership against this constant
+// rather than the literal so the two cannot drift.
+const benchClassifiedLang = "promql"
+
 // languages are the three heads, weighted PromQL-dominant to match a realistic
 // query mix (the healthy generator plants more promql classes).
-var benchLanguages = []string{"promql", "logql", "traceql"}
+var benchLanguages = []string{benchClassifiedLang, "logql", "traceql"}
 
 // GenerateBenchCorpus builds a deterministic labeled corpus from p. The same
 // seed yields byte-identical rows, so the metrics are reproducible.
@@ -301,6 +309,7 @@ func GenerateBenchCorpus(p BenchParams) *BenchCorpus {
 	plantHealthy(bc, rng, p)
 	plantRouteBFloor(bc, rng, p)
 	plantPathologies(bc, rng, p)
+	unclassifyNonPromQL(bc)
 
 	// Deterministic ordering so a chdb re-insert and the in-Go scan see the same
 	// row sequence (quantileExact is order-independent, but stability avoids
@@ -318,7 +327,7 @@ func GenerateBenchCorpus(p BenchParams) *BenchCorpus {
 func plantHealthy(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
 	for _, lang := range benchLanguages {
 		n := p.HealthyClassesPerLang
-		if lang != "promql" {
+		if lang != benchClassifiedLang {
 			n = max(1, n/2) // promql-dominant mix
 		}
 		for c := 0; c < n; c++ {
@@ -344,6 +353,12 @@ func plantHealthy(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
 					ExitStatus:          "ok",
 				})
 			}
+			// The classified columns above are what a PromQL row carries; on the
+			// other two heads unclassifyNonPromQL overwrites them (and this
+			// class's DecisionReason) with the unclassified shape. Filling them
+			// unconditionally keeps the healthy body ONE distribution — the same
+			// draws in the same order for every language — so a per-language
+			// runtime-cost watermark stays comparable across heads.
 			bc.Classes = append(bc.Classes, LabeledClass{
 				ShapeID: shape, Language: lang, DecisionReason: "below-threshold",
 				QueryHash: hash, Expect: nil, Severity: SevHealthy,
@@ -352,39 +367,85 @@ func plantHealthy(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
 	}
 }
 
-// plantRouteBFloor seeds healthy route-B classes whose high fan-out establishes
-// the route-B fanout floor the shard rules learn. These are negative classes
-// (exit ok, finishing reasonably), but with fan-out characteristic of route B.
+// plantRouteBFloor seeds a healthy route-B class whose high fan-out establishes
+// the route-B fanout floor the shard rules learn. It is a negative class (exit
+// ok, finishing reasonably) with fan-out characteristic of route B.
+//
+// PromQL only, and structurally so rather than as a sampling choice: route B is
+// a Solver outcome, Solver.Classify is PromQL-gated, and the fan-out floor is
+// learned from a geometry column restricted to classified rows. A LogQL route-B
+// seed would be a class production can never write, and its fan-out would be
+// folded into a floor no LogQL query can ever be measured against.
 func plantRouteBFloor(bc *BenchCorpus, rng *rand.Rand, p BenchParams) {
-	for _, lang := range []string{"promql", "logql"} {
-		shape := lang + ":routeb_healthy"
-		hash := uint64(2000 + len(bc.Classes))
-		for i := 0; i < p.HealthyClassSize; i++ {
-			// A healthy fan-out reaches query_log on every shard, so
-			// shards_observed equals k_shards; only an abnormal exit truncates it.
-			k := jitter(rng, 4, 8)
-			bc.Rows = append(bc.Rows, BenchRow{
-				ShapeID:             shape,
-				Language:            lang,
-				NormalizedQueryHash: hash,
-				Fanout:              routeBFloorFanout,
-				CumulativeD:         jitter(rng, healthyDBase, healthyDSpread),
-				Route:               "B",
-				KShards:             k,
-				ShardsObserved:      k,
-				Parallelism:         benchRouteBParallelism,
-				DecisionReason:      "routed",
-				ReadRows:            jitter(rng, healthyReadBase, healthyReadSpread),
-				ReadBytes:           jitter(rng, 1_000_000, 40_000_000),
-				QueryDurationMS:     jitter(rng, routeBFloorDurBase, routeBFloorDurSpread),
-				MemoryUsage:         jitter(rng, healthyMemBase, healthyMemSpread),
-				ExitStatus:          "ok",
-			})
-		}
-		bc.Classes = append(bc.Classes, LabeledClass{
-			ShapeID: shape, Language: lang, DecisionReason: "routed",
-			QueryHash: hash, Expect: nil, Severity: SevHealthy,
+	shape := benchClassifiedLang + ":routeb_healthy"
+	hash := uint64(2000 + len(bc.Classes))
+	for i := 0; i < p.HealthyClassSize; i++ {
+		// A healthy fan-out reaches query_log on every shard, so
+		// shards_observed equals k_shards; only an abnormal exit truncates it.
+		k := jitter(rng, 4, 8)
+		bc.Rows = append(bc.Rows, BenchRow{
+			ShapeID:             shape,
+			Language:            benchClassifiedLang,
+			NormalizedQueryHash: hash,
+			Fanout:              routeBFloorFanout,
+			CumulativeD:         jitter(rng, healthyDBase, healthyDSpread),
+			Route:               "B",
+			KShards:             k,
+			ShardsObserved:      k,
+			Parallelism:         benchRouteBParallelism,
+			DecisionReason:      "routed",
+			ReadRows:            jitter(rng, healthyReadBase, healthyReadSpread),
+			ReadBytes:           jitter(rng, 1_000_000, 40_000_000),
+			QueryDurationMS:     jitter(rng, routeBFloorDurBase, routeBFloorDurSpread),
+			MemoryUsage:         jitter(rng, healthyMemBase, healthyMemSpread),
+			ExitStatus:          "ok",
 		})
+	}
+	bc.Classes = append(bc.Classes, LabeledClass{
+		ShapeID: shape, Language: benchClassifiedLang, DecisionReason: "routed",
+		QueryHash: hash, Expect: nil, Severity: SevHealthy,
+	})
+}
+
+// unclassifyNonPromQL rewrites every LogQL and TraceQL row and class into the
+// shape production actually records for a head the router never classifies:
+// engine.routeFeatures reports present=false, an empty route, all-zero solver
+// geometry and the non-promql reason for any language other than PromQL, because
+// Solver.Classify is PromQL-gated.
+//
+// It runs as one post-pass over the finished corpus rather than as a branch
+// inside each planter, and that is the point: a spec author cannot forget it. A
+// non-PromQL row whose route and geometry were fabricated makes every
+// route-gated rule score against fiction, and makes a geometry percentile fitted
+// over that language look like a learned watermark when on real data its whole
+// population is zero.
+//
+// The runtime-cost columns are untouched. An unclassified query still runs, still
+// reads rows and still OOMs or times out, so read_rows / read_bytes /
+// query_duration_ms / memory_usage / exit_status are as real on a LogQL row as on
+// a PromQL one. shards_observed is zeroed with the geometry: it counts the shards
+// of a fan-out that never happened.
+func unclassifyNonPromQL(bc *BenchCorpus) {
+	for i := range bc.Rows {
+		r := &bc.Rows[i]
+		if r.Language == benchClassifiedLang {
+			continue
+		}
+		r.Route = routeUnclassified
+		r.DecisionReason = reasonNonPromQL
+		r.NAnchors, r.Fanout, r.CumulativeD = 0, 0, 0
+		r.OuterRange, r.Step, r.KShards = 0, 0, 0
+		r.ShardsObserved, r.Parallelism = 0, 0
+	}
+	for i := range bc.Classes {
+		c := &bc.Classes[i]
+		if c.Language == benchClassifiedLang {
+			continue
+		}
+		// A class is identified by its group-key dimensions, and decision_reason
+		// is one of them: it has to name the same token the rows now carry or no
+		// finding can be matched back to it.
+		c.DecisionReason = reasonNonPromQL
 	}
 }
 
@@ -492,7 +553,7 @@ func pathologyFailureSpecs() []pathologySpec {
 		// only when cumulative_d is in the per-language tail, so it is expected at
 		// SEVERE (d in tail) but NOT at MARGINAL (d in the healthy body).
 		{
-			shape: "prom:oom_heavy", lang: "promql", hashBase: 30000,
+			shape: "prom:oom_heavy", lang: benchClassifiedLang, hashBase: 30000,
 			expect: func(sev PathologySeverity) []string {
 				base := []string{"oom_on_route_a", "failure_cluster_by_reason"}
 				if sev == SevSevere {
@@ -517,8 +578,13 @@ func pathologyFailureSpecs() []pathologySpec {
 		// (route_a_slow_hot_shape, which gates only on route-A duration). The
 		// MARGINAL variant clears neither tail, so it expects only the two
 		// status-driven rules.
+		//
+		// PromQL, because "route A" is a claim only a classified head can make.
+		// The LogQL sibling below plants the same failure on a head that carries
+		// no route, and the two together are what separate "this rule needs a
+		// route" from "this rule needs only an exit status".
 		{
-			shape: "log:timeout_heavy", lang: "logql", hashBase: 31000,
+			shape: "prom:timeout_heavy", lang: benchClassifiedLang, hashBase: 39000,
 			expect: func(sev PathologySeverity) []string {
 				base := []string{"route_a_timeout_should_shard", "failure_cluster_by_reason"}
 				if sev == SevSevere {
@@ -537,10 +603,47 @@ func pathologyFailureSpecs() []pathologySpec {
 				}
 			},
 		},
+		// The same hard failure on a head the router never classifies. An
+		// unclassified query still runs and still times out, so this class is a
+		// real population — and it is the one that proves the ROUTE-AGNOSTIC
+		// failure clustering still reaches those heads while every route- or
+		// geometry-gated rule correctly does not.
+		//
+		// failure_cluster_by_reason alone, and each absence is structural rather
+		// than a tuning outcome:
+		//   - route_a_timeout_should_shard and route_a_slow_hot_shape gate on
+		//     route == A, and an unclassified row matches neither route token
+		//     (see the route asymmetry note on enumDomains);
+		//   - heavy_shape_geometry_failing reads d_high_watermark, a geometry
+		//     percentile restricted to classified rows and partitioned by
+		//     language, so LogQL has no partition key and the rule is never
+		//     evaluated for it at all.
+		//
+		// One severity rather than two: the severe/marginal split existed to probe
+		// retention in the duration and geometry tails, and neither detector can
+		// reach this class any more, so a second magnitude would label an
+		// identical expectation twice.
+		//
+		// The classification columns are deliberately absent from the fill —
+		// unclassifyNonPromQL is the single writer of route, decision_reason and
+		// geometry on a non-PromQL row.
+		{
+			shape: "log:timeout", lang: "logql", hashBase: 31000,
+			expect:     always("failure_cluster_by_reason"),
+			severities: []PathologySeverity{SevSevere},
+			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
+				return BenchRow{
+					ExitStatus:      "timeout",
+					QueryDurationMS: sevDurSevere,
+					MemoryUsage:     jitter(rng, healthyMemBase, healthyMemSpread),
+					ReadRows:        jitter(rng, 1_000_000, 4_000_000),
+				}
+			},
+		},
 		// Route-A sample-budget: route_a_hit_sample_budget +
 		// cerberus_side_rejection_pressure.
 		{
-			shape: "prom:topk_budget", lang: "promql", hashBase: 32000,
+			shape: "prom:topk_budget", lang: benchClassifiedLang, hashBase: 32000,
 			expect:     always("route_a_hit_sample_budget", "cerberus_side_rejection_pressure"),
 			severities: []PathologySeverity{SevSevere},
 			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
@@ -550,21 +653,27 @@ func pathologyFailureSpecs() []pathologySpec {
 				}
 			},
 		},
-		// Cerberus-side breaker: cerberus_side_rejection_pressure only.
+		// Cerberus-side breaker on an unclassified head:
+		// cerberus_side_rejection_pressure only. That rule gates on exit_status
+		// alone, so it is the one detector whose reach does not depend on a
+		// route — which is exactly why the corpus plants it on TraceQL.
+		//
+		// As with log:timeout, the classification columns are absent from the
+		// fill; unclassifyNonPromQL writes them.
 		{
 			shape: "trc:breaker", lang: "traceql", hashBase: 33000,
 			expect:     always("cerberus_side_rejection_pressure"),
 			severities: []PathologySeverity{SevSevere},
 			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
 				return BenchRow{
-					Route: "A", ExitStatus: "breaker", DecisionReason: "scalar-heavy",
-					ReadRows: jitter(rng, 100_000, 500_000),
+					ExitStatus: "breaker",
+					ReadRows:   jitter(rng, 100_000, 500_000),
 				}
 			},
 		},
 		// Explicit rejected: cerberus_side_rejection_pressure only.
 		{
-			shape: "prom:rejected", lang: "promql", hashBase: 34000,
+			shape: "prom:rejected", lang: benchClassifiedLang, hashBase: 34000,
 			expect:     always("cerberus_side_rejection_pressure"),
 			severities: []PathologySeverity{SevSevere},
 			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
@@ -577,7 +686,7 @@ func pathologyFailureSpecs() []pathologySpec {
 		// Route-B still failing: route_b_still_failing +
 		// failure_cluster_by_reason + heavy_shape_geometry_failing.
 		{
-			shape: "prom:routeb_fail", lang: "promql", hashBase: 35000,
+			shape: "prom:routeb_fail", lang: benchClassifiedLang, hashBase: 35000,
 			expect:     always("route_b_still_failing", "failure_cluster_by_reason", "heavy_shape_geometry_failing"),
 			severities: []PathologySeverity{SevSevere},
 			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
@@ -603,7 +712,7 @@ func pathologyTailSpecs() []pathologySpec {
 	return []pathologySpec{
 		// Route-B overshard regret: route_b_overshard_low_fanout only.
 		{
-			shape: "prom:overshard", lang: "promql", hashBase: 36000,
+			shape: "prom:overshard", lang: benchClassifiedLang, hashBase: 36000,
 			expect:     always("route_b_overshard_low_fanout"),
 			severities: []PathologySeverity{SevSevere},
 			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {
@@ -619,7 +728,7 @@ func pathologyTailSpecs() []pathologySpec {
 		},
 		// High-fanout route-A: route_a_high_fanout_should_shard only.
 		{
-			shape: "prom:hot_fanout", lang: "promql", hashBase: 37000,
+			shape: "prom:hot_fanout", lang: benchClassifiedLang, hashBase: 37000,
 			expect:     always("route_a_high_fanout_should_shard"),
 			severities: []PathologySeverity{SevSevere, SevMarginal},
 			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
@@ -636,7 +745,7 @@ func pathologyTailSpecs() []pathologySpec {
 		// Memory near cap (healthy but in the per-language memory tail):
 		// route_a_memory_near_cap only.
 		{
-			shape: "prom:mem_near_cap", lang: "promql", hashBase: 38000,
+			shape: "prom:mem_near_cap", lang: benchClassifiedLang, hashBase: 38000,
 			expect:     always("route_a_memory_near_cap"),
 			severities: []PathologySeverity{SevSevere, SevMarginal},
 			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
@@ -653,7 +762,7 @@ func pathologyTailSpecs() []pathologySpec {
 		// Slow hot shape (route A, in the per-language duration tail):
 		// route_a_slow_hot_shape only. Grouped by normalized_query_hash.
 		{
-			shape: "prom:slow_hot", lang: "promql", hashBase: benchSlowHotHashBase,
+			shape: "prom:slow_hot", lang: benchClassifiedLang, hashBase: benchSlowHotHashBase,
 			expect:     always("route_a_slow_hot_shape"),
 			severities: []PathologySeverity{SevSevere, SevMarginal},
 			fill: func(rng *rand.Rand, sev PathologySeverity) BenchRow {
@@ -669,7 +778,7 @@ func pathologyTailSpecs() []pathologySpec {
 		},
 		// Read-amplification (experimental rule): read_amplification_hot_shape.
 		{
-			shape: "prom:read_amp", lang: "promql", hashBase: 40000,
+			shape: "prom:read_amp", lang: benchClassifiedLang, hashBase: 40000,
 			expect:     always("read_amplification_hot_shape"),
 			severities: []PathologySeverity{SevSevere},
 			fill: func(rng *rand.Rand, _ PathologySeverity) BenchRow {

--- a/internal/routerrules/benchmark.go
+++ b/internal/routerrules/benchmark.go
@@ -654,9 +654,11 @@ func pathologyFailureSpecs() []pathologySpec {
 			},
 		},
 		// Cerberus-side breaker on an unclassified head:
-		// cerberus_side_rejection_pressure only. That rule gates on exit_status
-		// alone, so it is the one detector whose reach does not depend on a
-		// route — which is exactly why the corpus plants it on TraceQL.
+		// cerberus_side_rejection_pressure only. It is one of the two detectors
+		// that gate on exit_status alone (failure_cluster_by_reason, which
+		// log:timeout carries, is the other), so its reach does not depend on a
+		// route — which is exactly why the corpus plants it on TraceQL. The two
+		// classes cover both such detectors on an unclassified head.
 		//
 		// As with log:timeout, the classification columns are absent from the
 		// fill; unclassifyNonPromQL writes them.

--- a/internal/routerrules/columns.go
+++ b/internal/routerrules/columns.go
@@ -29,6 +29,17 @@ const (
 	routeUnclassified = ""
 )
 
+// reasonNonPromQL is the decision_reason token a row carries when its head never
+// entered the solver at all. It is corpus TAXONOMY rather than a solver Reason —
+// engine.CorpusReasonNonPromQL is where it is declared for the writer — and it is
+// re-declared here under the same deliberate no-import contract as
+// CorpusTableName above; decision_reason_gate_test.go pins that the two agree.
+//
+// It is a named constant rather than a literal because two places in this package
+// must agree on it exactly: the decision_reason enum domain a rule may name, and
+// the benchmark generator that stamps it on every non-PromQL row.
+const reasonNonPromQL = "non-promql"
+
 // ColumnKind classifies each corpus column so the validator can tell which
 // columns may legitimately carry an enum literal in a rule condition (the
 // closed-domain columns) versus which may only be compared against a resolved
@@ -242,7 +253,7 @@ var enumDomains = map[string]map[string]struct{}{
 		// exclude this population, not average it in.
 		"extraction-failed",
 		// Corpus-only: LogQL and TraceQL do not enter Solver.Classify.
-		"non-promql",
+		reasonNonPromQL,
 	),
 }
 

--- a/internal/routerrules/regression_floor_test.go
+++ b/internal/routerrules/regression_floor_test.go
@@ -66,6 +66,48 @@ func TestRegressionFloorNominal(t *testing.T) {
 			t.Errorf("rule %q has labeled positives but F1=0 — it detected none of them", r.Rule)
 		}
 	}
+
+	assertEveryEvaluatedRuleIsLabeled(t, cat, corpus)
+}
+
+// assertEveryEvaluatedRuleIsLabeled is what makes the per-rule F1 check above
+// mean something. That check skips a rule with no labeled positives, and
+// scoreReport does not even emit a row for a rule that neither fired nor was
+// labeled, so a rule the corpus stopped planting a pathology for leaves every
+// floor in this file green while detecting nothing.
+//
+// The hazard is concrete rather than theoretical. A route-gated rule can only be
+// labeled on the one head that carries a route: Solver.Classify is PromQL-gated,
+// so a LogQL or TraceQL class has no route for `route == A` to match. Moving the
+// last route-A pathology of some kind onto a non-PromQL head — or dropping it —
+// silently retires the rule from the benchmark. This asserts the corpus still
+// exercises every rule the evaluator runs, so that retirement is a failure
+// instead of an omission.
+//
+// Deprecated rules are excluded because the evaluator never runs them;
+// experimental ones are included because ScoreCatalog opts them in.
+func assertEveryEvaluatedRuleIsLabeled(t *testing.T, cat *Catalog, corpus *BenchCorpus) {
+	t.Helper()
+
+	labeled := map[string]struct{}{}
+	for _, c := range corpus.Classes {
+		for _, rule := range c.Expect {
+			labeled[rule] = struct{}{}
+		}
+	}
+	if len(labeled) == 0 {
+		t.Fatal("no class in the benchmark corpus is labeled with any rule — every floor in this file is vacuous")
+	}
+	for i := range cat.Rules {
+		rule := &cat.Rules[i]
+		if rule.Status == StatusDeprecated {
+			continue
+		}
+		if _, ok := labeled[rule.ID]; !ok {
+			t.Errorf("rule %q is evaluated but no benchmark class is labeled with it — it is scored on an empty population, "+
+				"so its precision/recall/F1 and every floor in this file are silent about it", rule.ID)
+		}
+	}
 }
 
 // TestRegressionFloorSaneRange pins recall + precision floors across the

--- a/test/regression/router_corpus_seed_test.go
+++ b/test/regression/router_corpus_seed_test.go
@@ -282,20 +282,17 @@ func TestRouterBenchCorpusIsProducible(t *testing.T) {
 		t.Error("no unclassified bench row — the two non-PromQL heads are absent from the benchmark, so invariant 2 holds vacuously")
 	}
 
-	// The labeled classes carry the same classification boundary, and a rule is
-	// matched back to a class by decision_reason: a non-PromQL class labeled with
-	// a solver reason would score findings against a class no row belongs to.
+	// The labeled ground truth carries decision_reason too, and a finding is
+	// matched back to its class by that column, so a class whose reason no row
+	// can carry scores rules against a class nothing belongs to. Two ways to get
+	// that wrong, checked in one pass: a token production never emits at all, and
+	// a token production emits only for a head this class is not on.
 	for i, c := range corpus.Classes {
 		if c.Language != solver.LangPromQL && c.DecisionReason != engine.CorpusReasonNonPromQL {
 			t.Errorf("bench class %d (%s/%s) has decision_reason %q; a head the solver never classifies carries %q",
 				i, c.ShapeID, c.Language, c.DecisionReason, engine.CorpusReasonNonPromQL)
+			continue
 		}
-	}
-
-	// The labeled ground truth carries decision_reason too, and a finding is
-	// matched back to its class by that column: a class labeled with an
-	// unproducible reason scores rules against a class no row can belong to.
-	for i, c := range corpus.Classes {
 		if c.DecisionReason == "" {
 			continue // a class may group on shape_id alone
 		}

--- a/test/regression/router_corpus_seed_test.go
+++ b/test/regression/router_corpus_seed_test.go
@@ -201,23 +201,27 @@ func checkCorpusFixture(t *testing.T, path string, valid map[string]struct{}) (c
 // parity lane all scored a corpus whose reason column was fiction, and the
 // route-B rows additionally claimed a refusal reason while carrying route B.
 //
-// Two of the three invariants documented on TestRouterCorpusFixturesAreProducible
-// are asserted here, both derived from the production consts rather than
-// restated:
+// All three invariants documented on TestRouterCorpusFixturesAreProducible are
+// asserted here, every one of them derived from the production consts rather
+// than restated:
 //
 //  1. decision_reason is a solver.Reasons member or the corpus-only non-PromQL
 //     token.
 //
+//  2. only solver.LangPromQL rows carry a classification, and a row on any
+//     other head names its own absence with the non-PromQL reason. The
+//     generated corpus is stricter than the JSONL fixtures on that second half:
+//     the fixtures predate the token and are allowed to carry an absent reason
+//     instead, while the generator writes every row itself and so has no vintage
+//     to be honest about.
+//
 //  3. route == "B" iff decision_reason == solver.ReasonRouted.
 //
-// Invariant 2 (only PromQL rows carry a classification) is NOT asserted here,
-// and deliberately so rather than silently: the benchmark corpus plants
-// classified LogQL and TraceQL classes — route A with real geometry — which the
-// solver cannot produce, because solver.Classify is PromQL-gated. Making those
-// classes honest changes which rules can fire on them and therefore the labeled
-// ground truth and the regression floors, so it is its own change, tracked in
-// issue #3204. Asserting the two invariants that DO hold is what keeps the
-// remaining gap visible instead of letting the whole corpus go unpinned.
+// Invariant 2 reaches the benchmark corpus through the same corpusRow helpers
+// the fixture check uses, so "classified" means one thing in this file. A
+// BenchRow's geometry is float64 where the fixture's is int64 — the generator
+// draws integer-valued jitter into the same UInt32 corpus columns — so the
+// conversion is exact and a fabricated non-zero cannot round itself away.
 func TestRouterBenchCorpusIsProducible(t *testing.T) {
 	t.Parallel()
 
@@ -232,8 +236,10 @@ func TestRouterBenchCorpusIsProducible(t *testing.T) {
 	valid := validRouterDecisionReasons()
 
 	// Both sides of invariant 3 must be exercised, or a corpus that happened to
-	// contain only route-A rows would satisfy it vacuously.
-	var routeB, routeA int
+	// contain only route-A rows would satisfy it vacuously; and both sides of
+	// the classification boundary must be populated, or invariant 2 is satisfied
+	// by a corpus that simply has no non-PromQL rows to get wrong.
+	var routeB, routeA, classified, unclassified int
 	for i, r := range corpus.Rows {
 		if _, ok := valid[r.DecisionReason]; !ok {
 			t.Errorf("bench row %d (%s/%s) has decision_reason %q, which is no token production can emit",
@@ -242,6 +248,19 @@ func TestRouterBenchCorpusIsProducible(t *testing.T) {
 		if routed := r.DecisionReason == solver.ReasonRouted; (r.Route == "B") != routed {
 			t.Errorf("bench row %d (%s/%s) has route=%q with decision_reason=%q; route B and %q are the same event",
 				i, r.ShapeID, r.Language, r.Route, r.DecisionReason, solver.ReasonRouted)
+		}
+		if row := benchCorpusRow(r); row.classified() {
+			classified++
+			if r.Language != solver.LangPromQL {
+				t.Errorf("bench row %d (%s) is %s but carries a classification (route=%q reason=%q geometry=%d); the solver only classifies %s",
+					i, r.ShapeID, r.Language, r.Route, r.DecisionReason, row.geometry(), solver.LangPromQL)
+			}
+		} else {
+			unclassified++
+			if r.Language != solver.LangPromQL && r.DecisionReason != engine.CorpusReasonNonPromQL {
+				t.Errorf("bench row %d (%s) is %s and unclassified but its decision_reason is %q, not %q; production names that absence rather than leaving it blank",
+					i, r.ShapeID, r.Language, r.DecisionReason, engine.CorpusReasonNonPromQL)
+			}
 		}
 		switch r.Route {
 		case "B":
@@ -256,6 +275,22 @@ func TestRouterBenchCorpusIsProducible(t *testing.T) {
 	if routeA == 0 {
 		t.Error("no route-A bench row — the refusal half of the routed-reason invariant is untested")
 	}
+	if classified == 0 {
+		t.Error("no classified bench row — the route-scoped rules score against nothing")
+	}
+	if unclassified == 0 {
+		t.Error("no unclassified bench row — the two non-PromQL heads are absent from the benchmark, so invariant 2 holds vacuously")
+	}
+
+	// The labeled classes carry the same classification boundary, and a rule is
+	// matched back to a class by decision_reason: a non-PromQL class labeled with
+	// a solver reason would score findings against a class no row belongs to.
+	for i, c := range corpus.Classes {
+		if c.Language != solver.LangPromQL && c.DecisionReason != engine.CorpusReasonNonPromQL {
+			t.Errorf("bench class %d (%s/%s) has decision_reason %q; a head the solver never classifies carries %q",
+				i, c.ShapeID, c.Language, c.DecisionReason, engine.CorpusReasonNonPromQL)
+		}
+	}
 
 	// The labeled ground truth carries decision_reason too, and a finding is
 	// matched back to its class by that column: a class labeled with an
@@ -268,5 +303,23 @@ func TestRouterBenchCorpusIsProducible(t *testing.T) {
 			t.Errorf("bench class %d (%s/%s) has decision_reason %q, which is no token production can emit",
 				i, c.ShapeID, c.Language, c.DecisionReason)
 		}
+	}
+}
+
+// benchCorpusRow projects a generated BenchRow onto the corpusRow shape the
+// fixture invariants are written against, so both populations are judged by one
+// definition of "classified" rather than by two that can drift.
+func benchCorpusRow(r routerrules.BenchRow) corpusRow {
+	return corpusRow{
+		Language:       r.Language,
+		Route:          r.Route,
+		DecisionReason: r.DecisionReason,
+		NAnchors:       int64(r.NAnchors),
+		Fanout:         int64(r.Fanout),
+		CumulativeD:    int64(r.CumulativeD),
+		OuterRange:     int64(r.OuterRange),
+		Step:           int64(r.Step),
+		KShards:        int64(r.KShards),
+		Parallelism:    int64(r.Parallelism),
 	}
 }


### PR DESCRIPTION
## What

`routerrules.GenerateBenchCorpus` planted LogQL and TraceQL rows carrying a
routing classification the solver cannot produce. `solver.Classify` is
PromQL-gated, so `engine.routeFeatures` returns `present=false`, an empty route,
all-zero geometry and `CorpusReasonNonPromQL` for every other head
(`internal/engine/engine.go:748-758`). The corpus gave those rows `route: A`,
real `decision_reason` tokens and non-zero geometry.

Closes #3204

## Measured before the change

Reproduced by running `GenerateBenchCorpus(BenchParams{})` and counting rows by
`(language, route, decision_reason)` — the issue's hypothesis, confirmed exactly:

| language | route | decision_reason | rows | rows with non-zero geometry |
| -------- | ----- | --------------- | ---: | --------------------------: |
| logql    | A     | below-threshold |   90 |                          90 |
| logql    | A     | high-D          |   16 |                          16 |
| logql    | B     | routed          |   30 |                          30 |
| traceql  | A     | below-threshold |   90 |                          90 |
| traceql  | A     | scalar-heavy    |   10 |                           0 |

236 non-PromQL rows across five shapes, in a 560-row / 30-class corpus. The
`trc:breaker` class carries no geometry, but its `route: A` and `scalar-heavy`
reason are classification all the same.

## Measured after

540 rows, 30 classes, two non-PromQL shapes:

| language | route | decision_reason | rows | rows with non-zero geometry |
| -------- | ----- | --------------- | ---: | --------------------------: |
| logql    | *(empty)* | non-promql |  100 |                           0 |
| traceql  | *(empty)* | non-promql |  100 |                           0 |

## What changed

**`unclassifyNonPromQL` is the single writer** of `route`, `decision_reason` and
the geometry columns on a non-PromQL row. It runs as one post-pass over the
finished corpus rather than as a branch inside each planter, so a future
pathology spec on those heads cannot opt out of the honest shape. The
runtime-cost columns are untouched — an unclassified query still runs, still
reads rows and still times out — and `shards_observed` is zeroed with the
geometry because it counts the shards of a fan-out that never happened.

**The route-B fan-out floor is seeded on PromQL alone.** Route B is a Solver
outcome, so a LogQL route-B seed was a class production can never write, and its
fan-out was folded into a floor no LogQL query can ever be measured against. The
learned floor is unchanged at 70 (the seed class is 30 rows at a single constant
and still dominates the p95).

**The route-A timeout pathology moved to the head that carries a route.**
`log:timeout_heavy` was the only class labeled for `route_a_timeout_should_shard`,
and `route == A` is a claim only a classified head can make, so it is re-planted
as `prom:timeout_heavy` with the same severe/marginal magnitudes. Its LogQL
sibling stays, honestly, as `log:timeout` — an unclassified head still times out,
and that class is what proves the route-agnostic failure clustering still reaches
it while the route- and geometry-gated rules correctly do not.

**Two non-PromQL classes, expecting only the `exit_status`-gated detectors.**
`log:timeout` expects `failure_cluster_by_reason`; `trc:breaker` expects
`cerberus_side_rejection_pressure`. Every other rule's absence is structural, not
a tuning outcome: `route_a_timeout_should_shard` and `route_a_slow_hot_shape`
gate on `route == A` and an unclassified row matches neither route token, while
`heavy_shape_geometry_failing` reads `d_high_watermark` — a geometry percentile
restricted to classified rows and partitioned by language — so those heads have
no partition key and the rule is never evaluated for them at all.

`log:timeout` collapses to one severity. The severe/marginal split existed to
probe retention in the duration and geometry tails; neither detector can reach an
unclassified class, so a second magnitude would label an identical expectation
twice.

## Floors

**No regression floor moved, in either direction.** Every floor in
`regression_floor_test.go` (`nominalF1Floor` 0.95, `nominalPrecisionFloor` 0.95,
`nominalRecallFloor` 0.95, `saneRangeRecallFloor` 0.90,
`saneRangePrecisionFloor` 0.80, `severeRecallFloor` 1.0) is untouched, and holds
with the same headroom or more.

Nominal scorecard, before → after:

| | before | after |
| --- | --- | --- |
| rows / classes | 560 / 30 | 540 / 30 |
| overall TP / FP / FN | 26 / 0 / 0 | 27 / 0 / 0 |
| overall precision / recall / F1 | 1.000 / 1.000 / 1.000 | 1.000 / 1.000 / 1.000 |
| rules with a labeled population | 12 of 12 | 12 of 12 |

The one per-rule count that moves is `failure_cluster_by_reason` (5 → 6 TP): it
gains both `prom:timeout_heavy` severities and loses the collapsed
`log:timeout_heavy_marginal`.

The degradation sweep improves rather than degrades, because the fabricated
route-A rows used to trip route-gated rules on healthy unclassified classes once
the watermark loosened:

| point | precision before | precision after |
| --- | --- | --- |
| wm 0.50, msup 5 | 0.426 | 0.509 |
| wm 0.75, msup 5 | 0.553 | 0.600 |
| wm 0.95, msup 1 | 0.520 | 0.574 |
| wm 0.95, msup 3 | 0.963 | 1.000 |

Marginal and severe recall curves are unchanged (7 marginal positive pairs before
and after; severe pairs 19 → 20).

### The floor movement this change avoided, and how it was measured

Making the corpus honest without re-planting the route-A timeout on PromQL costs
`route_a_timeout_should_shard` its entire labeled population. Measured by setting
that spec's `severities` to nil on the honest corpus: overall TP drops 27 → 21
and the scorecard still reads **precision 1.000 / recall 1.000 / F1 1.000**,
because `scoreReport` emits no row for a rule that neither fired nor was labeled
and the per-rule F1 check skips a rule with `TP+FN == 0`. One rule in twelve
would have gone entirely unmeasured with every floor green.

So `TestRegressionFloorNominal` now asserts what its own doc comment already
claimed — *"if a rule is weakened … or the corpus stops exercising a rule, one of
these floors trips"* — via `assertEveryEvaluatedRuleIsLabeled`: every rule the
evaluator runs (active plus experimental; deprecated ones are never evaluated)
must carry at least one labeled class.

## The widened pin

`TestRouterBenchCorpusIsProducible` now asserts all three invariants documented on
`TestRouterCorpusFixturesAreProducible`, reusing that file's `corpusRow.classified()`
and `geometry()` helpers so "classified" means one thing across both populations,
plus both-populations-non-empty guards so invariant 2 cannot hold vacuously. It
also asserts the stricter form the generator can honour: an unclassified row must
*name* its absence with the `non-promql` token, where the JSONL fixtures are
allowed a blank reason because they predate it. The inline exclusion note and the
#3204 reference are gone.

## Neutralization proof

Each fix was neutralized, watched red, and restored:

| neutralization | red test | message |
| --- | --- | --- |
| leave geometry fabricated on non-PromQL rows | `TestRouterBenchCorpusIsProducible` | `bench row 10 (logql:healthy_0) is logql but carries a classification (… geometry=3583)` |
| stamp `route: A` on non-PromQL rows | `TestRouterBenchCorpusIsProducible` | `bench row 0 (log:timeout) is logql but carries a classification (route="A" …)` |
| leave the row `decision_reason` blank | `TestRouterBenchCorpusIsProducible` | `is logql and unclassified but its decision_reason is "", not "non-promql"` |
| leave the class `decision_reason` unstamped | `TestRouterBenchCorpusIsProducible` | `bench class 1 (logql:healthy_0/logql) has decision_reason "below-threshold"` |
| claim `route_a_timeout_should_shard` on the unclassified LogQL class | `TestMultiRuleInteraction` | `class logql/log:timeout fired [failure_cluster_by_reason], expected exactly [failure_cluster_by_reason route_a_timeout_should_shard]` |
| move the route-A timeout pathology back onto LogQL | `TestMultiRuleInteraction`, `TestRegressionFloorNominal` | `nominal overall F1 0.920 below floor 0.950`; `rule "route_a_timeout_should_shard" has labeled positives but F1=0` |
| stop planting the PromQL route-A timeout class | `TestRegressionFloorNominal` | `rule "route_a_timeout_should_shard" is evaluated but no benchmark class is labeled with it` |

## Also

- `reasonNonPromQL` is a named constant in `columns.go`, so the `decision_reason`
  enum domain and the generator cannot drift on the token;
  `decision_reason_gate_test.go` keeps pinning it to `engine.CorpusReasonNonPromQL`.
- `benchClassifiedLang` replaces every `"promql"` literal in the generator's
  language tests.
- `docs/router-rules.md` drops the "does not yet satisfy the third invariant"
  paragraph and describes what the honest corpus can label and why.

## Verification

- `go test -count=1 ./internal/routerrules/... ./test/regression/` — green.
- `go test -tags chdb -count=1 ./internal/routerrules/...` — green, so the
  ClickHouse parity lane agrees finding-for-finding on the rewritten corpus
  (the corpus table's `route` Enum8 already carries the unclassified member).
- No generated artefact is touched: the router-rules floors are Go constants, not
  an `update-golden` shard.
