### PR TITLE
fix(optcorpus): create the router corpus table ON CLUSTER

### DIFF
--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1775,7 +1775,18 @@ const corpusSinkModeCHTable = "chtable"
 // the corpus sink, so a sink outage costs calibration data and nothing else.
 func buildCorpusSink(ctx context.Context, logger *slog.Logger, conn optcorpus.CHTableConn, cfg config.Config) (optcorpus.Sink, string, bool) {
 	if cfg.CHOptCorpus.SinkMode == corpusSinkModeCHTable {
-		sink, err := optcorpus.NewCHTableSink(ctx, conn)
+		// The corpus table is provisioned against the SAME cluster the
+		// auto-create hook renders its own DDL against
+		// (internal/schemaboot.DDLConfig threads this identical
+		// SchemaProvisioning.Cluster into internal/schema/ddl's
+		// Config.Cluster), so a distributed-DDL deployment gets the table
+		// on every node instead of only on the one that served this
+		// connection — cerberus issue #3225. Reading that knob here rather
+		// than adding a corpus-specific one keeps "which cluster is this"
+		// a single source of truth; it is read independently of
+		// CERBERUS_AUTO_CREATE_SCHEMA because this sink creates its own
+		// table whether or not that hook runs.
+		sink, err := optcorpus.NewCHTableSink(ctx, conn, cfg.SchemaProvisioning.Cluster)
 		if err != nil {
 			logger.Warn("ch_opt corpus CH-table sink unavailable; reconciler disabled", "err", err)
 			return nil, "", false

--- a/docs/helm-clickhouse.md
+++ b/docs/helm-clickhouse.md
@@ -560,3 +560,14 @@ own materialized view, and none of them is wired for the split. Combining
 than silently under-provisioning one of those tables. That carve-out is the
 EXPERIMENTAL mode's design boundary: the four features are
 single-data-shard-only.
+
+The router-calibration corpus (`cerberus_router_corpus`,
+`CERBERUS_CH_OPT_CORPUS_SINK_MODE=chtable`) is deliberately NOT in that
+carve-out. Its table is provisioned by the corpus sink rather than by
+`internal/schema/ddl`, and the sink stamps `ON CLUSTER
+<CERBERUS_SCHEMA_CLUSTER>` on its own `CREATE` and `ALTER` statements — which
+the chart always sets under `dataShards.count > 1` — so the table exists on
+every node and an INSERT is correct wherever it lands. It gets no
+`Distributed` wrapper and no replicating engine, so each node holds the rows
+written through it; nothing on the query path reads the corpus, and the
+consequences for the offline analysis that does are tracked in issue #3241.

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -1364,11 +1364,25 @@ To answer it the engine closes the loop the optimization corpus
   POSITIONALLY, so a missing column does not lose one field, it binds every
   later value to the wrong column or invalidates the batch outright, on every
   reconcile interval, forever. Both ALTERs are **best-effort** — a CH user with
-  `INSERT` + `CREATE` but no `ALTER` grant, or an operator-owned table that
-  needs `ON CLUSTER`, still gets a working sink whenever the deployed table
-  already matches. The `system.columns` read is the authority: it is the
-  server's own answer, so the sink is never built over a table that cannot hold
-  what the binary writes.
+  `INSERT` + `CREATE` but no `ALTER` grant still gets a working sink whenever
+  the deployed table already matches. The `system.columns` read is the
+  authority: it is the server's own answer, so the sink is never built over a
+  table that cannot hold what the binary writes.
+- **Distributed DDL.** Every DDL statement above — the `CREATE`, each `ADD
+  COLUMN`, each `MODIFY COLUMN` — carries `ON CLUSTER
+  <CERBERUS_SCHEMA_CLUSTER>` when that knob is set — the same resolved cluster
+  name `internal/schemaboot` threads into the auto-create hook's own DDL, read
+  independently of `CERBERUS_AUTO_CREATE_SCHEMA` because this sink provisions
+  its own table either way. Without the clause the `CREATE` reaches only the
+  node that served the connection, and on a multi-node cluster whose database is
+  `Atomic` — which is every `CERBERUS_CH_DATA_SHARDS > 1` deployment, since a
+  `Replicated` database engine and an `ON CLUSTER` cluster are mutually
+  exclusive — every later INSERT that lands elsewhere fails with `Table
+  cerberus_router_corpus does not exist`. Unset (the single-node default, and
+  the single-shard multi-replica shape, where the `Replicated` database engine
+  replicates the DDL itself) renders the clause-free statements unchanged. The
+  engine stays a plain `MergeTree` in every topology: the clause governs where
+  the TABLE exists, not where the ROWS live.
 - **A sink that cannot be built disables the reconciler**, logged at startup
   with the underlying error; it does not silently switch modes. There is no
   fallback from `chtable` to `jsonl` — an operator who asked for the CH table

--- a/internal/optcorpus/chtable.go
+++ b/internal/optcorpus/chtable.go
@@ -175,13 +175,13 @@ var reconciledEnumColumns = []reconciledEnumColumn{
 //
 // Only the CREATE and the verify can fail construction. Both ALTERs are
 // BEST-EFFORT by design: a deployment whose CH user holds INSERT and CREATE but
-// not ALTER, or whose corpus table is operator-owned and needs ON CLUSTER, is a
-// legitimate configuration, and on such a deployment an ALTER is a no-op in
-// every case that matters — the schema either already matches (nothing to do)
-// or it does not, which the verify catches on the server's own answer rather
-// than on whether the ALTER was permitted. That keeps the ALTER from turning a
-// working sink into a disabled one while leaving the guarantee intact: the sink
-// is never built over a schema that cannot hold what this binary writes.
+// not ALTER is a legitimate configuration, and on such a deployment an ALTER is
+// a no-op in every case that matters — the schema either already matches
+// (nothing to do) or it does not, which the verify catches on the server's own
+// answer rather than on whether the ALTER was permitted. That keeps the ALTER
+// from turning a working sink into a disabled one while leaving the guarantee
+// intact: the sink is never built over a schema that cannot hold what this
+// binary writes.
 //
 // Verifying against the server — rather than trusting the ALTERs did what they
 // were asked — is what makes the reconciliation honest rather than hopeful: a
@@ -189,22 +189,32 @@ var reconciledEnumColumns = []reconciledEnumColumn{
 // otherwise surface much later as a batch the table rejects, on every reconcile
 // interval, forever. A construction failure disables the reconciler (see
 // buildCorpusSink); the data plane is untouched either way.
-func NewCHTableSink(ctx context.Context, conn CHTableConn) (*CHTableSink, error) {
+//
+// cluster is the deployment's ClickHouse cluster name — cerberus's own
+// CERBERUS_SCHEMA_CLUSTER, the SAME resolved knob internal/schema/ddl threads
+// into every statement the auto-create hook emits (see its Config.Cluster).
+// Empty (the single-node default, and the Replicated-DATABASE deployment that
+// replicates its own DDL) renders exactly the DDL this sink emitted before the
+// parameter existed; non-empty adds `ON CLUSTER <cluster>` to every DDL
+// statement below — the CREATE and both ALTERs — so the table is created on
+// EVERY node of the cluster rather than on whichever one happened to serve this
+// connection (cerberus issue #3225).
+func NewCHTableSink(ctx context.Context, conn CHTableConn, cluster string) (*CHTableSink, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("optcorpus: nil CH connection for table sink")
 	}
-	if err := conn.Exec(ctx, corpusCreateTableSQL()); err != nil {
+	if err := conn.Exec(ctx, corpusCreateTableSQL(cluster)); err != nil {
 		return nil, fmt.Errorf("optcorpus: create %s: %w", CorpusTableName, err)
 	}
 	addErrs := map[string]error{}
 	for _, col := range CorpusColumns() {
-		if err := conn.Exec(ctx, corpusAddColumnSQL(col)); err != nil {
+		if err := conn.Exec(ctx, corpusAddColumnSQL(col, cluster)); err != nil {
 			addErrs[col.Name] = err
 		}
 	}
 	widenErrs := map[string]error{}
 	for _, col := range reconciledEnumColumns {
-		if err := conn.Exec(ctx, corpusAlterEnumColumnSQL(col)); err != nil {
+		if err := conn.Exec(ctx, corpusAlterEnumColumnSQL(col, cluster)); err != nil {
 			widenErrs[col.name] = err
 		}
 	}
@@ -234,17 +244,27 @@ func NewCHTableSink(ctx context.Context, conn CHTableConn) (*CHTableSink, error)
 // columnar INSERT batch names no columns and Append is POSITIONAL, so the
 // deployed order and CorpusColumns() order must agree, and appending is the one
 // edit that keeps them agreeing on a fresh table and a migrated one alike.
-func corpusAddColumnSQL(col chsql.ColumnDef) string {
-	return chsql.AlterTableAddColumn("", CorpusTableName, col.Name, col.Type).SQL()
+//
+// cluster carries the ON CLUSTER clause the CREATE carries — an ALTER that
+// stopped at the connected node would leave every other node's copy of the
+// table on the older column list, which is the same divergence the CREATE's own
+// clause exists to prevent. Empty leaves the clause off (see NewCHTableSink).
+func corpusAddColumnSQL(col chsql.ColumnDef, cluster string) string {
+	return chsql.AlterTableAddColumn("", CorpusTableName, col.Name, col.Type).
+		OnCluster(cluster).
+		SQL()
 }
 
 // corpusAlterEnumColumnSQL renders the statement that retypes the deployed
 // column to the member set this binary writes. Widening an Enum8 is
 // metadata-only on ClickHouse — no part is rewritten, no mutation is scheduled —
 // so it is safe to issue on every start, and IF EXISTS makes it a no-op on a
-// table the CREATE above just made with the wide type.
-func corpusAlterEnumColumnSQL(col reconciledEnumColumn) string {
-	return chsql.AlterTableModifyColumn("", CorpusTableName, col.name, col.enumType()).SQL()
+// table the CREATE above just made with the wide type. cluster carries the same
+// ON CLUSTER clause, for the same reason corpusAddColumnSQL does.
+func corpusAlterEnumColumnSQL(col reconciledEnumColumn, cluster string) string {
+	return chsql.AlterTableModifyColumn("", CorpusTableName, col.name, col.enumType()).
+		OnCluster(cluster).
+		SQL()
 }
 
 // readDeployedSchema reads the corpus table's DEPLOYED column name→type map out
@@ -459,9 +479,27 @@ func parseEnum8Value(rs []rune) (int64, int, bool) {
 //	  shards_observed UInt8, parallelism UInt8
 //	) ENGINE = MergeTree ORDER BY (shape_id, n_anchors, fanout)
 //	  TTL toDateTime(event_time) + toIntervalDay(30)
-func corpusCreateTableSQL() string {
+//
+// cluster (CERBERUS_SCHEMA_CLUSTER, see NewCHTableSink) adds the `ON CLUSTER`
+// clause between the table name and the column list, so a classic
+// distributed-DDL deployment — which is EVERY `CERBERUS_CH_DATA_SHARDS > 1`
+// deployment, since internal/schema/ddl's Config.Validate refuses that topology
+// without a cluster name — creates the table on every node instead of only on
+// the one that served this connection (cerberus issue #3225). Empty renders the
+// clause-free statement unchanged, which covers both the single-node default
+// and the single-shard multi-replica shape, where the `otel` database is itself
+// a Replicated database engine and replicates this DDL on its own.
+//
+// The engine stays a plain MergeTree in every topology: an ON CLUSTER CREATE
+// makes the table exist everywhere, which is what an INSERT landing on any node
+// needs, while a replicating engine or a Distributed wrapper would additionally
+// govern where the ROWS live and how a reader sees them — a separate property
+// this DDL has never claimed and one that already partitions the corpus per
+// replica on the supported multi-replica path (cerberus issue #3241).
+func corpusCreateTableSQL(cluster string) string {
 	return chsql.CreateTable(CorpusTableName).
 		IfNotExists().
+		OnCluster(cluster).
 		Columns(CorpusColumns()...).
 		Engine(chsql.EngineMergeTree()).
 		OrderBy("shape_id", "n_anchors", "fanout").

--- a/internal/optcorpus/chtable_test.go
+++ b/internal/optcorpus/chtable_test.go
@@ -13,12 +13,86 @@ import (
 	"github.com/tsouza/cerberus/internal/chsql"
 )
 
+// clusterName is the ClickHouse cluster the ON CLUSTER tests below configure —
+// the bundled chart's own `<cluster>` name, which is what a real
+// CERBERUS_CH_DATA_SHARDS > 1 deployment carries in CERBERUS_SCHEMA_CLUSTER.
+const clusterName = "bwc_cluster"
+
+// onClusterClause is the fragment every statement must carry when a cluster is
+// configured — and must NOT carry when one is not.
+const onClusterClause = "ON CLUSTER `" + clusterName + "`"
+
+// TestCorpusDDL_OnCluster pins the whole reconciliation's cluster-awareness on
+// BOTH sides of the switch: with a cluster configured EVERY statement
+// construction issues carries `ON CLUSTER`, and with none configured NOT ONE of
+// them does.
+//
+// Both halves matter, and neither is redundant. Without the first, the DDL is
+// executed only on whichever node served the connection: under
+// CERBERUS_CH_DATA_SHARDS > 1 the `otel` database is necessarily Atomic (a
+// Replicated database engine and an ON CLUSTER cluster are mutually exclusive),
+// so nothing propagates and every INSERT that later lands on one of the other
+// nodes fails with "Table otel.cerberus_router_corpus does not exist" —
+// cerberus issue #3225. Without the second, a fix could satisfy the first by
+// stamping ON CLUSTER unconditionally, which would break every single-node and
+// Replicated-database deployment (there is no cluster to name).
+//
+// It asserts over the statements the SINK ACTUALLY EXECUTES rather than over
+// the three renderers one by one, because the failure this pins is precisely a
+// statement that was left un-threaded: a renderer-by-renderer test passes while
+// the caller still hands one of them the wrong argument.
+func TestCorpusDDL_OnCluster(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		cluster string
+		want    bool
+	}{
+		{name: "sharded", cluster: clusterName, want: true},
+		{name: "single-node", cluster: "", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fe := &fakeExecer{}
+			if _, err := NewCHTableSink(context.Background(), fe, tc.cluster); err != nil {
+				t.Fatalf("NewCHTableSink(cluster=%q): %v", tc.cluster, err)
+			}
+			// One CREATE, one ADD COLUMN per corpus column, one MODIFY
+			// COLUMN per reconciled enum column: anything less means a
+			// statement was dropped rather than merely un-threaded.
+			if want := 1 + len(CorpusColumns()) + len(reconciledEnumColumns); len(fe.execSQL) != want {
+				t.Fatalf("construction ran %d statements, want %d: %q", len(fe.execSQL), want, fe.execSQL)
+			}
+			for _, sql := range fe.execSQL {
+				if got := strings.Contains(sql, onClusterClause); got != tc.want {
+					t.Errorf("statement carries %s = %v, want %v:\n%s", onClusterClause, got, tc.want, sql)
+				}
+			}
+		})
+	}
+}
+
+// TestCorpusCreateTableSQL_OnClusterPosition pins WHERE the clause lands.
+// ClickHouse accepts `ON CLUSTER` only between the table name and the column
+// list; a clause rendered anywhere else is a syntax error the fake executer
+// above would never notice, since it parses nothing.
+func TestCorpusCreateTableSQL_OnClusterPosition(t *testing.T) {
+	t.Parallel()
+
+	sql := corpusCreateTableSQL(clusterName)
+	if want := "CREATE TABLE IF NOT EXISTS " + CorpusTableName + " " + onClusterClause + " ("; !strings.Contains(sql, want) {
+		t.Errorf("DDL missing %q\nfull SQL:\n%s", want, sql)
+	}
+}
+
 // TestCorpusCreateTableSQL_Shape pins the rendered MergeTree DDL against the
 // dossier schema. The typed chsql builder produces it; this test is the golden
 // that catches a column / type / engine / order-by / TTL drift.
 func TestCorpusCreateTableSQL_Shape(t *testing.T) {
 	t.Parallel()
-	sql := corpusCreateTableSQL()
+	sql := corpusCreateTableSQL("")
 
 	wantFragments := []string{
 		"CREATE TABLE IF NOT EXISTS cerberus_router_corpus (",
@@ -201,7 +275,7 @@ func TestCHTableSink_CreatesTableAndWrites(t *testing.T) {
 	t.Parallel()
 
 	fe := &fakeExecer{}
-	sink, err := NewCHTableSink(context.Background(), fe)
+	sink, err := NewCHTableSink(context.Background(), fe, "")
 	if err != nil {
 		t.Fatalf("NewCHTableSink: %v", err)
 	}
@@ -414,7 +488,7 @@ func TestNewCHTableSink_RejectsNarrowDeployedColumn(t *testing.T) {
 			t.Parallel()
 
 			fe := &fakeExecer{deployedType: map[string]string{tc.column: tc.deployed}}
-			_, err := NewCHTableSink(context.Background(), fe)
+			_, err := NewCHTableSink(context.Background(), fe, "")
 			if err == nil {
 				t.Fatalf("NewCHTableSink over a narrow %s column: want an error, got nil", tc.column)
 			}
@@ -446,9 +520,8 @@ func addMarker(column string) string {
 // by itself disable the sink.
 //
 // A CH user holding INSERT and CREATE but not ALTER is a routine least-
-// privilege grant, and so is an operator-owned table that would need ON
-// CLUSTER. On such a deployment the widening is refused on every start while
-// the deployed column already holds every member — nothing is wrong, and
+// privilege grant. On such a deployment the widening is refused on every start
+// while the deployed column already holds every member — nothing is wrong, and
 // failing construction there would turn the whole corpus off for a statement
 // whose work was already done.
 func TestNewCHTableSink_WideningIsBestEffort(t *testing.T) {
@@ -462,7 +535,7 @@ func TestNewCHTableSink_WideningIsBestEffort(t *testing.T) {
 				failStatement: alterMarker(col.name),
 				failErr:       errors.New("not enough privileges"),
 			}
-			sink, err := NewCHTableSink(context.Background(), fe)
+			sink, err := NewCHTableSink(context.Background(), fe, "")
 			if err != nil {
 				t.Fatalf("NewCHTableSink over an already-wide %s with no ALTER grant: %v", col.name, err)
 			}
@@ -489,7 +562,7 @@ func TestNewCHTableSink_NarrowColumnReportsWideningFailure(t *testing.T) {
 		failStatement: alterMarker(exitStatusColumn),
 		failErr:       errors.New(grantErr),
 	}
-	_, err := NewCHTableSink(context.Background(), fe)
+	_, err := NewCHTableSink(context.Background(), fe, "")
 	if err == nil {
 		t.Fatal("NewCHTableSink over a narrow exit_status column: want an error, got nil")
 	}
@@ -511,7 +584,7 @@ func TestNewCHTableSink_SchemaReadFailureIsFatal(t *testing.T) {
 	t.Parallel()
 
 	fe := &fakeExecer{queryErr: errors.New("system.columns unavailable")}
-	if _, err := NewCHTableSink(context.Background(), fe); err == nil {
+	if _, err := NewCHTableSink(context.Background(), fe, ""); err == nil {
 		t.Fatal("NewCHTableSink with an unreadable schema: want an error, got nil")
 	}
 }
@@ -528,7 +601,7 @@ func TestNewCHTableSink_AddColumnIsBestEffort(t *testing.T) {
 		failStatement: addMarker(parallelismColumn),
 		failErr:       errors.New("not enough privileges"),
 	}
-	sink, err := NewCHTableSink(context.Background(), fe)
+	sink, err := NewCHTableSink(context.Background(), fe, "")
 	if err != nil {
 		t.Fatalf("NewCHTableSink over an already-complete table with no ALTER grant: %v", err)
 	}
@@ -558,7 +631,7 @@ func TestNewCHTableSink_RejectsMissingColumn(t *testing.T) {
 		failStatement: addMarker(shardsObservedColumn),
 		failErr:       errors.New(grantErr),
 	}
-	_, err := NewCHTableSink(context.Background(), fe)
+	_, err := NewCHTableSink(context.Background(), fe, "")
 	if err == nil {
 		t.Fatalf("NewCHTableSink over a table missing %s: want an error, got nil", shardsObservedColumn)
 	}
@@ -577,7 +650,7 @@ func TestNewCHTableSink_MissingColumnFailsWithoutAnAlterError(t *testing.T) {
 	t.Parallel()
 
 	fe := &fakeExecer{absentColumn: map[string]bool{parallelismColumn: true}}
-	_, err := NewCHTableSink(context.Background(), fe)
+	_, err := NewCHTableSink(context.Background(), fe, "")
 	if err == nil {
 		t.Fatalf("NewCHTableSink over a table missing %s: want an error, got nil", parallelismColumn)
 	}
@@ -595,7 +668,7 @@ func TestNewCHTableSink_CreateFailureIsFatal(t *testing.T) {
 		failStatement: "CREATE TABLE IF NOT EXISTS " + CorpusTableName,
 		failErr:       errors.New("not enough privileges"),
 	}
-	if _, err := NewCHTableSink(context.Background(), fe); err == nil {
+	if _, err := NewCHTableSink(context.Background(), fe, ""); err == nil {
 		t.Fatal("NewCHTableSink with a refused CREATE: want an error, got nil")
 	}
 }
@@ -625,7 +698,7 @@ func TestNewCHTableSink_RejectsRenumberedDeployedColumn(t *testing.T) {
 		exitStatusColumn: "Enum8('ok' = 0, 'oom' = 1, 'timeout' = 2, " +
 			"'sample_budget' = 3, 'breaker' = 4, 'rejected' = 5, 'error' = 6, 'aborted' = 7)",
 	}}
-	_, err := NewCHTableSink(context.Background(), fe)
+	_, err := NewCHTableSink(context.Background(), fe, "")
 	if err == nil {
 		t.Fatal("NewCHTableSink over a renumbered exit_status column: want an error, got nil")
 	}

--- a/internal/optcorpus/enummigrate_realch_integration_test.go
+++ b/internal/optcorpus/enummigrate_realch_integration_test.go
@@ -88,7 +88,7 @@ func TestCorpusEnumMigrationRealClickHouse(t *testing.T) {
 		t.Fatalf("create the narrow corpus table: %v", err)
 	}
 
-	sink, err := NewCHTableSink(ctx, conn)
+	sink, err := NewCHTableSink(ctx, conn, "")
 	if err != nil {
 		t.Fatalf("build CH table sink over the narrow table: %v", err)
 	}

--- a/internal/routerrules/realch_integration_test.go
+++ b/internal/routerrules/realch_integration_test.go
@@ -121,7 +121,7 @@ func TestCorpusWriteReadRealClickHouse(t *testing.T) {
 	// real sink against real ClickHouse and reading the rows back asserts the
 	// columnar Append landed every column — enums included — correctly.
 	rows := loadCorpusRows(t, "testdata/effectiveness.jsonl")
-	sink, err := optcorpus.NewCHTableSink(ctx, conn)
+	sink, err := optcorpus.NewCHTableSink(ctx, conn, "")
 	if err != nil {
 		t.Fatalf("create CH table sink (real CREATE DDL): %v", err)
 	}


### PR DESCRIPTION
## The bug

`internal/optcorpus`'s CH-table sink rendered a fixed, deployment-blind

```sql
CREATE TABLE IF NOT EXISTS cerberus_router_corpus (…) ENGINE = MergeTree …
```

with no `ON CLUSTER` clause, while every other cerberus-authored table is
provisioned through `internal/schema/ddl`, which threads the resolved
`CERBERUS_SCHEMA_CLUSTER` into every statement it emits
(`renderAddMetricProjection`, `renderModifyColumnCodec`, … all carry
`if cfg.Cluster != "" { stmt.OnCluster(cfg.Cluster) }`). The corpus sink read
none of that topology, so its DDL ran only on whichever node served the
connection.

## Verifying the report's analysis

Every link in issue #3225's chain holds, and each was checked against the code
rather than assumed:

- **The `CREATE` is unqualified and clusterless.** `corpusCreateTableSQL` built
  `chsql.CreateTable(CorpusTableName).IfNotExists().…Engine(chsql.EngineMergeTree())`
  — no `OnCluster`, no `Distributed`, no replicating engine. The two reconciling
  `ALTER`s were the same.
- **Single-shard + `replicas > 1` masks it.** `cerberus.bundled.apply`
  (`deploy/helm/cerberus/templates/clickhouse/_helpers.tpl`) sets
  `schema.replicated.enabled=true` only when `dataShardCount <= 1`, which becomes
  `CERBERUS_SCHEMA_DATABASE_REPLICATED=true` → `ddl.DatabaseEngine.Replicated` →
  a `Replicated` database engine, and that replicates any DDL executed against
  it.
- **The mutual exclusion is real and is decided in the chart.** The same helper's
  own comment states it, and it is enforced structurally: the `replicated` block
  is gated on `dataShardCount <= 1`, while the `dataShardCount > 1` block instead
  defaults `schema.CLUSTER` to `bwc_cluster` and `schema.TABLE_ENGINE` to the
  classic `ReplicatedMergeTree('/clickhouse/tables/{shard}/{database}/{table}',
  '{replica}')`. `ddl.Config.Validate` refuses `DataShardCount > 1` with no
  `Cluster` at all, so a sharded deployment always has a cluster name to use.
- **Why the corpus is not among the `ReplicatedMergeTree` tables `autoCreate`
  renders.** It is not rendered by `autoCreate` at all: the sink creates its own
  table at construction, independently of `CERBERUS_AUTO_CREATE_SCHEMA`, and
  never consulted the DDL config.

Reproduced and fixed against a real two-node ClickHouse 26.6 cluster with
Keeper, database `otel`, cluster `bwc_cluster`:

| step | result |
| --- | --- |
| today's DDL, session default db `otel` | table on node 1 only |
| `INSERT` on node 2 | `Code: 60 … Table otel.cerberus_router_corpus does not exist` |
| this PR's DDL | `otel.cerberus_router_corpus` on **both** nodes |
| `INSERT` on node 2 | succeeds |
| `ALTER … MODIFY COLUMN … ON CLUSTER` | widened enum visible on node 2 |

That run also settles the one thing the report did not raise: the statement is
unqualified, and ClickHouse's distributed-DDL path fills in the initiator's
session database, so the table lands in `otel` on the remote node rather than in
`default`.

## The fix

`NewCHTableSink` takes the cluster name and stamps `ON CLUSTER` on the `CREATE`
and on both `ALTER`s. `cmd/cerberus` passes `cfg.SchemaProvisioning.Cluster` —
the same value `internal/schemaboot.DDLConfig` hands the auto-create hook, so
"which cluster is this" stays one source of truth. An empty name leaves the
clause off (the chsql builders' documented contract), so the single-node default
and the single-shard multi-replica shape render byte-identical DDL and are
untouched.

The engine deliberately stays a plain `MergeTree`. `ON CLUSTER` governs where
the TABLE exists, which is what an INSERT landing on any node needs; a
replicating engine or a `Distributed` wrapper would govern where the ROWS live,
a separate property, and the wrapper in particular would move a design boundary
`docs/helm-clickhouse.md` states is permanent (the local/`Distributed` split is
base-signal-tables-only).

## Found but not fixed

The corpus's rows are partitioned per ClickHouse node in **every** multi-node
topology — including the supported single-shard `replicas > 1` one, where a plain
`MergeTree` inside a `Replicated` database is accepted and stays `MergeTree`
(checked on 26.6: `system.tables.engine` reports `MergeTree`), so the DDL
replicates and the data does not. `internal/routerrules` reads with a plain
single-node `SELECT`, so the go/no-go analysis silently mines a fraction of the
corpus. That predates this PR and is not what #3225 reports, so it is filed as
issue #3241 with the three candidate fixes.

## Test

`TestCorpusDDL_OnCluster` asserts over the statements construction actually
executes, on both sides of the switch: with a cluster configured every statement
carries `ON CLUSTER`, with none configured not one of them does, and the
statement count is pinned so a dropped statement cannot pass as an un-threaded
one. A renderer-by-renderer test would not be enough — the real failure shape is
one call site left un-threaded — so it was checked by reverting only the
`MODIFY COLUMN` threading, which the test catches by naming the two offending
statements. `TestCorpusCreateTableSQL_OnClusterPosition` pins the clause between
the table name and the column list, the one position ClickHouse accepts.

Closes #3225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196feCkr8wd6meQ3jr9W8rF
