### PR TITLE
fix(testsql): ignore leading comment parentheses in seed column catalog

### DIFF
--- a/internal/testsql/query_rewrite.go
+++ b/internal/testsql/query_rewrite.go
@@ -811,15 +811,15 @@ func SeedTableColumns(seed string) map[string][]string {
 			continue
 		}
 		name := strings.ToLower(strings.TrimSpace(firstToken(rest)))
-		open := strings.IndexByte(stmt, '(')
+		open := strings.IndexByte(trimmed, '(')
 		if open < 0 {
 			continue
 		}
-		closeParen := matchParen(stmt, open)
+		closeParen := matchParen(trimmed, open)
 		if closeParen < 0 {
 			continue
 		}
-		defs := splitTopLevelCommas(stmt[open+1 : closeParen])
+		defs := splitTopLevelCommas(trimmed[open+1 : closeParen])
 		names := make([]string, 0, len(defs))
 		for _, d := range defs {
 			d = strings.TrimSpace(d)

--- a/internal/testsql/seed_table_columns_test.go
+++ b/internal/testsql/seed_table_columns_test.go
@@ -1,0 +1,47 @@
+package testsql
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSeedTableColumns_LeadingCommentParentheses(t *testing.T) {
+	t.Parallel()
+	for _, comment := range []string{
+		"-- coalesce(nullIf(TraceId, ''), ResourceAttributes['TraceId'])\n",
+		"-- catalog note (unfinished\n",
+	} {
+		t.Run(strings.TrimSpace(comment), func(t *testing.T) {
+			t.Parallel()
+			seed := comment + `CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String DEFAULT '-- literal (with, parentheses)',
+    TraceId String MATERIALIZED 'trace',
+    ResourceAttributes Map(String, String) ALIAS map()
+) ENGINE = Memory;`
+			got := SeedTableColumns(seed)["otel_logs"]
+			want := []string{"Timestamp", "Body"}
+			if !slices.Equal(got, want) {
+				t.Fatalf("SeedTableColumns() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestExpandStarProjection_SeedLeadingCommentParentheses(t *testing.T) {
+	t.Parallel()
+	const seed = `-- derived key (comment_token, other_token)
+CREATE TABLE otel_logs (
+    Timestamp DateTime64(9),
+    Body String,
+    TraceId String MATERIALIZED 'trace'
+) ENGINE = Memory;`
+	const query = "SELECT s.* FROM (SELECT * FROM `otel_logs`) AS s"
+	got := ExpandStarProjection(query, SeedTableColumns(seed))
+	head, _ := splitOuterSelect(got)
+	want := "s.`Timestamp`, s.`Body`"
+	if strings.TrimSpace(head) != want {
+		t.Fatalf("expanded projection = %q, want %q", head, want)
+	}
+}


### PR DESCRIPTION
## Summary

Fix the seed column catalog prerequisite found during #3277 schema acceptance. `SeedTableColumns` already strips leading comments before parsing CREATE TABLE, but previously searched the original statement for column delimiters. Parentheses in those comments could therefore become fake column definitions or hide the table entirely.

Use the stripped statement consistently for delimiter lookup and column slicing. Cover balanced and unmatched comment parentheses, quoted DEFAULT literals, MATERIALIZED/ALIAS exclusion, and star expansion to the actual declared columns.

## Verification

The two new focused tests failed before the fix: the catalog returned comment expressions or no columns, and star expansion selected comment tokens. After the three-line fix, both new tests and the existing bare-table star-expansion regression pass with race detection:

```sh
go test -race -timeout 5m -count=1 -run '^(TestSeedTableColumns_LeadingCommentParentheses|TestExpandStarProjection_SeedLeadingCommentParentheses|TestExpandStarProjection_BareTableResolvesFromSeedDDL)$' ./internal/testsql/
```

No generated artifacts changed.

Closes #3354
