### PR TITLE
fix(promql): classify guard failures from exception messages only

### DIFF
--- a/internal/api/prom/guard_message.go
+++ b/internal/api/prom/guard_message.go
@@ -1,0 +1,61 @@
+package prom
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+)
+
+// guardExceptionMessage accepts typed guard exceptions on both ClickHouse
+// dials, or an anchored chDB exception envelope at the unwrapped driver error.
+// A guard literal appearing only in failing SQL is not an exception message.
+func guardExceptionMessage(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	var ex *clickhouse.Exception
+	if errors.As(err, &ex) {
+		// A typed non-guard exception is authoritative; never reinterpret its
+		// SQL or any enclosing text as an untyped guard rejection.
+		msg, ok := chclient.ThrowIfMessage(ex)
+		if !ok {
+			return "", false
+		}
+		return decodedGuardMessage(msg), true
+	}
+	if msg, ok := chclient.ThrowIfMessage(err); ok {
+		return decodedGuardMessage(msg), true
+	}
+	for errors.Unwrap(err) != nil {
+		err = errors.Unwrap(err)
+	}
+	// chdb-go's parquetStreamingRows.readNextChunkFromStream formats this
+	// prefix with %s rather than %w; its QueryContext returns the bare engine
+	// envelope. No other ambient prefix is accepted.
+	raw := strings.TrimPrefix(err.Error(), "error in chunk: ")
+	return stripGuardExceptionEnvelope(raw)
+}
+
+func decodedGuardMessage(msg string) string {
+	// ch-go can retain the engine's envelope inside the typed Message field;
+	// the native dial supplies the message without that envelope.
+	if clean, ok := stripGuardExceptionEnvelope(msg); ok {
+		return clean
+	}
+	return msg
+}
+
+func stripGuardExceptionEnvelope(raw string) (string, bool) {
+	for _, prefix := range []string{
+		"Code: 395. DB::Exception: ",
+		"Code: 768. DB::Exception: ",
+	} {
+		if msg, ok := strings.CutPrefix(raw, prefix); ok {
+			return msg, true
+		}
+	}
+	return "", false
+}

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1242,43 +1242,13 @@ func classifyDrainError(err error) error {
 }
 
 // throwIfMessageMatches reports whether err carries msg as a throwIf guard's
-// message — checked two ways, in order of trust:
-//
-//  1. Typed: errors.As against *chclient.ThrowIfError, which itself only
-//     wraps an error chain carrying a genuine ClickHouse code-395 exception
-//     (errors.As against *clickhouse.Exception). This is what a real,
-//     production data-plane query — anything through chclient.Client and
-//     the native TCP driver — always produces, and it is strictly
-//     trustworthy: the code already confirms this is a deliberate throwIf
-//     abort before the text is even inspected, so HasPrefix on the
-//     driver-decoded Message cannot be fooled by ambient formatting.
-//  2. Fallback: a raw substring check on err.Error(). This exists only for
-//     internal/chclienttest's chDB-backed handler tests — chdb-go returns
-//     errors through Go's generic database/sql/driver interface with no
-//     structured exception type at all (confirmed: it is a different
-//     driver library from clickhouse-go/v2, and errors.As against
-//     *clickhouse.Exception never matches a chdb-go error), so no typed
-//     signal exists to check there. The messages this project uses are
-//     specific enough (e.g. "range window sample fanout exceeds the
-//     series-times-anchors resource bound") that a plain substring match
-//     is not meaningfully riskier in a test-only, non-production path.
-//
-// An earlier version of this file string-matched a single GUESSED prefix
-// ("DB::Exception: " or "message: ") directly against err.Error() with no
-// typed path at all, and that guess silently differed between chdb's
-// CLI-style rendering and the native driver's bare "code: %d, message: %s"
-// — every one of these guards, including #2385's pre-existing histogram
-// merge budget, was unmatchable against real production traffic until this
-// was caught investigating #2429.
+// message. guardExceptionMessage verifies the exception code and extracts
+// its message on both typed production dials and the untyped chDB path.
+// Only a message prefix matches: failing SQL can contain every guard literal
+// without any of those guards having fired.
 func throwIfMessageMatches(err error, msg string) bool {
-	if err == nil {
-		return false
-	}
-	var tie *chclient.ThrowIfError
-	if errors.As(err, &tie) {
-		return strings.HasPrefix(tie.Message, msg)
-	}
-	return strings.Contains(err.Error(), msg)
+	guard, ok := guardExceptionMessage(err)
+	return ok && strings.HasPrefix(guard, msg)
 }
 
 // duplicateSeriesTagsMessage extracts the clean, client-facing sentence
@@ -1294,22 +1264,14 @@ func throwIfMessageMatches(err error, msg string) bool {
 // the extracted sentence instead of a bool, and the caller forwards it
 // verbatim.
 //
-// Detection mirrors throwIfMessageMatches's own two tiers (see that
-// function's doc for why both exist): chclient.ThrowIfMessage's typed path
-// for production traffic (and chdb-go's own typed exceptions), falling
-// back to a raw err.Error() scan for chdb-go's untyped
-// database/sql/driver error shape, which carries no structured exception
-// at all.
+// Detection uses the same verified exception message as throwIfMessageMatches;
+// the dynamic prefix must start that message, never occur inside SQL text.
 func duplicateSeriesTagsMessage(err error) (string, bool) {
-	if err == nil {
+	msg, ok := guardExceptionMessage(err)
+	if !ok {
 		return "", false
 	}
-	if msg, ok := chclient.ThrowIfMessage(err); ok {
-		if clean, ok := extractDuplicateSeriesTagsMessage(msg); ok {
-			return clean, true
-		}
-	}
-	return extractDuplicateSeriesTagsMessage(err.Error())
+	return extractDuplicateSeriesTagsMessage(msg)
 }
 
 // duplicateSeriesTagsTrailerMarker is where ClickHouse's own "while
@@ -1321,18 +1283,14 @@ func duplicateSeriesTagsMessage(err error) (string, bool) {
 // table/column aliases (e.g. "__table1.attrs").
 const duplicateSeriesTagsTrailerMarker = ": while executing '"
 
-// extractDuplicateSeriesTagsMessage finds
-// chplan.DuplicateSeriesTagsMessagePrefix inside raw — which may carry a
-// "Code: NNN. DB::Exception: " envelope ahead of it (chdb-go's CLI-style
-// err.Error() rendering) or nothing at all (the native driver's
-// already-decoded Message field) — and returns just the clean sentence
-// with ClickHouse's own trailer stripped.
+// extractDuplicateSeriesTagsMessage accepts an already-decoded message
+// beginning with chplan.DuplicateSeriesTagsMessagePrefix and strips
+// ClickHouse's execution trailer from the client-facing sentence.
 func extractDuplicateSeriesTagsMessage(raw string) (string, bool) {
-	idx := strings.Index(raw, chplan.DuplicateSeriesTagsMessagePrefix)
-	if idx < 0 {
+	if !strings.HasPrefix(raw, chplan.DuplicateSeriesTagsMessagePrefix) {
 		return "", false
 	}
-	msg := raw[idx:]
+	msg := raw
 	if trailer := strings.Index(msg, duplicateSeriesTagsTrailerMarker); trailer >= 0 {
 		msg = msg[:trailer]
 	}

--- a/internal/api/prom/handler_guard_classification_test.go
+++ b/internal/api/prom/handler_guard_classification_test.go
@@ -1,0 +1,95 @@
+package prom_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"github.com/tsouza/cerberus/internal/chclient"
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+func TestGuardClassification_ExceptionMessageBoundary(t *testing.T) {
+	t.Parallel()
+	const (
+		unknownIdentifierCode = 47
+		throwIfCode           = 395
+		duplicateSeriesCode   = 768
+		trailer               = ": while executing 'FUNCTION throwIf(...)'"
+	)
+	guard := chsql.RateWindowFanoutBudgetMessage
+	duplicate := chplan.DuplicateSeriesTagsMessagePrefix + " {job=api}, duplicate series in the same result set are not allowed"
+	typed := func(code int32, msg string) error {
+		return &clickhouse.Exception{Code: code, Message: msg}
+	}
+	cases := []struct {
+		name        string
+		err         error
+		wantMessage string
+	}{
+		{"native_guard", typed(throwIfCode, guard+trailer), guard},
+		{"wrapped_guard", &chclient.ThrowIfError{Message: guard + trailer, Cause: typed(throwIfCode, guard+trailer)}, guard},
+		{"standalone_guard_wrapper", &chclient.ThrowIfError{Message: guard + trailer}, guard},
+		{"columnar_guard", typed(throwIfCode, "Code: 395. DB::Exception: "+guard+trailer), guard},
+		{"text_guard", errors.New("Code: 395. DB::Exception: " + guard + trailer), guard},
+		{"stream_chunk_guard", errors.New("error in chunk: Code: 395. DB::Exception: " + guard + trailer), guard},
+		{"native_duplicate", typed(duplicateSeriesCode, duplicate+trailer), duplicate},
+		{"columnar_duplicate", typed(duplicateSeriesCode, "Code: 768. DB::Exception: "+duplicate+trailer), duplicate},
+		{"text_duplicate", errors.New("Code: 768. DB::Exception: " + duplicate + trailer), duplicate},
+		{"typed_unknown_identifier", typed(unknownIdentifierCode, "Unknown identifier in SELECT throwIf(1, '"+guard+"')"), ""},
+		{"text_unknown_identifier", errors.New("Code: 47. DB::Exception: Unknown identifier in SELECT throwIf(1, '" + guard + "')"), ""},
+		{"stream_chunk_unknown_identifier", errors.New("error in chunk: Code: 47. DB::Exception: SELECT '" + guard + "'"), ""},
+		{"typed_non_guard_overrides_wrapper", &chclient.ThrowIfError{Message: guard, Cause: typed(unknownIdentifierCode, "Code: 395. DB::Exception: "+guard)}, ""},
+		{"typed_unknown_duplicate", typed(unknownIdentifierCode, "Unknown identifier in SELECT '"+duplicate+"'"), ""},
+		{"text_unknown_duplicate", errors.New("Code: 47. DB::Exception: Unknown identifier in SELECT '" + duplicate + "'"), ""},
+		{"embedded_fake_envelope", errors.New("Code: 47. DB::Exception: SELECT 'Code: 395. DB::Exception: " + guard + "'"), ""},
+		{"ambient_guard", errors.New("failed SELECT throwIf(1, '" + guard + "')"), ""},
+		{"other_guard_with_sql_literal", typed(throwIfCode, "unrelated guard"+trailer+guard), ""},
+		{"other_duplicate_with_sql_literal", typed(duplicateSeriesCode, "unrelated rejection"+trailer+duplicate), ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, cursor := range []bool{false, true} {
+				t.Run(fmt.Sprintf("cursor=%t", cursor), func(t *testing.T) {
+					wrapped := fmt.Errorf("chclienttest: query: %w", tc.err)
+					querier := &gridNativeGuardQuerier{guardErr: wrapped}
+					srv := newServer(querier)
+					path := "/api/v1/query_range?query=up&start=1767225600&end=1767225660&step=60"
+					if !cursor {
+						querier.stubQuerier.err = wrapped
+						path = "/api/v1/query?query=up&time=1767225600"
+					}
+					t.Cleanup(srv.Close)
+					resp, err := http.Get(srv.URL + path)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer resp.Body.Close()
+					var body queryResponse
+					if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+						t.Fatal(err)
+					}
+					wantStatus, wantKind := http.StatusBadGateway, "internal"
+					if tc.wantMessage != "" {
+						wantStatus, wantKind = http.StatusUnprocessableEntity, "execution"
+					}
+					if resp.StatusCode != wantStatus || body.ErrorType != wantKind {
+						t.Fatalf("status=%d kind=%q message=%q; want %d %s", resp.StatusCode, body.ErrorType, body.Error, wantStatus, wantKind)
+					}
+					if body.Status != "error" {
+						t.Fatalf("response status=%q, want error", body.Status)
+					}
+					if tc.wantMessage != "" && body.Error != tc.wantMessage {
+						t.Fatalf("message=%q want%q", body.Error, tc.wantMessage)
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/api/prom/handler_guard_classification_test.go
+++ b/internal/api/prom/handler_guard_classification_test.go
@@ -62,7 +62,7 @@ func TestGuardClassification_ExceptionMessageBoundary(t *testing.T) {
 					srv := newServer(querier)
 					path := "/api/v1/query_range?query=up&start=1767225600&end=1767225660&step=60"
 					if !cursor {
-						querier.stubQuerier.err = wrapped
+						querier.err = wrapped
 						path = "/api/v1/query?query=up&time=1767225600"
 					}
 					t.Cleanup(srv.Close)


### PR DESCRIPTION
## Summary

Addresses the error-classification portion of #3289; the missing-name forwarding repair remains tracked there and this PR does not close the issue.

Classify guard failures from verified exception messages rather than guard literals embedded in failing SQL. Typed non-guard ClickHouse exceptions are authoritative. Support native and columnar typed guard messages, including retained engine envelopes; preserve chDB's anchored code-395/code-768 textual envelopes and its verified streaming `error in chunk: ` prefix. Static and dynamic duplicate-series messages must start the decoded exception message, not occur in its SQL trailer.

## Verification

- Focused pre-fix regression: eight negative cases returned incorrect HTTP 422 in both instant/open and cursor paths.
- Post-fix: 19 cases across both paths pass, pinning HTTP 502 for unrelated/unknown-identifier failures and HTTP 422 plus clean messages for genuine guards. Includes standalone and wrapped typed guards, typed non-guard precedence, columnar envelopes, textual/chunk errors, and dynamic duplicate-series messages.
- Existing typed grid-native budget regressions pass.
- Executed chDB positive regressions pass: `TestQueryRange_InstantNameDrop_DuplicateLabelset_ChDB` (395), `TestQuery_InstantNameDrop_DuplicateSeriesTags_ChDB` (768), and `TestQueryRange_Subquery_RateInner_DuplicateSeriesTags_ChDB` (768).

Targeted commands preserve race detection and the recipe's 15-minute timeout; no dedicated focused recipe exists:

```sh
go test -race -timeout 15m -count=1 -run '^TestGuardClassification_ExceptionMessageBoundary$' ./internal/api/prom/
GODEBUG=asyncpreemptoff=1 go test -race -tags chdb -timeout 15m -count=1 -run '^(TestQueryRange_InstantNameDrop_DuplicateLabelset_ChDB|TestQuery_InstantNameDrop_DuplicateSeriesTags_ChDB|TestQueryRange_Subquery_RateInner_DuplicateSeriesTags_ChDB)$' ./internal/api/prom/
```

The separately selected `TestInfo_ConflictingLabel_ChDB` fails before its guard on a missing histogram table. Reproduced unchanged on untouched main and tracked in #3290; no fixture or lowering changes are included here.
