### PR TITLE
test(promql): pin aggregate-storage scan role contracts

### DIFF
--- a/internal/promql/schema.go
+++ b/internal/promql/schema.go
@@ -17,11 +17,12 @@ func metricRoles(s schema.Metrics) []chplan.Column {
 }
 
 func metricScanRoles(s schema.Metrics, table string) []chplan.Column {
+	const aggregateStorageIdentityColumns = 2
 	roles := metricRoles(s)
 	if (s.DeltaPrefixTable != "" && table == s.DeltaPrefixTable) || table == schema.DownsampleTierTable {
 		// These storage relations contain bucket boundaries and aggregate
 		// states, not the raw sample timestamp/value columns.
-		return roles[:2]
+		return roles[:aggregateStorageIdentityColumns]
 	}
 	if table == s.HistogramTable || table == s.ExpHistogramTable {
 		// Histogram storage has no float Value; the histogram lowering

--- a/internal/promql/schema_scan_roles_test.go
+++ b/internal/promql/schema_scan_roles_test.go
@@ -1,0 +1,74 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestMetricScanRolesStorageContracts(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	s.MetricNameColumn = "custom_metric"
+	s.AttributesColumn = "custom_attributes"
+	s.TimestampColumn = "custom_timestamp"
+	s.ValueColumn = "custom_value"
+	s.ZeroThresholdColumn = "custom_zero_threshold"
+	identity := []chplan.Column{
+		{Name: s.MetricNameColumn, Role: chplan.RoleMetricName},
+		{Name: s.AttributesColumn, Role: chplan.RoleAttributes},
+	}
+	sample := append(append([]chplan.Column{}, identity...),
+		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+		chplan.Column{Name: s.ValueColumn, Role: chplan.RoleValue})
+	classic := append(append([]chplan.Column{}, identity...),
+		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+		chplan.Column{Name: s.CountColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.SumColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.BucketCountsColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.ExplicitBoundsColumn, Role: chplan.RoleHistogramField})
+	native := append(append([]chplan.Column{}, identity...),
+		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+		chplan.Column{Name: s.CountColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.SumColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.ScaleColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.ZeroThresholdColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.ZeroCountColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.PositiveOffsetColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.PositiveBucketCountsColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.NegativeOffsetColumn, Role: chplan.RoleHistogramField},
+		chplan.Column{Name: s.NegativeBucketCountsColumn, Role: chplan.RoleHistogramField})
+	const configuredPrefixTable = "custom_delta_prefix"
+	for _, tc := range []struct {
+		name   string
+		prefix string
+		table  string
+		want   []chplan.Column
+	}{
+		{name: "raw_prefix_disabled", table: s.GaugeTable, want: sample},
+		{name: "raw_prefix_enabled", prefix: configuredPrefixTable, table: s.GaugeTable, want: sample},
+		{name: "configured_prefix", prefix: configuredPrefixTable, table: configuredPrefixTable, want: identity},
+		{name: "downsample_prefix_disabled", table: schema.DownsampleTierTable, want: identity},
+		{name: "downsample_prefix_enabled", prefix: configuredPrefixTable, table: schema.DownsampleTierTable, want: identity},
+		{name: "classic_prefix_disabled", table: s.HistogramTable, want: classic},
+		{name: "classic_prefix_enabled", prefix: configuredPrefixTable, table: s.HistogramTable, want: classic},
+		{name: "native_prefix_disabled", table: s.ExpHistogramTable, want: native},
+		{name: "native_prefix_enabled", prefix: configuredPrefixTable, table: s.ExpHistogramTable, want: native},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configured := s
+			configured.DeltaPrefixTable = tc.prefix
+			want := chplan.Schema{Columns: tc.want}
+			if got := (chplan.Schema{Columns: metricScanRoles(configured, tc.table)}); !got.Equal(want) {
+				t.Fatalf("declared roles = %#v, want %#v", got, want)
+			}
+			// Verify the real scan constructor publishes the same roles; a
+			// wildcard scan remains open, without claiming storage column order.
+			scan := scanFromTables([]string{tc.table}, configured)
+			want.Open = true
+			if got := scan.RowType(); !got.Equal(want) {
+				t.Fatalf("scan output = %#v, want %#v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3293.

Pin the exact role declarations and actual `scanFromTables(...).RowType()` output for nine storage/configuration combinations: raw tables with delta-prefix support disabled/enabled, the configured prefix table, downsample tables independently of prefix configuration, and classic/native histogram controls. All sample aliases and the optional zero-threshold column are explicitly custom configured.

The sole production-source edit names the existing two-column identity-prefix length `aggregateStorageIdentityColumns`; classification and emitted SQL are unchanged.

## Verification

The post-merge #3283 phase4-promql-other job failed at 158/167 killed (94.61%). Four survivors changed the aggregate-storage predicate in `metricScanRoles`; the earlier phase-other proof did not include the newly added `schema.go`. Exact failure: https://github.com/tsouza/cerberus/actions/runs/34503420667/job/102961824208.

The focused unchanged-production test passed with race detection:

```sh
go test -timeout 5m -race -count=1 -run '^TestMetricScanRolesStorageContracts$' ./internal/promql
```

There is no parameterized recipe for one test; this narrows the race-detected unit recipe to the exact regression.

Four exact source-edit Go overlays each failed the new test with assertion failures, not compile errors:

- Outer OR to AND: configured-prefix and both downsample cases fail.
- Inner AND to OR: enabled-prefix raw/classic/native cases fail.
- Prefix nonempty test inverted: configured-prefix case fails.
- Prefix table equality inverted: configured-prefix and enabled-prefix raw/classic/native cases fail.

These are the exact AST changes printed by CI, with parentheses preserved. The unchanged 95% threshold and full phase are verified by this PR's CI; no full-phase local result is claimed. The focused proof adds four kills to the failing run's observed set, projecting 162/167 (97.01%) if other outcomes stay unchanged.
