### PR TITLE
fix(promql): narrow mixed rows before scalar comparison filters

### DIFF
--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -419,6 +419,7 @@ func foldSyntheticVectorBinary(
 	opExpr := &chplan.Binary{Op: op, Left: lhs, Right: rhs}
 
 	if isComparison(op) && !returnBool {
+		vec = mixedRowsFloatOnly(vec)
 		return &chplan.Filter{Input: vec, Predicate: opExpr}
 	}
 
@@ -844,6 +845,7 @@ func lowerVectorScalar(vec parser.Expr, s schema.Metrics, op chplan.BinaryOp, sc
 
 	if isComparison(op) && !returnBool {
 		// `up > 0.5` — keep all columns, filter on the comparison.
+		inner = mixedRowsFloatOnly(inner)
 		return &chplan.Filter{Input: inner, Predicate: opExpr}, nil
 	}
 

--- a/internal/promql/binary_nested_mixed_chdb_test.go
+++ b/internal/promql/binary_nested_mixed_chdb_test.go
@@ -1,0 +1,87 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"golang.org/x/tools/txtar"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+// Hist-first union shadows dup=42 before comparison removes the histogram.
+// Non-bool comparisons retain the vector's name/value, even with a scalar LHS.
+func TestNestedMixedComparisonParity_ChDB(t *testing.T) {
+	const (
+		fixturePermissions = 0o600
+		solo               = `["tk_shadow_float_side_gauge",{"series":"solo"},"2026-01-01T00:00:00Z",7,0,0,0,0,0,0,[],0,[],0]`
+		dup                = `["tk_shadow_float_side_gauge",{"series":"dup"},"2026-01-01T00:00:00Z",42,0,0,0,0,0,0,[],0,[],0]`
+		boolSolo           = `["",{"series":"solo"},"2026-01-01T00:00:00Z",0]`
+		boolDup            = `["",{"series":"dup"},"2026-01-01T00:00:00Z",0]`
+	)
+	for _, histFirst := range []bool{true, false} {
+		left, right := tkShadowFloatMetric, tkShadowHistMetric
+		if histFirst {
+			left, right = right, left
+		}
+		vector := fmt.Sprintf(`sort_by_label(%s or %s, "series")`, left, right)
+		nonempty, boolRows := "["+solo+"]", "["+boolSolo+"]"
+		if !histFirst {
+			nonempty, boolRows = "["+dup+","+solo+"]", "["+boolDup+","+boolSolo+"]"
+		}
+		for _, tc := range []struct{ name, query, want string }{
+			{"literal_right_empty", vector + " == 0", "[]"},
+			{"literal_left_empty", "0 == " + vector, "[]"},
+			{"computed_right_empty", vector + " == scalar(vector(0))", "[]"},
+			{"computed_left_empty", "scalar(vector(0)) == " + vector, "[]"},
+			{"literal_right_values", vector + " < 50", nonempty},
+			{"literal_left_values", "50 > " + vector, nonempty},
+			{"computed_right_values", vector + " < scalar(vector(50))", nonempty},
+			{"computed_left_values", "scalar(vector(50)) > " + vector, nonempty},
+			{"literal_bool", vector + " == bool 0", boolRows},
+			{"computed_bool", "scalar(vector(0)) == bool " + vector, boolRows},
+		} {
+			t.Run(fmt.Sprintf("hist_first_%t/%s", histFirst, tc.name), func(t *testing.T) {
+				archive := &txtar.Archive{Files: []txtar.File{
+					{Name: "query.promql", Data: []byte(tc.query + "\n")},
+					{Name: "parity", Data: []byte("oracle: prometheus\nendpoint: /api/v1/query\nscope: full\n")},
+					{Name: "seed", Data: []byte(tkShadowSeed)},
+					{Name: "expected_rows", Data: []byte(tc.want + "\n")},
+				}}
+				path := filepath.Join(t.TempDir(), "nested_comparison.txtar")
+				if err := os.WriteFile(path, txtar.Format(archive), fixturePermissions); err != nil {
+					t.Fatal(err)
+				}
+				fixture, err := spec.Load(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+				expr, err := p.ParseExpr(tc.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+				plan, err := promql.LowerAt(context.Background(), expr, schema.DefaultOTelMetrics(), foEvalTS, foEvalTS)
+				if err != nil {
+					t.Fatal(err)
+				}
+				optimized := spec.AssertScanTimeBoundAccepts(t, plan)
+				sqlText, args, err := chsql.Emit(context.Background(), optimized)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rows := spec.RunRoundTripSQL(t, fixture, sqlText, args)
+				spec.RunParity(t, fixture, spec.ParityEval{Start: foEvalTS, End: foEvalTS}, rows)
+			})
+		}
+	}
+}

--- a/internal/promql/binary_nested_mixed_test.go
+++ b/internal/promql/binary_nested_mixed_test.go
@@ -1,0 +1,92 @@
+package promql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestNestedMixedComparisonNarrowsAfterOperand(t *testing.T) {
+	t.Parallel()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, rangeQuery := range []bool{false, true} {
+		for _, sortFn := range []string{"sort_by_label", "sort_by_label_desc"} {
+			for _, operand := range []string{"latency_exp_hist or num_cpus", "num_cpus or latency_exp_hist", "num_cpus"} {
+				for _, scalar := range []string{"0", "scalar(vector(0))"} {
+					for _, scalarLeft := range []bool{false, true} {
+						vector := fmt.Sprintf("%s(%s, \"job\")", sortFn, operand)
+						query := vector + " < " + scalar
+						if scalarLeft {
+							query = scalar + " < " + vector
+						}
+						t.Run(fmt.Sprintf("range_%t/%s", rangeQuery, query), func(t *testing.T) {
+							lower := func(query string) chplan.Node {
+								t.Helper()
+								expr, err := p.ParseExpr(query)
+								if err != nil {
+									t.Fatal(err)
+								}
+								var plan chplan.Node
+								if rangeQuery {
+									const step = 15 * time.Second
+									plan, err = LowerAtRange(context.Background(), expr, s, at.Add(-time.Minute), at, step)
+								} else {
+									plan, err = LowerAt(context.Background(), expr, s, at, at)
+								}
+								if err != nil {
+									t.Fatal(err)
+								}
+								return plan
+							}
+							original := lower(vector)
+							plan := lower(query)
+							comparison, ok := plan.(*chplan.Filter)
+							if !ok {
+								t.Fatalf("comparison is %T, want Filter", plan)
+							}
+							predicate, ok := comparison.Predicate.(*chplan.Binary)
+							if !ok || predicate.Op != chplan.OpLt {
+								t.Fatalf("comparison predicate = %#v", comparison.Predicate)
+							}
+							value := predicate.Left
+							if scalarLeft {
+								value = predicate.Right
+							}
+							column, ok := value.(*chplan.ColumnRef)
+							if !ok || column.Name != s.ValueColumn {
+								t.Fatalf("vector value/order changed: %#v", predicate)
+							}
+							if operand == "num_cpus" {
+								if !comparison.Input.Equal(original) {
+									t.Fatal("ordinary float operand changed")
+								}
+								return
+							}
+							if !chplan.IsMixedFloatNarrowing(comparison.Input) {
+								t.Fatalf("comparison input %T does not strictly narrow floats", comparison.Input)
+							}
+							narrow := comparison.Input.(*chplan.Filter)
+							if chplan.RowShapeOf(narrow.Input) != chplan.MixedRowShape {
+								t.Fatal("narrowing must consume mixed operand")
+							}
+							if !narrow.Input.Equal(original) {
+								t.Fatal("mixed operand changed before narrowing: union shadowing/order must be preserved")
+							}
+							if chplan.RowShapeOf(plan) != chplan.SampleRowShape {
+								t.Fatal("comparison result must contain only floats")
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/promql/binary_scalar_left_mixed_chdb_test.go
+++ b/internal/promql/binary_scalar_left_mixed_chdb_test.go
@@ -1,0 +1,154 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+)
+
+func TestMixedScalarLeftComparisonBaseline_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, foSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	type sample struct {
+		Name  string
+		Value float64
+	}
+	cases := []struct {
+		name string
+		op   string
+		want map[string]sample
+	}{
+		{"less_filter", "<", map[string]sample{"f2": {foFloatMetric, 9}}},
+		{"greater_filter", ">", map[string]sample{"f1": {foFloatMetric, 3}, "f3": {foFloatMetric, 1}}},
+		{"less_bool", "< bool", map[string]sample{"f1": {"", 0}, "f2": {"", 1}, "f3": {"", 0}}},
+		{"greater_bool", "> bool", map[string]sample{"f1": {"", 1}, "f2": {"", 0}, "f3": {"", 1}}},
+	}
+	for _, orientation := range []struct{ name, expr string }{
+		{"hist_first", foHistMetric + " or " + foFloatMetric},
+		{"float_first", foFloatMetric + " or " + foHistMetric},
+	} {
+		for _, tc := range cases {
+			t.Run(orientation.name+"/"+tc.name, func(t *testing.T) {
+				query := "5 " + tc.op + " (" + orientation.expr + ")"
+				expr, err := p.ParseExpr(query)
+				if err != nil {
+					t.Fatal(err)
+				}
+				plan, err := promql.LowerAt(context.Background(), expr, s, foEvalTS, foEvalTS)
+				if err != nil {
+					t.Fatalf("LowerAt(%s): %v", query, err)
+				}
+				sqlText, args, err := chsql.Emit(context.Background(), plan)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rows := fixture.queryOverEmitted(t, "`Attributes`['series'], `MetricName`, `Value`", sqlText, args)
+				defer func() { _ = rows.Close() }()
+				got := map[string]sample{}
+				for rows.Next() {
+					var series string
+					var value sample
+					if err := rows.Scan(&series, &value.Name, &value.Value); err != nil {
+						t.Fatal(err)
+					}
+					if _, exists := got[series]; exists {
+						t.Fatalf("duplicate series %q", series)
+					}
+					got[series] = value
+				}
+				if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("query %s: got %#v; want %#v", query, got, tc.want)
+				}
+			})
+		}
+	}
+}
+
+func TestMixedScalarLeftComparisonShadowBaseline_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, tkShadowSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	type sample struct {
+		Name  string
+		Value float64
+	}
+	cases := []struct {
+		name, op, expr string
+		want           map[string]sample
+	}{
+		{
+			"hist_first_filter", "<", tkShadowHistMetric + " or " + tkShadowFloatMetric,
+			map[string]sample{"solo": {tkShadowFloatMetric, 7}},
+		},
+		{
+			"float_first_filter", "<", tkShadowFloatMetric + " or " + tkShadowHistMetric,
+			map[string]sample{"solo": {tkShadowFloatMetric, 7}, "dup": {tkShadowFloatMetric, 42}},
+		},
+		{
+			"hist_first_bool", "< bool", tkShadowHistMetric + " or " + tkShadowFloatMetric,
+			map[string]sample{"solo": {"", 1}},
+		},
+		{
+			"float_first_bool", "< bool", tkShadowFloatMetric + " or " + tkShadowHistMetric,
+			map[string]sample{"solo": {"", 1}, "dup": {"", 1}},
+		},
+		{
+			"hist_first_false_bool", "> bool", tkShadowHistMetric + " or " + tkShadowFloatMetric,
+			map[string]sample{"solo": {"", 0}},
+		},
+		{
+			"float_first_false_bool", "> bool", tkShadowFloatMetric + " or " + tkShadowHistMetric,
+			map[string]sample{"solo": {"", 0}, "dup": {"", 0}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			query := "5 " + tc.op + " (" + tc.expr + ")"
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, foEvalTS, foEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%s): %v", query, err)
+			}
+			sqlText, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rows := fixture.queryOverEmitted(t, "`Attributes`['series'], `MetricName`, `Value`", sqlText, args)
+			defer func() { _ = rows.Close() }()
+			got := map[string]sample{}
+			for rows.Next() {
+				var series string
+				var value sample
+				if err := rows.Scan(&series, &value.Name, &value.Value); err != nil {
+					t.Fatal(err)
+				}
+				if _, exists := got[series]; exists {
+					t.Fatalf("duplicate series %q", series)
+				}
+				got[series] = value
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("query %s: got %#v; want %#v", query, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3301. Related to #3277.

Nested mixed histogram/float operands could reach the generic non-bool scalar comparison filters with the histogram's placeholder `Value` still present. A comparison against zero could retain that histogram even though Prometheus removes histogram/scalar comparisons.

Apply `mixedRowsFloatOnly` immediately before the comparison filter in the literal-scalar and folded-synthetic-scalar paths. Narrow the already-lowered operand, after union shadowing, without changing the comparison's operand order or the surviving vector's name and value. Ordinary float inputs remain unchanged; arithmetic and `bool` paths are untouched.

## Evidence and verification

The original histogram-first nested `== 0` failure was reproduced on main `b4ea3f1dc64139b5384487c2877d8df800c49177`: optimized chDB returned a histogram row while an independent live Prometheus returned no rows. Computed-scalar and scalar-left variants reproduced the same mismatch; reversed-union and `bool` controls passed before the repair.

- 48 structural cases pass with the race detector: instant and range queries, both sort directions, both union orientations, literal and computed scalars, both scalar sides, and ordinary float controls. They assert exact original-operand preservation beneath strict narrowing and the comparison's operand order.
- 20 optimized chDB/live Prometheus parity cases pass: eight empty-result regressions, eight nonempty name/value/shadowing controls, and four `bool` controls.
- 14 direct-mixed scalar-left baseline controls pass, covering filter and `bool` results, operand orientation, names, values, and duplicate absence.

Focused commands:

```sh
go test -race -timeout 15m ./internal/promql -run '^TestNestedMixedComparisonNarrowsAfterOperand$' -count=1
GODEBUG=asyncpreemptoff=1 go test -race -tags chdb -timeout 15m ./internal/promql -run '^Test(NestedMixedComparisonParity|MixedScalarLeftComparisonBaseline|MixedScalarLeftComparisonShadowBaseline)_ChDB$' -count=1 -v
```

The production change is two lines. No generated artifacts or mixed-wrapper policy changes are included.
