### PR TITLE
fix(optcorpus,perf): correct the release-gate discriminator and pin the config wiring

### DIFF
--- a/cmd/cerberus/corpus_sink_mode_test.go
+++ b/cmd/cerberus/corpus_sink_mode_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/config"
+	"github.com/tsouza/cerberus/internal/optcorpus"
 )
 
 // errCorpusSinkDDL is the failure a CH-table sink construction hits on a
@@ -75,5 +78,168 @@ func TestBuildCorpusSink_JSONLModeIgnoresCHFailure(t *testing.T) {
 	t.Cleanup(func() { _ = sink.Close() })
 	if want := "jsonl:" + cfg.CHOptCorpus.SinkPath; desc != want {
 		t.Errorf("sink description = %q; want %q", desc, want)
+	}
+}
+
+// recordingCorpusConn is an optcorpus.CHTableConn that records every statement
+// and answers both construction reads the way a server that HONOURED the DDL
+// would: the engine it reports back is the one the recorded CREATE asked for,
+// and the column list is the one this binary writes.
+//
+// Deriving the engine from the CREATE rather than hardcoding it is what makes
+// the wiring test below double-discriminating. Drop the config plumbing and the
+// CREATE emits a plain MergeTree, so a `DatabaseReplicated` deployment both
+// fails the DDL assertion AND fails sink construction outright — the server's
+// answer no longer matches what the deployment needs.
+type recordingCorpusConn struct {
+	stmts []string
+}
+
+func (c *recordingCorpusConn) Exec(_ context.Context, query string, _ ...any) error {
+	c.stmts = append(c.stmts, query)
+	return nil
+}
+
+// createSQL returns the recorded CREATE TABLE statement, or "" if none ran.
+func (c *recordingCorpusConn) createSQL() string {
+	for _, s := range c.stmts {
+		if strings.HasPrefix(s, "CREATE TABLE") {
+			return s
+		}
+	}
+	return ""
+}
+
+func (c *recordingCorpusConn) Query(_ context.Context, query string, _ ...any) (driver.Rows, error) {
+	if strings.Contains(query, "`system`.`tables`") {
+		engine := "MergeTree"
+		if strings.Contains(c.createSQL(), "ENGINE = ReplicatedMergeTree") {
+			engine = "ReplicatedMergeTree"
+		}
+		return &corpusStringRows{cols: 1, rows: [][]string{{engine}}}, nil
+	}
+	rows := &corpusStringRows{cols: 2}
+	for _, col := range optcorpus.CorpusColumns() {
+		rows.rows = append(rows.rows, []string{col.Name, chsql.RenderDDL(col.Type)})
+	}
+	return rows, nil
+}
+
+func (c *recordingCorpusConn) PrepareBatch(context.Context, string, ...driver.PrepareBatchOption) (driver.Batch, error) {
+	return nil, errCorpusSinkDDL
+}
+
+// corpusStringRows is an all-String driver.Rows: the shape both construction
+// reads consume.
+type corpusStringRows struct {
+	cols int
+	rows [][]string
+	next int
+}
+
+func (r *corpusStringRows) Next() bool {
+	if r.next >= len(r.rows) {
+		return false
+	}
+	r.next++
+	return true
+}
+
+func (r *corpusStringRows) Scan(dest ...any) error {
+	if len(dest) != r.cols {
+		return errors.New("corpusStringRows: wrong scan arity")
+	}
+	for i, d := range dest {
+		p, ok := d.(*string)
+		if !ok {
+			return errors.New("corpusStringRows: want *string scan destinations")
+		}
+		*p = r.rows[r.next-1][i]
+	}
+	return nil
+}
+
+func (r *corpusStringRows) HasData() bool                    { return r.next < len(r.rows) }
+func (r *corpusStringRows) ScanStruct(any) error             { return nil }
+func (r *corpusStringRows) ColumnTypes() []driver.ColumnType { return nil }
+func (r *corpusStringRows) Totals(...any) error              { return nil }
+func (r *corpusStringRows) Columns() []string                { return nil }
+func (r *corpusStringRows) Close() error                     { return nil }
+func (r *corpusStringRows) Err() error                       { return nil }
+
+// TestBuildCorpusSink_ThreadsTheDeploymentTopology pins the WIRING between
+// config and the corpus DDL — the seam both cerberus issue #3225 and #3241 were
+// lost in, and the one no test in internal/optcorpus can reach.
+//
+// Every optcorpus test constructs a CorpusTableTopology by hand, so deleting
+// either field from buildCorpusSink's literal leaves that whole package green
+// while a real deployment silently goes back to a table that exists on one node
+// (#3225) or holds rows on one replica (#3241). Only a test that starts from a
+// config.Config and reads the emitted statement closes that.
+//
+// The two cases are the two topologies the chart actually renders on the
+// SUPPORTED paths: the single-node default, and single-shard `replicas > 1`,
+// where the chart sets CERBERUS_SCHEMA_DATABASE_REPLICATED. The classic
+// ON CLUSTER + explicit-engine shape is cerberus issue #3250.
+func TestBuildCorpusSink_ThreadsTheDeploymentTopology(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "bwc_cluster"
+	for _, tc := range []struct {
+		name       string
+		cluster    string
+		replicated bool
+		want       []string
+		deny       []string
+	}{
+		{
+			name: "single-node",
+			want: []string{"ENGINE = MergeTree"},
+			deny: []string{"ON CLUSTER", "ENGINE = ReplicatedMergeTree"},
+		},
+		{
+			name:       "replicated-database",
+			replicated: true,
+			want:       []string{"ENGINE = ReplicatedMergeTree"},
+			deny:       []string{"ON CLUSTER"},
+		},
+		{
+			name:    "classic-cluster",
+			cluster: clusterName,
+			want:    []string{"ON CLUSTER `" + clusterName + "`", "ENGINE = MergeTree"},
+			deny:    []string{"ENGINE = ReplicatedMergeTree"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := config.Config{}
+			cfg.CHOptCorpus.SinkMode = corpusSinkModeCHTable
+			cfg.SchemaProvisioning.Cluster = tc.cluster
+			cfg.SchemaProvisioning.DatabaseReplicated = tc.replicated
+
+			conn := &recordingCorpusConn{}
+			sink, _, ok := buildCorpusSink(context.Background(), discardLogger(), conn, cfg)
+			if !ok {
+				t.Fatalf("chtable sink construction failed against a server that honoured the DDL; "+
+					"statements: %q", conn.stmts)
+			}
+			t.Cleanup(func() { _ = sink.Close() })
+
+			create := conn.createSQL()
+			if create == "" {
+				t.Fatalf("construction ran no CREATE TABLE; statements: %q", conn.stmts)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(create, w) {
+					t.Errorf("CREATE does not carry %q:\n%s", w, create)
+				}
+			}
+			for _, d := range tc.deny {
+				if strings.Contains(create, d) {
+					t.Errorf("CREATE wrongly carries %q:\n%s", d, create)
+				}
+			}
+		})
 	}
 }

--- a/cmd/cerberus/main.go
+++ b/cmd/cerberus/main.go
@@ -1759,7 +1759,8 @@ func startOptCorpus(ctx context.Context, logger *slog.Logger, client *chclient.C
 	)
 }
 
-// corpusSinkModeCHTable selects the cerberus_router_corpus MergeTree sink.
+// corpusSinkModeCHTable selects the cerberus_router_corpus table sink (whose
+// MergeTree-family engine follows the deployment — see optcorpus.CorpusTableTopology).
 const corpusSinkModeCHTable = "chtable"
 
 // buildCorpusSink selects the durable corpus sink from CHOptCorpus.SinkMode:
@@ -1781,12 +1782,15 @@ func buildCorpusSink(ctx context.Context, logger *slog.Logger, conn optcorpus.CH
 		// SchemaProvisioning fields into internal/schema/ddl's Config.Cluster
 		// and DatabaseEngine.Replicated), so the corpus table exists on every
 		// node of a distributed-DDL cluster (cerberus issue #3225) AND
-		// replicates its rows wherever the signal tables beside it do
-		// (cerberus issue #3241). Reading those knobs here rather than adding
-		// corpus-specific ones keeps "what does this deployment look like" a
-		// single source of truth; they are read independently of
-		// CERBERUS_AUTO_CREATE_SCHEMA because this sink creates its own table
-		// whether or not that hook runs.
+		// replicates its rows on the Replicated-DATABASE path the chart renders
+		// for single-shard `replicas > 1` (cerberus issue #3241). A classic
+		// ON CLUSTER deployment that replicates through the THIRD knob,
+		// SchemaProvisioning.TableEngine, is NOT covered — see
+		// optcorpus.CorpusTableTopology and cerberus issue #3250. Reading these
+		// knobs here rather than adding corpus-specific ones keeps "what does
+		// this deployment look like" a single source of truth; they are read
+		// independently of CERBERUS_AUTO_CREATE_SCHEMA because this sink
+		// creates its own table whether or not that hook runs.
 		sink, err := optcorpus.NewCHTableSink(ctx, conn, optcorpus.CorpusTableTopology{
 			Cluster:            cfg.SchemaProvisioning.Cluster,
 			DatabaseReplicated: cfg.SchemaProvisioning.DatabaseReplicated,

--- a/docs/helm-clickhouse.md
+++ b/docs/helm-clickhouse.md
@@ -568,12 +568,18 @@ carve-out. Its table is provisioned by the corpus sink rather than by
 <CERBERUS_SCHEMA_CLUSTER>` on its own `CREATE` and `ALTER` statements — which
 the chart always sets under `dataShards.count > 1` — so the table exists on
 every node and an INSERT is correct wherever it lands. It also resolves its
-ENGINE from `CERBERUS_SCHEMA_DATABASE_REPLICATED`, exactly as
-`internal/schema/ddl` does for the signal tables, so on the SUPPORTED
+ENGINE from `CERBERUS_SCHEMA_DATABASE_REPLICATED`, so on the SUPPORTED
 single-shard `replicas > 1` path — where the chart makes `otel` a `Replicated`
 database — the corpus rows replicate instead of accumulating per replica
-(issue #3241). What it still gets no part of is the `Distributed` wrapper: rows
-stay within their own shard, so a `dataShards.count > 1` deployment holds a
-per-shard slice of the corpus. That is this boundary, not a gap in it — nothing
-on the query path reads the corpus, and the offline calibration that does is
-single-shard-scoped like every other harness in this repository.
+(issue #3241).
+
+Under `dataShards.count > 1` it does neither. The corpus gets no `Distributed`
+wrapper, so rows never leave the shard they were written on — that part IS this
+boundary, and it costs nothing on the query path, which never reads the corpus.
+But this combination is also the one where the chart leaves
+`CERBERUS_SCHEMA_DATABASE_REPLICATED` unset and gives the SIGNAL tables an
+explicit `ReplicatedMergeTree(...)` through `schema.TABLE_ENGINE` instead — a
+knob the corpus sink does not read. So with `replicas > 1` on top, the corpus
+table stays a plain `MergeTree` and accumulates per REPLICA as well as per
+shard, and nothing reports it. That half is a gap, not a boundary, and it is
+tracked in issue #3250.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3814,19 +3814,25 @@ because `just release-prep <version>` runs `just capture-release-perf-baseline
 <version>` and stages `test/perf/release-baseline/<version>/` into the release
 commit itself, sourced byte-for-byte from the working tree's own rolling
 `test/perf/cardinality-baseline/`. The gate resolves the SEMVER-HIGHEST
-subdirectory present, so the release commit is judged against a reference
-captured from itself and the lane goes green at the cut.
+subdirectory present, so the release commit is judged against a copy of the
+rolling baseline it is shipping — which clears the lane exactly when
+`TestCardinalityRatchet` was already green on those fixtures. A fixture drifting
+from the rolling baseline at cut time stays red, as it should: the cut copies
+that tree, it does not re-profile.
 
 Between cuts, any correctness fix that legitimately changes a fixture's
 measured cardinality leaves `perf-guards` red on `main` until the next release.
 That is the gate working, not a blocker: it is reporting a real difference
-against what actually shipped. The failure names which of the two cases it is —
-a change since the release that the rolling baseline shows was already recorded
-and reviewed, or live drift `TestCardinalityRatchet` is failing on too
-(cerberus issue #3244). Only the second needs root-causing. **Never regenerate
-a frozen release baseline on a fix branch to clear the first**; a release
-reference that moves outside a cut stops describing what shipped, which is the
-one thing it exists to do.
+against what actually shipped. The failure names which of the two cases it is
+(cerberus issue #3244) — a value the rolling baseline shows some PR recorded
+since the release, or live drift nothing has looked at. The second is
+root-caused. The first is not a defect hunt: read the recording PR's own
+justification against the release value, which is the whole point of a gate
+built to catch what a cycle's individually-justified re-baselines SUM to (step
+3, "audit the delta", is where that reading belongs). **Never regenerate a
+frozen release baseline on a fix branch to clear either**; a release reference
+that moves outside a cut stops describing what shipped, which is the one thing
+it exists to do.
 
 The single publish in step 5 runs through the machinery below — the head
 release by merging its release PR.

--- a/docs/solver.md
+++ b/docs/solver.md
@@ -1397,11 +1397,18 @@ To answer it the engine closes the loop the optimization corpus
   `ALTER` converts an engine, construction also reads the DEPLOYED engine back
   from `system.tables` and **fails** on a replicated deployment whose corpus
   table cannot replicate, naming the one remedy: drop it and let the next start
-  recreate it (the corpus is a rolling 30-day sample). A multi-DATA-shard
-  deployment still holds a per-shard slice — the corpus gets no `Distributed`
-  wrapper, by the same permanent boundary `docs/helm-clickhouse.md` states for
-  the auxiliary tables — but that path is EXPERIMENTAL, while the replicated
-  one is supported.
+  recreate it (the corpus is a rolling 30-day sample).
+- **What that does NOT cover.** The sink reads two of the three knobs that
+  decide the signal tables' engine; the third,
+  `CERBERUS_SCHEMA_TABLE_ENGINE`, is how a classic `ON CLUSTER` deployment
+  supplies an explicit `ReplicatedMergeTree('/path', '{replica}')`. It is a
+  whole engine EXPRESSION, which the typed `chsql` builder cannot carry and
+  whose semantics were chosen for a different table, so the corpus table stays a
+  plain `MergeTree` there and the verify above is silent — the #3241 defect
+  surviving on a topology this does not reach, tracked in issue #3250. A
+  multi-DATA-shard deployment additionally holds a per-shard slice, since the
+  corpus gets no `Distributed` wrapper, by the same permanent boundary
+  `docs/helm-clickhouse.md` states for the auxiliary tables.
 - **A sink that cannot be built disables the reconciler**, logged at startup
   with the underlying error; it does not silently switch modes. There is no
   fallback from `chtable` to `jsonl` — an operator who asked for the CH table

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -607,8 +607,9 @@ type CHOptCorpusConfig struct {
 	RingCapacity int
 	// SinkMode selects the durable sink (CERBERUS_CH_OPT_CORPUS_SINK_MODE):
 	// "jsonl" (default) appends rows to the SinkPath file; "chtable" writes them
-	// to the cerberus_router_corpus MergeTree the operator queries with the
-	// go/no-go analysis SQL. The CH-table sink needs no SinkPath. Any
+	// to the cerberus_router_corpus table the operator queries with the
+	// go/no-go analysis SQL (its MergeTree-family engine follows the deployment
+	// — see optcorpus.CorpusTableTopology). The CH-table sink needs no SinkPath. Any
 	// unrecognised value falls back to the JSONL sink.
 	SinkMode string
 }
@@ -1805,7 +1806,7 @@ const (
 	// any query unless an operator names one — the knob is off by default.
 	defaultCHQueryWorkload = ""
 	// defaultCHOptCorpusSinkMode is the JSONL file sink; "chtable" selects the
-	// cerberus_router_corpus MergeTree instead.
+	// cerberus_router_corpus table instead.
 	defaultCHOptCorpusSinkMode = "jsonl"
 	// defaultCHOptCorpusRing is the reconciler ring capacity when the operator
 	// does not override it. It mirrors optcorpus's own internal default; the

--- a/internal/optcorpus/chtable.go
+++ b/internal/optcorpus/chtable.go
@@ -162,11 +162,21 @@ var reconciledEnumColumns = []reconciledEnumColumn{
 }
 
 // CorpusTableTopology is the ClickHouse deployment shape the corpus table has
-// to be provisioned for. Both fields are read from the SAME resolved knobs
-// internal/schema/ddl threads into every statement the auto-create hook emits,
-// so the corpus table is provisioned exactly like the signal tables beside it
-// rather than against a second, corpus-only notion of "what does this cluster
-// look like".
+// to be provisioned for. Both fields are read from resolved knobs
+// internal/schema/ddl already threads into every statement the auto-create hook
+// emits, rather than from a second, corpus-only notion of "what does this
+// cluster look like".
+//
+// It reads two of the THREE knobs that decide the signal tables' engine. The
+// third, SchemaProvisioning.TableEngine (CERBERUS_SCHEMA_TABLE_ENGINE), is how
+// a classic ON CLUSTER deployment supplies an explicit
+// `ReplicatedMergeTree('/path', '{replica}')` — a whole engine EXPRESSION,
+// which the typed chsql CreateTable builder has no way to carry and which
+// carries semantics chosen for a different table (a ReplacingMergeTree pinned
+// for the signal tables would silently dedupe corpus rows by their sort key).
+// So on that topology the corpus table is still a plain MergeTree and still
+// partitions per replica, and verifyTableEngine below is silent about it:
+// cerberus issue #3250, filed rather than guessed at here.
 //
 // The two fields answer two DIFFERENT questions, and getting one right does not
 // answer the other — that split is cerberus issues #3225 and #3241:
@@ -198,9 +208,14 @@ type CorpusTableTopology struct {
 }
 
 // NewCHTableSink builds a CH-table sink over conn and reconciles the corpus
-// table with the schema this binary writes, in four steps:
+// table with the schema this binary writes, in five steps:
 //
 //	CREATE TABLE IF NOT EXISTS   — makes the table on a fresh deployment.
+//	verify the ENGINE            — reads system.tables back and fails
+//	                               construction when the deployed engine cannot
+//	                               replicate on a deployment whose database
+//	                               does. First, because that verdict does not
+//	                               depend on any column below it.
 //	ALTER TABLE ADD COLUMN       — appends each CorpusColumns() entry a table
 //	                               created by an older binary was made without.
 //	ALTER TABLE MODIFY COLUMN    — widens each reconciledEnumColumns entry on a
@@ -208,11 +223,9 @@ type CorpusTableTopology struct {
 //	                               emit. CREATE IF NOT EXISTS alone cannot do
 //	                               either: it is a no-op against an existing
 //	                               table however its columns are declared.
-//	verify                       — reads the deployed ENGINE and schema back
-//	                               and fails construction if the engine cannot
-//	                               replicate on a replicated deployment, if a
-//	                               column is absent, or if an enum member is
-//	                               missing.
+//	verify the SCHEMA            — reads the deployed columns back and fails
+//	                               construction if a column is absent or an
+//	                               enum member is missing.
 //
 // The ADD runs before the MODIFY so a column added here arrives with the wide
 // enum type and the widening finds nothing left to do.
@@ -245,6 +258,19 @@ func NewCHTableSink(ctx context.Context, conn CHTableConn, topology CorpusTableT
 	if err := conn.Exec(ctx, corpusCreateTableSQL(topology)); err != nil {
 		return nil, fmt.Errorf("optcorpus: create %s: %w", CorpusTableName, err)
 	}
+	// The engine is checked BEFORE the ALTERs, not alongside the other
+	// verifies: a table that cannot replicate is refused whatever its columns
+	// say, so running the reconciliation first would issue one ADD COLUMN per
+	// corpus column and one MODIFY per enum column — through a Replicated
+	// database's own DDL queue — against a table this construction is about to
+	// reject anyway.
+	deployedEngine, err := readDeployedEngine(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyTableEngine(deployedEngine, topology); err != nil {
+		return nil, err
+	}
 	addErrs := map[string]error{}
 	for _, col := range CorpusColumns() {
 		if err := conn.Exec(ctx, corpusAddColumnSQL(col, cluster)); err != nil {
@@ -256,13 +282,6 @@ func NewCHTableSink(ctx context.Context, conn CHTableConn, topology CorpusTableT
 		if err := conn.Exec(ctx, corpusAlterEnumColumnSQL(col, cluster)); err != nil {
 			widenErrs[col.name] = err
 		}
-	}
-	deployedEngine, err := readDeployedEngine(ctx, conn)
-	if err != nil {
-		return nil, err
-	}
-	if err := verifyTableEngine(deployedEngine, topology); err != nil {
-		return nil, err
 	}
 	deployed, err := readDeployedSchema(ctx, conn)
 	if err != nil {
@@ -564,12 +583,28 @@ func corpusCreateTableSQL(topology CorpusTableTopology) string {
 // cerberus issue #3241, the exact defect internal/schema/ddl already carries
 // TestApply_ReplicatedDatabase for on the signal tables.
 //
-// A multi-DATA-shard deployment (the EXPERIMENTAL CERBERUS_CH_DATA_SHARDS > 1
-// path) still holds a per-shard slice of the corpus: this engine replicates
-// WITHIN a replica set, and nothing here fans a read across shards. That is the
-// deliberate boundary docs/helm-clickhouse.md states — the local/Distributed
-// split is base-signal-tables-only — not an oversight; the corpus is written
-// and read by the offline calibration alone, never by the data plane.
+// The policy is stated here rather than shared with internal/schema/ddl for two
+// reasons, neither of them the arch-lint edge (.go-arch-lint.yml forbids
+// optcorpus → schema/ddl, but both packages depend on chsql, so a shared
+// chsql.DefaultTableEngine would clear that). First, the two do not actually
+// agree in the non-replicated case: ddl's default is upstream's `MergeTree()`
+// WITH parentheses, preserved because its rendered DDL is a committed golden,
+// while this builder emits the bare `MergeTree`. Second, the shared half — that
+// a Replicated database needs the BARE ReplicatedMergeTree and rejects explicit
+// arguments with code 36 — already lives in one place, chsql's own
+// EngineReplicatedMergeTree doc, which both call sites cite.
+//
+// Two topologies keep a partial corpus after this, and they are different
+// things. A multi-DATA-shard deployment (the EXPERIMENTAL
+// CERBERUS_CH_DATA_SHARDS > 1 path) holds a per-shard slice: this engine
+// replicates WITHIN a replica set, and the corpus gets no Distributed wrapper —
+// the deliberate boundary docs/helm-clickhouse.md states, the local/Distributed
+// split being base-signal-tables-only. A classic ON CLUSTER deployment whose
+// operator supplies an explicit replicating engine through
+// CERBERUS_SCHEMA_TABLE_ENGINE keeps a per-REPLICA slice, which is the #3241
+// defect itself surviving on a topology this change does not reach — cerberus
+// issue #3250. Neither is reached by the supported single-shard replicated
+// path, and nothing on the query path reads the corpus in any of them.
 func corpusTableEngine(topology CorpusTableTopology) chsql.Frag {
 	if topology.DatabaseReplicated {
 		return chsql.EngineReplicatedMergeTree()
@@ -602,6 +637,12 @@ const replicatedEngineFamilyPrefix = "Replicated"
 // dropping the table and letting the next start recreate it costs at most that
 // window and nothing a query ever reads.
 func verifyTableEngine(deployed string, topology CorpusTableTopology) error {
+	// A deployment whose database does not replicate is not thereby a
+	// deployment whose ROWS do not need to: a classic ON CLUSTER cluster
+	// replicates through CERBERUS_SCHEMA_TABLE_ENGINE instead, which
+	// CorpusTableTopology does not carry, so this check is silent there.
+	// That silence is cerberus issue #3250, not an assertion that the corpus
+	// is complete.
 	if !topology.DatabaseReplicated {
 		return nil
 	}
@@ -611,9 +652,10 @@ func verifyTableEngine(deployed string, topology CorpusTableTopology) error {
 	return fmt.Errorf("optcorpus: deployed %s engine %q does not replicate its rows, but this deployment's "+
 		"database does (CERBERUS_SCHEMA_DATABASE_REPLICATED): each replica would hold only the rows written "+
 		"through it and the offline calibration would mine one replica's slice as if it were the whole corpus. "+
-		"A Replicated database does not convert a MergeTree, and no ALTER does either — DROP TABLE %s on every "+
-		"replica and let the next start recreate it with the %sMergeTree engine (the corpus is a rolling %d-day "+
-		"sample, so nothing older than that is lost)",
+		"A Replicated database does not convert a MergeTree, and no ALTER does either — DROP TABLE %s (the "+
+		"Replicated database propagates the DROP itself; do not repeat it per replica) and restart, which "+
+		"recreates it with the %sMergeTree engine (the corpus is a rolling %d-day sample, so nothing older "+
+		"than that is lost)",
 		CorpusTableName, deployed, CorpusTableName, replicatedEngineFamilyPrefix, corpusRetentionDays)
 }
 

--- a/internal/optcorpus/chtable_test.go
+++ b/internal/optcorpus/chtable_test.go
@@ -182,6 +182,43 @@ func TestCorpusCreateTableSQL_EngineFollowsDatabaseReplication(t *testing.T) {
 	}
 }
 
+// TestNewCHTableSink_EngineReadFailureIsFatal pins that an unreadable
+// deployed-engine read fails construction rather than being read as "no
+// engine".
+//
+// All three are real driver outcomes and all three are silent by default: a
+// query the server refuses, a Scan that fails mid-row, and an error the driver
+// only reports after iteration. If any were swallowed, readDeployedEngine would
+// hand back the zero string,
+// verifyTableEngine would read that as a non-replicating engine, and the sink
+// would be refused on a deployment whose table is perfectly fine — or, on a
+// non-replicated deployment, the unread failure would simply vanish. Neither is
+// an answer about the server; only an error is.
+func TestNewCHTableSink_EngineReadFailureIsFatal(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		fe   *fakeExecer
+	}{
+		{name: "query-fails", fe: &fakeExecer{engineQueryErr: errors.New("query boom")}},
+		{name: "scan-fails", fe: &fakeExecer{engineScanErr: errors.New("scan boom")}},
+		{name: "iteration-reports-an-error", fe: &fakeExecer{engineRowsErr: errors.New("rows boom")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewCHTableSink(context.Background(), tc.fe, CorpusTableTopology{})
+			if err == nil {
+				t.Fatal("NewCHTableSink over an unreadable deployed engine: want an error, got nil")
+			}
+			if !strings.Contains(err.Error(), "engine") {
+				t.Errorf("error %q does not say the ENGINE read is what failed", err)
+			}
+		})
+	}
+}
+
 // TestNewCHTableSink_RejectsNonReplicatingDeployedEngine pins the migration half
 // of cerberus issue #3241: emitting the right engine only fixes a table this
 // binary CREATES, and `CREATE TABLE IF NOT EXISTS` is a no-op against a table an
@@ -190,10 +227,14 @@ func TestCorpusCreateTableSQL_EngineFollowsDatabaseReplication(t *testing.T) {
 // the SERVER reports — and if construction accepted it anyway, the corpus would
 // go on being mined one replica at a time with nothing saying so.
 //
-// The three cases are the whole truth table: the deployment that needs
+// Three of the 2x2's four cells are covered: the deployment that needs
 // replication and does not have it FAILS, the one that needs it and has it is
 // built, and the single-node deployment — where a plain MergeTree is correct and
-// there is no Keeper — is untouched by the check.
+// there is no Keeper — is untouched by the check. The fourth, a REPLICATING
+// engine deployed on a non-replicated deployment, is deliberately unchecked:
+// replicating more than the deployment asked for costs correctness nothing, and
+// refusing it would brick a deployment that turned replication off after the
+// table was made.
 func TestNewCHTableSink_RejectsNonReplicatingDeployedEngine(t *testing.T) {
 	t.Parallel()
 
@@ -256,7 +297,11 @@ func TestNewCHTableSink_RejectsNonReplicatingDeployedEngine(t *testing.T) {
 // writes, so construction succeeds unless a test says otherwise.
 // failStatement / failErr make ONE statement fail while the rest succeed, which
 // is how a least-privilege deployment presents (a CH user may hold CREATE but
-// not ALTER); execErr fails every statement; queryErr fails the schema read.
+// not ALTER); execErr fails every statement. The two reads are failed
+// SEPARATELY — engineQueryErr for the system.tables engine read, queryErr for
+// the system.columns schema read — because they run one after the other, so a
+// single shared error would only ever pin whichever runs first and would leave
+// the other read's fatal path with no coverage at all.
 type fakeExecer struct {
 	execSQL        []string
 	execErr        error
@@ -267,8 +312,21 @@ type fakeExecer struct {
 	deployedType   map[string]string
 	absentColumn   map[string]bool
 	deployedEngine string
+	engineScanErr  error
+	engineRowsErr  error
+	engineQueryErr error
 	queryErr       error
 }
+
+// systemTablesRelation is the relation the ENGINE read names, rendered the same
+// way corpusEngineQuery renders it, so the fake dispatches on the production
+// statement rather than on a hand-typed copy of it.
+var systemTablesRelation = chsql.RenderDDL(chsql.Qual("system", "tables"))
+
+// isEngineQuery reports whether query is the deployed-ENGINE read rather than
+// the deployed-SCHEMA read. Construction issues both against the same table
+// name, so the bound argument cannot tell them apart — the relation can.
+func isEngineQuery(query string) bool { return strings.Contains(query, systemTablesRelation) }
 
 func (f *fakeExecer) Exec(_ context.Context, query string, _ ...any) error {
 	f.execSQL = append(f.execSQL, query)
@@ -287,7 +345,11 @@ func (f *fakeExecer) Exec(_ context.Context, query string, _ ...any) error {
 // The table name is the query's last bound argument; checking it keeps the fake
 // honest about WHICH table it is answering for.
 func (f *fakeExecer) Query(_ context.Context, query string, args ...any) (driver.Rows, error) {
-	if f.queryErr != nil {
+	if isEngineQuery(query) {
+		if f.engineQueryErr != nil {
+			return nil, f.engineQueryErr
+		}
+	} else if f.queryErr != nil {
 		return nil, f.queryErr
 	}
 	if len(args) == 0 {
@@ -300,16 +362,17 @@ func (f *fakeExecer) Query(_ context.Context, query string, args ...any) (driver
 	if table != CorpusTableName {
 		return nil, errors.New("fakeExecer: schema query asked about table " + table)
 	}
-	// Construction issues TWO reads against the same table name — the engine
-	// (system.tables) and the column list (system.columns) — so the fake
-	// dispatches on the relation the statement names rather than on the bound
-	// argument they share.
-	if strings.Contains(query, chsql.RenderDDL(chsql.Qual("system", "tables"))) {
+	if isEngineQuery(query) {
 		engine := f.deployedEngine
 		if engine == "" {
 			engine = chsql.RenderDDL(corpusTableEngine(CorpusTableTopology{}))
 		}
-		return &fakeRows{cols: []string{"engine"}, rows: [][]string{{engine}}}, nil
+		return &fakeRows{
+			cols:     []string{"engine"},
+			rows:     [][]string{{engine}},
+			scanErr:  f.engineScanErr,
+			finalErr: f.engineRowsErr,
+		}, nil
 	}
 	rows := &fakeRows{cols: []string{"name", "type"}}
 	for _, c := range CorpusColumns() {
@@ -342,6 +405,11 @@ type fakeRows struct {
 	cols []string
 	rows [][]string
 	next int
+	// scanErr / finalErr make the row set fail mid-iteration and after it —
+	// the two ways a real driver reports a read that started fine and did not
+	// finish. Both are silent unless a test sets them.
+	scanErr  error
+	finalErr error
 }
 
 func (r *fakeRows) Next() bool {
@@ -353,6 +421,9 @@ func (r *fakeRows) Next() bool {
 }
 
 func (r *fakeRows) Scan(dest ...any) error {
+	if r.scanErr != nil {
+		return r.scanErr
+	}
 	if len(dest) != len(r.cols) {
 		return errors.New("fakeRows: want exactly one scan destination per column")
 	}
@@ -376,7 +447,7 @@ func (r *fakeRows) ColumnTypes() []driver.ColumnType { return nil }
 func (r *fakeRows) Totals(...any) error              { return nil }
 func (r *fakeRows) Columns() []string                { return r.cols }
 func (r *fakeRows) Close() error                     { return nil }
-func (r *fakeRows) Err() error                       { return nil }
+func (r *fakeRows) Err() error                       { return r.finalErr }
 
 func (f *fakeExecer) PrepareBatch(_ context.Context, _ string, _ ...driver.PrepareBatchOption) (driver.Batch, error) {
 	if f.batchErr != nil {

--- a/internal/optcorpus/optcorpus.go
+++ b/internal/optcorpus/optcorpus.go
@@ -365,7 +365,7 @@ type Row struct {
 	// replayed offline. They are zero-valued when the dispatch carried no
 	// routing classification (Solver off / unclassified head) — Route is then
 	// "" and the scalar columns are 0. The field shape stays column-for-column
-	// aligned with the cerberus_router_corpus MergeTree (see chtable.go) so the
+	// aligned with the cerberus_router_corpus table (see chtable.go) so the
 	// JSONL and CH-table sinks write the same Row.
 	NAnchors    uint32 `json:"n_anchors"`
 	Fanout      uint32 `json:"fanout"`

--- a/internal/optcorpus/replicated_realch_integration_test.go
+++ b/internal/optcorpus/replicated_realch_integration_test.go
@@ -81,6 +81,22 @@ const (
 // enough: the property under test is whether ClickHouse registers the corpus
 // table as a REPLICA at all, which is a per-table engine fact, not a
 // multi-node one.
+//
+// It is the same server shape internal/schema/ddl's own replicated lane raises
+// (ddl_replicated_integration_test.go). The two are not shared: a common home
+// would be a new internal/** test package, which invariant 16 makes a
+// registration of its own in .go-arch-lint.yml and the coverage-floor ledger,
+// and it would couple two independent integration lanes' container bootstraps.
+// They are cross-referenced instead, so a Keeper-timing fix to either is
+// visibly owed to the other.
+//
+// This lane pins queryExitCHImage (the CH_TEST_IMAGE `just
+// router-corpus-integration` already pre-pulls) rather than the older floor
+// image its sibling uses: that a BARE ReplicatedMergeTree is valid DDL on
+// cerberus's minimum supported server is that lane's claim and is pinned there,
+// while this one asks a different question — whether the corpus table in
+// particular registers as a replica — and reusing the recipe's own image keeps
+// the lane to one server pull.
 const replicatedServerConfigTemplate = `<clickhouse>
     <keeper_server>
         <tcp_port>9181</tcp_port>
@@ -137,7 +153,7 @@ func TestCorpusReplicatedEngineRealClickHouse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), queryExitCHStartTimeout)
 	defer cancel()
 
-	bootstrap := startReplicatedCH(ctx, t)
+	bootstrap, addr := startReplicatedCH(ctx, t)
 
 	createDB := chsql.CreateDatabase(replicatedCorpusDatabase).
 		IfNotExists().
@@ -147,7 +163,7 @@ func TestCorpusReplicatedEngineRealClickHouse(t *testing.T) {
 		t.Fatalf("create the Replicated database (%s): %v", createDB, err)
 	}
 
-	conn := openReplicatedCH(ctx, t, replicatedCorpusDatabase)
+	conn := openReplicatedCH(ctx, t, addr, replicatedCorpusDatabase)
 
 	topology := CorpusTableTopology{DatabaseReplicated: true}
 	sink, err := NewCHTableSink(ctx, conn, topology)
@@ -206,12 +222,12 @@ func TestCorpusReplicatedEngineRealClickHouse(t *testing.T) {
 }
 
 // startReplicatedCH spins up a ClickHouse configured with an embedded Keeper and
-// {shard}/{replica} macros, and returns a connection bound to the built-in
+// {shard}/{replica} macros. It returns a connection bound to the built-in
 // `default` database — the Replicated one does not exist yet, exactly like a
-// cold bootstrap against a clustered ClickHouse. The container's address is
-// recorded on the test so openReplicatedCH can dial it again once the database
-// exists.
-func startReplicatedCH(ctx context.Context, t *testing.T) driver.Conn {
+// cold bootstrap against a clustered ClickHouse — plus the container's
+// native-protocol address, so the caller can dial it a second time once the
+// Replicated database does exist.
+func startReplicatedCH(ctx context.Context, t *testing.T) (driver.Conn, string) {
 	t.Helper()
 
 	cfgPath := filepath.Join(t.TempDir(), "replicated.xml")
@@ -240,23 +256,17 @@ func startReplicatedCH(ctx context.Context, t *testing.T) driver.Conn {
 	if err != nil {
 		t.Fatalf("port: %v", err)
 	}
-	replicatedCHAddr = host + ":" + port.Port()
+	addr := host + ":" + port.Port()
 
-	return openReplicatedCH(ctx, t, replicatedBootstrapDB)
+	return openReplicatedCH(ctx, t, addr, replicatedBootstrapDB), addr
 }
 
-// replicatedCHAddr is the running container's native-protocol address, set by
-// startReplicatedCH so the second dial (into the Replicated database, once it
-// exists) reaches the same server. The lane runs one container per test and does
-// not run in parallel, so a package-level value is the whole state it needs.
-var replicatedCHAddr string
-
-// openReplicatedCH dials the running container, bound to database.
-func openReplicatedCH(ctx context.Context, t *testing.T, database string) driver.Conn {
+// openReplicatedCH dials the container at addr, bound to database.
+func openReplicatedCH(ctx context.Context, t *testing.T, addr, database string) driver.Conn {
 	t.Helper()
 
 	conn, err := clickhouse.Open(&clickhouse.Options{
-		Addr: []string{replicatedCHAddr},
+		Addr: []string{addr},
 		Auth: clickhouse.Auth{
 			Database: database,
 			Username: replicatedCorpusUser,

--- a/internal/schema/ddl/ddl_replicated_integration_test.go
+++ b/internal/schema/ddl/ddl_replicated_integration_test.go
@@ -20,7 +20,9 @@ import (
 // replicatedServerConfig is a single-node ClickHouse config that turns on an
 // embedded clickhouse-keeper, points the server's ZooKeeper client at it, and
 // defines the {shard} / {replica} macros — the minimum a Replicated database
-// engine needs to coordinate. It is deliberately a ONE-node cluster: that is
+// engine needs to coordinate. internal/optcorpus's replicated lane
+// (replicated_realch_integration_test.go, cerberus issue #3241) raises the same
+// server shape for the corpus table; a Keeper-timing fix here is owed there too. It is deliberately a ONE-node cluster: that is
 // enough to prove the DDL cerberus emits is ACCEPTED by ClickHouse and that the
 // tables register in system.replicas (i.e. they actually replicate DATA), which
 // is the exact behaviour string-assertion unit tests can never observe.

--- a/test/perf/cardinality_ratchet_test.go
+++ b/test/perf/cardinality_ratchet_test.go
@@ -181,6 +181,7 @@ package perf
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"sync"
@@ -436,7 +437,7 @@ func TestCardinalityRatchet(t *testing.T) {
 	}
 	sort.Strings(matched)
 	for _, id := range matched {
-		compareCardinalityEntry(t, id, current[id], baseline[id], rollingRemedy)
+		compareCardinalityEntry(t, id, current[id], baseline[id], func() string { return rollingRemedy })
 	}
 }
 
@@ -529,19 +530,62 @@ func cardinalityEntryProblems(id string, cur, base baselineEntry) []cardinalityP
 }
 
 // compareCardinalityEntry reports every difference cardinalityEntryProblems
-// finds, appending remedy — the caller's own wording for what to do about a
+// finds, appending remedy() — the caller's own wording for what to do about a
 // difference that CAN legitimately be recorded. The rolling ratchet names its
 // recipe there; the release gate has no command to name and says what is true
 // instead (see releaseRemedy).
-func compareCardinalityEntry(t *testing.T, id string, cur, base baselineEntry, remedy string) {
+//
+// remedy is a func, not a string, because the release gate's wording costs a
+// SECOND full comparison per fixture to produce (against the rolling baseline)
+// and the overwhelmingly common case is a fixture with nothing to report at
+// all. Building it eagerly would pay that for every one of the ~950 fixtures on
+// every leg to throw it away.
+func compareCardinalityEntry(t *testing.T, id string, cur, base baselineEntry, remedy func() string) {
 	t.Helper()
+	var remedied string
 	for _, p := range cardinalityEntryProblems(id, cur, base) {
 		if p.remediable {
-			t.Errorf("%s %s", p.msg, remedy)
+			if remedied == "" {
+				remedied = remedy()
+			}
+			t.Errorf("%s %s", p.msg, remedied)
 			continue
 		}
 		t.Errorf("%s", p.msg)
 	}
+}
+
+// cardinalityEntryMatches reports whether cur is the measurement base RECORDS.
+//
+// It is deliberately NOT cardinalityEntryProblems == 0. That function is a
+// RATCHET: it reports only the bad direction, so it stays silent on a fan_factor
+// that fell, a recursion that got shallower, a CROSS JOIN that disappeared, and
+// a fixture that became measurable after being recorded as unmeasured. Every one
+// of those is a fixture whose committed row no longer describes it, which is the
+// opposite of what a caller asking "was THIS value recorded?" wants to hear —
+// and answering yes there is how the release gate would come to call an
+// unreviewed upward drift a ratified change (see releaseRemedy).
+//
+// Every field the baseline stores as a CLAIM about the fixture is compared.
+// UncountableLevels is not: it is diagnostic-only (see baselineEntry), a symptom
+// count carried for a reviewer rather than an assertion, and the nil-ness of
+// FanFactor it explains is compared directly.
+func cardinalityEntryMatches(cur, base baselineEntry) bool {
+	if (cur.FanFactor == nil) != (base.FanFactor == nil) {
+		return false
+	}
+	// The same epsilon the ratchet compares with: both sides are the profiler's
+	// own quotient round-tripped through the baseline's JSON, so an exact
+	// comparison would make representation noise read as a different fixture.
+	if cur.FanFactor != nil && math.Abs(*cur.FanFactor-*base.FanFactor) > fanFactorEpsilon {
+		return false
+	}
+	return cur.ScanRows == base.ScanRows &&
+		cur.PeakIntermediate == base.PeakIntermediate &&
+		cur.HasCrossJoin == base.HasCrossJoin &&
+		cur.HasArrayJoin == base.HasArrayJoin &&
+		cur.HasRecursiveCTE == base.HasRecursiveCTE &&
+		cur.MaxRecursionDepth == base.MaxRecursionDepth
 }
 
 // TestCardinalityBaselineCoversTheCorpus asserts the committed tree holds one

--- a/test/perf/release_regression_test.go
+++ b/test/perf/release_regression_test.go
@@ -94,27 +94,34 @@ const releaseRegen = "just capture-release-perf-baseline <version>"
 // situations produced the difference. The gate could not previously tell them
 // apart, so it said "a real regression" for both (cerberus issue #3244):
 //
-//   - RATIFIED SINCE THE RELEASE. The fixture's current measurement matches the
-//     committed ROLLING baseline, which means some PR between that release and
-//     now measured this exact value, re-recorded the row, and had the change
-//     reviewed. #3214's LogQL `[start, end)` fix is the worked example: a
-//     half-open entry window legitimately stops scanning the endpoint sample,
-//     so logql/range_filter went from 2 scan rows to 1 — correct, reviewed, and
-//     not a regression of anything. It is still reported, because a difference
-//     against what actually shipped is exactly what this gate exists to
-//     surface; it just is not a defect to root-cause, and it clears on its own
-//     at the next cut, when `just release-prep` freezes today's rolling
-//     baseline as the new reference.
-//   - LIVE DRIFT. The current measurement does not match the rolling baseline
-//     either, so TestCardinalityRatchet is failing on this fixture too and
-//     nobody has reviewed this value. That is the regression case, and it is
-//     root-caused, never recorded.
+//   - RECORDED SINCE THE RELEASE. The fixture's current measurement is exactly
+//     what the committed ROLLING baseline holds, so some PR between that
+//     release and now measured this value and re-recorded the row. #3214's
+//     LogQL `[start, end)` fix is the worked example: a half-open entry window
+//     legitimately stops scanning the endpoint sample, so logql/range_filter
+//     went from 2 scan rows to 1. What that establishes is that the value was
+//     RECORDED, not that the release-over-release delta is fine — this gate
+//     exists precisely because a cycle's worth of individually-justified
+//     re-baselines can sum to something none of them shows (see
+//     `just capture-release-perf-baseline`'s own doc and issue #3150). So the
+//     remedy sends the reader to that PR's justification, measured against the
+//     release value, rather than to a defect hunt that will find nothing.
+//   - LIVE DRIFT. The current measurement is not what the rolling baseline
+//     holds either, so nothing has reviewed this value at all —
+//     TestCardinalityRatchet is failing on this fixture too whenever the
+//     difference runs in its direction. That is the root-cause case.
 //
-// Neither branch is an escape hatch: both still FAIL. What changes is that the
-// reader is told which one they are looking at, rather than being told to
-// root-cause a change that was already reviewed and ratified — which is the
-// dead end issue #3244 hit. The frozen reference is never re-cut on a fix
-// branch in either case.
+// Neither branch is an escape hatch: both still FAIL, and neither regenerates
+// anything. What changes is that the reader is told which one they are looking
+// at instead of being sent to root-cause a value some PR already recorded on
+// purpose — the dead end issue #3244 hit.
+//
+// The discriminator is cardinalityEntryMatches, an EQUALITY, deliberately not
+// "cardinalityEntryProblems is empty". That function is a one-sided ratchet: it
+// stays silent on a fan_factor that fell, a recursion that got shallower and a
+// fixture that became measurable, so a current value the rolling baseline does
+// NOT hold would read as recorded. That is the wrong verdict on exactly the
+// unreviewed drift this gate is for.
 //
 // rolling is the committed rolling baseline row for this fixture and ok says
 // whether one exists. It always should: TestCardinalityBaselineCoversTheCorpus
@@ -129,17 +136,20 @@ func releaseRemedy(version, id string, cur, rolling baselineEntry, ok bool) stri
 			"`%s` records it, and TestCardinalityBaselineCoversTheCorpus is the gate that should have "+
 			"caught the gap.", rollingPath, cardinalityRegen)
 	}
-	if len(cardinalityEntryProblems(id, cur, rolling)) == 0 {
-		return fmt.Sprintf("This is a CHANGE SINCE v%s, not a fresh regression: the current measurement "+
-			"matches the committed rolling baseline (%s), so it was recorded and reviewed by the PR that "+
-			"made it. Nothing is regenerated here — a frozen release reference moves only at a release "+
-			"cut, and `just release-prep` freezes today's rolling baseline as the next release's "+
-			"reference, which clears this (docs/operations.md, \"The release ritual\").", version, rollingPath)
+	if cardinalityEntryMatches(cur, rolling) {
+		return fmt.Sprintf("This is a CHANGE SINCE v%s: the current measurement is exactly what the "+
+			"committed rolling baseline records (%s), so some PR between v%s and now measured this "+
+			"value and re-recorded the row. Read that PR's justification against v%s's value — this "+
+			"gate's whole job is the SUM of a cycle's individually-justified re-baselines, which no "+
+			"single one of them shows. Nothing is regenerated here either way: a frozen release "+
+			"reference moves only at a release cut, where `just release-prep` freezes today's rolling "+
+			"baseline as the next release's reference (docs/operations.md, \"The release ritual\").",
+			version, rollingPath, version, version)
 	}
-	return fmt.Sprintf("This is LIVE DRIFT, not a change ratified since v%s: the current measurement does "+
-		"not match the committed rolling baseline either (%s), so TestCardinalityRatchet is failing on "+
-		"this fixture too and nobody has reviewed this value. Root-cause it; re-cutting the frozen v%s "+
-		"reference is never the fix.", version, rollingPath, version)
+	return fmt.Sprintf("This is LIVE DRIFT, not a change recorded since v%s: the current measurement is "+
+		"not what the committed rolling baseline records either (%s), so nothing has reviewed this "+
+		"value at all. Root-cause it; re-cutting the frozen v%s reference is never the fix.",
+		version, rollingPath, version)
 }
 
 // releaseBaselineVersion returns the semver-highest subdirectory name under
@@ -247,16 +257,29 @@ func TestReleasePerfRegression(t *testing.T) {
 	}
 
 	// The ROLLING baseline is the second reference this gate reads, and it reads
-	// it for one purpose only: to tell a difference the corpus already ratified
-	// between releases from one nobody has reviewed. It is never compared
-	// against for the verdict — every difference below is still a failure
-	// against the FROZEN reference (cerberus issue #3244).
-	rolling := profile.FilterShardMap(shard, loadBaseline(t))
+	// it for ONE purpose: to tell a difference some PR already recorded between
+	// releases from one nothing has looked at. It is never compared against for
+	// the verdict — every difference below is still a failure against the FROZEN
+	// reference (cerberus issue #3244).
+	//
+	// Its integrity is deliberately NOT fatal here, unlike in
+	// TestCardinalityRatchet, which owns that tree. This gate's verdict does not
+	// depend on it, so an unreadable rolling tree degrades the WORDING of a
+	// failure rather than replacing this gate's own answer with a different
+	// gate's complaint; releaseRemedy says so in as many words when a row is
+	// missing.
+	rollingAll, rollingErr := cardinalityShards.load()
+	if rollingErr != nil {
+		t.Logf("the rolling baseline is unreadable (%v) — every difference below is reported without "+
+			"the recorded/live-drift distinction; %s owns that tree", rollingErr, baselinePath)
+	}
+	rolling := profile.FilterShardMap(shard, rollingAll)
 
 	for _, id := range matched {
 		rollingEntry, haveRolling := rolling[id]
-		compareCardinalityEntry(t, id, current[id], release[id],
-			releaseRemedy(version, id, current[id], rollingEntry, haveRolling))
+		compareCardinalityEntry(t, id, current[id], release[id], func() string {
+			return releaseRemedy(version, id, current[id], rollingEntry, haveRolling)
+		})
 	}
 	t.Logf("release perf regression gate: %d fixture(s) checked against v%s", len(matched), version)
 }
@@ -289,15 +312,25 @@ func TestReleaseRemedy_DistinguishesRatifiedChangeFromLiveDrift(t *testing.T) {
 	// its rolling baseline both say 1.
 	current := baselineEntry{Fixture: id, ScanRows: 1, PeakIntermediate: 1}
 
-	ratified := releaseRemedy(version, id, current, baselineEntry{Fixture: id, ScanRows: 1, PeakIntermediate: 1}, true)
-	// A rolling row that ALSO disagrees with the measurement — the rolling
-	// ratchet is red on this fixture too, so nothing has reviewed this value.
+	recorded := releaseRemedy(version, id, current, baselineEntry{Fixture: id, ScanRows: 1, PeakIntermediate: 1}, true)
+	// A rolling row that ALSO disagrees with the measurement, in the direction
+	// the ratchet reports.
 	live := releaseRemedy(version, id, current, baselineEntry{Fixture: id, ScanRows: 7, PeakIntermediate: 7}, true)
 	absent := releaseRemedy(version, id, current, baselineEntry{}, false)
+	// The case the discriminator is actually easy to get wrong on: the rolling
+	// row disagrees in the direction the RATCHET IGNORES. fan_factor 3.0 against
+	// a recorded 5.0 is a decrease, which TestCardinalityRatchet allows without
+	// comment — so "the ratchet is silent" would call this recorded, when the
+	// rolling baseline plainly holds a different number and nothing measured
+	// 3.0 on purpose. Only an equality gets it right.
+	fanFactor := func(v float64) *float64 { return &v }
+	asymmetric := releaseRemedy(version, id,
+		baselineEntry{Fixture: id, FanFactor: fanFactor(3), ScanRows: 1, PeakIntermediate: 3},
+		baselineEntry{Fixture: id, FanFactor: fanFactor(5), ScanRows: 1, PeakIntermediate: 5}, true)
 
-	if ratified == live {
-		t.Fatalf("a ratified between-release change and live drift produce the SAME remedy, which is the "+
-			"whole defect issue #3244 reports:\n%s", ratified)
+	if recorded == live {
+		t.Fatalf("a change recorded between releases and live drift produce the SAME remedy, which is "+
+			"the whole defect issue #3244 reports:\n%s", recorded)
 	}
 	for _, tc := range []struct {
 		name string
@@ -306,19 +339,29 @@ func TestReleaseRemedy_DistinguishesRatifiedChangeFromLiveDrift(t *testing.T) {
 		deny []string
 	}{
 		{
-			name: "ratified",
-			got:  ratified,
-			// It must name the reference version, say plainly that this is not
-			// a regression, and point at the cut that clears it.
-			want: []string{"CHANGE SINCE v" + version, "rolling baseline", "just release-prep", baselinePath},
+			name: "recorded-since-the-release",
+			got:  recorded,
+			// It must name the reference version, say plainly that the value
+			// was recorded, and send the reader at the recording PR's own
+			// justification rather than at a defect hunt.
+			want: []string{"CHANGE SINCE v" + version, "rolling baseline", "justification", baselinePath},
 			// Root-causing is exactly the wrong instruction here.
 			deny: []string{"Root-cause"},
 		},
 		{
 			name: "live-drift",
 			got:  live,
-			want: []string{"LIVE DRIFT", "TestCardinalityRatchet", "Root-cause", baselinePath},
-			deny: []string{"just release-prep"},
+			want: []string{"LIVE DRIFT", "Root-cause", baselinePath},
+			deny: []string{"CHANGE SINCE"},
+		},
+		{
+			// The whole point of the asymmetric fixture: a difference the
+			// ratchet would not report is still a difference, so this must
+			// land on the SAME side as live drift, never on "recorded".
+			name: "rolling-disagrees-in-the-direction-the-ratchet-ignores",
+			got:  asymmetric,
+			want: []string{"LIVE DRIFT", "Root-cause"},
+			deny: []string{"CHANGE SINCE"},
 		},
 		{
 			name: "no-rolling-row",


### PR DESCRIPTION
## Summary

Follow-up to #3249, which merged before its adversarial review pass landed. Four
findings, one of them a correctness defect that is on `main` right now.

- **The #3244 discriminator is wrong on `main`.** `releaseRemedy` asks "does
  `cardinalityEntryProblems` report anything against the rolling baseline", and that
  function is a **one-sided ratchet** — silent on a `fan_factor` that fell, a
  recursion that got shallower, a `CROSS JOIN` that disappeared, and a fixture that
  became measurable after being recorded as unmeasured. So a fixture with frozen
  `2.0` / rolling `5.0` / current `3.0` — an unreviewed upward drift against the
  release, exactly what this gate exists for — is reported as
  *"the current measurement matches the committed rolling baseline … recorded and
  reviewed by the PR that made it"*. Nothing measured `3.0` on purpose. Replaced with
  `cardinalityEntryMatches`, an **equality** over every field the baseline stores as a
  claim about the fixture, and pinned by a fixture that fails under the old rule.
- **The "ratified, not a defect" wording dismissed the population the gate is for.**
  Matching the rolling tree proves a value was *recorded*, not that a cycle's
  individually-justified re-baselines sum to something acceptable — which is the whole
  reason `test/perf/release-baseline/` exists (#3150). The remedy now sends the reader
  at the recording PR's own justification measured against the release value, and
  `docs/operations.md` says the reading belongs in the audit step.
- **Nothing pinned config → DDL**, which is the seam both #3225 and #3241 were lost
  in. Every `internal/optcorpus` test builds a `CorpusTableTopology` by hand, so
  deleting either field from `buildCorpusSink`'s literal left that package green while
  a real deployment went back to a table on one node (#3225) or rows on one replica
  (#3241). `TestBuildCorpusSink_ThreadsTheDeploymentTopology` starts from a
  `config.Config`, drives the real `buildCorpusSink`, and reads the emitted `CREATE`.
- **Three docs and a code comment overclaimed.** `dataShards.count > 1` **with**
  `replicas > 1` is precisely the shape where the chart leaves
  `CERBERUS_SCHEMA_DATABASE_REPLICATED` unset and gives the *signal* tables an
  explicit `ReplicatedMergeTree(...)` through `schema.TABLE_ENGINE` — a knob the
  corpus sink does not read — so the corpus there accumulates per **replica**, not
  merely per shard. Stated as the gap it is, and tracked in #3250.

Also in here: the deployed-engine read moves ahead of both `ALTER` loops so a table
about to be rejected is not reconciled first (on a `Replicated` database those go
through its DDL queue); the remediation no longer tells an operator to repeat a
`DROP` the `Replicated` database propagates itself; the fake's two construction reads
fail separately, so `TestNewCHTableSink_SchemaReadFailureIsFatal` tests the schema
read again instead of silently becoming a second engine-read test; the release gate
no longer `t.Fatal`s on a rolling tree whose integrity it does not own; the remedy is
built lazily instead of once per fixture.

## Why this is a separate PR

#3249 was merged at 23:41:54Z while the review pass was still running. The fixes were
pushed to its head branch a few minutes later, which GitHub accepted onto the ref
without reopening anything — the classic silent-branch-resurrection. Rather than push
further to a merged PR's head, this is a fresh branch off current `main` carrying the
same commit. `fix/3241-3244` is deleted once this merges.

No `Closes` line: #3241 and #3244 are already closed by #3249. #3250 stays open — it
is named more accurately by this change, not fixed by it.

## Test plan

- [x] `go test ./internal/optcorpus/ ./cmd/cerberus/ ./internal/config/` — pass.
- [x] `go test -tags chdb -run 'TestReleaseRemedy|TestCardinalityEntryProblems'
      ./test/perf/` — pass.
- [x] `go test -tags=integration -run RealClickHouse ./internal/optcorpus/
      ./internal/routerrules/` — the whole `just router-corpus-integration` set, pass
      (46s + 13s) against real ClickHouse 25.9 with an embedded Keeper.
- [x] `node .github/scripts/forbid-sql-raw.mjs` — clean.
- [x] `markdownlint-cli2` on the touched docs — clean.
- [x] CI green (17 required contexts).

### Both new tests proven discriminating

| Test | Against the code on `main` today |
| ---- | ---- |
| `TestReleaseRemedy_…/rolling-disagrees-in-the-direction-the-ratchet-ignores` | FAIL — remedy says `CHANGE SINCE v1.20.0` for a value the rolling baseline does not hold |
| `TestBuildCorpusSink_ThreadsTheDeploymentTopology/replicated-database` | FAIL when `DatabaseReplicated:` is dropped from `buildCorpusSink`'s literal — `CREATE` emits `ENGINE = MergeTree` |

## Notes for reviewers

- `cardinalityEntryMatches` deliberately compares `PeakIntermediate` too, even though
  the ratchet treats it as diagnostic-only: the question here is "is this the
  measurement the row RECORDS", not "is this an acceptable move", and a row whose
  peak differs does not describe the current fixture. `UncountableLevels` is excluded
  — it is a symptom count explaining a `nil` `FanFactor`, and that nil-ness is
  compared directly.
- Both `releaseRemedy` branches still **fail**. Nothing here adds a way to pass, a
  tolerance file, or an allow-list, and no frozen release baseline is regenerated
  (invariant 7).
- `compareCardinalityEntry`'s `remedy` became a `func() string` so the release gate's
  second full comparison is not paid for the ~950 fixtures per leg that have nothing
  to report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196feCkr8wd6meQ3jr9W8rF
