### PR TITLE
chore(perf): regenerate the cardinality baseline after a traceql fixture rename

### DIFF
--- a/test/perf/cardinality-baseline/traceql/span_childcount_constant_false.json
+++ b/test/perf/cardinality-baseline/traceql/span_childcount_constant_false.json
@@ -1,5 +1,5 @@
 {
-  "fixture": "traceql/trace_scoped_intrinsic_constant_false",
+  "fixture": "traceql/span_childcount_constant_false",
   "fan_factor": 0,
   "scan_rows": 0,
   "peak_intermediate": 0,


### PR DESCRIPTION
`perf-guards` has been red on `main` since #3245, and it is a release-gate check.

## What is wrong

`TestCardinalityBaselineCoversTheCorpus` fails in both directions at once — the
rolling cardinality baseline and the fixture corpus no longer name the same set:

```
cardinality_ratchet_test.go:556: 1 profilable fixture(s) have no row in
  cardinality-baseline: [traceql/span_childcount_constant_false]
cardinality_ratchet_test.go:561: 1 row(s) in cardinality-baseline name a fixture
  the corpus no longer holds: [traceql/trace_scoped_intrinsic_constant_false]
```

`e2f135b61` (#3245) renamed the fixture and did not regenerate the generated
baseline beside it.

## Why it went unnoticed

`perf-guards` is named in `release.yml`'s `RELEASE_REQUIRED_CHECKS` but is **not**
one of the 17 contexts a pull request must pass. So the rename merged green, and
the only lane that catches this runs on `main` — where nothing was reading it.
The release preflight would have blocked on it instead.

The stale-row half is the more dangerous one: a baseline row naming a fixture
that no longer exists is not inert, because the ratchet keeps honouring it. A
threshold that nothing can ever re-measure stays in force.

## The fix

Regenerate the `cardinality` shard via `update-golden.yml` (invariant 9 —
regenerate, never hand-edit).

This is the **rolling** `test/perf/cardinality-baseline/`, not a frozen
`test/perf/release-baseline/<ver>/` reference. Regenerating the rolling baseline
in an ordinary fix PR is correct and is exactly what the failure message
instructs; the frozen per-release references are untouched here and continue to
move only at a legitimate re-cut.

Closes #3257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196feCkr8wd6meQ3jr9W8rF
