### PR TITLE
fix(promql): narrow mixed samples before computed clamp bounds

### DIFF
--- a/internal/promql/clamp_computed_mixed_chdb_test.go
+++ b/internal/promql/clamp_computed_mixed_chdb_test.go
@@ -1,0 +1,83 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"golang.org/x/tools/txtar"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+// The shared seed contains a colliding histogram/float labelset (dup) and an
+// unshadowed float (solo). Hist-first or must shadow the real dup float before
+// clamp drops the histogram; reading its placeholder Value would invent dup=0.
+func TestComputedClampOverNestedMixed_Parity_ChDB(t *testing.T) {
+	const (
+		fixturePermissions = 0o600
+		onlySolo           = `[["",{"series":"solo"},"2026-01-01T00:00:00Z",7]]`
+		bothFloats         = `[["",{"series":"dup"},"2026-01-01T00:00:00Z",10],["",{"series":"solo"},"2026-01-01T00:00:00Z",7]]`
+	)
+	for _, tc := range []struct {
+		name      string
+		histFirst bool
+		inverted  bool
+		wantRows  string
+	}{
+		{"hist_first_normal", true, false, onlySolo},
+		{"float_first_normal", false, false, bothFloats},
+		{"hist_first_inverted", true, true, "[]"},
+		{"float_first_inverted", false, true, "[]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			left, right := tkShadowFloatMetric, tkShadowHistMetric
+			if tc.histFirst {
+				left, right = right, left
+			}
+			bounds := "scalar(vector(0)), scalar(vector(10))"
+			if tc.inverted {
+				bounds = "scalar(vector(2)), scalar(vector(1))"
+			}
+			query := fmt.Sprintf(`clamp(sort_by_label(%s or %s, "series"), %s)`, left, right, bounds)
+			archive := &txtar.Archive{Files: []txtar.File{
+				{Name: "query.promql", Data: []byte(query + "\n")},
+				{Name: "parity", Data: []byte("oracle: prometheus\nendpoint: /api/v1/query\nscope: full\n")},
+				{Name: "seed", Data: []byte(tkShadowSeed)},
+				{Name: "expected_rows", Data: []byte(tc.wantRows + "\n")},
+			}}
+			path := filepath.Join(t.TempDir(), "computed_clamp.txtar")
+			if err := os.WriteFile(path, txtar.Format(archive), fixturePermissions); err != nil {
+				t.Fatal(err)
+			}
+			fixture, err := spec.Load(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, schema.DefaultOTelMetrics(), foEvalTS, foEvalTS)
+			if err != nil {
+				t.Fatal(err)
+			}
+			optimized := spec.AssertScanTimeBoundAccepts(t, plan)
+			sqlText, args, err := chsql.Emit(context.Background(), optimized)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rows := spec.RunRoundTripSQL(t, fixture, sqlText, args)
+			spec.RunParity(t, fixture, spec.ParityEval{Start: foEvalTS, End: foEvalTS}, rows)
+		})
+	}
+}

--- a/internal/promql/clamp_computed_mixed_test.go
+++ b/internal/promql/clamp_computed_mixed_test.go
@@ -1,0 +1,126 @@
+package promql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestComputedClampNarrowsMixedBeforeBoundFilter(t *testing.T) {
+	t.Parallel()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, sortFn := range []string{"sort_by_label", "sort_by_label_desc"} {
+		for _, union := range []string{"latency_exp_hist or num_cpus", "num_cpus or latency_exp_hist"} {
+			for _, bounds := range []string{"scalar(vector(0)), scalar(vector(10))", "scalar(vector(2)), scalar(vector(1))"} {
+				query := fmt.Sprintf(`clamp(%s(%s, "job"), %s)`, sortFn, union, bounds)
+				t.Run(query, func(t *testing.T) {
+					expr, err := p.ParseExpr(query)
+					if err != nil {
+						t.Fatal(err)
+					}
+					plan, err := LowerAt(context.Background(), expr, s, at, at)
+					if err != nil {
+						t.Fatal(err)
+					}
+					bound := computedClampBoundFilter(t, plan)
+					if !chplan.IsMixedFloatNarrowing(bound.Input) {
+						t.Fatalf("bound Filter input %T must first narrow mixed rows to floats", bound.Input)
+					}
+					narrow := bound.Input.(*chplan.Filter)
+					if chplan.RowShapeOf(narrow.Input) != chplan.MixedRowShape {
+						t.Fatalf("narrowing input shape = %v, want mixed", chplan.RowShapeOf(narrow.Input))
+					}
+					if chplan.RowShapeOf(plan) != chplan.SampleRowShape {
+						t.Fatalf("clamp result shape = %v, want sample", chplan.RowShapeOf(plan))
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestComputedClampRangeNarrowsBeforeBoundFilter(t *testing.T) {
+	t.Parallel()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	expr, err := p.ParseExpr(`clamp(sort_by_label_desc(latency_exp_hist or num_cpus, "job"), scalar(vector(0)), scalar(vector(10)))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	end := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	const queryStep = 15 * time.Second
+	plan, err := LowerAtRange(context.Background(), expr, schema.DefaultOTelMetrics(), end.Add(-time.Minute), end, queryStep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound := computedClampBoundFilter(t, plan)
+	if !chplan.IsMixedFloatNarrowing(bound.Input) {
+		t.Fatalf("range bound Filter input %T must first narrow mixed rows to floats", bound.Input)
+	}
+}
+
+func TestComputedClampKeepsOrdinaryFloatInput(t *testing.T) {
+	t.Parallel()
+	p := parser.NewParser(parser.Options{})
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, bounds := range []string{"scalar(vector(0)), scalar(vector(10))", "scalar(vector(2)), scalar(vector(1))"} {
+		t.Run(bounds, func(t *testing.T) {
+			expr, err := p.ParseExpr(`clamp(up, ` + bounds + `)`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := LowerAt(context.Background(), expr, s, at, at)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bound := computedClampBoundFilter(t, plan)
+			ordinaryExpr, err := p.ParseExpr("up")
+			if err != nil {
+				t.Fatal(err)
+			}
+			ordinary, err := LowerAt(context.Background(), ordinaryExpr, s, at, at)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bound.Input.Equal(ordinary) {
+				t.Fatalf("ordinary float input was changed before bound Filter: %T", bound.Input)
+			}
+		})
+	}
+}
+
+func computedClampBoundFilter(t *testing.T, plan chplan.Node) *chplan.Filter {
+	t.Helper()
+	var found *chplan.Filter
+	chplan.Walk(plan, func(node chplan.Node) bool {
+		filter, ok := node.(*chplan.Filter)
+		if !ok {
+			return true
+		}
+		predicate, ok := filter.Predicate.(*chplan.FuncCall)
+		if !ok || predicate.Fn != chplan.FnNot || len(predicate.Args) != 1 {
+			return true
+		}
+		comparison, ok := predicate.Args[0].(*chplan.Binary)
+		if !ok || comparison.Op != chplan.OpLt {
+			return true
+		}
+		if found != nil {
+			t.Fatal("multiple computed clamp bound filters")
+		}
+		found = filter
+		return true
+	})
+	if found == nil {
+		t.Fatal("computed clamp bound Filter not found")
+	}
+	return found
+}

--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -303,6 +303,10 @@ func lowerClamp(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, er
 		if err != nil {
 			return nil, err
 		}
+		// Narrow while the operand still carries its Mixed shape. The bound
+		// Filter below has a legacy Sample shape and would otherwise hide
+		// histogram rows from guardedValueProjection's float-only check.
+		inner = mixedRowsFloatOnly(inner)
 		// Runtime mirror of the literal path's maxB < minB fold: keep
 		// rows only while NOT (max < min). NaN bounds compare false —
 		// rows survive and the NaN guard below turns the values NaN,


### PR DESCRIPTION
## Summary

Closes #3299.

Narrow a generic computed three-argument clamp's mixed operand to float rows before constructing its runtime bound filter. That filter has a legacy Sample row shape, which previously concealed histogram rows from the later float-only check. Argument evaluation order and the existing bound filter/projection are unchanged; ordinary float operands pass through unchanged.

The reproduced histogram-first union returned a spurious `dup=0` alongside `solo=7`, while the independent Prometheus engine returned only `solo=7`. The repaired query returns only `solo=7`; float-first order still returns `dup=10` and `solo=7`, and both inverted-bound cases return no rows. It also prevents the role-forwarder assertion failure reproduced in #3299; that refactor is not part of this change.

## Verification

- Before the fix, all eight mixed structural cases failed the missing-narrowing assertion; both ordinary-float controls passed.
- After the fix, both sort directions, both union orders, normal/inverted computed bounds, ordinary-float identity controls, and a nonzero-step range context pass focused canonical `test-unit` with race detection.
- The permanent four-case chDB test asserts complete rows and compares them with the live independent Prometheus oracle. The same four cases were independently verified against the immutable repair checkpoint.
- No checked-in TXTAR or other generated artifacts changed. No family migration or row-shape reinterpretation is included.
