### PR TITLE
fix(traceql): preserve the scoped spelling of intrinsics with a bare twin

### DIFF
--- a/internal/traceql/ast/attribute.go
+++ b/internal/traceql/ast/attribute.go
@@ -5,14 +5,25 @@ import (
 )
 
 // Attribute is a reference to a span/resource/trace field or an intrinsic.
-// All four fields are exported because lowering reads them directly and
-// compares Attribute values for the zero value, so the struct is kept
-// comparable (no slice/map fields).
+// All fields are exported because lowering reads them directly and compares
+// Attribute values for the zero value, so the struct is kept comparable (no
+// slice/map fields).
 type Attribute struct {
 	Name      string
 	Scope     AttributeScope
 	Parent    bool
 	Intrinsic Intrinsic
+	// Spelling records which ScopedIntrinsic* surface spelling produced
+	// Intrinsic, for the handful of intrinsics reachable through both a
+	// bare identifier and a scope-colon form (span:status vs status,
+	// trace:duration vs duration, …) that lower and validate identically —
+	// Intrinsic itself always holds the bare constant so every existing
+	// switch over it keeps seeing one value regardless of spelling. It is
+	// IntrinsicNone (the zero value) for a bare spelling and for any
+	// intrinsic with only one spelling (span:id, event:name, …), whose own
+	// Intrinsic.String() already renders the sole scoped form. Read only
+	// by String(); see scopedIntrinsic in parser.go for where it is set.
+	Spelling Intrinsic
 }
 
 func (Attribute) isFieldExpression() {}
@@ -76,7 +87,13 @@ func (a Attribute) String() string {
 	}
 
 	name := a.Name
-	if a.Intrinsic != IntrinsicNone {
+	switch {
+	case a.Spelling != IntrinsicNone:
+		// A scoped spelling of an intrinsic that also has a bare form
+		// (span:status, trace:duration, …): render the surface spelling
+		// the query used, not the bare Intrinsic it resolves to.
+		name = a.Spelling.String()
+	case a.Intrinsic != IntrinsicNone:
 		name = a.Intrinsic.String()
 	}
 

--- a/internal/traceql/ast/parser.go
+++ b/internal/traceql/ast/parser.go
@@ -799,68 +799,79 @@ func bareIntrinsic(k tokenKind) (Intrinsic, bool) {
 func (c *cursor) parseScopedIntrinsic() Attribute {
 	scope := c.advance().kind
 	field := c.advance().kind
-	in, ok := scopedIntrinsic(scope, field)
+	in, spelling, ok := scopedIntrinsic(scope, field)
 	if !ok {
 		c.fail("syntax error: %s is not a valid scoped intrinsic", field)
 	}
-	return NewIntrinsic(in)
+	attr := NewIntrinsic(in)
+	attr.Spelling = spelling
+	return attr
 }
 
-func scopedIntrinsic(scope, field tokenKind) (Intrinsic, bool) {
+// scopedIntrinsic resolves a scope-colon token pair (span:, trace:, …) to
+// the intrinsic it names. Lowering and validation dispatch on that bare
+// Intrinsic alone, so a scoped spelling that also has a bare form
+// (span:status vs status, trace:duration vs duration, …) resolves to the
+// SAME Intrinsic constant its bare twin does — behaviour is identical
+// either way, only the surface text differs. spelling carries that surface
+// text, as the matching ScopedIntrinsic* constant, for Attribute.String()
+// to render; it is IntrinsicNone for a field with only one spelling
+// (span:id, event:name, …), whose own Intrinsic already renders scoped.
+func scopedIntrinsic(scope, field tokenKind) (in, spelling Intrinsic, ok bool) {
 	switch scope {
 	case tokTraceColon:
 		switch field {
 		case tokIDuration:
-			return IntrinsicTraceDuration, true
+			return IntrinsicTraceDuration, ScopedIntrinsicTraceDuration, true
 		case tokRootName:
-			return IntrinsicTraceRootSpan, true
+			return IntrinsicTraceRootSpan, ScopedIntrinsicTraceRootName, true
 		case tokRootService:
-			return IntrinsicTraceRootService, true
+			return IntrinsicTraceRootService, ScopedIntrinsicTraceRootService, true
 		case tokID:
-			return IntrinsicTraceID, true
+			return IntrinsicTraceID, IntrinsicNone, true
 		}
 	case tokSpanColon:
 		switch field {
 		case tokIDuration:
-			return IntrinsicDuration, true
+			return IntrinsicDuration, ScopedIntrinsicSpanDuration, true
 		case tokName:
-			return IntrinsicName, true
+			return IntrinsicName, ScopedIntrinsicSpanName, true
 		case tokKind:
-			return IntrinsicKind, true
+			return IntrinsicKind, ScopedIntrinsicSpanKind, true
 		case tokStatus:
-			return IntrinsicStatus, true
+			return IntrinsicStatus, ScopedIntrinsicSpanStatus, true
 		case tokStatusMessage:
-			return IntrinsicStatusMessage, true
+			return IntrinsicStatusMessage, ScopedIntrinsicSpanStatusMessage, true
 		case tokID:
-			return IntrinsicSpanID, true
+			return IntrinsicSpanID, IntrinsicNone, true
 		case tokParentID:
-			return IntrinsicParentID, true
+			return IntrinsicParentID, IntrinsicNone, true
 		case tokChildCount:
-			return IntrinsicChildCount, true
+			return IntrinsicChildCount, IntrinsicNone, true
 		}
 	case tokEventColon:
 		switch field {
 		case tokName:
-			return IntrinsicEventName, true
+			return IntrinsicEventName, IntrinsicNone, true
 		case tokTimeSinceStart:
-			return IntrinsicEventTimeSinceStart, true
+			return IntrinsicEventTimeSinceStart, IntrinsicNone, true
 		}
 	case tokLinkColon:
 		switch field {
 		case tokTraceID:
-			return IntrinsicLinkTraceID, true
+			return IntrinsicLinkTraceID, IntrinsicNone, true
 		case tokSpanID:
-			return IntrinsicLinkSpanID, true
+			return IntrinsicLinkSpanID, IntrinsicNone, true
 		}
 	case tokInstrColon:
 		switch field {
 		case tokName:
-			return IntrinsicInstrumentationName, true
+			return IntrinsicInstrumentationName, IntrinsicNone, true
 		case tokVersion:
-			return IntrinsicInstrumentationVersion, true
+			return IntrinsicInstrumentationVersion, IntrinsicNone, true
 		}
 	}
-	return IntrinsicNone, false
+	return IntrinsicNone, IntrinsicNone, false
 }
 
 func (c *cursor) parseAttributeField() Attribute {

--- a/internal/traceql/ast/parser_test.go
+++ b/internal/traceql/ast/parser_test.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -413,6 +414,70 @@ func TestParseScopedIntrinsics(t *testing.T) {
 			attr := bin.LHS.(Attribute)
 			if attr.Intrinsic != tc.in {
 				t.Errorf("Intrinsic = %v; want %v", attr.Intrinsic, tc.in)
+			}
+		})
+	}
+}
+
+// TestScopedIntrinsicSpellingRoundTrip pins issue #3270: the eight scoped
+// intrinsic spellings that also have a bare form (span:status vs status,
+// trace:duration vs duration, …) must round-trip through String() as the
+// spelling the query actually used, not be canonicalised onto the bare
+// form. impliedType must also agree between the two spellings of the same
+// intrinsic, since they denote the same field and must lower identically.
+func TestScopedIntrinsicSpellingRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		scoped, bare string
+		in           Intrinsic
+	}{
+		{`span:status = error`, `status = error`, IntrinsicStatus},
+		{`span:statusMessage = "x"`, `statusMessage = "x"`, IntrinsicStatusMessage},
+		{`span:duration > 1s`, `duration > 1s`, IntrinsicDuration},
+		{`span:name = "x"`, `name = "x"`, IntrinsicName},
+		{`span:kind = server`, `kind = server`, IntrinsicKind},
+		{`trace:rootName = "x"`, `rootName = "x"`, IntrinsicTraceRootSpan},
+		{`trace:rootService = "x"`, `rootServiceName = "x"`, IntrinsicTraceRootService},
+		{`trace:duration > 1s`, `traceDuration > 1s`, IntrinsicTraceDuration},
+	}
+	attrOf := func(t *testing.T, expr string) Attribute {
+		t.Helper()
+		sf := firstElem(t, "{ "+expr+" }").(*SpansetFilter)
+		bin := sf.Expression.(*BinaryOperation)
+		attr, ok := bin.LHS.(Attribute)
+		if !ok {
+			t.Fatalf("LHS = %T; want Attribute", bin.LHS)
+		}
+		return attr
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.scoped, func(t *testing.T) {
+			t.Parallel()
+			scopedSpelling := tc.scoped[:strings.IndexByte(tc.scoped, ' ')]
+			bareSpelling := tc.bare[:strings.IndexByte(tc.bare, ' ')]
+
+			scoped := attrOf(t, tc.scoped)
+			if scoped.Intrinsic != tc.in {
+				t.Errorf("scoped Intrinsic = %v; want %v", scoped.Intrinsic, tc.in)
+			}
+			if got := scoped.String(); got != scopedSpelling {
+				t.Errorf("scoped String() = %q; want %q (the spelling used)", got, scopedSpelling)
+			}
+
+			bare := attrOf(t, tc.bare)
+			if bare.Intrinsic != tc.in {
+				t.Errorf("bare Intrinsic = %v; want %v", bare.Intrinsic, tc.in)
+			}
+			// Control: the bare spelling must still round-trip bare, never
+			// picking up a scope it was never written with.
+			if got := bare.String(); got != bareSpelling {
+				t.Errorf("bare String() = %q; want %q (bare, unchanged)", got, bareSpelling)
+			}
+
+			if scoped.impliedType() != bare.impliedType() {
+				t.Errorf("impliedType diverges: scoped=%v bare=%v; the two spellings must lower identically",
+					scoped.impliedType(), bare.impliedType())
 			}
 		})
 	}

--- a/internal/traceql/ast/validate_test.go
+++ b/internal/traceql/ast/validate_test.go
@@ -581,12 +581,15 @@ func TestParseRejectsNilComparisonOnIntrinsic(t *testing.T) {
 		want  string // the attribute the message must name
 	}{
 		// The three forms issue #3260 reports, in the reference's own
-		// invalid-query corpus (pkg/traceql/test_examples.yaml).
-		{`{ span:status = nil }`, "status"},
+		// invalid-query corpus (pkg/traceql/test_examples.yaml). The
+		// scoped spelling names itself in the message (#3270) — the
+		// reference does the same, since it never canonicalises
+		// span:status onto its bare twin either.
+		{`{ span:status = nil }`, "span:status"},
 		{`{ name = nil }`, "name"},
 		// Written the other way round: the grammar folds `nil = x` to the
 		// same OpNotExists node, and the reference lists both spellings.
-		{`{ nil = span:status }`, "status"},
+		{`{ nil = span:status }`, "span:status"},
 		// Every intrinsic, not an enumerated subset — the reference's
 		// clause is `attr.Intrinsic != IntrinsicNone`.
 		{`{ kind = nil }`, "kind"},


### PR DESCRIPTION
## Summary

- `scopedIntrinsic` in `internal/traceql/ast/parser.go` canonicalised every scoped intrinsic spelling with a bare twin (`span:status`, `span:name`, `span:duration`, `span:kind`, `span:statusMessage`, `trace:rootName`, `trace:rootService`, `trace:duration`) onto that bare `Intrinsic` constant, so `Attribute.String()` rendered the bare alias and every `validate.go` message named the wrong attribute for a query written in the scoped form.
- Added `Attribute.Spelling`, a second `Intrinsic` field read only by `String()`. `scopedIntrinsic` now returns it alongside the existing bare constant for the eight ambiguous spellings; `Intrinsic` itself is unchanged for every existing switch (lowering, validation, `impliedType`), so behaviour for `span:status` and `status` stays identical everywhere except the rendered spelling.

## Design chosen and why the alternative is worse

The issue proposed two shapes:
1. Make `scopedIntrinsic` produce the `ScopedIntrinsic*` constants directly into `Attribute.Intrinsic`, and teach every consumer to canonicalise via a new `Canonical()` method.
2. Keep `Intrinsic` semantic and carry the surface spelling in a second field.

I chose (2). Evidence against (1): `internal/traceql/lower.go` already has ~30 call sites switching on `a.Intrinsic` (`numericIntrinsicColumn`, `isTraceScopedIntrinsic`, `intrinsicColumn`, nested-set handling, trace-scoped value resolution, etc.), plus more in `metrics_pipeline.go`, `internal/api/tempo/{search_tag_values.go,...}`, and `ast/references.go`. Every one would need either a `.Canonical()` call or a new case arm, and a single missed arm silently changes semantics — the exact risk the issue itself flagged. Design (2) touches none of them: `a.Intrinsic` never becomes a `ScopedIntrinsic*` value, so `numericIntrinsicColumn`'s comment ("the `ScopedIntrinsic*` constants never reach lowering") and `isTraceScopedIntrinsic`'s defensive dead-code comment (written anticipating exactly this fork in the road) both stay literally true, unmodified.

## Discrimination table

All new/updated assertions, run against the pre-fix code (`git checkout --` on `attribute.go`/`parser.go` only) and against the fix:

| Test | Pre-fix | Post-fix |
|---|---|---|
| `TestScopedIntrinsicSpellingRoundTrip` (all 8 scoped spellings + bare controls + `impliedType` parity) | FAIL — scoped forms rendered bare (`"status"` not `"span:status"`, etc.) | PASS |
| `TestParseRejectsNilComparisonOnIntrinsic/{ span:status = nil }` | FAIL — message said `status=nil ...` | PASS — message says `span:status=nil ...` |
| `TestParseRejectsNilComparisonOnIntrinsic/{ nil = span:status }` | FAIL (same) | PASS |

Also re-ran the full existing `internal/traceql/ast` and `internal/traceql` suites (race-enabled) — all green, including `TestParseScopedIntrinsics`, `TestReferencesIntrinsic_Name`, and every other pre-existing scoped-intrinsic test, confirming zero behavioural change to lowering/validation for either spelling.

## Verification

- `go build ./...` clean.
- `go test -race ./internal/traceql/... ./internal/api/tempo/...` green.
- `go test ./internal/traceql/ast/...` green (new + updated tests).

Closes #3270

🤖 Generated with [Claude Code](https://claude.com/claude-code)
