### PR TITLE
ci(mutation): print the source every surviving mutant actually ran

### DIFF
--- a/.github/scripts/gremlins-threshold.mjs
+++ b/.github/scripts/gremlins-threshold.mjs
@@ -324,7 +324,9 @@ function main() {
         `detected ${detected} of ${attempted} attempted (killed ${counts.killed}, run timed out ` +
         `${counts.runTimedOut}, lived ${counts.lived}, timed out ${counts.timedOut}). A mutant the ` +
         `compile+run backstop claimed is unadjudicated, not detected: it counts against this ratio ` +
-        `(#2903). gremlins reported ${reported}% over killed+lived only.`,
+        `(#2903). gremlins reported ${reported}% over killed+lived only. To act on a survivor read ` +
+        `the LIVED diff printed above it, not its line:column — a mutant is an AST edit, so swapping ` +
+        `the operator in the source can give a different program (#3215).`,
     );
     process.exit(1);
   }

--- a/.github/scripts/mutation-run.mjs
+++ b/.github/scripts/mutation-run.mjs
@@ -114,6 +114,28 @@ const perMutantResidentMemoryMax = '1GiB';
 // TIMED OUT.
 const perMutantMemoryHoldGraceSeconds = 30;
 
+// survivorDiffStatuses asks gremlins to print, for every LIVED mutant, the
+// unified diff between the original source and the source it actually ran. `l`
+// is gremlins' letter for LIVED, and it is the only status here on purpose:
+// survivors are the ones a reader has to reason about, and the killed majority
+// would bury them.
+//
+// A mutant is an edit to the AST, not to the text, and gremlins re-prints the
+// mutated file with `go/printer`. So a mutation that changes an operator's
+// PRECEDENCE re-parenthesises the expression to preserve the tree, and the
+// mutant does not read like the operator swapped in place. INVERT_LOGICAL on
+// the first `&&` of `a && b && c` gives `(a || b) && c`, never `a || b && c`;
+// INVERT_BITWISE on `&`/`|` moves across Go precedence levels the same way.
+// Both mutants are real and they are killed by different tests.
+//
+// Without the diff, the report says only `INVERT_LOGICAL at lower.go:2203:30`
+// and a reader reconstructs the mutant by swapping the operator in the source —
+// which yields the OTHER program, and then "the shard reports a survivor its own
+// tree kills" (tsouza/cerberus#3215: two tests were written against the
+// text-level mutant, neither of which the AST-level one is affected by). The
+// tool already knows exactly what it ran; printing it is the whole fix.
+const survivorDiffStatuses = 'l';
+
 const goDurationUnitSeconds = { ns: 1e-9, us: 1e-6, ms: 1e-3, s: 1, m: 60, h: 3600 };
 
 function required(name) {
@@ -322,6 +344,8 @@ function runGremlins({ report, budgetSeconds, ledger, diffRef = '' }) {
     '--output',
     report,
     '--on-shutdown-status=not-run',
+    '--output-diff-statuses',
+    survivorDiffStatuses,
     '--timeout-max',
     `${bounds.runSeconds}s`,
     '--compile-allowance',

--- a/.github/scripts/mutation-run.test.mjs
+++ b/.github/scripts/mutation-run.test.mjs
@@ -245,6 +245,24 @@ test('both invocations pin the per-mutant budget to the derived value', (t) => {
   }
 });
 
+// A survivor's `(file, line, column, type)` tuple does not determine the
+// program gremlins ran: the mutation is applied to the AST and the file is
+// re-printed, so a precedence-changing operator swap comes back
+// re-parenthesised and is NOT the program a reader gets by swapping the
+// operator in the source. Both invocations must ask for the diff, because
+// either can be the one that produces the leg's survivors (#3215).
+test('both invocations print the source every survivor actually ran', (t) => {
+  const f = fixture(t, [0, 7]);
+  assert.equal(run(f, { DIFF_REF: 'a'.repeat(40) }).status, 0);
+  const calls = invocations(f);
+  assert.equal(calls.length, 2);
+  for (const args of calls) {
+    const at = args.indexOf('--output-diff-statuses');
+    assert.notEqual(at, -1, `--output-diff-statuses missing from ${JSON.stringify(args)}`);
+    assert.equal(args[at + 1], 'l', 'survivors are the statuses whose source a reader has to read');
+  }
+});
+
 test('the probe is timed once and reused across the fallback invocation', (t) => {
   const f = fixture(t, [0, 7]);
   assert.equal(run(f, { DIFF_REF: 'a'.repeat(40) }).status, 0);

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1430,6 +1430,41 @@ Prior PRs #504 and #664 carry pattern-#3 refactors. They are not
 reverted (their diffs are now load-bearing for the published
 thresholds), but new violations should follow remedy #1 or #2.
 
+#### Read the mutant; do not retype it
+
+Both remedies need to know what the mutant IS, and a survivor's
+`(file, line, column, mutator)` tuple does not say. gremlins mutates the
+parsed **AST** and re-prints the file with `go/printer`, so a mutation
+that moves an operator to a different precedence level comes back
+re-parenthesised in order to preserve the tree. INVERT_LOGICAL on the
+first `&&` of `a && b && c` is `(a || b) && c`, never `a || b && c`;
+INVERT_BITWISE crosses Go's `&` / `|` levels the same way. The two
+programs are both legal, both real, and killed by different tests.
+
+So retyping the mutant from the report — swapping the operator at that
+line and column in an editor — can adjudicate a mutant the lane never
+ran. That is a live failure mode, not a hypothetical. Cerberus issue #3215
+records two tests written against the text-level rewrite of the
+`isAttributeRead` predicate in `internal/traceql/lower.go`, and then the
+conclusion that the lane must be testing stale sources — while the lane
+was reporting the AST-level mutant correctly the whole time.
+
+The lane prints the answer. `.github/scripts/mutation-run.mjs` passes
+`--output-diff-statuses l`, so every LIVED mutant's log line is followed
+by a unified diff of the original source against the source that
+actually ran:
+
+```text
+ LIVED INVERT_LOGICAL at lower.go:2226:30
+-    return v.Fn == chplan.FnIf && len(v.Args) == 3 &&
++    return (v.Fn == chplan.FnIf || len(v.Args) == 3) &&
+         isAttributeRead(v.Args[1]) && isAttributeRead(v.Args[2])
+```
+
+Read that diff before writing either a test or an equivalence note. It
+is asked for on survivors only: killed mutants need no adjudication, and
+printing a diff per kill would bury the handful that do.
+
 #### When a capacity mutant is equivalent
 
 "An `ARITHMETIC_BASE` mutant on a `make` capacity argument is

--- a/internal/traceql/unscoped_attr_numeric_test.go
+++ b/internal/traceql/unscoped_attr_numeric_test.go
@@ -129,18 +129,20 @@ func TestIsNumericExprRejectsTheUnscopedAttributeShape(t *testing.T) {
 	}
 }
 
-// TestIsAttributeReadRequiresBothCoalesceArms pins the conjunction in
-// isAttributeRead's FuncCall arm: BOTH branches of the span-then-resource
-// coalesce must themselves be attribute reads. A half-matching FnIf — one arm
-// an attribute read, the other any other expression — is not the shape
-// unscopedAttributeExpr builds, and treating it as one would extend the
-// "bare attribute" numeric intent to a call this lowering never produced.
+// TestIsAttributeReadRecognisesOnlyTheCoalesceShape pins every conjunct of
+// isAttributeRead's FuncCall arm. The shape it recognises is exactly the
+// span-then-resource coalesce unscopedAttributeExpr builds — `if()`, three
+// arguments, and BOTH value arms themselves attribute reads — and each of
+// those conditions must be able to fail on its own, or the predicate extends
+// the "bare attribute" numeric intent to calls this lowering never produced.
 //
-// The `&&` between the two arm checks survived mutation to `||` because every
-// existing case supplied two attribute reads or none. These cases supply
-// exactly one, on each side in turn, so the operator is pinned in both
-// directions.
-func TestIsAttributeReadRequiresBothCoalesceArms(t *testing.T) {
+// The function-identity case is what tells the conjunction apart from a
+// disjunction over the same operands. `multiIf(cond, then, else)` has the
+// coalesce's arity and two attribute-read arms and is still not the coalesce,
+// so it answers false only because the `if()` check is AND-ed with the rest.
+// Without it, `v.Fn == chplan.FnIf && len(v.Args) == 3` and
+// `v.Fn == chplan.FnIf || len(v.Args) == 3` agree on every case here.
+func TestIsAttributeReadRecognisesOnlyTheCoalesceShape(t *testing.T) {
 	t.Parallel()
 
 	attr := func() chplan.Expr {
@@ -153,17 +155,19 @@ func TestIsAttributeReadRequiresBothCoalesceArms(t *testing.T) {
 
 	for _, c := range []struct {
 		name      string
+		fn        chplan.Fn
 		then, els chplan.Expr
 		want      bool
 	}{
-		{"both arms are attribute reads", attr(), attr(), true},
-		{"only the then-arm is an attribute read", attr(), notAttr(), false},
-		{"only the else-arm is an attribute read", notAttr(), attr(), false},
-		{"neither arm is an attribute read", notAttr(), notAttr(), false},
+		{"both arms are attribute reads", chplan.FnIf, attr(), attr(), true},
+		{"only the then-arm is an attribute read", chplan.FnIf, attr(), notAttr(), false},
+		{"only the else-arm is an attribute read", chplan.FnIf, notAttr(), attr(), false},
+		{"neither arm is an attribute read", chplan.FnIf, notAttr(), notAttr(), false},
+		{"a three-argument call that is not if()", chplan.FnMultiIf, attr(), attr(), false},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			e := &chplan.FuncCall{Fn: chplan.FnIf, Args: []chplan.Expr{contains, c.then, c.els}}
+			e := &chplan.FuncCall{Fn: c.fn, Args: []chplan.Expr{contains, c.then, c.els}}
 			if got := isAttributeRead(e); got != c.want {
 				t.Fatalf("isAttributeRead(%s) = %v, want %v", c.name, got, c.want)
 			}


### PR DESCRIPTION
## What this found

The `phase4-traceql-lower` shard was right. It reported no survivor its own tree
kills, and it was not testing stale sources: the workdir copy, the mutant
selection and the coverage pass all describe the commit each run checked out.

What is missing is the mutant itself. gremlins mutates the parsed **AST** and
re-prints the file with `go/printer`, so a mutation that moves an operator to a
different precedence level comes back re-parenthesised in order to preserve the
tree. `INVERT_LOGICAL` on the first `&&` of `a && b && c` is `(a || b) && c` —
never `a || b && c`. The report publishes only `(file, line, column, mutator)`,
which does not distinguish the two.

So `lower.go`'s `isAttributeRead` survivor is

```go
return (v.Fn == chplan.FnIf || len(v.Args) == 3) &&
        isAttributeRead(v.Args[1]) && isAttributeRead(v.Args[2])
```

and for every fixture built from an `if()` with three arguments that is
*identical* to the original — `(true || true)` and `true` agree. The tests
written to kill it were written against the text-level rewrite
`v.Fn == chplan.FnIf || (len(v.Args) == 3 && ...)`, which is a different
program. Hence two heads, byte-identical survivor sets, and an efficacy that
would not move.

### Evidence

* Applying the AST-level mutant through `go/printer` exactly as
  `TokenMutator.Apply` does, on the tree the shard ran (`31bdbe20f`), and
  running `go test -vet=off -timeout 15s -failfast ./internal/traceql` exactly
  as `mutantExecutor.getTestArgs` builds it: **`ok`**. The mutant genuinely
  lives; `LIVED` was the correct verdict.
* Applying the text-level rewrite to the same tree: **`FAIL`**, three subtests.
  That is the program the two runs were being compared against, and it is not
  the one the lane ran.
* Reproduced in miniature against the pinned fork
  (`v0.6.0-cerberus-workdir-fd-leak-consume`) on a four-line module: a
  `kind == "if" && n == 3 && a && b` predicate reports
  `LIVED INVERT_LOGICAL` with the diff `+ return (kind == "if" || n == 3) &&`.

None of the three candidates in the issue is the cause. Nothing is cached
across runs (`os.MkdirTemp` per invocation, `filepath.Walk` of the module root
per worker), and the coverage profile is gathered from the checked-out tree at
the start of each run. `mutants_total` stayed at 171 because the mutants are a
function of `lower.go`, which the second commit did not touch.

## What changed

**The lane prints what it ran.** `.github/scripts/mutation-run.mjs` passes
gremlins' own `--output-diff-statuses l`, so every `LIVED` line is followed by a
unified diff of original against mutated source. Survivors only: killed mutants
need no adjudication and a diff per kill would bury the handful that do. No
fork change — the flag and the snippets already exist in
`v0.6.0-cerberus-workdir-fd-leak-consume`.

**The threshold error says to read it.** `gremlins-threshold.mjs`'s failure
message now points at the diff rather than at the `line:column` a reader would
otherwise retype.

**`docs/test-strategy.md` states the rule** where the two surviving-mutant
remedies are chosen, since both require knowing what the mutant is.

**The survivor is killed.** `TestIsAttributeReadRecognisesOnlyTheCoalesceShape`
gains `multiIf(cond, then, else)` — the coalesce's arity, two attribute-read
arms, and still not the coalesce, so it can only answer `false` while the
`if()` check is AND-ed with the rest. The old test's four cases all fix
`Fn: chplan.FnIf`, which is why `&&` and `||` agreed across every one of them.

## The demonstration #3215 asks for — done, and it holds

"Done when: the shard's reported survivor set reflects the tests present at the
commit it ran on — demonstrated by adding a test that kills a known survivor and
watching the count fall on the next run."

Both runs are the same leg, same 171 mutants, one commit apart:

| run | commit | attempted | killed | lived | efficacy | verdict |
|---|---|---|---|---|---|---|
| [34317381369](https://github.com/tsouza/cerberus/actions/runs/34317381369) | `528c5ef98` (this PR's base) | 171 | 162 | 9 | 94.7368% | FAIL vs 95% |
| [34319851499](https://github.com/tsouza/cerberus/actions/runs/34319851499) | this PR | 171 | 163 | **8** | **95.3216%** | **PASS** |

The survivor that disappeared is exactly the one the new test targets —
`INVERT_LOGICAL at lower.go:2226:30` is present in the base run's
`gremlins.json` and absent from this PR's. The other eight are byte-identical
across the two, so the count moved because a test killed a mutant and for no
other reason. `mutants_total` is unchanged at 171, which is the control: the
change adds no production statement.

That is the count falling on the next run, on the shard that reported the
problem, off the artifacts both runs published.

The new flag is live in that same run rather than merely configured — each of
the eight remaining survivors is now printed with the source it ran, e.g.

```text
 LIVED INVERT_LOGICAL at lower.go:1961:34
-	regexOp := op == chplan.OpMatch || op == chplan.OpNotMatch
+	regexOp := op == chplan.OpMatch && op == chplan.OpNotMatch
```

Locally, ahead of CI: the package passes with the AST-level mutant applied
before this commit, and fails on
`TestIsAttributeReadRecognisesOnlyTheCoalesceShape/a_three-argument_call_that_is_not_if()`
after it.

## Why the `mutation` roll-up may be red here

Changing a lane harness file makes the selector sweep the **full** matrix rather
than the legs this diff's scope touches, so this PR runs all 30 gremlins legs
instead of the two over `./internal/traceql`. That picks up
`phase2-other (./internal/chsql @ 95%)`, which has been below its floor on
`main` since before this branch existed (93.01%, 27 survivors, run
34313501819). It is unrelated to this change and not chased here — it is a
pre-existing efficacy floor rather than a correctness defect, and it is tracked
as an epic in #3221 with the survivors listed per file and the structural
question stated.

`mutation` is informational: it is not one of `main`'s 17 required status checks
and not in `release.yml`'s `RELEASE_REQUIRED_CHECKS`. This PR merges on the 17
required contexts.

Closes #3215
