### PR TITLE
fix(promql): narrow nested mixed sorts and preserve float proofs

### DIFF
--- a/internal/promql/sample_forward.go
+++ b/internal/promql/sample_forward.go
@@ -221,17 +221,21 @@ func sampleForwardColumn(ref *chplan.ColumnRef, output string, materialize bool)
 	return projection
 }
 
-// Additional filters preserve an already-proven float-only subset. They cannot
-// turn an OR predicate into a proof or reintroduce removed histogram rows.
+// Additional filters and ordering preserve an already-proven float-only subset.
+// Neither can introduce histogram rows or change their payload. Other nodes
+// remain proof barriers; an OR predicate is never itself a narrowing proof.
 func mixedFloatRowsProven(inner chplan.Node) bool {
 	for {
 		if chplan.IsMixedFloatNarrowing(inner) {
 			return true
 		}
-		filter, ok := inner.(*chplan.Filter)
-		if !ok {
+		switch node := inner.(type) {
+		case *chplan.Filter:
+			inner = node.Input
+		case *chplan.OrderBy:
+			inner = node.Input
+		default:
 			return false
 		}
-		inner = filter.Input
 	}
 }

--- a/internal/promql/sample_forward_test.go
+++ b/internal/promql/sample_forward_test.go
@@ -164,6 +164,7 @@ func TestSampleForwardFloatNarrowingIsConservative(t *testing.T) {
 	input := sampleForwardTestInput(columns...)
 	equal := &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "kind"}, Right: &chplan.LitInt{V: 0}}
 	narrowed := &chplan.Filter{Input: input, Predicate: equal}
+	ordered := &chplan.OrderBy{Input: narrowed}
 	for _, tc := range []struct {
 		name string
 		node chplan.Node
@@ -171,6 +172,13 @@ func TestSampleForwardFloatNarrowingIsConservative(t *testing.T) {
 	}{
 		{name: "unfiltered", node: input},
 		{name: "equal", node: narrowed, okay: true},
+		{name: "ordered_float_subset", node: ordered, okay: true},
+		{name: "filter_over_order", node: &chplan.Filter{Input: ordered, Predicate: &chplan.LitBool{V: true}}, okay: true},
+		{name: "order_filter_order", node: &chplan.OrderBy{Input: &chplan.Filter{Input: ordered, Predicate: &chplan.LitBool{V: true}}}, okay: true},
+		{name: "ordered_unrestricted_mixed", node: &chplan.OrderBy{Input: input}},
+		{name: "ordered_or_is_not_proof", node: &chplan.OrderBy{Input: &chplan.Filter{Input: input, Predicate: &chplan.Binary{Op: chplan.OpOr, Left: equal, Right: &chplan.LitBool{V: true}}}}},
+		{name: "ordered_project_barrier", node: &chplan.OrderBy{Input: &chplan.Project{Input: narrowed}}},
+		{name: "ordered_qualified_is_not_proof", node: &chplan.OrderBy{Input: &chplan.Filter{Input: input, Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "kind", Qualifier: "other"}, Right: &chplan.LitInt{V: 0}}}}},
 		{name: "extra_filter", node: &chplan.Filter{Input: narrowed, Predicate: &chplan.LitBool{V: true}}, okay: true},
 		{name: "and", node: &chplan.Filter{Input: input, Predicate: &chplan.Binary{Op: chplan.OpAnd, Left: equal, Right: &chplan.LitBool{V: true}}}, okay: true},
 		{name: "or", node: &chplan.Filter{Input: input, Predicate: &chplan.Binary{Op: chplan.OpOr, Left: equal, Right: &chplan.LitBool{V: true}}}},
@@ -181,6 +189,9 @@ func TestSampleForwardFloatNarrowingIsConservative(t *testing.T) {
 		}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			if got := mixedFloatRowsProven(tc.node); got != tc.okay {
+				t.Fatalf("float subset proof=%v, want %v", got, tc.okay)
+			}
 			call := func() {
 				plan := projectSampleRoles(tc.node, s,
 					sampleProjectionPolicy{name: dropSampleName, payload: floatSamplePayload},

--- a/internal/promql/sort.go
+++ b/internal/promql/sort.go
@@ -93,6 +93,9 @@ func lowerSort(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, err
 	if err := requireMixedPlanPolicy(inner, mixedSortFamily); err != nil {
 		return nil, err
 	}
+	// A preserving wrapper can hide a mixed union from the direct recognizer.
+	// Resolve the complete operand first, then drop histograms before sorting.
+	inner = mixedRowsFloatOnly(inner)
 	return &chplan.OrderBy{
 		Input: inner,
 		Keys: []chplan.OrderKey{

--- a/internal/promql/sort_mixed_chdb_test.go
+++ b/internal/promql/sort_mixed_chdb_test.go
@@ -62,6 +62,35 @@ func TestSortNestedMixedFloatOnly_ChDB(t *testing.T) {
 				t.Run(fmt.Sprintf("%s/%v/%s", fn, histFirst, wrapper), func(t *testing.T) {
 					checkSortFloatTuples(t, query, direct, seed, want, 0)
 				})
+				if wrapper == "" {
+					continue
+				}
+				for _, outer := range []struct {
+					name, format string
+					keepMetric   bool
+				}{
+					{"abs", "abs(%s)", false},
+					{"round", "round(%s)", false},
+					{"clamp_min", "clamp_min(%s, 0)", false},
+					{"label_replace", `label_replace(%s, "series", "$1", "series", "(.*)")`, true},
+				} {
+					t.Run(fmt.Sprintf("%s/%v/%s/outer_%s", fn, histFirst, wrapper, outer.name), func(t *testing.T) {
+						outerWant := slices.Clone(want)
+						if !outer.keepMetric {
+							for i := range outerWant {
+								outerWant[i].metric = ""
+							}
+						}
+						outerQuery := fmt.Sprintf(outer.format, query)
+						outerDirect := fmt.Sprintf(outer.format, direct)
+						// Label projection already reorders a directly sorted input.
+						// Pin its payload/membership here, and final sort order below.
+						checkSortFloatTuplesWithOrder(t, outerQuery, outerDirect, seed, outerWant, 0, !outer.keepMetric)
+						if outer.keepMetric {
+							checkSortFloatTuples(t, fn+"("+outerQuery+")", fn+"("+outerDirect+")", seed, want, 0)
+						}
+					})
+				}
 			}
 		}
 		for index, control := range []struct {
@@ -95,6 +124,11 @@ func TestSortNestedMixedFloatOnly_ChDB(t *testing.T) {
 }
 
 func checkSortFloatTuples(t *testing.T, query, direct, seed string, want []sortFloatTuple, step time.Duration) {
+	t.Helper()
+	checkSortFloatTuplesWithOrder(t, query, direct, seed, want, step, true)
+}
+
+func checkSortFloatTuplesWithOrder(t *testing.T, query, direct, seed string, want []sortFloatTuple, step time.Duration, ordered bool) {
 	t.Helper()
 	const permissions = 0o600
 	expected := make([][]any, 0, len(want))
@@ -133,6 +167,9 @@ func checkSortFloatTuples(t *testing.T, query, direct, seed string, want []sortF
 		if err != nil {
 			t.Fatal(err)
 		}
+		if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+			t.Fatalf("raw emission for %s: %v", query, err)
+		}
 		optimized := spec.AssertScanTimeBoundAccepts(t, plan)
 		sql, args, err := chsql.Emit(context.Background(), optimized)
 		if err != nil {
@@ -164,8 +201,10 @@ func checkSortFloatTuples(t *testing.T, query, direct, seed string, want []sortF
 	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
 		t.Fatal(err)
 	}
-	if step > 0 {
-		// query_range compares series membership per step, not vector order.
+	if step > 0 || !ordered {
+		// Range queries and outer label projections compare membership; every
+		// root-sort instant query retains the exact ordered tuple assertion.
+		want = slices.Clone(want)
 		compare := func(a, b sortFloatTuple) int {
 			return cmp.Or(cmp.Compare(a.timestamp, b.timestamp), cmp.Compare(a.metric, b.metric), cmp.Compare(a.series, b.series))
 		}

--- a/internal/promql/sort_mixed_chdb_test.go
+++ b/internal/promql/sort_mixed_chdb_test.go
@@ -1,0 +1,178 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"golang.org/x/tools/txtar"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+type sortFloatTuple struct {
+	metric, series string
+	timestamp      int64
+	value          float64
+}
+
+func TestSortNestedMixedFloatOnly_ChDB(t *testing.T) {
+	// A histogram-only row keeps float-first union from hiding the bug by
+	// shadowing its sole histogram. The duplicate still proves shadow-then-drop.
+	seed := strings.Replace(tkShadowSeed, "[6], 0, []);", "[6], 0, []), ('"+tkShadowHistMetric+"', map('series', 'hist_only'), toDateTime64('2026-01-01 00:00:00', 9), 2, 4.0, 0, 0, 0, [6], 0, []);", 1)
+	if seed == tkShadowSeed {
+		t.Fatal("histogram-only seed insertion did not match")
+	}
+	sampleTime := foEvalTS.Add(-time.Second).UnixNano()
+	solo := sortFloatTuple{tkShadowFloatMetric, "solo", sampleTime, 7}
+	duplicate := sortFloatTuple{tkShadowFloatMetric, "dup", sampleTime, 42}
+	for _, fn := range []string{"sort", "sort_desc"} {
+		bothFloats := []sortFloatTuple{solo, duplicate}
+		if fn == "sort_desc" {
+			bothFloats = []sortFloatTuple{duplicate, solo}
+		}
+		for _, histFirst := range []bool{false, true} {
+			operand := tkShadowFloatMetric + " or " + tkShadowHistMetric
+			want := bothFloats
+			if histFirst {
+				operand = tkShadowHistMetric + " or " + tkShadowFloatMetric
+				want = []sortFloatTuple{solo}
+			}
+			direct := fn + "(" + operand + ")"
+			for _, wrapper := range []string{"", "sort_by_label", "sort_by_label_desc"} {
+				query := direct
+				if wrapper != "" {
+					query = fn + "(" + wrapper + "(" + operand + `, "series"))`
+				}
+				t.Run(fmt.Sprintf("%s/%v/%s", fn, histFirst, wrapper), func(t *testing.T) {
+					checkSortFloatTuples(t, query, direct, seed, want, 0)
+				})
+			}
+		}
+		for index, control := range []struct {
+			operand string
+			want    []sortFloatTuple
+		}{
+			{tkShadowFloatMetric, bothFloats},
+			{tkShadowFloatMetric + `{series="solo"}`, []sortFloatTuple{solo}},
+			{tkShadowHistMetric, nil},
+			{tkShadowHistMetric + " + 0", nil},
+		} {
+			t.Run(fmt.Sprintf("%s/control/%d", fn, index), func(t *testing.T) {
+				query := fn + "(" + control.operand + ")"
+				checkSortFloatTuples(t, query, query, seed, control.want, 0)
+			})
+		}
+	}
+	t.Run("range-membership", func(t *testing.T) {
+		const step = time.Minute
+		operand := tkShadowFloatMetric + " or " + tkShadowHistMetric
+		query := "sort_desc(sort_by_label(" + operand + `, "series"))`
+		direct := "sort_desc(" + operand + ")"
+		var want []sortFloatTuple
+		for _, at := range []time.Time{foEvalTS, foEvalTS.Add(step)} {
+			want = append(want,
+				sortFloatTuple{tkShadowFloatMetric, "dup", at.UnixNano(), 42},
+				sortFloatTuple{tkShadowFloatMetric, "solo", at.UnixNano(), 7})
+		}
+		checkSortFloatTuples(t, query, direct, seed, want, step)
+	})
+}
+
+func checkSortFloatTuples(t *testing.T, query, direct, seed string, want []sortFloatTuple, step time.Duration) {
+	t.Helper()
+	const permissions = 0o600
+	expected := make([][]any, 0, len(want))
+	for _, tuple := range want {
+		expected = append(expected, []any{tuple.metric, map[string]string{"series": tuple.series}, time.Unix(0, tuple.timestamp).UTC().Format(time.RFC3339), tuple.value})
+	}
+	expectedBytes, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint := "/api/v1/query"
+	if step > 0 {
+		endpoint = "/api/v1/query_range"
+	}
+	archive := &txtar.Archive{Files: []txtar.File{
+		{Name: "query.promql", Data: []byte(query + "\n")},
+		{Name: "parity", Data: []byte("oracle: prometheus\nendpoint: " + endpoint + "\nscope: full\n")},
+		{Name: "seed", Data: []byte(seed)},
+		{Name: "expected_rows", Data: expectedBytes},
+	}}
+	path := filepath.Join(t.TempDir(), "sort.txtar")
+	if err := os.WriteFile(path, txtar.Format(archive), permissions); err != nil {
+		t.Fatal(err)
+	}
+	fixture, err := spec.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	emit := func(query string) (string, []any) {
+		p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+		expr, err := p.ParseExpr(query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, err := promql.LowerAtRange(context.Background(), expr, schema.DefaultOTelMetrics(), foEvalTS, foEvalTS.Add(step), step)
+		if err != nil {
+			t.Fatal(err)
+		}
+		optimized := spec.AssertScanTimeBoundAccepts(t, plan)
+		sql, args, err := chsql.Emit(context.Background(), optimized)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return sql, args
+	}
+	// First establish the direct control and independently evaluate the actual
+	// query in Prometheus over seeded rows. Its comparison normalizes order.
+	directSQL, directArgs := emit(direct)
+	result := spec.RunRoundTripSQL(t, fixture, directSQL, directArgs)
+	spec.RunParity(t, fixture, spec.ParityEval{Start: foEvalTS, End: foEvalTS.Add(step), Step: step}, result)
+
+	// Then assert actual optimized SQL's ordered tuples, including exact row
+	// count, labels, metric name and source timestamp. A map would hide duplicate
+	// rows, and the canonical parity comparison alone cannot prove sort order.
+	sql, args := emit(query)
+	db := newChDBFixture(t, seed)
+	rows := db.queryOverEmitted(t, "`MetricName` AS metric, `Attributes`['series'] AS series, toUnixTimestamp64Nano(`TimeUnix`) AS timestamp, `Value` AS value", sql, args)
+	defer func() { _ = rows.Close() }()
+	var got []sortFloatTuple
+	for rows.Next() {
+		var tuple sortFloatTuple
+		if err := rows.Scan(&tuple.metric, &tuple.series, &tuple.timestamp, &tuple.value); err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, tuple)
+	}
+	if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+		t.Fatal(err)
+	}
+	if step > 0 {
+		// query_range compares series membership per step, not vector order.
+		compare := func(a, b sortFloatTuple) int {
+			return cmp.Or(cmp.Compare(a.timestamp, b.timestamp), cmp.Compare(a.metric, b.metric), cmp.Compare(a.series, b.series))
+		}
+		slices.SortFunc(got, compare)
+		slices.SortFunc(want, compare)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("query=%s\ngot=%v\nwant=%v", query, got, want)
+	}
+}

--- a/internal/promql/sort_mixed_test.go
+++ b/internal/promql/sort_mixed_test.go
@@ -1,0 +1,64 @@
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestSortNestedMixedNarrowsBeforeOrdering(t *testing.T) {
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+	standard := schema.DefaultOTelMetrics()
+	aliased := standard
+	aliased.MetricNameColumn = "metric_id"
+	aliased.AttributesColumn = "labels_map"
+	aliased.TimestampColumn = "sample_time"
+	aliased.ValueColumn = "sample_value"
+	for _, s := range []schema.Metrics{standard, aliased} {
+		for _, step := range []time.Duration{0, time.Minute} {
+			for _, fn := range []string{"sort", "sort_desc"} {
+				for _, nested := range []string{"sort_by_label", "sort_by_label_desc"} {
+					for _, operand := range []string{"latency_exp_hist or num_cpus", "num_cpus or latency_exp_hist"} {
+						query := fn + "(" + nested + "(" + operand + `, "series"))`
+						t.Run(fmt.Sprintf("%s/%s/%s", s.ValueColumn, step, query), func(t *testing.T) {
+							expr, err := p.ParseExpr(query)
+							if err != nil {
+								t.Fatal(err)
+							}
+							plan, err := promql.LowerAtRange(context.Background(), expr, s, at.Add(-step), at, step)
+							if err != nil {
+								t.Fatal(err)
+							}
+							order, ok := plan.(*chplan.OrderBy)
+							if !ok {
+								t.Fatalf("root=%T, want OrderBy", plan)
+							}
+							filter, ok := order.Input.(*chplan.Filter)
+							if !ok || !chplan.IsMixedFloatNarrowing(filter) {
+								t.Fatalf("sort input=%T, want strict float narrowing", order.Input)
+							}
+							if got := chplan.RowShapeOf(filter.Input); got != chplan.MixedRowShape {
+								t.Fatalf("filter input=%s, want the complete mixed operand", got)
+							}
+							if len(order.Keys) != 1 || order.Keys[0].Desc != (fn == "sort_desc") {
+								t.Fatalf("sort keys changed: %#v", order.Keys)
+							}
+							column, ok := order.Keys[0].Expr.(*chplan.ColumnRef)
+							if !ok || column.Name != s.ValueColumn {
+								t.Fatalf("sort value role=%#v, want %s", order.Keys[0].Expr, s.ValueColumn)
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/promql/sort_mixed_test.go
+++ b/internal/promql/sort_mixed_test.go
@@ -9,9 +9,41 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
 	"github.com/tsouza/cerberus/internal/promql"
 	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
 )
+
+func TestSortNestedMixedOuterProjection(t *testing.T) {
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, format := range []string{
+		`abs(%s)`,
+		`round(%s)`,
+		`clamp_min(%s, 0)`,
+		`label_replace(%s, "series", "$1", "series", "(.*)")`,
+	} {
+		query := fmt.Sprintf(format, `sort(sort_by_label(latency_exp_hist or num_cpus, "job"))`)
+		t.Run(query, func(t *testing.T) {
+			expr, err := p.ParseExpr(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, schema.DefaultOTelMetrics(), at, at)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := chsql.Emit(context.Background(), plan); err != nil {
+				t.Fatalf("raw emission: %v", err)
+			}
+			optimized := spec.AssertScanTimeBoundAccepts(t, plan)
+			if _, _, err := chsql.Emit(context.Background(), optimized); err != nil {
+				t.Fatalf("optimized emission: %v", err)
+			}
+		})
+	}
+}
 
 func TestSortNestedMixedNarrowsBeforeOrdering(t *testing.T) {
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})


### PR DESCRIPTION
## Summary

Closes #3309. Refs #3277.

Narrow the already-lowered mixed operand to float rows after the existing sort-family policy check and before OrderBy. This fixes nested value-sort over label-sort while preserving shadow resolution before histogram removal.

Carry an existing strict float-only proof through OrderBy, which preserves rows and columns, so safe outer math and label projections can consume the sorted result without a payload-policy panic. Traversal crosses only Filter and OrderBy: projects remain barriers; unrestricted mixed rows, OR predicates, and qualified discriminator predicates are negative controls.

Policy modes remain bespoke. This is a correctness prerequisite, not the subsequent FloatOnly policy migration. Direct union handling and histogram-only/drop early returns are unchanged.

## Reproduction and verification

On immutable d8f7929ab54d0ef896531276558c4dc9ba7eece2, eight combinations of sort direction, nested label-sort direction, and union order retained histogram rows. Direct-sort controls and independent Prometheus evaluation passed. The fixture has duplicate histogram/float labels, a histogram-only row, and two unequal float values.

The obsolete unpublished c05b3cb6 narrowing patch exposed a lowering panic for `abs(sort(sort_by_label(latency_exp_hist or num_cpus, "job")))`, which passed on d8: physical histogram columns survived ordering but the float proof stopped there. The corrected patch preserves that proof without admitting new payload shapes. The d8 and current-main fb0 sort implementations are identical.

Validation on the corrected change, based on main fb0d84143f72d5e86291bf0833ed91ce5e27d7a9:

- 32 structural narrowing cases across sort directions, union orders, instant/range modes, and default/aliased columns.
- Four persistent outer-wrapper raw and optimized emission regressions: abs, round, clamp_min, and label_replace.
- 61 optimized chDB/live-Prometheus cases, including 32 outer-wrapper cases and eight final-sort label-projection controls. Raw emission is checked too.
- Root-sort instant assertions retain exact tuple order/count, values, names, labels, and source timestamps. Range assertions compare per-step membership. Outer label projection compares payload/membership explicitly because the direct-sort baseline also reorders it; a final outer sort separately pins observable order.
- Focused race tests: passed (1.073s).
- New runtime cases plus existing sort regressions: passed (23.740s).
- Existing selected raw/optimized goldens and reference parity: passed (2.511s).
- Strict rejection/surface metadata checks and code citations: passed.
- No generated artifacts changed; diff whitespace check passed.

No scalar/arithmetic migration, row-shape classifier change, or matching/timestamp repair is included.
