### PR TITLE
fix(traceql): reject `<x> = nil` at validation, the stage the reference does

### DIFF
--- a/compatibility/parity-baseline/tempo-grpc/0a.json
+++ b/compatibility/parity-baseline/tempo-grpc/0a.json
@@ -2,5 +2,7 @@
   "schema_version": 1,
   "head": "tempo-grpc",
   "bucket": "0a",
-  "cases": []
+  "cases": [
+    "search | intrinsic_eq_nil_rejected"
+  ]
 }

--- a/compatibility/parity-baseline/tempo-grpc/3e.json
+++ b/compatibility/parity-baseline/tempo-grpc/3e.json
@@ -2,5 +2,7 @@
   "schema_version": 1,
   "head": "tempo-grpc",
   "bucket": "3e",
-  "cases": []
+  "cases": [
+    "search | resource_service_name_eq_nil_rejected"
+  ]
 }

--- a/compatibility/parity-baseline/tempo/0a.json
+++ b/compatibility/parity-baseline/tempo/0a.json
@@ -2,5 +2,7 @@
   "schema_version": 1,
   "head": "tempo",
   "bucket": "0a",
-  "cases": []
+  "cases": [
+    "search | intrinsic_eq_nil_rejected"
+  ]
 }

--- a/compatibility/parity-baseline/tempo/3e.json
+++ b/compatibility/parity-baseline/tempo/3e.json
@@ -2,5 +2,7 @@
   "schema_version": 1,
   "head": "tempo",
   "bucket": "3e",
-  "cases": []
+  "cases": [
+    "search | resource_service_name_eq_nil_rejected"
+  ]
 }

--- a/compatibility/tempo/driver/corpus/smoke.txtar
+++ b/compatibility/tempo/driver/corpus/smoke.txtar
@@ -1248,8 +1248,9 @@ shipping
 # children, which pin that `kind != nil` is constant-true, NOT an
 # enum-zero check. For attributes it is key existence. The rejected
 # forms (`<intrinsic> = nil`, `resource.service.name = nil` — both
-# 400 on reference, ast_validate.go) cannot ride the corpus (200-shaped
-# cases only); internal/traceql/nested_set_nil_test.go pins them.
+# 400 on reference, ast_validate.go) ride the corpus on the
+# status-parity axis rather than the body axis — see
+# intrinsic_eq_nil_rejected and resource_service_name_eq_nil_rejected.
 
 -- name --
 kind_not_nil
@@ -1665,6 +1666,58 @@ name_gt_int_rejected
 # code (modules/frontend/combiner/common.go's erroredResponse).
 -- query --
 { name > 3 }
+-- endpoint --
+search
+-- expect_status --
+400
+-- expect_grpc_code --
+InvalidArgument
+
+-- name --
+intrinsic_eq_nil_rejected
+# An intrinsic is a property every span has by construction, so it can
+# never be absent: reference Tempo rejects `<intrinsic> = nil` at
+# validation for EVERY intrinsic ("intrinsics cannot be nil",
+# pkg/traceql/ast_validate.go's UnaryOperation.validate, repeated at
+# fetch time by vparquet4's checkConditions and listed invalid in
+# pkg/traceql/test_examples.yaml).
+#
+# The STATUS is the whole point of this case, which is why it is here
+# and not only in a unit test. cerberus rejected this all along, but in
+# the lowering, and the Tempo head answers a lowering error 422
+# (internal/api/tempo/errclass.go's ErrClassLower) where the reference
+# answers 400 — so the two backends disagreed about whether the query
+# was malformed or merely unservable, and nothing graded that (#3260).
+# Moving the rule into the parse-stage validator settles it at 400;
+# this case is what holds it there against both backends live.
+#
+# The `!= nil` twin must NOT join it: OpExists is outside the
+# reference's rule and is load-bearing for Grafana Traces Drilldown.
+# It rides the body axis as kind_not_nil / status_not_nil /
+# name_not_nil above.
+-- query --
+{ span:status = nil }
+-- endpoint --
+search
+-- expect_status --
+400
+-- expect_grpc_code --
+InvalidArgument
+
+-- name --
+resource_service_name_eq_nil_rejected
+# The second clause of the same reference rule: service.name is the one
+# resource attribute OTLP makes mandatory, so like an intrinsic it is
+# never absent and `= nil` can only be a mistake in the query text
+# ("resource.service.name cannot be nil"). Graded on status for the
+# same reason as intrinsic_eq_nil_rejected above.
+#
+# Its accepted siblings elsewhere in this corpus pin that the rule is
+# no wider than the reference's: `resource.service.name != nil`
+# (OpExists) and `span.http.method = nil` (an ordinary attribute, which
+# may legitimately be absent) both ride the body axis.
+-- query --
+{ resource.service.name = nil }
 -- endpoint --
 search
 -- expect_status --

--- a/internal/traceql/ast/validate.go
+++ b/internal/traceql/ast/validate.go
@@ -28,13 +28,21 @@ import (
 // and the Tempo head answers it with 400 and the reference backend's own
 // wording, exactly as the reference does.
 //
-// Two of the reference's rules are deliberately NOT adopted, because
-// cerberus answers queries the reference declines rather than mirroring
-// the rejection (see #2035):
-//   - UnaryOperation's `intrinsic = nil` rejection — `{ kind != nil }` is
-//     in cerberus's own corpus and lowers to a real predicate.
-//   - Attribute's parent-scope unsupported-error — `{ parent = "<hex>" }`
-//     lowers against ParentSpanId.
+// One of the reference's rules is deliberately NOT adopted, because
+// cerberus answers a query the reference declines rather than mirroring
+// the rejection (see #2035): Attribute's parent-scope unsupported-error —
+// `{ parent = "<hex>" }` lowers against ParentSpanId.
+//
+// UnaryOperation's `<x> = nil` rejection used to be listed beside it, on
+// the grounds that `{ kind != nil }` is in cerberus's own corpus and
+// lowers to a real predicate. That reasoning never supported the
+// conclusion: the reference's guard is `o.Op == OpNotExists` alone, so
+// `!= nil` (OpExists) was never within the rule's reach and adopting it
+// costs `{ kind != nil }` nothing. The rule was in fact enforced all
+// along, one stage too late — in the lowering, whose errors the Tempo
+// head answers 422 (internal/api/tempo/errclass.go's ErrClassLower)
+// where the reference answers 400. validateNilComparison below now
+// applies it here, in the stage the reference applies it in (#3260).
 
 // typeMismatchFormat reproduces the reference backend's own wording for a
 // mismatched binary operation, verbatim. A client (or a compatibility
@@ -53,6 +61,19 @@ const illegalOperationTypesFormat = "illegal operation for the given types: %s"
 // illegalOperationTypesFormat (singular "type", matching the reference
 // verbatim) — `-name`: unary `-` requires a numeric operand.
 const illegalOperationTypeFormat = "illegal operation for the given type: %s"
+
+// intrinsicNilFormat reproduces the reference's wording for
+// `<intrinsic> = nil` — `{ span:status = nil }`. An intrinsic is a
+// property every span has by construction, so it can never be absent and
+// the comparison can only be a mistake in the query text. The `%s=nil`
+// spacing (no spaces around the `=`) is the reference's own, verbatim.
+const intrinsicNilFormat = "%s=nil is not valid because intrinsics cannot be nil"
+
+// resourceServiceNameNilFormat reproduces the reference's wording for the
+// second clause of the same rule — `{ resource.service.name = nil }`.
+// service.name is the one resource attribute OTLP makes mandatory, so
+// like an intrinsic it is never absent.
+const resourceServiceNameNilFormat = "%s=nil is not valid because resource.service.name cannot be nil"
 
 // aggregateNumericFormat reproduces the reference's wording for an
 // aggregate (`max` / `min` / `sum` / `avg`) whose inner expression cannot
@@ -556,11 +577,74 @@ func isParentMarker(e typedExpression) bool {
 }
 
 // validateUnaryOperand applies the reference's unary operand-type rule —
-// `{ -name = "a" }`: unary `-` requires a numeric operand.
+// `{ -name = "a" }`: unary `-` requires a numeric operand — after the
+// `= nil` rule, in the reference's own order (pkg/traceql/ast_validate.go's
+// `UnaryOperation.validate` checks the nil clause before it reads
+// impliedType).
 func validateUnaryOperand(o UnaryOperation) error {
+	if err := validateNilComparison(o); err != nil {
+		return err
+	}
 	t := o.Expression.impliedType()
 	if !o.Op.unaryTypesValid(t) {
 		return newValidationError(illegalOperationTypeFormat, o.String())
+	}
+	return nil
+}
+
+// resourceServiceNameAttribute is the one NON-intrinsic attribute the
+// reference singles out in its `= nil` rule, spelled the way the
+// reference spells it (pkg/traceql/ast_validate.go compares against
+// `NewScopedAttribute(AttributeScopeResource, false, "service.name")`).
+var resourceServiceNameAttribute = NewScopedAttribute(AttributeScopeResource, false, "service.name")
+
+// validateNilComparison applies the reference's `<x> = nil` rejection
+// (pkg/traceql/ast_validate.go's `UnaryOperation.validate`, repeated at
+// fetch time by tempodb/encoding/vparquet4's `checkConditions`, and
+// listed as invalid in pkg/traceql/test_examples.yaml).
+//
+// The predicate is narrow on three axes, and widening any of them would
+// take a working query off a dashboard:
+//
+//   - The OPERATOR. Only OpNotExists — the node both `{ x = nil }` and
+//     `{ nil = x }` fold to — is covered. `!= nil` (OpExists) is legal on
+//     every operand, and load-bearing: Grafana Traces Drilldown appends
+//     `&& <groupBy> != nil` to every breakdown query it issues.
+//   - The OPERAND SHAPE. Only a bare Attribute. A compound operand
+//     (`{ (span.a + 1) = nil }`) always evaluates to a non-nil Static, so
+//     the reference folds it to a constant rather than rejecting it.
+//   - The ATTRIBUTE. Any intrinsic, plus resource.service.name and
+//     nothing else. An ordinary user attribute may legitimately be absent
+//     in any scope, `{ span.foo = nil }` included, and `service.name` is
+//     special only under the resource scope — `{ span.service.name = nil }`
+//     and `{ .service.name = nil }` both stay accepted.
+//
+// The parent qualifier is the one place this reads wider than the
+// reference's literal expression, and it has to. The reference compares
+// the whole Attribute struct, parent flag included, so
+// `parent.resource.service.name` misses this clause there — but only
+// because `Attribute.validate` a few lines further on rejects EVERY
+// parent-scoped attribute as unsupported, so the reference rejects that
+// query anyway. cerberus supports the parent scope (#2035), and the
+// reason resource.service.name can never be nil — OTLP mandates it on
+// every resource — holds for the parent span's resource identically.
+// Matching on scope and name therefore rejects exactly the set the
+// reference rejects, where struct equality would have let one member of
+// it through.
+func validateNilComparison(o UnaryOperation) error {
+	if o.Op != OpNotExists {
+		return nil
+	}
+	attr, ok := o.Expression.(Attribute)
+	if !ok {
+		return nil
+	}
+	switch {
+	case attr.Intrinsic != IntrinsicNone:
+		return newValidationError(intrinsicNilFormat, attr)
+	case attr.Scope == resourceServiceNameAttribute.Scope &&
+		attr.Name == resourceServiceNameAttribute.Name:
+		return newValidationError(resourceServiceNameNilFormat, attr)
 	}
 	return nil
 }

--- a/internal/traceql/ast/validate_test.go
+++ b/internal/traceql/ast/validate_test.go
@@ -566,3 +566,122 @@ func TestParseAcceptsWhatReferenceAccepts(t *testing.T) {
 		})
 	}
 }
+
+// TestParseRejectsNilComparisonOnIntrinsic pins the reference's
+// `<intrinsic> = nil` rejection (pkg/traceql/ast_validate.go's
+// `UnaryOperation.validate`, mirrored at fetch time by vparquet4's
+// `checkConditions`). Before issue #3260 cerberus enforced this at
+// LOWERING instead, which is a different error class: the Tempo head
+// answers a lowering error 422 (errclass.go's ErrClassLower) where the
+// reference answers 400, so a query the reference calls malformed came
+// back to Grafana as "valid TraceQL cerberus cannot serve".
+func TestParseRejectsNilComparisonOnIntrinsic(t *testing.T) {
+	cases := []struct {
+		query string
+		want  string // the attribute the message must name
+	}{
+		// The three forms issue #3260 reports, in the reference's own
+		// invalid-query corpus (pkg/traceql/test_examples.yaml).
+		{`{ span:status = nil }`, "status"},
+		{`{ name = nil }`, "name"},
+		// Written the other way round: the grammar folds `nil = x` to the
+		// same OpNotExists node, and the reference lists both spellings.
+		{`{ nil = span:status }`, "status"},
+		// Every intrinsic, not an enumerated subset — the reference's
+		// clause is `attr.Intrinsic != IntrinsicNone`.
+		{`{ kind = nil }`, "kind"},
+		{`{ duration = nil }`, "duration"},
+		{`{ span:childCount = nil }`, "span:childCount"},
+		{`{ nestedSetLeft = nil }`, "nestedSetLeft"},
+		{`{ trace:id = nil }`, "trace:id"},
+		// The rule reaches inside a boolean tree and through a pipeline,
+		// so a walk that only inspected the top-level filter still fails.
+		{`{ span.foo = "a" && name = nil }`, "name"},
+		{`{ name = nil } | rate()`, "name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			_, err := Parse(tc.query)
+			if err == nil {
+				t.Fatalf("Parse(%q) = nil error, want an intrinsic-nil rejection", tc.query)
+			}
+			var verr *ValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("Parse(%q) error = %T (%v), want *ValidationError", tc.query, err, err)
+			}
+			msg := verr.Error()
+			want := "invalid TraceQL query: " + tc.want + "=nil is not valid because intrinsics cannot be nil"
+			if msg != want {
+				t.Errorf("Parse(%q) message = %q, want %q", tc.query, msg, want)
+			}
+		})
+	}
+}
+
+// TestParseRejectsNilComparisonOnResourceServiceName pins the second
+// clause of the same reference rule: resource.service.name is mandatory
+// on every OTLP resource, so it can never be absent.
+func TestParseRejectsNilComparisonOnResourceServiceName(t *testing.T) {
+	for _, q := range []string{
+		`{ resource.service.name = nil }`,
+		`{ nil = resource.service.name }`,
+		// The quoted spelling names the same attribute.
+		`{ resource."service.name" = nil }`,
+	} {
+		t.Run(q, func(t *testing.T) {
+			_, err := Parse(q)
+			if err == nil {
+				t.Fatalf("Parse(%q) = nil error, want a resource.service.name rejection", q)
+			}
+			var verr *ValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("Parse(%q) error = %T (%v), want *ValidationError", q, err, err)
+			}
+			want := "invalid TraceQL query: resource.service.name=nil is not valid because resource.service.name cannot be nil"
+			if got := verr.Error(); got != want {
+				t.Errorf("Parse(%q) message = %q, want %q", q, got, want)
+			}
+		})
+	}
+}
+
+// TestParseAcceptsLegalNilComparisons is the other half of the ratchet.
+// The reference's rule covers `= nil` (OpNotExists) on an intrinsic or on
+// resource.service.name and NOTHING else; every query here is one the
+// reference answers, and over-rejecting any of them would take a working
+// panel off a dashboard — including the `<groupBy> != nil` conjunct
+// Grafana Traces Drilldown stamps on every breakdown query.
+func TestParseAcceptsLegalNilComparisons(t *testing.T) {
+	queries := []string{
+		// A user attribute may legitimately be absent, in every scope.
+		`{ span.foo = nil }`,
+		`{ .foo = nil }`,
+		`{ resource.foo = nil }`,
+		`{ event.exception.type = nil }`,
+		`{ link.foo = nil }`,
+		`{ instrumentation.foo = nil }`,
+		// service.name is special ONLY in the resource scope: the same
+		// name under another scope (or none) is an ordinary attribute.
+		`{ span.service.name = nil }`,
+		`{ .service.name = nil }`,
+		// `!= nil` (OpExists) is untouched by the rule on BOTH clauses —
+		// the reference's guard is `o.Op == OpNotExists` alone.
+		`{ name != nil }`,
+		`{ kind != nil }`,
+		`{ status != nil }`,
+		`{ span:childCount != nil }`,
+		`{ resource.service.name != nil }`,
+		`{ nil != name }`,
+		`{ nil != resource.service.name }`,
+		// A compound operand is not an Attribute, so neither clause
+		// applies — the reference folds it to a constant instead.
+		`{ (span.a + 1) = nil }`,
+	}
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			if _, err := Parse(q); err != nil {
+				t.Errorf("Parse(%q) = %v, want it accepted", q, err)
+			}
+		})
+	}
+}

--- a/internal/traceql/intrinsic_reject_test.go
+++ b/internal/traceql/intrinsic_reject_test.go
@@ -266,7 +266,9 @@ func TestUnaryNotReferenceBugParity(t *testing.T) {
 // legitimately still rejects: upstream's own validate rule forbids
 // `<intrinsic> = nil` for EVERY intrinsic, so it is not a childCount
 // inconsistency — and keeping it here stops a "fix" that simply
-// accepted everything from passing.
+// accepted everything from passing. That one rejects at PARSE since
+// #3260, the stage the reference rejects it in, so it is asserted
+// against Parse rather than Lower.
 func TestChildCountAnswersOneStatusClassForEveryOperator(t *testing.T) {
 	t.Parallel()
 	s := schema.DefaultOTelTraces()
@@ -288,11 +290,7 @@ func TestChildCountAnswersOneStatusClassForEveryOperator(t *testing.T) {
 	}
 
 	const rejected = `{ span:childCount = nil }`
-	expr, err := tempo.Parse(rejected)
-	if err != nil {
-		t.Fatalf("Parse(%q): %v", rejected, err)
-	}
-	if _, err := traceql.Lower(context.Background(), expr, s); err == nil {
-		t.Errorf("Lower(%q): want a rejection (upstream forbids `<intrinsic> = nil`), got none", rejected)
+	if _, err := tempo.Parse(rejected); err == nil {
+		t.Errorf("Parse(%q): want a rejection (upstream forbids `<intrinsic> = nil`), got none", rejected)
 	}
 }

--- a/internal/traceql/nested_set_nil_test.go
+++ b/internal/traceql/nested_set_nil_test.go
@@ -150,61 +150,19 @@ func TestLower_RootIdiomLiteralVariants(t *testing.T) {
 	}
 }
 
-// TestLower_NilComparisonRejections pins the nil-comparison forms
-// reference Tempo itself rejects — and ONLY those. Reference
-// validation (pkg/traceql/ast_validate.go UnaryOperation.validate)
-// rejects `= nil` on every intrinsic and on resource.service.name;
-// vparquet4's checkConditions errors on any childCount condition.
-// Everything else — including `!= nil` on intrinsics, which the
-// Traces Drilldown app stamps on every intrinsic breakdown groupBy —
-// must lower (see TestLower_NilComparisonSemantics).
-func TestLower_NilComparisonRejections(t *testing.T) {
-	t.Parallel()
-
-	s := schema.DefaultOTelTraces()
-	cases := []struct {
-		name    string
-		query   string
-		wantSub string
-	}{
-		{
-			name:    "intrinsic_eq_nil_kind",
-			query:   `{ kind = nil }`,
-			wantSub: "intrinsics cannot be nil",
-		},
-		{
-			name:    "intrinsic_eq_nil_name",
-			query:   `{ name = nil }`,
-			wantSub: "intrinsics cannot be nil",
-		},
-		{
-			name:    "intrinsic_eq_nil_literal_first",
-			query:   `{ nil = status }`,
-			wantSub: "intrinsics cannot be nil",
-		},
-		{
-			name:    "resource_service_name_eq_nil",
-			query:   `{ resource.service.name = nil }`,
-			wantSub: "resource.service.name cannot be nil",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			expr, err := tempo.Parse(tc.query)
-			if err != nil {
-				t.Fatalf("Parse(%q): %v", tc.query, err)
-			}
-			_, err = traceql.Lower(context.Background(), expr, s)
-			if err == nil {
-				t.Fatalf("Lower(%q) succeeded; want error containing %q", tc.query, tc.wantSub)
-			}
-			if !strings.Contains(err.Error(), tc.wantSub) {
-				t.Errorf("Lower(%q) error %q does not contain %q", tc.query, err, tc.wantSub)
-			}
-		})
-	}
-}
+// The nil-comparison forms reference Tempo itself rejects —
+// `<intrinsic> = nil` and `resource.service.name = nil` — are rejected
+// at PARSE now, not here: they are reference validation rules
+// (pkg/traceql/ast_validate.go's `UnaryOperation.validate`), so cerberus
+// applies them in the stage the reference applies them in and the Tempo
+// head answers them 400 rather than 422 (#3260). Their pins live in
+// internal/traceql/ast/validate_test.go
+// (TestParseRejectsNilComparisonOnIntrinsic and friends), and the
+// lowering's own belt-and-braces guard — the sibling of the reference's
+// second copy in vparquet4's `checkConditions` — is pinned white-box in
+// nil_comparison_guard_test.go. Everything else, `!= nil` on intrinsics
+// included (the Traces Drilldown app stamps it on every breakdown
+// groupBy), must lower: see TestLower_NilComparisonSemantics below.
 
 // TestLower_NilComparisonSemantics pins the lowered predicate for every
 // accepted nil-comparison shape, derived from reference Tempo:

--- a/internal/traceql/nil_comparison_guard_test.go
+++ b/internal/traceql/nil_comparison_guard_test.go
@@ -1,0 +1,92 @@
+package traceql
+
+import (
+	"strings"
+	"testing"
+
+	traceql "github.com/tsouza/cerberus/internal/traceql/ast"
+
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestLowerNilComparisonGuardsRejectOpNotExists pins the lowering's own
+// copy of the reference's `<x> = nil` rule.
+//
+// Since #3260 the rule's primary home is the parse-stage validator
+// (internal/traceql/ast.validateNilComparison), which is the stage the
+// reference applies it in and the one whose errors the Tempo head
+// answers 400. No query reaching Lower can therefore carry an
+// OpNotExists over an intrinsic or over resource.service.name, and
+// these two guards are unreachable from the wire — exactly as the
+// reference's own second copy in tempodb/encoding/vparquet4's
+// `checkConditions` is unreachable behind pkg/traceql/ast_validate.go.
+//
+// They are kept rather than deleted because falling through them is
+// silently WRONG rather than merely unhandled: everything below the
+// intrinsic guard computes an OpExists answer, so an OpNotExists that
+// slipped past would lower to `true` — a filter matching every span —
+// and the resource.service.name guard would emit a
+// `NOT mapContains(ResourceAttributes, 'service.name')` that is false
+// on every conforming span. This test is what keeps them honest: it
+// calls them directly, past Parse, so "unreachable" never decays into
+// "untested" (a guard no test can fail is a gap, not a defence).
+func TestLowerNilComparisonGuardsRejectOpNotExists(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelTraces()
+
+	t.Run("intrinsic", func(t *testing.T) {
+		t.Parallel()
+		// Every intrinsic, so the guard cannot be narrowed to the
+		// handful the switch beneath it names.
+		for _, in := range []traceql.Intrinsic{
+			traceql.IntrinsicKind,
+			traceql.IntrinsicName,
+			traceql.IntrinsicStatus,
+			traceql.IntrinsicDuration,
+			traceql.IntrinsicChildCount,
+			traceql.IntrinsicEventName,
+			traceql.IntrinsicLinkTraceID,
+			traceql.IntrinsicNestedSetLeft,
+		} {
+			attr := traceql.NewIntrinsic(in)
+			_, err := lowerNilComparison(traceql.OpNotExists, attr, s)
+			if err == nil {
+				t.Errorf("lowerNilComparison(OpNotExists, %s): want a rejection, got none", in)
+				continue
+			}
+			if !strings.Contains(err.Error(), "intrinsics cannot be nil") {
+				t.Errorf("lowerNilComparison(OpNotExists, %s) error = %q, want it to name the intrinsic rule", in, err)
+			}
+		}
+	})
+
+	t.Run("resource_service_name", func(t *testing.T) {
+		t.Parallel()
+		attr := traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name")
+		_, err := lowerNilComparison(traceql.OpNotExists, attr, s)
+		if err == nil {
+			t.Fatal("lowerNilComparison(OpNotExists, resource.service.name): want a rejection, got none")
+		}
+		if !strings.Contains(err.Error(), "resource.service.name cannot be nil") {
+			t.Errorf("lowerNilComparison error = %q, want it to name the resource.service.name rule", err)
+		}
+	})
+
+	// The other half: OpExists over the same operands must still lower,
+	// so the guards cannot be widened into a blanket nil-comparison
+	// rejection that would take `{ kind != nil }` off every Traces
+	// Drilldown breakdown panel.
+	t.Run("op_exists_still_lowers", func(t *testing.T) {
+		t.Parallel()
+		for _, attr := range []traceql.Attribute{
+			traceql.NewIntrinsic(traceql.IntrinsicKind),
+			traceql.NewIntrinsic(traceql.IntrinsicChildCount),
+			traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name"),
+			traceql.NewScopedAttribute(traceql.AttributeScopeSpan, false, "foo"),
+		} {
+			if _, err := lowerNilComparison(traceql.OpExists, attr, s); err != nil {
+				t.Errorf("lowerNilComparison(OpExists, %s) = %v, want it to lower", attr, err)
+			}
+		}
+	})
+}

--- a/test/rejection-parity/catalogue/internal__traceql__lower.go__lowerIntrinsicNilComparison.json
+++ b/test/rejection-parity/catalogue/internal__traceql__lower.go__lowerIntrinsicNilComparison.json
@@ -21,14 +21,17 @@
       "head": "traceql",
       "site": "internal/traceql/lower.go:lowerIntrinsicNilComparison#5c445f2a",
       "message": "traceql: %s = nil is not valid because intrinsics cannot be nil",
-      "class": "rejection",
-      "trigger_query": "{ kind = nil }",
+      "class": "internal",
+      "rationale": "the parse-stage validator rejects `\u003cintrinsic\u003e = nil` before lowering — validateNilComparison in internal/traceql/ast, which is the stage the reference applies this rule in (pkg/traceql/ast_validate.go) and the one whose errors the Tempo head answers 400 rather than 422 — so no wire query reaches this guard. It is retained rather than deleted, as the sibling of the reference's own second copy in vparquet4's checkConditions: everything below it in lowerIntrinsicNilComparison computes the OpExists answer, so an OpNotExists falling through would lower to a filter matching every span. internal/traceql/nil_comparison_guard_test.go calls it directly, past Parse, so unreachable does not decay into untested",
       "evidence": {
         "guard": [
           "if op == traceql.OpNotExists"
         ],
         "callers": [
           "lowerNilComparison"
+        ],
+        "cited": [
+          "lowerIntrinsicNilComparison"
         ]
       }
     },

--- a/test/rejection-parity/catalogue/internal__traceql__lower.go__lowerNilComparison.json
+++ b/test/rejection-parity/catalogue/internal__traceql__lower.go__lowerNilComparison.json
@@ -22,8 +22,8 @@
       "head": "traceql",
       "site": "internal/traceql/lower.go:lowerNilComparison#fca86ae4",
       "message": "traceql: %s = nil is not valid because resource.service.name cannot be nil",
-      "class": "rejection",
-      "trigger_query": "{ resource.service.name = nil }",
+      "class": "internal",
+      "rationale": "the parse-stage validator rejects `resource.service.name = nil` before lowering — validateNilComparison in internal/traceql/ast, which is the stage the reference applies this rule in (pkg/traceql/ast_validate.go) and the one whose errors the Tempo head answers 400 rather than 422 — so no wire query reaches this guard. It is retained rather than deleted because falling through it would emit a NOT mapContains(ResourceAttributes, 'service.name') predicate that is false on every conforming span; internal/traceql/nil_comparison_guard_test.go calls lowerNilComparison directly, past Parse, so unreachable does not decay into untested",
       "evidence": {
         "guard": [
           "past returning if attr.Intrinsic != traceql.IntrinsicNone",
@@ -31,6 +31,9 @@
         ],
         "callers": [
           "lowerUnaryOperation"
+        ],
+        "cited": [
+          "lowerNilComparison"
         ]
       }
     }


### PR DESCRIPTION
## What the issue reported, and what was actually wrong

#3260 reports that cerberus ACCEPTS three `= nil` forms upstream Tempo rejects,
probed against `internal/traceql/ast.Parse`.

Probed end-to-end instead, cerberus **rejects all three** — but in the
**lowering**, not at parse:

```
{ span:status = nil }           LOWER-REJECT  traceql: status = nil is not valid because intrinsics cannot be nil
{ resource.service.name = nil } LOWER-REJECT  traceql: resource.service.name = nil is not valid because ...
{ name = nil }                  LOWER-REJECT  traceql: name = nil is not valid because intrinsics cannot be nil
```

The acceptance holds only for `ast.Parse` in isolation. The divergence
underneath it is real, and is what this PR fixes:

- **Status class.** `internal/api/tempo/errclass.go` maps `ErrClassParse` -> 400
  and `ErrClassLower` -> 422. Every TraceQL endpoint converges on 422 for these
  (search via `handler.go:539`, and hardcoded at `metrics_query_instant.go:110`
  / `metrics_query_range.go:378`). Reference Tempo answers **400**. So the two
  backends disagreed about whether the query is malformed or merely unservable
  — and no layer graded that axis.
- **Parse-only consumer.** `internal/migrateverify/lane.go:91`'s `routeTraceQL`
  marks a corpus entry `Replayable` on `ast.Parse` success alone, never calling
  `Lower`. These queries were classified replayable and only failed later, live.
- **A rationale that did not follow.** `validate.go` listed this reference rule
  as "deliberately NOT adopted" because `{ kind != nil }` is in cerberus's
  corpus. The reference's guard is `o.Op == OpNotExists` alone, so `!= nil`
  (OpExists) was never within the rule's reach — and the rule was in fact being
  enforced, just in the wrong stage.

## The upstream predicate, read at the source

`pkg/traceql/ast_validate.go:271-287`, `UnaryOperation.validate`:

```go
if o.Op == OpNotExists {
    if attr, ok := o.Expression.(Attribute); ok {
        switch {
        case attr.Intrinsic != IntrinsicNone:
            return fmt.Errorf("%s=nil is not valid because intrinsics cannot be nil", attr.String())
        case attr == NewScopedAttribute(AttributeScopeResource, false, "service.name"):
            return fmt.Errorf("%s=nil is not valid because resource.service.name cannot be nil", attr.String())
        }
    }
}
```

Repeated at fetch time in `tempodb/encoding/vparquet4/block_traceql.go:1090-1096`,
and listed invalid in `pkg/traceql/test_examples.yaml:327-330` (both operand
orders). cerberus's parser already folds `X = nil` / `nil = X` to `OpNotExists`
and `X != nil` / `nil != X` to `OpExists` exactly as upstream's grammar does
(`expr.y:407-413`), so the fold needed no change.

The predicate is narrow on three axes, and widening any of them would take a
working query off a dashboard:

| Axis | Covered | NOT covered |
|---|---|---|
| Operator | `OpNotExists` (`= nil`) | `OpExists` (`!= nil`) — load-bearing for Grafana Traces Drilldown |
| Operand shape | a bare `Attribute` | a compound operand (`{ (span.a + 1) = nil }`), which folds to a constant |
| Attribute | any intrinsic; `resource.service.name` | any other attribute in any scope, `{ span.service.name = nil }` and `{ .service.name = nil }` included |

**The one deliberate widening** is the parent qualifier. The reference compares
the whole `Attribute` struct, so `parent.resource.service.name` misses that
clause there — but only because `Attribute.validate` rejects EVERY parent-scoped
attribute a few lines further on, so the reference rejects that query anyway.
cerberus supports the parent scope (#2035), and OTLP mandates `service.name` on
the parent span's resource identically. Matching on scope+name therefore rejects
exactly the set the reference rejects, where struct equality would have let one
member of it through. Reasoned out in full on `validateNilComparison`.

## Discrimination table

Every test added FAILS against the unfixed parser and PASSES after. Baseline
captured by running the new tests before touching `validate.go`.

| Test | Case | Before | After |
|---|---|---|---|
| `TestParseRejectsNilComparisonOnIntrinsic` | `{ span:status = nil }` | FAIL (accepted) | PASS |
| | `{ name = nil }` | FAIL (accepted) | PASS |
| | `{ nil = span:status }` | FAIL (accepted) | PASS |
| | `{ kind = nil }` | FAIL (accepted) | PASS |
| | `{ duration = nil }` | FAIL (accepted) | PASS |
| | `{ span:childCount = nil }` | FAIL (accepted) | PASS |
| | `{ nestedSetLeft = nil }` | FAIL (accepted) | PASS |
| | `{ trace:id = nil }` | FAIL (accepted) | PASS |
| | `{ span.foo = "a" && name = nil }` | FAIL (accepted) | PASS |
| | `{ name = nil } \| rate()` | FAIL (accepted) | PASS |
| `TestParseRejectsNilComparisonOnResourceServiceName` | `{ resource.service.name = nil }` | FAIL (accepted) | PASS |
| | `{ nil = resource.service.name }` | FAIL (accepted) | PASS |
| | `{ resource."service.name" = nil }` | FAIL (accepted) | PASS |
| `TestParseAcceptsLegalNilComparisons` | 16 must-stay-accepted forms | PASS | PASS |
| `TestLowerNilComparisonGuardsRejectOpNotExists` | 8 intrinsics + resource.service.name | FAIL with the guards removed | PASS |

The acceptance test passing in BOTH columns is the point of it: it is the
over-rejection ratchet, and it is non-vacuous — deleting the lowering guards
makes the white-box guard test fail on all nine cases, verified by doing it.

`{ span.foo = nil }` stays accepted, along with `{ .foo = nil }`,
`{ resource.foo = nil }`, `{ event.exception.type = nil }`, `{ link.foo = nil }`,
`{ instrumentation.foo = nil }`, `{ span.service.name = nil }`,
`{ .service.name = nil }`, every `!= nil` form on both clauses, and
`{ (span.a + 1) = nil }`.

## Differential coverage moves up with the rule

The catalogue's `rejection` class asserts only that the reference ALSO rejects
the trigger — never with which status, which is the very thing that was wrong
here. So the two forms now ride `compatibility/tempo/driver`'s status-parity
axis (`-- expect_status -- 400` plus the `-- expect_grpc_code -- InvalidArgument`
sibling), which grades the status against real Tempo on both transports. That
is strictly stronger than what they had.

`test/rejection-parity/` cannot host these: its scan covers `internal/promql`,
`internal/logql`, `internal/traceql` non-recursively and matches on a
`"<head>: "` message prefix, so `internal/traceql/ast`'s
`"invalid TraceQL query: "` errors are outside its universe twice over.

## Why the lowering guards stay

They are unreachable from the wire now, and deleted would be wrong: everything
below the intrinsic guard computes the `OpExists` answer, so an `OpNotExists`
falling through would lower to `true` — a filter matching **every span** — and
the `resource.service.name` guard would emit a `NOT mapContains(...)` that is
false on every conforming span. They are the sibling of the reference's own
second copy in vparquet4's `checkConditions`.

Reclassified `rejection` -> `internal` in the catalogue with a rationale (the
regenerated `cited` block holds it to account), and pinned white-box past
`Parse` in `nil_comparison_guard_test.go` so "unreachable" does not decay into
"untested".

## Generated artefacts

`test/rejection-parity/catalogue/` regenerated with its own documented command
(`CERBERUS_UPDATE_INVENTORY=1`, per `catalogue_test.go:36`), not hand-edited;
the class/rationale curation it asks for is the human half of that loop. The
surface-parity ledgers are unmoved — no `= nil` form appears in them — and the
divergence ceiling is untouched (no `divergence` entry added).

`go test ./...` is green across the tree.

Closes #3260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196feCkr8wd6meQ3jr9W8rF
