### PR TITLE
fix(promql): preserve label rewrites over name-dropped windows

### DIFF
--- a/internal/api/prom/handler_chdb_label_forwarding_test.go
+++ b/internal/api/prom/handler_chdb_label_forwarding_test.go
@@ -1,0 +1,128 @@
+//go:build chdb
+
+package prom_test
+
+import (
+	"fmt"
+	"maps"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// TestQueryRange_LabelRewritePhysicalColumns_ChDB exercises name-dropping
+// windows behind broadcasts and value rewrites through the complete HTTP path.
+// The label rewrite must forward the physical timestamps without referring to
+// a metric-name column that its input no longer publishes.
+func TestQueryRange_LabelRewritePhysicalColumns_ChDB(t *testing.T) {
+	const (
+		seedLeadMinutes = 20
+		seedSampleCount = 31
+		querySteps      = 5
+		valueTolerance  = 1e-12
+	)
+	start := time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)
+	step := time.Minute
+	end := start.Add(querySteps * step)
+	rows := make([]string, 0, seedSampleCount)
+	for i := range seedSampleCount {
+		ts := start.Add(time.Duration(i-seedLeadMinutes) * step).Format("2006-01-02 15:04:05.000000000")
+		rows = append(rows, fmt.Sprintf("('http_requests_total', map('job','api'), 'svc', toDateTime64('%s',9), %d.0)", ts, i))
+	}
+	seedDDL := strings.Replace(rangeOffsetSumDDL, "Value Float64", fmt.Sprintf("Value Float64, AggregationTemporality Int32 DEFAULT %d", schema.AggregationTemporalityCumulative), 1)
+	seed := seedDDL + "\nINSERT INTO otel_metrics_sum (MetricName,Attributes,ServiceName,TimeUnix,Value) VALUES " + strings.Join(rows, ",") + ";"
+	for _, schemaName := range []string{"default", "custom"} {
+		t.Run(schemaName, func(t *testing.T) {
+			metrics := schema.DefaultOTelMetrics()
+			physicalSeed := seed
+			if schemaName == "custom" {
+				metrics.MetricNameColumn = "metric_id"
+				metrics.AttributesColumn = "labels"
+				metrics.TimestampColumn = "sample_time"
+				metrics.ValueColumn = "sample_value"
+				// Preserve ResourceAttributes as a separate physical field while
+				// renaming the canonical sample attributes column.
+				physicalSeed = strings.NewReplacer("ResourceAttributes", "ResourceAttributes", "MetricName", metrics.MetricNameColumn, "Attributes", metrics.AttributesColumn, "TimeUnix", metrics.TimestampColumn, "Value", metrics.ValueColumn).Replace(seed)
+			}
+			client := chclienttest.NewChDB(t)
+			client.Seed(t, physicalSeed)
+			handler := prom.New(client, metrics, nil)
+			mux := http.NewServeMux()
+			handler.Mount(mux)
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+			replace := func(inner string) string {
+				return `label_replace(` + inner + `, "dst", "$1", "job", "(.*)")`
+			}
+			join := func(inner string) string {
+				return `label_join(` + inner + `, "dst", "-", "job", "job")`
+			}
+			const rate = `rate(http_requests_total[5m])`
+			pinned := fmt.Sprintf(`rate(http_requests_total[5m] @ %d)`, start.Unix())
+			for _, tc := range []struct {
+				name, query, dst, metricName string
+				lastSample                   bool
+			}{
+				{name: "replace_direct", query: replace(rate), dst: "api"},
+				{name: "replace_pinned", query: replace(pinned), dst: "api"},
+				{name: "replace_abs", query: replace("abs(" + rate + ")"), dst: "api"},
+				{name: "join_direct", query: join(rate), dst: "api-api"},
+				{name: "join_pinned", query: join(pinned), dst: "api-api"},
+				{name: "join_abs", query: join("abs(" + rate + ")"), dst: "api-api"},
+				{name: "replace_after_join", query: replace(join("abs(" + rate + ")")), dst: "api"},
+				{name: "join_after_replace", query: join(replace(pinned)), dst: "api-api"},
+				{name: "replace_nested_abs", query: replace("abs(abs(" + rate + "))"), dst: "api"},
+				{name: "replace_offset", query: replace("abs(rate(http_requests_total[5m] offset 1m))"), dst: "api"},
+				{name: "replace_last", query: replace("last_over_time(http_requests_total[5m])"), dst: "api", metricName: "http_requests_total", lastSample: true},
+				{name: "join_last", query: join("last_over_time(http_requests_total[5m])"), dst: "api-api", metricName: "http_requests_total", lastSample: true},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					matrix := runRangeModeQueryRange(t, srv.URL, tc.query, start, end, step)
+					if len(matrix) != 1 {
+						t.Fatalf("got %d series, want one", len(matrix))
+					}
+					got := matrix[0]
+					wantLabels := map[string]string{"job": "api", "dst": tc.dst, "service_name": "svc"}
+					if tc.metricName != "" {
+						wantLabels["__name__"] = tc.metricName
+					}
+					if !maps.Equal(got.Metric, wantLabels) {
+						t.Fatalf("labels = %v, want %v", got.Metric, wantLabels)
+					}
+					if len(got.Values) != querySteps+1 {
+						t.Fatalf("got %d points, want %d", len(got.Values), querySteps+1)
+					}
+					for i, point := range got.Values {
+						wantTime := float64(start.Add(time.Duration(i) * step).Unix())
+						if point[0] != wantTime {
+							t.Fatalf("point %d timestamp = %v, want %v", i, point[0], wantTime)
+						}
+						valueText, ok := point[1].(string)
+						if !ok {
+							t.Fatalf("point %d value = %T, want string", i, point[1])
+						}
+						value, err := strconv.ParseFloat(valueText, 64)
+						if err != nil {
+							t.Fatal(err)
+						}
+						wantValue := 1 / step.Seconds()
+						if tc.lastSample {
+							wantValue = float64(seedLeadMinutes + i)
+						}
+						if math.IsNaN(value) || math.Abs(value-wantValue) > valueTolerance {
+							t.Fatalf("point %d value = %v, want %v", i, value, wantValue)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -181,8 +181,14 @@ func stringArg(e parser.Expr, fnName, paramName string) (string, error) {
 //     already collapsed each series to a single row — which is why the
 //     timestamp columns are conditional rather than unconditional.
 //
-//   - Every other inner shape keeps the full Sample row, so we forward all
-//     four canonical columns.
+//   - Broadcasts and value-rewrite Projects can retain the legacy Sample
+//     classification despite having dropped MetricName. A closed, float-only
+//     physical schema with a real timestamp proves that absence; materialize
+//     the dropped name as an empty string and retain the canonical sample
+//     layout. Open schemas and outputs carrying any histogram helper or
+//     discriminator retain their prior path, outside this narrow repair.
+//
+//   - Remaining Sample inputs retain the canonical four-column path.
 //
 // The return type is the concrete *chplan.Project rather than the Node
 // interface because [guardLabelRewriteCollision] reads the projection list
@@ -216,11 +222,29 @@ func projectAttributesOverInner(inner chplan.Node, s schema.Metrics, attrs chpla
 		projections = append(projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: s.ValueColumn}})
 		return &chplan.Project{Roles: metricRoles(s), Input: inner, Projections: projections}
 	}
+	metricName := chplan.Projection{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}}
+	physical := inner.RowType()
+	_, hasMetricName := physical.ByName(s.MetricNameColumn)
+	attributes, _ := physical.ByName(s.AttributesColumn)
+	timestamp, _ := physical.ByName(s.TimestampColumn)
+	value, _ := physical.ByName(s.ValueColumn)
+	// A closed float-only Sample output may have dropped its metric name.
+	// Materialize the same empty-name convention as projectValueOverInner,
+	// keeping the real timestamp and canonical layout. Merely removing the
+	// name changes the collision guard to a derived output; a pinned broadcast
+	// is not a RangeWindow grid and that path synthesizes the wrong timestamp.
+	// Any histogram helper/discriminator excludes this narrow repair; this is
+	// not a definition of complete histogram payload or a new payload policy.
+	if !physical.Open && !hasMetricName && !physical.Has(chplan.RoleMetricName) &&
+		!physical.Has(chplan.RoleHistogramField) && !physical.Has(chplan.RoleDiscriminator) &&
+		attributes.Role == chplan.RoleAttributes && timestamp.Role == chplan.RoleTimestamp && value.Role == chplan.RoleValue {
+		metricName = chplan.Projection{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn}
+	}
 	return &chplan.Project{
 		Roles: metricRoles(s),
 		Input: inner,
 		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
+			metricName,
 			{Expr: attrs, Alias: s.AttributesColumn},
 			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},

--- a/internal/promql/label_forwarding_contract_test.go
+++ b/internal/promql/label_forwarding_contract_test.go
@@ -1,0 +1,96 @@
+package promql
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestAttributeRewriteUnnamedFloatPhysicalColumns(t *testing.T) {
+	for _, custom := range []bool{false, true} {
+		s := schema.DefaultOTelMetrics()
+		name := "default"
+		if custom {
+			name = "custom"
+			s.MetricNameColumn = "metric_id"
+			s.AttributesColumn = "arbitrary_labels"
+			s.TimestampColumn = "sample_time"
+			s.ValueColumn = "sample_value"
+		}
+		t.Run(name, func(t *testing.T) {
+			attributes := chplan.Column{Name: s.AttributesColumn, Role: chplan.RoleAttributes}
+			value := chplan.Column{Name: s.ValueColumn, Role: chplan.RoleValue}
+			timestamp := chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleTimestamp}
+			anchor := chplan.Column{Name: chplan.RangeWindowAnchorColumn, Role: chplan.RoleAnchor}
+			metric := chplan.Column{Name: s.MetricNameColumn, Role: chplan.RoleMetricName}
+			canonical := []string{s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.ValueColumn}
+			for _, tc := range []struct {
+				name      string
+				columns   []chplan.Column
+				open      bool
+				emptyName bool
+			}{
+				{name: "grid", columns: []chplan.Column{attributes, anchor, timestamp, value}, emptyName: true},
+				{name: "timestamp_without_anchor", columns: []chplan.Column{attributes, timestamp, value}, emptyName: true},
+				{name: "anchor_without_timestamp", columns: []chplan.Column{attributes, anchor, value}},
+				{name: "neither_timestamp", columns: []chplan.Column{attributes, value}},
+				{name: "name_preserved", columns: []chplan.Column{metric, attributes, timestamp, value}},
+				{name: "opaque_name_preserved", columns: []chplan.Column{{Name: s.MetricNameColumn}, attributes, timestamp, value}},
+				{name: "other_metric_role_preserved", columns: []chplan.Column{{Name: "another_metric", Role: chplan.RoleMetricName}, attributes, timestamp, value}},
+				{name: "open_unknown_name", columns: []chplan.Column{attributes, anchor, timestamp, value}, open: true},
+				{name: "opaque_outputs", columns: []chplan.Column{{Name: s.AttributesColumn}, {Name: s.ValueColumn}}},
+				{name: "missing_attributes", columns: []chplan.Column{timestamp, value}},
+				{name: "missing_value", columns: []chplan.Column{attributes, timestamp}},
+				{name: "opaque_attributes", columns: []chplan.Column{{Name: s.AttributesColumn}, timestamp, value}},
+				{name: "opaque_timestamp", columns: []chplan.Column{attributes, {Name: s.TimestampColumn}, value}},
+				{name: "opaque_value", columns: []chplan.Column{attributes, timestamp, {Name: s.ValueColumn}}},
+				{name: "histogram_payload_retains_legacy_boundary", columns: append([]chplan.Column{attributes, anchor, timestamp, value}, chplan.HistogramPayloadColumns()...)},
+				{name: "histogram_helper_retains_legacy_boundary", columns: []chplan.Column{attributes, timestamp, value, {Name: chplan.HistogramCountColumn, Role: chplan.RoleHistogramField}}},
+				{name: "discriminator_retains_legacy_boundary", columns: []chplan.Column{attributes, timestamp, value, {Name: "sample_kind", Role: chplan.RoleDiscriminator}}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					scan := &chplan.Scan{Roles: slices.Clone(tc.columns)}
+					inner := &chplan.Project{Input: scan}
+					if !tc.open {
+						for _, column := range tc.columns {
+							scan.Columns = append(scan.Columns, column.Name)
+							inner.Projections = append(inner.Projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}})
+						}
+					}
+					if got := chplan.RowShapeOf(inner); got != chplan.SampleRowShape {
+						t.Fatalf("fixture legacy shape = %v, want Sample", got)
+					}
+					newAttrs := &chplan.MapWithoutKeys{Map: &chplan.ColumnRef{Name: s.AttributesColumn}, Keys: []string{"remove_me"}}
+					project := projectAttributesOverInner(inner, s, newAttrs)
+					if project.Input != inner {
+						t.Fatal("rewrite changed its input")
+					}
+					var names []string
+					for _, projection := range project.Projections {
+						names = append(names, chplan.ProjectionOutputName(projection))
+					}
+					if !slices.Equal(names, canonical) {
+						t.Fatalf("forwarded columns = %v, want %v", names, canonical)
+					}
+					if project.Projections[1].Alias != s.AttributesColumn || project.Projections[1].Expr != newAttrs {
+						t.Fatal("rewrite did not preserve the requested attributes expression and alias")
+					}
+					nameProjection := project.Projections[0]
+					if tc.emptyName {
+						literal, ok := nameProjection.Expr.(*chplan.LitString)
+						if !ok || literal.V != "" || nameProjection.Alias != s.MetricNameColumn {
+							t.Fatalf("name projection = %#v, want empty string AS %s", nameProjection, s.MetricNameColumn)
+						}
+					} else {
+						column, ok := nameProjection.Expr.(*chplan.ColumnRef)
+						if !ok || column.Name != s.MetricNameColumn || nameProjection.Alias != "" {
+							t.Fatalf("name projection = %#v, want unchanged %s reference", nameProjection, s.MetricNameColumn)
+						}
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix label_replace/label_join over name-dropping value wrappers and pinned range broadcasts. A legacy Sample-classified input can publish attributes, a real timestamp, and value without publishing its metric-name column. When its closed physical schema proves that float-only contract, materialize the existing empty-name convention in the canonical quartet instead of referencing a missing column.

Keep the established canonical temporal layout: simply dropping the name and forwarding anchor/time changes the collision aggregate to a derived output, which synthesizes the wrong timestamp for pinned broadcasts. The canonical layout preserves the actual request grid and the duplicate-labelset guard.

The repair does not change open/unknown schemas, name-preserving inputs, timestampless outputs, histogram helpers/payloads, or discriminator-bearing outputs. Excluding any histogram helper here is a conservative boundary for this specific float repair, not a definition of a complete histogram payload. General role-driven forwarding remains part of #3277.

Closes #3289. Its independent error-classification repair already merged in #3291.

## Verification

- New full-handler chDB regressions: all 24 cases pass with race detection. Two schemas cover label_replace/label_join, pinned rate, single/nested abs, nested label chains, offset rate, and name-preserving last_over_time controls. Assertions compare complete label maps (including absence of __name__), all six exact timestamps, and numeric sample values.
- Before the repair, those cases produced 14 missing-name failures and 10 passing controls. The final implementation preserves the controls and repairs every failure.
- New structural regressions: all 34 cases pass with race detection, covering arbitrary attribute aliases and closed/open, named/unnamed, missing or opaque required roles, timestamp, histogram-payload/helper, and discriminator boundaries.
- Existing label-related TXTAR comparisons pass unchanged, including optimized SQL/args/settings and IR. No generated artifact changed.
- Existing native-histogram/mixed label and collision-guard unit regressions are included in the focused final check.

The custom-schema HTTP lane uses the supported non-default Map alias `labels`; arbitrary `labels_map` execution is not claimed. The independently reproduced chDB adapter limitation is tracked in #3292. Arbitrary aliases are covered structurally by the new unit tests.
