### PR TITLE
test(chsql): adjudicate every phase2-other survivor and settle the catch-all

### DIFF
--- a/.github/scripts/mutation-phases.mjs
+++ b/.github/scripts/mutation-phases.mjs
@@ -168,46 +168,93 @@ export const PHASES = [
     scope: './internal/chsql',
     efficacy: EFFICACY,
     workers: DEFAULT_WORKERS,
-    // catch-all leg: prewhere + ddl + structural_join + set_op +
-    // range_window_grid_native + scan_resource_bound + emit_size_bound +
-    // query_exemplars + histogram_quantile + tableshape +
-    // range_bucket_grid_native + range_bucket_grid_native_bound, plus every
-    // file no other leg claims (the true zero-mutant/uncovered files:
-    // absent_over_time, chaos_sleep, chaos_sleep_stub, doc,
-    // histogram_float_vector_join, histogram_vector_join, info_join,
-    // mixed_vector_join, search_trace_limit — range_bucket_grid_native and
-    // range_bucket_grid_native_bound were wrongly listed here before cerberus
-    // issue #2741: both carry real, covered mutants, they just had no
-    // dedicated `_mutation_test.go` file defending their input-validation
-    // guards until #2741 added one). A file newly added to internal/chsql
-    // needs no edit here — it is picked up automatically, which is why this
-    // leg keeps no positive file list to fall out of sync.
+    // The scope's CATCH-ALL leg: every internal/chsql file the three curated
+    // legs above do not name, including every file added since this table was
+    // last edited. On the CI run cerberus issue #3221 worked from, the files
+    // carrying executed mutants here were ddl, prewhere, structural_join,
+    // set_op, range_window_grid_native, scan_resource_bound, query_exemplars,
+    // histogram_quantile, range_bucket_grid_native,
+    // range_window_downsample_tier, range_window_grid_native_instant,
+    // range_bucket_grid_native_bound, emit_size_bound,
+    // histogram_quantile_rankwalk_native, tableshape, search_trace_limit,
+    // distinct_attr_keys and attr_strategy_fullmap; the rest of the leg's
+    // files carry only mutants the untagged build never reaches. A file newly
+    // added to internal/chsql needs no edit here — it is picked up
+    // automatically, which is why this leg keeps no positive file list to fall
+    // out of sync, and see the include_files-vs-exclude_files note at the top
+    // of this file for why exactly one leg per scope may work that way.
+    //
+    // WHY THIS LEG KEPT FAILING, AND WHY THE ANSWER IS NOT THE PARTITION
+    // (cerberus issue #3221). It fell below the 95% floor three times —
+    // #2338 (18 survivors), #2741 (13), #3221 (27) — while its three siblings
+    // over the same package never did. The first two closed the instance.
+    // #3221 adjudicated all 27 and found ONE cause behind every real gap, and
+    // it is neither this leg's size nor its composition:
+    //
+    //   An emitter lands here by default, and an emitter's real tests are
+    //   routinely BUILD-TAGGED (`//go:build chdb`, `//go:build integration`)
+    //   because emitted SQL is proven against an engine. The mutation lane
+    //   compiles the UNTAGGED build, so for it those tests do not exist. What
+    //   is left untagged is often only a DISCRIMINATION test —
+    //   chplan_ir_discriminates_test.go asserts that two plans emit DIFFERENT
+    //   SQL, never what either one emits — which makes the emitter's lines
+    //   COVERED while pinning no token in them. Covered-and-unpinned is
+    //   exactly the state that reports LIVED, and a coverage floor cannot see
+    //   it.
+    //
+    // That is why the survivors clustered: 21 of the 27 sat in the three files
+    // whose only untagged defence was that discrimination test
+    // (range_window_downsample_tier.go,
+    // histogram_quantile_rankwalk_native.go) or nothing at all
+    // (search_trace_limit.go). Carving those three into curated legs of their
+    // own — the phase4-traceql-lower shape #3221 asked about — was considered
+    // and REJECTED: they execute 12, 8 and 7 mutants, so each would be a leg
+    // measuring a single file, and a one-file leg over an undefended emitter
+    // reports its own catastrophic efficacy instead of dragging a 386-mutant
+    // leg to 93%. Splitting relocates the number and kills no mutant. #3221
+    // fixed the files instead — three new UNTAGGED `_mutation_test.go` files
+    // that pin the SQL those emitters render.
+    //
+    // GRADUATION RULE. A file leaves this leg for a curated sibling on ONE
+    // criterion, WALL CLOCK, measured: when `gremlins unleash --dry-run` puts
+    // this leg materially past the ~315-executed-mutant band the four-way
+    // split targets, re-measure every file and re-balance greedily, exactly
+    // as that split was derived. Never move a file because it hosts
+    // survivors. The survivors move with it and the receiving leg inherits
+    // the failure, so the only thing that changes is which number reports it
+    // — the same evasion as lowering `efficacy`, and the sibling of what
+    // "Rebalance by re-measuring" above already forbids.
     //
     // Documented-equivalent tally (docs/test-strategy.md's "Surviving-mutant
     // policy" #1 — proven, permanent, and NOT absorbed by lowering `efficacy`
-    // below `MUTATION_MIN_EFFICACY`; see that section for why). Re-measured
-    // via `gremlins unleash --dry-run` scoped to this leg's own
-    // `exclude_files`: 356 executed mutants today. 10 are proven equivalent
-    // (≈2.8%, comfortably under the ~5-point margin `efficacy` below leaves):
-    // prewhere.go:131,:148,:187,:207 (INVERT_LOOPCTRL — a "found it, stop"
-    // boolean latch or a sorted-subarray early exit; scanning further can
-    // never change the result) and :283 (INVERT_LOGICAL — a swap guard whose
-    // two orientations always resolve the same (columnOK, literalOK) pair —
-    // see prewhere_mutation_test.go's own footer), set_op.go:327,:490 and
-    // structural_join.go:525,:738 (set_op_mutation_test.go /
-    // structural_join_anchor_mutation_test.go's own footers), and
-    // emit_size_bound.go:251 (CONDITIONALS_BOUNDARY on a running-max update
-    // that reassigns the SAME value at the boundary — see
-    // emit_size_bound_mutation_test.go's own footer). cerberus issue #2741's
-    // own 13-survivor CI failure was NOT caused by this list growing past
-    // the margin — six of the thirteen were real, previously-undefended
-    // gaps in range_bucket_grid_native.go / range_bucket_grid_native_bound.go
-    // (now fixed) and one more was a #2730-class CI-timing flake on an
-    // existing, correct test (prewhere.go:287, reproduced and confirmed by
-    // manual mutation-and-revert — see prewhere_mutation_test.go's own
-    // TestIsNarrowIntegerDiscriminatorFinalReturnLogical). Re-count this
-    // tally the next time a mutant here gets a new "NOT KILLABLE" note, and
-    // re-partition the leg wider if it ever approaches the margin.
+    // below `MUTATION_MIN_EFFICACY`; see that section for why). Measured from
+    // the leg's own CI run on `main`: 386 executed mutants, of which exactly
+    // 10 are proven equivalent (≈2.6%, comfortably under the ~5-point margin
+    // `efficacy` below leaves), and after #3221 those 10 are the leg's ONLY
+    // survivors. Each is adjudicated in its own file's "NOT KILLABLE" footer:
+    // prewhere.go's three terminal `break`s (INVERT_LOOPCTRL — a "found it,
+    // stop" boolean latch or a sorted-subarray early exit; scanning further
+    // can never change the result), its `!columnOK || !literalOK` swap guard
+    // (INVERT_LOGICAL — both orientations resolve the same (columnOK,
+    // literalOK) pair) and its `r < best` running minimum
+    // (CONDITIONALS_BOUNDARY — the equal case is unreachable across distinct
+    // columns); set_op.go's `i < j` in-place reversal and its `break` in the
+    // shared-conjunct scan; structural_join.go's `len(cols) > 0` and
+    // `len(seedWhere) > 0` (both render byte-identical SQL at zero); and
+    // emit_size_bound.go's `d > deepest` running maximum (a same-value
+    // reassignment at the boundary). #3221 re-derived all ten independently
+    // and confirmed each.
+    //
+    // #2741's report that one of its thirteen was a #2730-class CI-timing
+    // flake on prewhere.go's `columnOK && literalOK` is RETRACTED by #3221.
+    // A mutant is an AST edit re-printed by go/printer, so the real one is
+    // `(columnOK || literalOK) && …`, not the `columnOK || (literalOK && …)`
+    // that retyping the operator in the source produces (#3215's class). The
+    // test claiming the kill was written against the retyped form: applied by
+    // hand, the real mutant leaves it PASSING, so the LIVED report was right
+    // and the flake diagnosis was wrong. That test now feeds an input that
+    // discriminates. Re-count this tally the next time a mutant here gets a
+    // new "NOT KILLABLE" note.
     exclude_files:
       '^(aggregate_range_lwr_fusion|builder|emit|emit_node|exemplars|fnresolution|histogram_over_time|histogram_projection|histogram_quantile_native|lwr_fanout_bound|metrics_compare|metrics_second_stage|nary_vector_set_op|nested_set_annotate|range_bucket_fanout|range_lwr|range_window|range_window_fused|range_window_stale_resample|range_window_variants|rate_window_fanout_bound|vector_join|vector_set_op)\\.go$',
   },

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -1376,6 +1376,27 @@ suite carry the discipline:
    distinguishable.** This is pattern #11 (DEFEAT-MUTANT) — the
    codebase loses clarity to satisfy the mutation tool. Don't do it.
 
+Before picking a remedy, ask **why the mutant was reachable at all**. A
+mutant reported LIVED is by definition COVERED, and in an emitter
+package that coverage routinely comes from somewhere that pins nothing.
+An emitter's real tests are build-tagged (`//go:build chdb`,
+`//go:build integration`) because emitted SQL is proven against an
+engine, and the mutation lane compiles the UNTAGGED build, so for it
+those tests do not exist. What is left untagged is often only a
+DISCRIMINATION test — `chplan_ir_discriminates_test.go` asserts two
+plans emit *different* SQL, never what either one emits — which
+executes the emitter's lines while asserting nothing about them.
+Covered-and-unpinned is remedy 2 every time and never remedy 1: the
+mutant is not equivalent, it is undefended, and no coverage floor can
+see the difference. The tell is a source file with no untagged
+`<file>_mutation_test.go` beside it. Cerberus issue #3221 found 21 of
+`phase2-other`'s 27 survivors in three files in exactly that state,
+after #2338 and #2741 had each closed the same leg's failure as an
+instance; that issue's answer to "should the clustered files become
+curated legs of their own" — no, plus the graduation rule that replaces
+the question — is recorded in `mutation-phases.mjs`'s own
+`phase2-other` comment.
+
 Remedies 1 and 2 are opposite verdicts on one mutant, so recording both
 means one of them is false — and it is almost always the kill, because a
 `// TestX kills …` header costs nothing to write. Two mutants on `main`

--- a/internal/chsql/histogram_quantile_rankwalk_native_mutation_test.go
+++ b/internal/chsql/histogram_quantile_rankwalk_native_mutation_test.go
@@ -1,0 +1,176 @@
+package chsql
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// This file pins histogram_quantile_rankwalk_native.go's emission against the
+// gremlins mutation lane (phase2-other, scope ./internal/chsql). Before it the
+// file's only tests were a `//go:build integration` real-ClickHouse
+// differential and chplan_ir_discriminates_test.go, which asserts only that
+// the native and legacy quantile plans emit DIFFERENT SQL. That makes the
+// emitter's lines COVERED without pinning any token in them, which is how five
+// mutants stayed alive here. Each test names the construct it defends.
+
+// rankWalkNativePlan builds an emittable native-aggregate HistogramQuantile.
+func rankWalkNativePlan() *chplan.HistogramQuantile {
+	return &chplan.HistogramQuantile{
+		Input:                      &chplan.Scan{Table: "otel_metrics_histogram"},
+		Phi:                        0.9,
+		MetricNameColumn:           "MetricName",
+		AttributesColumn:           "Attributes",
+		TimestampColumn:            "TimeUnix",
+		BucketCountsColumn:         "BucketCounts",
+		ExplicitBoundsColumn:       "ExplicitBounds",
+		GroupBy:                    []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+		GroupByAliases:             []string{"AttrsAlias"},
+		UseNativeQuantileAggregate: true,
+	}
+}
+
+// TestEmitHistogramQuantileRankWalkNative_RequiresBothArrayColumns pins that
+// the emitter rejects a plan missing EITHER array column, not only one missing
+// both.
+//
+// Kills the INVERT_LOGICAL mutant of
+// histogram_quantile_rankwalk_native.go:`if h.BucketCountsColumn == "" || h.ExplicitBoundsColumn == ""`.
+// The mutant reads `... == "" && ... == ""`, which accepts a plan naming only
+// one of the two arrays and goes on to render `arrayFilter(i -> i = 1 OR “[i]
+// != “[i - 1], …)` over a nameless column. Only the two one-sided cases
+// distinguish the forms; the both-empty and both-present cases agree under
+// either spelling, and are asserted alongside them so the test states the
+// whole contract rather than just the discriminating half.
+func TestEmitHistogramQuantileRankWalkNative_RequiresBothArrayColumns(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		counts  string
+		bounds  string
+		wantErr bool
+	}{
+		{name: "both present", counts: "BucketCounts", bounds: "ExplicitBounds", wantErr: false},
+		{name: "bounds unset", counts: "BucketCounts", bounds: "", wantErr: true},
+		{name: "counts unset", counts: "", bounds: "ExplicitBounds", wantErr: true},
+		{name: "both unset", counts: "", bounds: "", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := rankWalkNativePlan()
+			h.BucketCountsColumn = tc.counts
+			h.ExplicitBoundsColumn = tc.bounds
+			sql, _, err := Emit(context.Background(), h)
+			if tc.wantErr {
+				if !errors.Is(err, ErrUnsupported) {
+					t.Fatalf("Emit err = %v, want ErrUnsupported (SQL: %s)", err, sql)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+		})
+	}
+}
+
+// TestEmitHistogramQuantileRankWalkNative_GroupByAliases pins the alias
+// pairing between h.GroupBy and h.GroupByAliases, and with it the fact that a
+// statement is emitted at all.
+//
+// Kills the CONDITIONALS_NEGATION mutant of
+// histogram_quantile_rankwalk_native.go:`if i < len(h.GroupByAliases)`, which
+// inverts the guard to `i >= len(…)` and so drops the alias from every group
+// key that HAS one — the aliased case below then projects a bare
+// “ `Attributes` “ and the output column the caller reads by name is gone.
+//
+// Kills the CONDITIONALS_BOUNDARY mutant of the same construct
+// (`i <= len(…)`) via the second case: with fewer aliases than group keys the
+// mutant indexes h.GroupByAliases one past its end and panics, where the
+// original leaves the surplus key unaliased. A plan with a short alias slice
+// is exactly what that guard exists for, so pinning it is pinning the
+// contract, not manufacturing an input.
+//
+// Kills the CONDITIONALS_NEGATION mutant of the `if err != nil` guard below
+// histogram_quantile_rankwalk_native.go:`sub, err := e.subqueryFrag(h.Input)`:
+// negated, the guard returns a nil error on the SUCCESS path before any stage
+// is built, so the emitter produces no statement. The projection assertions
+// below fail on the empty result.
+func TestEmitHistogramQuantileRankWalkNative_GroupByAliases(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		groupBy []chplan.Expr
+		aliases []string
+		want    string
+	}{
+		{
+			name:    "one key one alias",
+			groupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+			aliases: []string{"AttrsAlias"},
+			want:    "SELECT `Attributes` AS `AttrsAlias`, ",
+		},
+		{
+			name:    "two keys one alias",
+			groupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}, &chplan.ColumnRef{Name: "MetricName"}},
+			aliases: []string{"AttrsAlias"},
+			want:    "SELECT `Attributes` AS `AttrsAlias`, `MetricName`, ",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := rankWalkNativePlan()
+			h.GroupBy = tc.groupBy
+			h.GroupByAliases = tc.aliases
+			sql, _, err := Emit(context.Background(), h)
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if !strings.HasPrefix(sql, tc.want) {
+				t.Errorf("emitted SQL does not start with %q\nSQL: %s", tc.want, sql)
+			}
+			// The aggregate itself: present only when the emitter ran past
+			// its own error guards and built every stage.
+			if !strings.Contains(sql, "quantilePrometheusHistogram(") {
+				t.Errorf("emitted SQL carries no quantilePrometheusHistogram call\nSQL: %s", sql)
+			}
+		})
+	}
+}
+
+// TestHistogramQuantileRankWalkNativeValueFrag_ComputedPhiNaNGuard pins that
+// the leading `isNaN(phi) -> nan` branch is added for a COMPUTED phi and
+// omitted for a literal one.
+//
+// Kills the CONDITIONALS_NEGATION mutant of
+// histogram_quantile_rankwalk_native.go:`if h.PhiExpr == nil`, which swaps the
+// two: a literal-phi plan would gain a guard the existing fixtures do not
+// carry, and a computed-phi plan — the only one that can actually be NaN at
+// runtime — would lose the guard Prometheus's bucketQuantile contract
+// requires. Asserting the PREFIX is what discriminates, because the clamp
+// inside the aggregate's parametric argument spells `isNaN` on both paths.
+func TestHistogramQuantileRankWalkNativeValueFrag_ComputedPhiNaNGuard(t *testing.T) {
+	t.Parallel()
+	helpers := hqClassicHelperColumns{
+		keptIdx:      hqClassicKeptIdxColumn,
+		buckets:      hqClassicBucketsColumn,
+		bounds:       hqClassicBoundsColumn,
+		cum:          hqClassicCumColumn,
+		observations: hqClassicObservationsColumn,
+	}
+	const guard = "if(isNaN("
+
+	literal := rankWalkNativePlan()
+	if got := renderFragToSQL(histogramQuantileRankWalkNativeValueFrag(literal, helpers)); strings.HasPrefix(got, guard) {
+		t.Errorf("literal-phi Value starts with the NaN guard %q, want the bare core\n  %s", guard, got)
+	}
+
+	computed := rankWalkNativePlan()
+	computed.PhiExpr = &chplan.ColumnRef{Name: "PhiCol"}
+	if got := renderFragToSQL(histogramQuantileRankWalkNativeValueFrag(computed, helpers)); !strings.HasPrefix(got, guard) {
+		t.Errorf("computed-phi Value does not start with the NaN guard %q\n  %s", guard, got)
+	}
+}

--- a/internal/chsql/prewhere_mutation_test.go
+++ b/internal/chsql/prewhere_mutation_test.go
@@ -134,27 +134,89 @@ func TestSortRankForMinimum(t *testing.T) {
 	}
 }
 
+// TestCollectColumnRefsMaterializedFieldAccess defends the materialized-column
+// branch of collectColumnRefs' FieldAccess arm
+// (prewhere.go:`if v.MaterializedColumn != ""`).
+//
+// Mutation CONDITIONALS_NEGATION inverts it to `== ""`, which swaps the two
+// arms: a materialized attribute reference then records the empty string and
+// walks the wide Source map instead of the narrow column the emitter actually
+// reads, and an UNmaterialized one records the empty string instead of walking
+// Source at all. Both directions change what classifyPredicate reports, and
+// therefore whether the predicate is PREWHERE-eligible — a materialized
+// FieldAccess over a wide map would be judged wide-touching and demoted to
+// WHERE, which is precisely the pushdown this arm exists to enable. Both
+// shapes are asserted because either alone leaves half the swap unpinned.
+func TestCollectColumnRefsMaterializedFieldAccess(t *testing.T) {
+	t.Parallel()
+	shape := TableShape{WideColumns: []string{"SpanAttributes"}}
+
+	materialized := &chplan.FieldAccess{
+		Source:             &chplan.ColumnRef{Name: "SpanAttributes"},
+		Path:               "http.status_code",
+		MaterializedColumn: "HttpStatusCode",
+	}
+	cols, _, wide := classifyPredicate(materialized, shape)
+	if len(cols) != 1 || cols[0] != "HttpStatusCode" {
+		t.Errorf("classifyPredicate(materialized FieldAccess) cols = %v, want [HttpStatusCode]", cols)
+	}
+	if wide {
+		t.Errorf("classifyPredicate(materialized FieldAccess) touchesWide = true; the narrow column is what the emitter reads")
+	}
+
+	unmaterialized := &chplan.FieldAccess{
+		Source: &chplan.ColumnRef{Name: "SpanAttributes"},
+		Path:   "http.status_code",
+	}
+	cols, _, wide = classifyPredicate(unmaterialized, shape)
+	if len(cols) != 1 || cols[0] != "SpanAttributes" {
+		t.Errorf("classifyPredicate(unmaterialized FieldAccess) cols = %v, want [SpanAttributes]", cols)
+	}
+	if !wide {
+		t.Errorf("classifyPredicate(unmaterialized FieldAccess) touchesWide = false; it reads the wide map")
+	}
+}
+
 // TestIsNarrowIntegerDiscriminatorFinalReturnLogical defends
 // isNarrowIntegerDiscriminator's final return
 // (prewhere.go:`columnOK && literalOK`): the chain
 // `columnOK && literalOK && column.Qualifier == "" && shape.IsInteger...
 // && sortRankFor(...) < 0`.
 //
-// Mutation INVERT_LOGICAL turns the FIRST `&&` (between columnOK and
-// literalOK) into `||`. Go's `&&` binds tighter than `||`, so the mutant
-// parses as `columnOK || (literalOK && qualifier=="" && isDiscriminator &&
-// rank<0)`: any predicate whose left/right operand resolves to a bare
-// ColumnRef — columnOK true — would report true regardless of whether the
-// OTHER operand is even an integer literal. We feed a column-to-column
-// equality (`ServiceName = OtherCol`): columnOK becomes true (one side is a
-// ColumnRef) but literalOK is false (neither side is a LitInt), so the
-// correct answer is false. The `||` mutant would return true.
+// Mutation INVERT_LOGICAL turns the FIRST `&&` into `||`. gremlins mutates the
+// AST and re-prints with go/printer, so the mutant is
+// `(columnOK || literalOK) && column.Qualifier == "" && …` — the OR is
+// re-parenthesised to preserve the tree, NOT the `columnOK || (literalOK &&
+// …)` a reader gets by retyping the operator in the source (cerberus issue
+// #3215 is the worked example of that mistake, and this test was one of its
+// victims: its first cut fed `ServiceName = OtherCol` with only ServiceName
+// registered as a discriminator, which the real mutant also answers false for,
+// because after the swap guard `column` is OtherCol and
+// IsIntegerDiscriminatorColumn rejects it).
+//
+// The discriminating input is a column-to-column equality whose RIGHT operand
+// is the registered discriminator. The swap guard then leaves columnOK true
+// (Right is a ColumnRef) and literalOK false (Left is not a LitInt), and the
+// rest of the chain holds, so the original's `&&` answers false while the
+// mutant's `||` answers true.
 func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 	t.Parallel()
 	shape := TableShape{
 		WideColumns:                 []string{"Body"},
 		IntegerDiscriminatorColumns: []string{"ServiceName"},
 	}
+	// columnOK true, literalOK false, and the surviving `column` IS the
+	// registered discriminator: the `||` mutant reports true here.
+	colEqDiscriminator := &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "OtherCol"},
+		Right: &chplan.ColumnRef{Name: "ServiceName"},
+	}
+	if isNarrowIntegerDiscriminator(colEqDiscriminator, shape) {
+		t.Errorf("isNarrowIntegerDiscriminator(OtherCol = ServiceName) = true, want false (neither operand is a LitInt)")
+	}
+
+	// The mirror orientation, which the original also rejects.
 	colEqCol := &chplan.Binary{
 		Op:    chplan.OpEq,
 		Left:  &chplan.ColumnRef{Name: "ServiceName"},
@@ -175,23 +237,6 @@ func TestIsNarrowIntegerDiscriminatorFinalReturnLogical(t *testing.T) {
 	}
 }
 
-// CI-TIMING NOISE, not a test gap — cerberus issue #2741.
-//
-// prewhere.go:`columnOK && literalOK` (INVERT_LOGICAL, the same mutation
-// TestIsNarrowIntegerDiscriminatorFinalReturnLogical above defends) showed
-// LIVED on the v1.19.0 release-gate's phase2-other run despite this test
-// existing and being correct. Reproduced locally per cerberus issue #2730's
-// precedent (manual mutation-and-revert, no CI resource contention): apply
-// exactly this mutation by hand (`columnOK && literalOK` →
-// `columnOK || literalOK`) and `go test -run
-// '^TestIsNarrowIntegerDiscriminatorFinalReturnLogical$' ./internal/chsql/`
-// fails as expected; revert and it passes. #2730 root-caused this exact
-// class for phase4-promql-h: an unrelated flaky test elsewhere in the same
-// whole-package `go test` run can corrupt gremlins' exit-code read for an
-// otherwise-correctly-killed mutant. No code or test change follows from
-// this — the fix is the documentation trail so the next occurrence isn't
-// re-investigated from scratch.
-//
 // NOT KILLABLE — documented, not defended by a test.
 //
 // The INVERT_LOOPCTRL mutants of the three terminal `break`s in prewhere.go.

--- a/internal/chsql/range_window_downsample_tier_mutation_test.go
+++ b/internal/chsql/range_window_downsample_tier_mutation_test.go
@@ -1,0 +1,168 @@
+package chsql
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// This file pins range_window_downsample_tier.go's emission against the
+// gremlins mutation lane (phase2-other, scope ./internal/chsql). Before it
+// the file's only tests were `//go:build chdb` and
+// `//go:build integration` roundtrips plus
+// chplan_ir_discriminates_test.go, which asserts only that the tier plan and
+// the raw plan emit DIFFERENT SQL. That combination makes the emitter's lines
+// COVERED without pinning any token in them, which is exactly the state that
+// leaves a mutant alive: nine survivors sat here, and thirteen further mutants
+// in downsampleTierValueExprFrag's own arms were never executed at all because
+// no untagged test called it. Every test below names the construct it defends.
+
+// downsampleTierMutationPlan builds an emittable DownsampleTier RangeWindow.
+// The grid is deliberately ten steps wide so the anchor count
+// (End-Start)/Step + 1 is 11 — a value no arithmetic mutation of that
+// expression reproduces.
+func downsampleTierMutationPlan(fn string) *chplan.RangeWindow {
+	const (
+		windowRange = 10 * time.Minute
+		gridStep    = time.Minute
+	)
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &chplan.RangeWindow{
+		Input:               &chplan.Scan{Table: "otel_metrics_gauge"},
+		DownsampleTierInput: &chplan.Scan{Table: "otel_metrics_gauge_downsampled"},
+		DownsampleTier:      true,
+		Func:                fn,
+		Range:               windowRange,
+		Step:                gridStep,
+		Start:               start,
+		End:                 start.Add(windowRange),
+		TimestampColumn:     "TimeUnix",
+		ValueColumn:         "Value",
+		TemporalityColumn:   "Temporality",
+		GroupBy:             []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
+	}
+}
+
+// TestDownsampleTierValueExprFrag_PerFunc pins the rendered value expression
+// of every Func downsampleTierMinSamples accepts, byte for byte.
+//
+// Kills the CONDITIONALS_NEGATION mutant of
+// range_window_downsample_tier.go:`if fn == "last_over_time"` and of
+// range_window_downsample_tier.go:`if fn == "idelta"`: each negation routes a
+// Func to a different arm, so at least two of the three cases below render the
+// wrong expression.
+//
+// Kills the INVERT_NEGATIVES and ARITHMETIC_BASE mutants of every negative
+// trailing-pair subscript the three arms pass to downsampleTierValFrag and
+// downsampleTierTsFrag. Each is rendered literally, so `[-1]` becoming `[1]`
+// (or `[-2]` becoming `[2]`) reads the array's FRONT instead of its trailing
+// pair, and the expected strings below spell the sign. The subscripts are
+// named in prose rather than cited because the same call repeats across the
+// arms and no construct citation can pick one out.
+//
+// The irate case additionally pins downsampleTierIntervalSecondsFrag's two
+// `toUnixTimestamp64Nano` subscripts and the nanosecond divisor, whose mutants
+// were NOT COVERED before this test: nothing untagged called the irate arm.
+func TestDownsampleTierValueExprFrag_PerFunc(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		fn   string
+		want string
+	}{
+		{
+			fn:   "last_over_time",
+			want: "`downsample_tier_sorted`[-1].2",
+		},
+		{
+			fn:   "idelta",
+			want: "`downsample_tier_sorted`[-1].2 - `downsample_tier_sorted`[-2].2",
+		},
+		{
+			fn: "irate",
+			want: "if(`downsample_tier_temporality` = 1, `downsample_tier_sorted`[-1].2, " +
+				"if(`downsample_tier_sorted`[-1].2 < `downsample_tier_sorted`[-2].2, " +
+				"`downsample_tier_sorted`[-1].2, " +
+				"`downsample_tier_sorted`[-1].2 - `downsample_tier_sorted`[-2].2)) / " +
+				"((toUnixTimestamp64Nano(`downsample_tier_sorted`[-1].1) - " +
+				"toUnixTimestamp64Nano(`downsample_tier_sorted`[-2].1)) / 1000000000)",
+		},
+	} {
+		t.Run(tc.fn, func(t *testing.T) {
+			t.Parallel()
+			if got := renderFragToSQL(downsampleTierValueExprFrag(tc.fn)); got != tc.want {
+				t.Errorf("downsampleTierValueExprFrag(%q) rendered\n  %s\nwant\n  %s", tc.fn, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEmitRangeWindowDownsampleTier_AnchorCountAndProjection pins the two
+// numbers the emitter computes itself and the conditional timestamp
+// projection.
+//
+// Kills both ARITHMETIC_BASE mutants of
+// range_window_downsample_tier.go:`numAnchors := r.End.Sub(r.Start).Nanoseconds()/stepNS + 1`.
+// The plan spans ten one-minute steps, so the end-inclusive anchor count is
+// 11 and reaches the SQL as sampleAnchorFanoutFrag's `least(11, …)` upper
+// bound; `+ 1` becoming `- 1` renders `least(9, …)` and `/` becoming `*`
+// renders a number in the 10^22 range that wraps.
+//
+// Kills the CONDITIONALS_NEGATION mutant of
+// range_window_downsample_tier.go:`if r.TimestampColumn != RangeWindowAnchorAlias`:
+// this plan's TimestampColumn is `TimeUnix`, which is not the anchor alias, so
+// the anchor must be re-projected under it. The negation drops that projection
+// and the request's own timestamp column disappears from the result shape.
+//
+// Kills the three CONDITIONALS_NEGATION mutants of the `if err != nil` guards
+// that follow downsampleTierMinSamples, collectGroupByFrags and subqueryFrag.
+// Each negation returns a nil error on the SUCCESS path, before emitSelect
+// ever runs, so the emitter produces no statement at all — which is why this
+// test asserts the four SQL levels are present rather than only that Emit
+// returned no error.
+func TestEmitRangeWindowDownsampleTier_AnchorCountAndProjection(t *testing.T) {
+	t.Parallel()
+	sql, _, err := Emit(context.Background(), downsampleTierMutationPlan("last_over_time"))
+	if err != nil {
+		t.Fatalf("Emit(downsample tier): %v", err)
+	}
+	for _, want := range []string{
+		// The end-inclusive anchor count, as sampleAnchorFanoutFrag's bound.
+		"least(11, ",
+		// The conditional re-projection of the anchor under TimestampColumn.
+		"`anchor_ts` AS `TimeUnix`",
+		// The four levels: fan, merged, sorted, outer. Their presence is what
+		// distinguishes "emitted the statement" from "returned early with a
+		// nil error and emitted nothing".
+		"arrayJoin(arrayMap(",
+		"timeSeriesLastTwoSamplesMerge(`LastTwoSamples`)",
+		"arraySort(x -> x.1, arrayFilter(",
+		"WHERE length(`downsample_tier_sorted`) >= 1",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("emitted SQL is missing %q\nSQL: %s", want, sql)
+		}
+	}
+}
+
+// TestEmitRangeWindowDownsampleTier_RejectsUnsupportedFunc pins that a Func
+// outside downsampleTierMinSamples' accepted set is rejected rather than
+// emitted with a zero minimum-sample guard.
+//
+// Kills the CONDITIONALS_NEGATION mutant of the `if err != nil` guard below
+// range_window_downsample_tier.go:`minSamples, err := downsampleTierMinSamples(r.Func)`
+// from the other side: with the guard negated the ERROR path falls through,
+// minSamples stays 0, and the emitter answers a statement plus a nil error for
+// a Func it cannot compute. Both directions of that one mutant are pinned —
+// this test for the error path, the projection test above for the success
+// path — because either alone leaves the other half of the branch unasserted.
+func TestEmitRangeWindowDownsampleTier_RejectsUnsupportedFunc(t *testing.T) {
+	t.Parallel()
+	sql, _, err := Emit(context.Background(), downsampleTierMutationPlan("sum_over_time"))
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("Emit(downsample tier, sum_over_time) err = %v, want ErrUnsupported (SQL: %s)", err, sql)
+	}
+}

--- a/internal/chsql/search_trace_limit_mutation_test.go
+++ b/internal/chsql/search_trace_limit_mutation_test.go
@@ -1,0 +1,61 @@
+package chsql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+// TestEmitSearchTraceLimit_RequiresBothColumnNames pins that the top-N
+// trace restriction rejects a plan missing EITHER column name.
+//
+// Kills the INVERT_LOGICAL mutant of
+// search_trace_limit.go:`if n.TraceIDColumn == "" || n.TimestampColumn == ""`.
+// The mutant reads `... == "" && ... == ""`, so a plan naming only one of the
+// two is accepted and emits a ranking subquery over a nameless column —
+// `ORDER BY min(“) DESC` for a missing TimestampColumn, or a
+// “ “ GLOBAL IN (…)“ restriction for a missing TraceIDColumn. Both are
+// invalid SQL that no fail-closed guard would then catch, which is why the
+// guard is an OR. The one-sided cases are what discriminate the two spellings;
+// the both-unset and both-present cases agree under either, and are asserted
+// beside them so the test states the whole contract.
+//
+// search_trace_limit.go's other guards (a non-positive TraceLimit, the two
+// subqueryFrag error returns) are already killed by fail_closed_guards_test.go
+// and the scan-window suites; this file exists for the one mutant they leave.
+func TestEmitSearchTraceLimit_RequiresBothColumnNames(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		traceID   string
+		timestamp string
+		wantErr   bool
+	}{
+		{name: "both present", traceID: "TraceId", timestamp: "Timestamp", wantErr: false},
+		{name: "timestamp unset", traceID: "TraceId", timestamp: "", wantErr: true},
+		{name: "trace id unset", traceID: "", timestamp: "Timestamp", wantErr: true},
+		{name: "both unset", traceID: "", timestamp: "", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			n := &chplan.SearchTraceLimit{
+				Input:           &chplan.Scan{Table: "otel_traces"},
+				TraceIDColumn:   tc.traceID,
+				TimestampColumn: tc.timestamp,
+				TraceLimit:      7,
+			}
+			sql, _, err := Emit(context.Background(), n)
+			if tc.wantErr {
+				if !errors.Is(err, ErrUnsupported) {
+					t.Fatalf("Emit err = %v, want ErrUnsupported (SQL: %s)", err, sql)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this settles

`phase2-other` fell below its 95% efficacy floor three times — #2338 (18
survivors), #2741 (13), #3221 (27) — while its three siblings over the same
package never did. Each earlier issue closed the instance. This closes the
class.

**No leg's `efficacy` is lowered and no file changes legs**, so every mutant is
still executed by the same leg that executed it before. The partition change
here is documentation: a rejected option, a written reason, and a rule.

## All 27 survivors, adjudicated

Every verdict was established from the LIVED diff in the leg's own CI log (run
34416648191, job 102683004881), never from the `line:col` — a mutant is an AST
edit re-printed by `go/printer` (#3215). Each kill was then proven by hand:
apply the mutant, run the narrowed test, confirm it fails; revert, confirm it
passes.

Seventeen were real gaps and are now killed. Ten are equivalent, were already
documented in their files' `NOT KILLABLE` footers, and were re-derived
independently here rather than taken on trust.

| # | file | mutant | verdict |
|---|---|---|---|
| 1 | `emit_size_bound.go` | `d > deepest` → `>=` | equivalent — running max; at equality the mutant reassigns the same `int` |
| 2 | `histogram_quantile_rankwalk_native.go` | `\|\|` → `&&` on the two array-column guards | gap → killed |
| 3 | ″ | `err != nil` → `== nil` after `subqueryFrag` | gap → killed |
| 4 | ″ | `i < len(GroupByAliases)` → `>=` | gap → killed |
| 5 | ″ | `i < len(GroupByAliases)` → `<=` | gap → killed |
| 6 | ″ | `PhiExpr == nil` → `!=` | gap → killed |
| 7 | `prewhere.go` | `MaterializedColumn != ""` → `==` | gap → killed |
| 8 | ″ | `break` → `continue`, `touchesWide` latch | equivalent — set once, never reset |
| 9 | ″ | `r < best` → `<=` | equivalent — `r == best` unreachable across distinct columns |
| 10 | ″ | `break` → `continue`, `hitsSkip` latch | equivalent — same shape as 8 |
| 11 | ″ | `break` → `continue`, insertion-sort exit | equivalent — the prefix below the stop point is already ordered |
| 12 | ″ | `!columnOK \|\| !literalOK` → `&&` | equivalent — all four inputs reach the same final pair |
| 13 | ″ | `columnOK && literalOK` → `(columnOK \|\| literalOK)` | gap → killed (see the retraction below) |
| 14 | `range_window_downsample_tier.go` | `fn == "last_over_time"` → `!=` | gap → killed |
| 15-16 | ″ | `downsampleTierValFrag(-1)` → `(+1)`, two mutators | gap → killed |
| 17-19 | ″ | three `err != nil` → `== nil` guards | gap → killed |
| 20-21 | ″ | `numAnchors` `+ 1` → `- 1` and `/` → `*` | gap → killed |
| 22 | ″ | `TimestampColumn != RangeWindowAnchorAlias` → `==` | gap → killed |
| 23 | `search_trace_limit.go` | `\|\|` → `&&` on the two column-name guards | gap → killed |
| 24 | `set_op.go` | `i < j` → `i <= j`, in-place reversal | equivalent — adds only the `i == j` self-swap |
| 25 | ″ | `break` → `continue`, `shared[i]` latch | equivalent — only ever written false |
| 26 | `structural_join.go` | `len(cols) > 0` → `>= 0` | equivalent — at zero an empty `Select()` renders `SELECT *` |
| 27 | ″ | `len(seedWhere) > 0` → `>= 0` | equivalent — `Where()` with no args appends nothing |

## The gaps had one cause, and it is not the partition

An emitter lands in the catch-all by default, and an emitter's real tests are
routinely **build-tagged** (`//go:build chdb`, `//go:build integration`)
because emitted SQL is proven against an engine. The mutation lane compiles the
**untagged** build, so for it those tests do not exist. What was left untagged
for the clustered files was only `chplan_ir_discriminates_test.go`, which
asserts that two plans emit *different* SQL and never what either one emits —
executing the emitter's lines while pinning no token in them.

Covered-and-unpinned is exactly the state that reports LIVED, and no coverage
floor can see it. That is why 21 of the 27 sat in three files:
`range_window_downsample_tier.go` and `histogram_quantile_rankwalk_native.go`
(discrimination test only) and `search_trace_limit.go` (nothing untagged at
all).

Three new **untagged** `_mutation_test.go` files fix that. They also reach
mutants that were never *executed* before, not merely unkilled: nothing
untagged called `downsampleTierValueExprFrag`'s `idelta` / `irate` arms, so its
13 `NOT COVERED` mutants now run, and are killed by the byte-exact expected
strings.

## The partition decision

**Rejected:** carving `range_window_downsample_tier.go`, `prewhere.go` and
`histogram_quantile_rankwalk_native.go` into curated `include_files` legs the
way `phase4-traceql-lower` is. They execute 12, 69 and 8 mutants; two of the
three would be a leg measuring a single small file, and a one-file leg over an
undefended emitter reports its own catastrophic efficacy instead of dragging a
386-mutant leg to 93%. Splitting relocates the number and kills no mutant.

**Written down instead**, in the phase table where the next person will hit it:

- why the catch-all keeps absorbing new emitters (it must — see that file's own
  `include_files` vs `exclude_files` note) and why that is not the defect;
- a **graduation rule** with exactly one criterion: a file leaves this leg for
  a curated sibling on measured **wall clock**, when `gremlins unleash
  --dry-run` puts the leg materially past the ~315-executed-mutant band the
  four-way split targets. Never because it hosts survivors — the survivors move
  with it and the receiving leg inherits the failure, which is the same evasion
  as lowering `efficacy`;
- the corrected documented-equivalent tally: 10 of 386 executed (≈2.6%), and
  after this change those 10 are the leg's only survivors.

`docs/test-strategy.md` § "Surviving-mutant policy" gains the diagnostic that
comes before choosing a remedy: covered-and-unpinned is remedy 2 every time and
never remedy 1, and the tell is a source file with no untagged
`<file>_mutation_test.go` beside it.

## One retraction

#2741 recorded `prewhere.go`'s `columnOK && literalOK` INVERT_LOGICAL as a
"#2730-class CI-timing flake on an existing, correct test". It is not, and the
note claiming so is removed.

The real mutant is `(columnOK || literalOK) && …` — `go/printer`
re-parenthesises to preserve the tree — not the `columnOK || (literalOK && …)`
a reader gets by retyping the operator in the source. The test was written
against the retyped form. I checked out the pre-existing test, applied the real
mutant, and it **passed**: the kill claim was false and the LIVED report was
correct all along. The test now feeds `OtherCol = ServiceName`, where the
surviving `column` *is* the registered discriminator, and kills it.

## Verification

- Each of the 17 kills: mutant applied by hand, narrowed test **fails**;
  reverted, **passes**. Sources restored byte-identical (`git status` clean
  between runs).
- `go build ./...`, `go test ./internal/chsql/` — green.
- `verify-code-citations.mjs`, `forbid-contradicted-mutants.mjs`,
  `mutation-matrix.mjs` (table sound, 30 phases), `markdownlint-cli2` — green.

Closes #3221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196feCkr8wd6meQ3jr9W8rF
