### PR TITLE
docs(promql): point the doubly-nested fanout deferral at its own issue

### DIFF
--- a/internal/promql/histogram_native_mixed_or_subquery_last_first.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_last_first.go
@@ -218,8 +218,8 @@ func mixedLastFirstSeriesKeyAliases(s schema.Metrics) []string {
 // grid, whose group key is shared with three other continuations that
 // thread `[anchor, Attributes]` through their own downstream stages.
 // Widening it there is the same series-identity question cerberus issue
-// #3232 tracks for the reductions that key on Attributes alone, and it is
-// answered there rather than here.
+// #3240 tracks for the four continuations that share that fanout's key, and
+// it is answered there rather than here.
 //
 // The two reductions in THIS file publish MetricName as a group key
 // instead ([mixedLastFirstSeriesKey]), so they take


### PR DESCRIPTION
`mixedLastFirstAggs`'s doc comment
(`internal/promql/histogram_native_mixed_or_subquery_last_first.go`) deferred
the Attributes-only reduction key of `buildOuterRangeSubqueryFanout` to issue
#3232:

> Widening it there is the same series-identity question cerberus issue #3232
> tracks for the reductions that key on Attributes alone, and it is answered
> there rather than here.

PR #3236 merged with `Closes #3232`, so that citation now points at a closed
tracker while the key it describes is unchanged on `main`:
`internal/promql/histogram_native_subquery_call_subquery.go:95` still reduces on
`s.AttributesColumn` alone.

`forbid-deferral` is blind to this by construction — the gate scans a change's
own additions, and the comment predates the branch that closed the issue — so
the dangling citation survives a green CI run.

## Why a separate tracker rather than reopening #3232

#3232 is the SINGLY-nested SELECT family, which #3236 genuinely answered
(`selectFnSubqueryNameGuard` across all three grid modes, plus the singly-nested
resets/changes reduction). The doubly-nested key is different scope: four
continuations — `lowerMixedLastFirstOverCallSubqueryInput`,
`lowerMixedResetsOrChangesOverCallSubqueryInput`,
`lowerExpHistogramFoldOverCallSubqueryInput` and
`lowerMixedFoldOverCallSubqueryInput` — thread `[anchor, Attributes]` through
their own downstream selection and reshape stages, so widening the key is a
change to all four rather than to one.

#3240 tracks exactly that. This change repoints the deferral at it and names the
four continuations rather than the single caller the comment previously singled
out.

Comment-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196feCkr8wd6meQ3jr9W8rF
