### PR TITLE
refactor(promql): validate public payload before sample forwarding

### DIFF
--- a/internal/promql/sample_forward.go
+++ b/internal/promql/sample_forward.go
@@ -91,6 +91,28 @@ func projectSampleRoles(
 	row := inner.RowType()
 	completeHistogram := row.HasHistogramPayload()
 	discriminated := row.Has(chplan.RoleDiscriminator)
+	// Private histogram working columns can accompany a real float Value.
+	// Public histogram-role fields or a discriminator claim the wire contract:
+	// validate that contract before a float-row proof may discard its columns.
+	publicHistogram := false
+	for _, field := range chplan.HistogramPayloadColumns() {
+		for _, column := range row.Columns {
+			if column.Name == field.Name && column.Role == chplan.RoleHistogramField {
+				publicHistogram = true
+			}
+		}
+	}
+	if publicHistogram || discriminated {
+		if !completeHistogram {
+			panic("promql: sample forwarder received incomplete public histogram payload")
+		}
+		for _, field := range chplan.HistogramPayloadColumns() {
+			requireUniqueNamedColumn(row, field)
+		}
+		if discriminated {
+			requireSampleRole(row, chplan.RoleDiscriminator)
+		}
+	}
 	floatOnly := !completeHistogram && !discriminated || mixedFloatRowsProven(inner)
 	liveMixed := completeHistogram && discriminated && !floatOnly
 	if !floatOnly && (policy.payload != preserveMixedSamplePayload || !liveMixed) {

--- a/internal/promql/sample_forward.go
+++ b/internal/promql/sample_forward.go
@@ -89,30 +89,7 @@ func projectSampleRoles(
 		panic("promql: sample forwarder cannot combine canonical and direct-grid envelopes")
 	}
 	row := inner.RowType()
-	completeHistogram := row.HasHistogramPayload()
-	discriminated := row.Has(chplan.RoleDiscriminator)
-	// Private histogram working columns can accompany a real float Value.
-	// Public histogram-role fields or a discriminator claim the wire contract:
-	// validate that contract before a float-row proof may discard its columns.
-	publicHistogram := false
-	for _, field := range chplan.HistogramPayloadColumns() {
-		for _, column := range row.Columns {
-			if column.Name == field.Name && column.Role == chplan.RoleHistogramField {
-				publicHistogram = true
-			}
-		}
-	}
-	if publicHistogram || discriminated {
-		if !completeHistogram {
-			panic("promql: sample forwarder received incomplete public histogram payload")
-		}
-		for _, field := range chplan.HistogramPayloadColumns() {
-			requireUniqueNamedColumn(row, field)
-		}
-		if discriminated {
-			requireSampleRole(row, chplan.RoleDiscriminator)
-		}
-	}
+	completeHistogram, discriminated := validateSamplePayload(row)
 	floatOnly := !completeHistogram && !discriminated || mixedFloatRowsProven(inner)
 	liveMixed := completeHistogram && discriminated && !floatOnly
 	if !floatOnly && (policy.payload != preserveMixedSamplePayload || !liveMixed) {
@@ -164,6 +141,34 @@ func projectSampleRoles(
 		projections = append(projections, sampleForwardColumn(discriminator, mixedDiscriminatorColumn, false))
 	}
 	return &chplan.Project{Input: inner, Roles: metricRoles(s), Projections: projections}
+}
+
+// validateSamplePayload checks the wire contract before a float-row proof may
+// discard its columns. Private histogram working columns may accompany a real
+// float Value; public histogram-role fields or a discriminator claim the payload.
+func validateSamplePayload(row chplan.Schema) (bool, bool) {
+	completeHistogram := row.HasHistogramPayload()
+	discriminated := row.Has(chplan.RoleDiscriminator)
+	publicHistogram := false
+	for _, field := range chplan.HistogramPayloadColumns() {
+		for _, column := range row.Columns {
+			if column.Name == field.Name && column.Role == chplan.RoleHistogramField {
+				publicHistogram = true
+			}
+		}
+	}
+	if publicHistogram || discriminated {
+		if !completeHistogram {
+			panic("promql: sample forwarder received incomplete public histogram payload")
+		}
+		for _, field := range chplan.HistogramPayloadColumns() {
+			requireUniqueNamedColumn(row, field)
+		}
+		if discriminated {
+			requireSampleRole(row, chplan.RoleDiscriminator)
+		}
+	}
+	return completeHistogram, discriminated
 }
 
 func resolveSampleRoleRefs(row chplan.Schema, s schema.Metrics, policy sampleProjectionPolicy, layout sampleProjectionLayout) sampleRoleRefs {

--- a/internal/promql/sample_payload_validation_test.go
+++ b/internal/promql/sample_payload_validation_test.go
@@ -1,0 +1,110 @@
+package promql
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestSampleForwardHistogramNamesDoNotOverrideSampleRoles(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	for _, field := range chplan.HistogramPayloadColumns() {
+		for i, sample := range metricRoles(s) {
+			t.Run(fmt.Sprintf("%s/role_%d", field.Name, sample.Role), func(t *testing.T) {
+				columns := metricRoles(s)
+				columns[i].Name = field.Name
+				plan := projectSampleRoles(sampleForwardTestInput(columns...), s,
+					sampleProjectionPolicy{name: preserveSampleName, payload: floatSamplePayload},
+					sampleProjectionLayout{canonical: true},
+					func(refs sampleRoleRefs) sampleRoleRewrite { return sampleRoleRewrite{value: refs.Value} })
+				if got := plan.RowType(); !got.Equal(chplan.Schema{Columns: metricRoles(s)}) {
+					t.Fatalf("custom sample-role output = %#v", got)
+				}
+			})
+		}
+	}
+}
+
+func TestSampleForwardRejectsShadowedPublicPayload(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	columns := metricRoles(s)
+	for _, field := range chplan.HistogramPayloadColumns() {
+		columns = append(columns, chplan.Column{Name: field.Name, Role: chplan.RoleOpaque})
+	}
+	groupBy := make([]chplan.Expr, len(columns))
+	for i, column := range columns {
+		groupBy[i] = &chplan.ColumnRef{Name: column.Name}
+	}
+	// Malformed grouping shadows every appended payload field with an earlier
+	// opaque name. Validation must inspect the entire schema, not first matches.
+	input := &chplan.HistogramProjection{Input: sampleForwardTestInput(columns...), GroupBy: groupBy}
+	row := input.RowType()
+	if !row.Has(chplan.RoleHistogramField) || row.HasHistogramPayload() {
+		t.Fatalf("test did not construct shadowed histogram roles: %#v", row)
+	}
+	capturePanic(t, func() {
+		projectSampleRoles(input, s,
+			sampleProjectionPolicy{name: dropSampleName, payload: floatSamplePayload},
+			sampleProjectionLayout{canonical: true},
+			func(sampleRoleRefs) sampleRoleRewrite {
+				t.Fatal("shadowed public payload reached rewrite callback")
+				return sampleRoleRewrite{}
+			})
+	})
+}
+
+func TestSampleForwardRejectsMalformedPublicPayload(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	payload := chplan.HistogramPayloadColumns()
+	kind := chplan.Column{Name: "sample_kind", Role: chplan.RoleDiscriminator}
+	type payloadCase struct {
+		name    string
+		columns []chplan.Column
+	}
+	cases := []payloadCase{
+		{name: "orphan_discriminator", columns: []chplan.Column{kind}},
+		{name: "duplicate_discriminator", columns: append(slices.Clone(payload), kind, chplan.Column{Name: "other_kind", Role: chplan.RoleDiscriminator})},
+		{name: "unnamed_discriminator", columns: append(slices.Clone(payload), chplan.Column{Role: chplan.RoleDiscriminator})},
+		{name: "ambiguous_discriminator_name", columns: append(slices.Clone(payload), kind, chplan.Column{Name: kind.Name})},
+	}
+	for i, field := range payload {
+		missing := slices.Delete(slices.Clone(payload), i, i+1)
+		wrongRole := slices.Clone(payload)
+		wrongRole[i].Role = chplan.RoleOpaque
+		cases = append(
+			cases,
+			payloadCase{name: "missing/" + field.Name, columns: missing},
+			payloadCase{name: "missing_mixed/" + field.Name, columns: append(slices.Clone(missing), kind)},
+			payloadCase{name: "wrong_role/" + field.Name, columns: append(wrongRole, kind)},
+			payloadCase{name: "duplicate_field/" + field.Name, columns: append(slices.Clone(payload), field, kind)},
+		)
+	}
+	for _, tc := range cases {
+		for _, narrowed := range []bool{false, true} {
+			name := "direct/"
+			if narrowed {
+				name = "narrowed/"
+			}
+			t.Run(name+tc.name, func(t *testing.T) {
+				var input chplan.Node = sampleForwardTestInput(append(metricRoles(s), tc.columns...)...)
+				if narrowed {
+					input = &chplan.Filter{Input: input, Predicate: &chplan.Binary{
+						Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: kind.Name}, Right: &chplan.LitInt{V: 0},
+					}}
+				}
+				capturePanic(t, func() {
+					projectSampleRoles(input, s,
+						sampleProjectionPolicy{name: dropSampleName, payload: floatSamplePayload},
+						sampleProjectionLayout{canonical: true},
+						func(sampleRoleRefs) sampleRoleRewrite {
+							t.Fatal("malformed public payload reached rewrite callback")
+							return sampleRoleRewrite{}
+						})
+				})
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Advances #3277 by validating public histogram payloads before shared sample forwarding uses a float-row proof to discard their columns.

Canonical histogram-role fields or a discriminator require a complete, uniquely named payload. A discriminator must also have one unambiguous named role. Detection inspects every physical column, including duplicate names, before invoking the rewrite callback.

Explicit sample roles remain authoritative: custom float column names may coincide with canonical histogram names. Private histogram working columns alongside a real float value retain their existing admission behavior.

This hardens malformed-IR handling. The tests do not establish a user query that produces these malformed schemas, and valid query SQL remains unchanged in the checked fixtures.

## Validation

- Reproduced 46 malformed-payload callback escapes before the guard.
- Added 80 malformed-payload cases, 36 positive sample-alias cases, and a concrete shadowed-payload case using `HistogramProjection`.
- Focused canonical race suite: 19 top-level tests passed, including existing sample-forwarding, label-family, math-policy, and unnamed-float contracts.
- Canonical chDB fixture lane: 25 mixed-wrapper fixtures passed raw and optimized expectations and their runtime/parity assertions.
- Canonical parity-ledger regeneration passed with no generated changes.
- Independent source/test review passed; source-citation and whitespace checks passed.

Closes #3341
