### PR TITLE
refactor(promql): share scalar arithmetic value projection

### DIFF
--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -851,6 +851,9 @@ func lowerVectorScalar(vec parser.Expr, s schema.Metrics, op chplan.BinaryOp, sc
 	if err != nil {
 		return nil, err
 	}
+	if mixedScalarBinaryFamily(op, scalarOnLeft) == mixedArithmeticFamily {
+		return finishScalarArithmetic(inner, vec, s, ctx, op, scalar, scalarOnLeft, scalarArithmeticGuarded)
+	}
 	if err := requireMixedPlanPolicy(inner, mixedScalarBinaryFamily(op, scalarOnLeft)); err != nil {
 		return nil, err
 	}

--- a/internal/promql/histogram_native_mixed_or_arithmetic.go
+++ b/internal/promql/histogram_native_mixed_or_arithmetic.go
@@ -110,30 +110,12 @@ func arithmeticOverMixedExpHistogramSetOp(expr parser.Expr, s schema.Metrics, ct
 // sample — mirrors [mathFnValueExpr]'s callers and
 // [lowerVectorScalar]'s own projection.
 func lowerArithmeticOverMixedExpHistogramSetOp(setOp *parser.BinaryExpr, op chplan.BinaryOp, scalar float64, scalarOnLeft bool, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
-	inner, err := lowerMixedExpHistogramSetOp(setOp, s, ctx)
+	inner, err := lowerArithmeticRoot(func() (chplan.Node, error) {
+		return lowerMixedExpHistogramSetOp(setOp, s, ctx)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	floatRowsOnly := mixedDiscriminatorFilter(inner, mixedDiscriminatorFloat)
-
-	valueRef := chplan.Expr(&chplan.ColumnRef{Name: s.ValueColumn})
-	scalarLit := chplan.Expr(&chplan.LitFloat{V: scalar})
-	var opExpr chplan.Expr
-	if scalarOnLeft {
-		opExpr = &chplan.Binary{Op: op, Left: scalarLit, Right: valueRef}
-	} else {
-		opExpr = &chplan.Binary{Op: op, Left: valueRef, Right: scalarLit}
-	}
-
-	return &chplan.Project{
-		Roles: metricRoles(s),
-		Input: floatRowsOnly,
-		Projections: []chplan.Projection{
-			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
-			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
-			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
-			{Expr: opExpr, Alias: s.ValueColumn},
-		},
-	}, nil
+	return finishScalarArithmetic(inner, setOp, s, ctx, op, scalar, scalarOnLeft, scalarArithmeticCanonical)
 }

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -676,9 +676,7 @@ func lowerMixedExpHistogramFamily(expr parser.Expr, s schema.Metrics, ctx lowerC
 	// doc comment for why only the DROP-family ops (not MUL / histogram-
 	// left DIV, and not comparisons) are recognised here.
 	if b, op, scalar, scalarOnLeft, ok := arithmeticOverMixedExpHistogramSetOp(expr, s, ctx); ok {
-		plan, err := lowerWithMixedOperandPolicy(mixedArithmeticFamily, mixedRootAdmission, func() (chplan.Node, error) {
-			return lowerArithmeticOverMixedExpHistogramSetOp(b, op, scalar, scalarOnLeft, s, ctx)
-		})
+		plan, err := lowerArithmeticOverMixedExpHistogramSetOp(b, op, scalar, scalarOnLeft, s, ctx)
 		return plan, true, err
 	}
 	// A scalar comparison binop (`==`, `!=`, `<`, `<=`, `>`, `>=`, with or

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -96,6 +96,8 @@ type mixedWrapperKey struct {
 // composition implements those reference contracts correctly. In particular,
 // generic already-lowered aggregate inputs retain their existing behavior here;
 // the nested sum/avg mismatch is tracked separately in cerberus issue #3297.
+// Scalar arithmetic's root and existing-plan entries execute the float-only
+// policy through its shared value kernel, preserving each projection boundary.
 var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedLeafFamily, mixedRootAdmission}:              mixedBespoke,
 	{mixedSumAvgFamily, mixedRootAdmission}:            mixedBespoke,
@@ -106,7 +108,7 @@ var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedLabelFamily, mixedRootAdmission}:             mixedPreserve,
 	{mixedMathFamily, mixedRootAdmission}:              mixedFloatOnly,
 	{mixedScaleFamily, mixedRootAdmission}:             mixedBespoke,
-	{mixedArithmeticFamily, mixedRootAdmission}:        mixedBespoke,
+	{mixedArithmeticFamily, mixedRootAdmission}:        mixedFloatOnly,
 	{mixedComparisonFamily, mixedRootAdmission}:        mixedBespoke,
 	{mixedVectorArithmeticFamily, mixedRootAdmission}:  mixedBespoke,
 	{mixedVectorComparisonFamily, mixedRootAdmission}:  mixedBespoke,
@@ -127,7 +129,7 @@ var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedDateFamily, mixedPlanAdmission}:              mixedBespoke,
 	{mixedTimestampFamily, mixedPlanAdmission}:         mixedBespoke,
 	{mixedUnaryFamily, mixedPlanAdmission}:             mixedBespoke,
-	{mixedArithmeticFamily, mixedPlanAdmission}:        mixedBespoke,
+	{mixedArithmeticFamily, mixedPlanAdmission}:        mixedFloatOnly,
 	{mixedComparisonFamily, mixedPlanAdmission}:        mixedBespoke,
 	{mixedScaleFamily, mixedPlanAdmission}:             mixedBespoke,
 	{mixedLabelFamily, mixedPlanAdmission}:             mixedPreserve,

--- a/internal/promql/mixed_operand_policy_test.go
+++ b/internal/promql/mixed_operand_policy_test.go
@@ -198,7 +198,7 @@ func TestMixedOperandPolicyAdmissionInventory(t *testing.T) {
 			key := mixedWrapperKey{family: family, site: site}
 			wantPolicy := mixedBespoke
 			switch family {
-			case mixedMathFamily:
+			case mixedMathFamily, mixedArithmeticFamily:
 				wantPolicy = mixedFloatOnly
 			case mixedLabelFamily:
 				wantPolicy = mixedPreserve
@@ -238,20 +238,6 @@ func TestMixedOperandPolicyRejectsUnknownBeforeLowering(t *testing.T) {
 func TestMixedOperandPolicyPreservesBespokeResultAndError(t *testing.T) {
 	for key, policy := range mixedOperandPolicies {
 		t.Run(string(key.family)+"/"+string(key.site), func(t *testing.T) {
-			if key.family == mixedMathFamily || key.family == mixedLabelFamily {
-				called := false
-				plan, err := lowerWithMixedOperandPolicy(key.family, key.site, func() (chplan.Node, error) {
-					called = true
-					return &chplan.OneRow{}, nil
-				})
-				if called || plan != nil || err == nil {
-					t.Fatalf("migrated mode reached bespoke continuation: called=%v plan=%v err=%v", called, plan, err)
-				}
-				return
-			}
-			if policy != mixedBespoke {
-				t.Fatalf("unmigrated admission has policy %v, want bespoke", policy)
-			}
 			wantPlan := &chplan.OneRow{}
 			wantError := errors.New("operand lowering error")
 			calls := 0
@@ -259,6 +245,12 @@ func TestMixedOperandPolicyPreservesBespokeResultAndError(t *testing.T) {
 				calls++
 				return wantPlan, wantError
 			})
+			if policy != mixedBespoke {
+				if calls != 0 || plan != nil || err == nil {
+					t.Fatalf("migrated policy reached bespoke callback: calls=%d plan=%v err=%v", calls, plan, err)
+				}
+				return
+			}
 			if calls != 1 || plan != wantPlan || err != wantError {
 				t.Fatalf("bespoke result calls=%d plan=%v err=%v", calls, plan, err)
 			}

--- a/internal/promql/scalar_arithmetic.go
+++ b/internal/promql/scalar_arithmetic.go
@@ -1,0 +1,74 @@
+package promql
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// Scalar arithmetic has two established projection boundaries. Direct mixed
+// roots materialize the canonical aliases; ordinary operands retain their
+// temporal envelope and name-drop collision guard. Neither choice admits a new
+// operand shape or changes how the operand's set operation resolves shadowing.
+type scalarArithmeticBoundary uint8
+
+const (
+	scalarArithmeticGuarded scalarArithmeticBoundary = iota
+	scalarArithmeticCanonical
+)
+
+func requireFloatArithmeticPolicy(site mixedAdmissionSite) error {
+	key := mixedWrapperKey{family: mixedArithmeticFamily, site: site}
+	if mixedOperandPolicies[key] != mixedFloatOnly {
+		return fmt.Errorf("promql: mixed operand is not admitted for %s at %s", key.family, key.site)
+	}
+	return nil
+}
+
+// lowerArithmeticRoot checks authority before the original union loader runs.
+// The loader keeps its histogram-first error order and completes shadow
+// resolution before the common finalizer discards histogram rows.
+func lowerArithmeticRoot(build func() (chplan.Node, error)) (chplan.Node, error) {
+	if err := requireFloatArithmeticPolicy(mixedRootAdmission); err != nil {
+		return nil, err
+	}
+	return build()
+}
+
+func scalarArithmeticValue(value chplan.Expr, op chplan.BinaryOp, scalar float64, scalarOnLeft bool) chplan.Expr {
+	var left, right chplan.Expr = value, &chplan.LitFloat{V: scalar}
+	if scalarOnLeft {
+		left, right = right, left
+	}
+	return &chplan.Binary{Op: op, Left: left, Right: right}
+}
+
+func finishScalarArithmetic(inner chplan.Node, arg parser.Expr, s schema.Metrics, ctx lowerCtx,
+	op chplan.BinaryOp, scalar float64, scalarOnLeft bool, boundary scalarArithmeticBoundary,
+) (chplan.Node, error) {
+	if boundary != scalarArithmeticGuarded && boundary != scalarArithmeticCanonical {
+		return nil, fmt.Errorf("promql: unknown scalar arithmetic projection boundary %d", boundary)
+	}
+	if boundary == scalarArithmeticCanonical {
+		if err := requireFloatArithmeticPolicy(mixedRootAdmission); err != nil {
+			return nil, err
+		}
+	}
+	if boundary == scalarArithmeticGuarded && chplan.RowShapeOf(inner) == chplan.MixedRowShape {
+		if err := requireFloatArithmeticPolicy(mixedPlanAdmission); err != nil {
+			return nil, err
+		}
+	}
+	inner = mixedRowsFloatOnly(inner)
+	layout := sampleProjectionLayout{canonical: true, materializeAliases: true}
+	if boundary == scalarArithmeticGuarded {
+		inner = guardNameDropCollision(inner, arg, s, ctx)
+		layout = legacySampleProjectionLayout(inner)
+	}
+	return projectValueOverInner(inner, s, layout, func(refs sampleRoleRefs) chplan.Expr {
+		return scalarArithmeticValue(refs.Value, op, scalar, scalarOnLeft)
+	}), nil
+}

--- a/internal/promql/scalar_arithmetic_chdb_test.go
+++ b/internal/promql/scalar_arithmetic_chdb_test.go
@@ -1,0 +1,132 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"golang.org/x/tools/txtar"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+func arithmeticWireValue(value float64) any {
+	switch {
+	case math.IsNaN(value):
+		return "NaN"
+	case math.IsInf(value, 1):
+		return "+Inf"
+	case math.IsInf(value, -1):
+		return "-Inf"
+	default:
+		return value
+	}
+}
+
+func TestScalarArithmeticShadowAndValuesParity_ChDB(t *testing.T) {
+	const fixturePermissions = 0o600
+	for _, tc := range []struct {
+		op, scalar string
+		left       bool
+		negative   bool
+		value      func(float64) float64
+	}{
+		{"+", "-3", false, false, func(v float64) float64 { return v - 3 }},
+		{"+", "-3", true, false, func(v float64) float64 { return -3 + v }},
+		{"-", "3", false, false, func(v float64) float64 { return v - 3 }},
+		{"-", "3", true, false, func(v float64) float64 { return 3 - v }},
+		{"%", "3", false, false, func(v float64) float64 { return math.Mod(v, 3) }},
+		{"%", "3", true, false, func(v float64) float64 { return math.Mod(3, v) }},
+		{"^", "2", false, false, func(v float64) float64 { return v * v }},
+		{"^", "-2", true, false, func(v float64) float64 { return math.Pow(-2, v) }},
+		// Axis/quadrant probes have exact shared Float64 answers. General
+		// angles can differ by one libm rounding bit from Go's math.Atan2;
+		// nonzero operands are pinned separately by SQL/IR equivalence.
+		{"atan2", "0", false, true, func(v float64) float64 { return math.Atan2(v, 0) }},
+		{"atan2", "0", true, true, func(v float64) float64 { return math.Atan2(0, v) }},
+		{"/", "3", true, false, func(v float64) float64 { return 3 / v }},
+		{"%", "0", false, false, func(float64) float64 { return math.NaN() }},
+		{"+", "NaN", false, false, func(float64) float64 { return math.NaN() }},
+		{"+", "+Inf", true, false, func(float64) float64 { return math.Inf(1) }},
+		{"-", "-Inf", true, false, func(float64) float64 { return math.Inf(-1) }},
+		{"^", "0.5", false, true, func(v float64) float64 { return math.Sqrt(v) }},
+	} {
+		for _, histFirst := range []bool{false, true} {
+			for _, nested := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/left=%v/histFirst=%v/nested=%v", tc.op, tc.scalar, tc.left, histFirst, nested), func(t *testing.T) {
+					left, right := tkShadowFloatMetric, tkShadowHistMetric
+					if histFirst {
+						left, right = right, left
+					}
+					operand := "(" + left + " or " + right + ")"
+					if nested {
+						operand = "sort_by_label(" + operand + `, "series")`
+					}
+					// Parentheses make a negative literal the actual scalar base,
+					// rather than unary minus applied outside exponentiation.
+					scalar := "(" + tc.scalar + ")"
+					query := operand + " " + tc.op + " " + scalar
+					if tc.left {
+						query = scalar + " " + tc.op + " " + operand
+					}
+					seed := tkShadowSeed
+					solo := 7.0
+					if tc.negative {
+						seed = strings.ReplaceAll(seed, ", 7.0)", ", -7.0)")
+						solo = -solo
+					}
+					rows := [][]any{}
+					if !histFirst {
+						rows = append(rows, []any{"", map[string]string{"series": "dup"}, "2026-01-01T00:00:00Z", arithmeticWireValue(tc.value(42))})
+					}
+					rows = append(rows, []any{"", map[string]string{"series": "solo"}, "2026-01-01T00:00:00Z", arithmeticWireValue(tc.value(solo))})
+					expected, err := json.Marshal(rows)
+					if err != nil {
+						t.Fatal(err)
+					}
+					archive := &txtar.Archive{Files: []txtar.File{
+						{Name: "query.promql", Data: []byte(query + "\n")},
+						{Name: "parity", Data: []byte("oracle: prometheus\nendpoint: /api/v1/query\nscope: full\n")},
+						{Name: "seed", Data: []byte(seed)},
+						{Name: "expected_rows", Data: expected},
+					}}
+					path := filepath.Join(t.TempDir(), "arithmetic.txtar")
+					if err := os.WriteFile(path, txtar.Format(archive), fixturePermissions); err != nil {
+						t.Fatal(err)
+					}
+					fixture, err := spec.Load(path)
+					if err != nil {
+						t.Fatal(err)
+					}
+					p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+					expr, err := p.ParseExpr(query)
+					if err != nil {
+						t.Fatal(err)
+					}
+					plan, err := promql.LowerAt(context.Background(), expr, schema.DefaultOTelMetrics(), foEvalTS, foEvalTS)
+					if err != nil {
+						t.Fatal(err)
+					}
+					optimized := spec.AssertScanTimeBoundAccepts(t, plan)
+					sql, params, err := chsql.Emit(context.Background(), optimized)
+					if err != nil {
+						t.Fatal(err)
+					}
+					result := spec.RunRoundTripSQL(t, fixture, sql, params)
+					spec.RunParity(t, fixture, spec.ParityEval{Start: foEvalTS, End: foEvalTS}, result)
+				})
+			}
+		}
+	}
+}

--- a/internal/promql/scalar_arithmetic_test.go
+++ b/internal/promql/scalar_arithmetic_test.go
@@ -1,0 +1,313 @@
+package promql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+// This constructor pins the two projection contracts before scalar arithmetic
+// shared its kernel. It intentionally does not call the new finalizer or value
+// builder: changes to either must still preserve the old aliases and topology.
+func scalarArithmeticPriorProjection(inner chplan.Node, arg parser.Expr, s schema.Metrics, ctx lowerCtx, op chplan.BinaryOp, scalar float64, left, direct bool) chplan.Node {
+	build := func(value chplan.Expr) chplan.Expr {
+		literal := &chplan.LitFloat{V: scalar}
+		if left {
+			return &chplan.Binary{Op: op, Left: literal, Right: value}
+		}
+		return &chplan.Binary{Op: op, Left: value, Right: literal}
+	}
+	if direct {
+		return &chplan.Project{Roles: metricRoles(s), Input: mixedDiscriminatorFilter(inner, mixedDiscriminatorFloat), Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
+			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+			{Expr: build(&chplan.ColumnRef{Name: s.ValueColumn}), Alias: s.ValueColumn},
+		}}
+	}
+	inner = mixedRowsFloatOnly(inner)
+	inner = guardNameDropCollision(inner, arg, s, ctx)
+	return projectValueOverInner(inner, s, legacySampleProjectionLayout(inner), func(refs sampleRoleRefs) chplan.Expr { return build(refs.Value) })
+}
+
+func assertScalarArithmeticPlansEqual(t *testing.T, got, want chplan.Node) {
+	t.Helper()
+	if !got.Equal(want) {
+		t.Fatalf("arithmetic plan differs from prior projection: got %T, want %T", got, want)
+	}
+	for _, optimize := range []bool{false, true} {
+		a, b := got, want
+		if optimize {
+			a = spec.AssertScanTimeBoundAccepts(t, chplan.CloneNode(got))
+			b = spec.AssertScanTimeBoundAccepts(t, chplan.CloneNode(want))
+			if !a.Equal(b) {
+				t.Fatal("optimized arithmetic plans differ")
+			}
+		}
+		aSQL, aArgs, err := chsql.Emit(context.Background(), a)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bSQL, bArgs, err := chsql.Emit(context.Background(), b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if aSQL != bSQL || fmt.Sprintf("%#v", aArgs) != fmt.Sprintf("%#v", bArgs) {
+			t.Fatalf("SQL/args changed (optimized=%v)\ngot %s %v\nwant %s %v", optimize, aSQL, aArgs, bSQL, bArgs)
+		}
+	}
+}
+
+func TestScalarArithmeticPriorBoundaryEquivalence(t *testing.T) {
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.AttributesColumn, custom.TimestampColumn, custom.ValueColumn = "metric_id", "labels_map", "sample_time", "sample_value"
+	for _, s := range []schema.Metrics{standard, custom} {
+		for _, step := range []time.Duration{0, time.Minute} {
+			ctx := lowerCtx{start: at.Add(-2 * step), end: at, step: step, lowerers: RangeLowerers{}.withDefaults()}
+			for _, operand := range []string{
+				`latency_exp_hist or num_cpus`, `num_cpus or latency_exp_hist`,
+				`sort_by_label(latency_exp_hist or num_cpus, "job")`,
+				`sort_by_label(num_cpus or latency_exp_hist, "job")`,
+				`num_cpus`, `{__name__=~"cpu_a|cpu_b"}`, `sum_over_time(num_cpus[5m])`,
+				`latency_exp_hist offset 1m or num_cpus`,
+				`latency_exp_hist or num_cpus offset 1m`,
+				`num_cpus offset 1m`, `num_cpus @ 1767225600`,
+				`sum_over_time(num_cpus[5m] offset 1m)`,
+				`sum_over_time(num_cpus[5m] @ 1767225600)`,
+				`latency_exp_hist + 1`,
+			} {
+				for _, op := range []chplan.BinaryOp{chplan.OpAdd, chplan.OpSub, chplan.OpMod, chplan.OpPow, chplan.OpAtan2, chplan.OpDiv} {
+					for _, left := range []bool{false, true} {
+						if mixedScalarBinaryFamily(op, left) != mixedArithmeticFamily {
+							continue // Histogram scaling is a different family.
+						}
+						t.Run(fmt.Sprintf("%s/%s/%s/%s/left=%v", s.ValueColumn, step, operand, op, left), func(t *testing.T) {
+							expr, err := p.ParseExpr(operand)
+							if err != nil {
+								t.Fatal(err)
+							}
+							setOp, direct := mixedExpHistogramSetOp(expr, s, ctx)
+							var inner, got chplan.Node
+							const scalar = -3.0
+							if direct {
+								inner, err = lowerMixedExpHistogramSetOp(setOp, s, ctx)
+								if err == nil {
+									got, err = lowerArithmeticOverMixedExpHistogramSetOp(setOp, op, scalar, left, s, ctx)
+								}
+							} else {
+								inner, err = lowerScalarBinopOperand(expr, s, ctx)
+								if err == nil {
+									got, err = lowerVectorScalar(expr, s, op, scalar, left, false, ctx)
+								}
+							}
+							if err != nil {
+								t.Fatal(err)
+							}
+							want := scalarArithmeticPriorProjection(inner, expr, s, ctx, op, scalar, left, direct)
+							assertScalarArithmeticPlansEqual(t, got, want)
+						})
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestScalarArithmeticPolicyBeforeLoadAndProjection(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	for _, site := range []mixedAdmissionSite{mixedRootAdmission, mixedPlanAdmission} {
+		for _, mode := range []mixedOperandPolicy{mixedReject, mixedBespoke, mixedPreserve} {
+			t.Run(fmt.Sprintf("%s/%d", site, mode), func(t *testing.T) {
+				key := mixedWrapperKey{family: mixedArithmeticFamily, site: site}
+				previous := mixedOperandPolicies[key]
+				mixedOperandPolicies[key] = mode
+				t.Cleanup(func() { mixedOperandPolicies[key] = previous })
+				if site == mixedRootAdmission {
+					called := false
+					plan, err := lowerArithmeticRoot(func() (chplan.Node, error) {
+						called = true
+						return nil, errors.New("must not lower")
+					})
+					if called || plan != nil || err == nil {
+						t.Fatalf("denied root invoked loader: %v %T %v", called, plan, err)
+					}
+				}
+				boundary := scalarArithmeticGuarded
+				if site == mixedRootAdmission {
+					boundary = scalarArithmeticCanonical
+				}
+				// Malformed roles would panic in the projection callback; policy
+				// rejection must happen before narrowing or role resolution.
+				plan, err := finishScalarArithmetic(&chplan.VectorSetOp{Mixed: true}, nil, s, lowerCtx{}, chplan.OpAdd, 1, false, boundary)
+				if plan != nil || err == nil {
+					t.Fatalf("denied projection continued: %T %v", plan, err)
+				}
+			})
+		}
+	}
+	wantError := errors.New("histogram operand error")
+	calls := 0
+	_, err := lowerArithmeticRoot(func() (chplan.Node, error) { calls++; return nil, wantError })
+	if calls != 1 || err != wantError {
+		t.Fatalf("loader error changed: calls=%d error=%v", calls, err)
+	}
+}
+
+func TestScalarArithmeticRecognizerBoundary(t *testing.T) {
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	s := schema.DefaultOTelMetrics()
+	for _, tc := range []struct {
+		query string
+		want  bool
+	}{
+		{`(latency_exp_hist or num_cpus) + (1 + 2)`, true},
+		{`(1 + 2) / (latency_exp_hist or num_cpus)`, true},
+		{`(latency_exp_hist or num_cpus) * 2`, false},
+		{`(latency_exp_hist or num_cpus) / 2`, false},
+		{`(latency_exp_hist or num_cpus) > 2`, false},
+		{`(latency_exp_hist or num_cpus) > bool 2`, false},
+		{`(latency_exp_hist or num_cpus) + scalar(vector(2))`, false},
+		{`(latency_exp_hist or num_cpus) + time()`, false},
+		{`abs((latency_exp_hist or num_cpus) + 2)`, false},
+	} {
+		expr, err := p.ParseExpr(tc.query)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _, _, _, ok := arithmeticOverMixedExpHistogramSetOp(expr, s, lowerCtx{})
+		if ok != tc.want {
+			t.Errorf("recognition %s = %v, want %v", tc.query, ok, tc.want)
+		}
+	}
+	// A removed row must deny real dispatch, not only the executor helper.
+	for _, tc := range []struct {
+		query string
+		site  mixedAdmissionSite
+	}{
+		{`(latency_exp_hist or num_cpus) + 2`, mixedRootAdmission},
+		{`sort_by_label(latency_exp_hist or num_cpus, "job") + 2`, mixedPlanAdmission},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			key := mixedWrapperKey{family: mixedArithmeticFamily, site: tc.site}
+			old := mixedOperandPolicies[key]
+			delete(mixedOperandPolicies, key)
+			t.Cleanup(func() { mixedOperandPolicies[key] = old })
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = Lower(context.Background(), expr, s)
+			if err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for scalar-arithmetic at "+string(tc.site)) {
+				t.Fatalf("actual dispatch bypassed policy: %v", err)
+			}
+		})
+	}
+}
+
+func TestScalarArithmeticLiteralBitsAndPolarity(t *testing.T) {
+	value := &chplan.ColumnRef{Name: "opaque_value"}
+	for _, scalar := range []float64{0, math.Copysign(0, -1), math.NaN(), math.Inf(1), math.Inf(-1)} {
+		for _, left := range []bool{false, true} {
+			got := scalarArithmeticValue(value, chplan.OpSub, scalar, left).(*chplan.Binary)
+			vector, literal := got.Left, got.Right
+			if left {
+				vector, literal = got.Right, got.Left
+			}
+			if vector != value || got.Op != chplan.OpSub {
+				t.Fatalf("operand polarity changed: %#v", got)
+			}
+			if bits := math.Float64bits(literal.(*chplan.LitFloat).V); bits != math.Float64bits(scalar) {
+				t.Fatalf("scalar bits changed: got %x, want %x", bits, math.Float64bits(scalar))
+			}
+		}
+	}
+}
+
+func TestScalarArithmeticHistogramOnlyKeepsDroppingRecognizer(t *testing.T) {
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	s := schema.DefaultOTelMetrics()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, step := range []time.Duration{0, time.Minute} {
+		ctx := lowerCtx{start: at.Add(-2 * step), end: at, step: step, lowerers: RangeLowerers{}.withDefaults()}
+		for _, op := range []chplan.BinaryOp{chplan.OpAdd, chplan.OpSub, chplan.OpMod, chplan.OpPow, chplan.OpAtan2, chplan.OpDiv} {
+			for _, left := range []bool{false, true} {
+				if mixedScalarBinaryFamily(op, left) != mixedArithmeticFamily {
+					continue
+				}
+				query := "latency_exp_hist " + string(op) + " (-3)"
+				if left {
+					query = "(-3) " + string(op) + " latency_exp_hist"
+				}
+				t.Run(fmt.Sprintf("%s/%s", step, query), func(t *testing.T) {
+					expr, err := p.ParseExpr(query)
+					if err != nil {
+						t.Fatal(err)
+					}
+					histSide, matched := expHistogramDroppingScalarBinop(expr, s, ctx)
+					if !matched {
+						t.Fatal("existing histogram drop recognizer did not match")
+					}
+					// Root admission uses the histogram-preserving empty Filter,
+					// not the float envelope the nested dropping helper adds.
+					want, err := lowerExpHistogramScalarBinop(histSide, "", nil, s, ctx, true)
+					if err != nil {
+						t.Fatal(err)
+					}
+					got, err := LowerAtRange(context.Background(), expr, s, ctx.start, ctx.end, step)
+					if err != nil {
+						t.Fatal(err)
+					}
+					assertScalarArithmeticPlansEqual(t, got, want)
+				})
+			}
+		}
+	}
+}
+
+func TestScalarArithmeticUnknownBoundaryFailsBeforeInput(t *testing.T) {
+	const unknownBoundary scalarArithmeticBoundary = 255
+	plan, err := finishScalarArithmetic(nil, nil, schema.DefaultOTelMetrics(), lowerCtx{}, chplan.OpAdd, 1, false, unknownBoundary)
+	if plan != nil || err == nil || !strings.Contains(err.Error(), "unknown scalar arithmetic projection boundary") {
+		t.Fatalf("unknown boundary continued: plan=%T error=%v", plan, err)
+	}
+}
+
+func TestScalarArithmeticOrdinaryFloatIndependentOfMixedPolicy(t *testing.T) {
+	for _, site := range []mixedAdmissionSite{mixedRootAdmission, mixedPlanAdmission} {
+		key := mixedWrapperKey{family: mixedArithmeticFamily, site: site}
+		old := mixedOperandPolicies[key]
+		delete(mixedOperandPolicies, key)
+		t.Cleanup(func() { mixedOperandPolicies[key] = old })
+	}
+	s := schema.DefaultOTelMetrics()
+	inner := sampleForwardTestInput(metricRoles(s)...)
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	arg, err := p.ParseExpr("num_cpus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, left := range []bool{false, true} {
+		got, err := finishScalarArithmetic(inner, arg, s, lowerCtx{}, chplan.OpSub, 1, left, scalarArithmeticGuarded)
+		if err != nil {
+			t.Fatalf("ordinary float inherited mixed denial: %v", err)
+		}
+		want := scalarArithmeticPriorProjection(inner, arg, s, lowerCtx{}, chplan.OpSub, 1, left, false)
+		if !got.Equal(want) {
+			t.Fatal("ordinary float projection changed while mixed policies were denied")
+		}
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__mixed_operand_policy.go__requireMixedBespokePolicy.json
+++ b/test/rejection-parity/catalogue/internal__promql__mixed_operand_policy.go__requireMixedBespokePolicy.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/mixed_operand_policy.go:requireMixedBespokePolicy#efa3d4e1",
       "message": "promql: mixed operand is not admitted for %s at %s",
       "class": "internal",
-      "rationale": "This is a fail-closed registration invariant for the callers still routed through the bespoke guard, not a semantic rejection of an admitted query shape. lowerWithMixedOperandPolicy uses explicit matched root/operand family-site pairs, and requireMixedPlanPolicy authorizes existing mixed consumers with their real family. Every production pair that reaches this guard with a Mixed input is registered as bespoke. Math is no longer such a pair: mathPayloadPreparation resolves its separate root and existing-plan mixedFloatOnly rows, and prepareMathValueInput narrows before the ordinary guarded projection reaches requireMixedPlanPolicy, which bypasses the resulting non-Mixed input. The binary and aggregate family classifiers cover their parser-checked operators; unknown internal operators, missing registrations, and unsupported modes are exercised only by synthetic calls or authority-test table mutation. The table is not query-controlled. Any new caller or payload-mode migration must re-verify these separate routing claims. Label calls likewise use the independent labelPayloadPolicy at root or existing-plan admission; both label rows are mixedPreserve and retain mixed payload columns without entering this bespoke guard.",
+      "rationale": "This is a fail-closed registration invariant for the callers still routed through the bespoke guard, not a semantic rejection of an admitted query shape. lowerWithMixedOperandPolicy uses explicit matched root/operand family-site pairs, and requireMixedPlanPolicy authorizes existing mixed consumers with their real family. Every production pair that reaches this guard with a Mixed input is registered as bespoke. Math is no longer such a pair: mathPayloadPreparation resolves its separate root and existing-plan mixedFloatOnly rows, and prepareMathValueInput narrows before the ordinary guarded projection reaches requireMixedPlanPolicy, which bypasses the resulting non-Mixed input. The binary and aggregate family classifiers cover their parser-checked operators; unknown internal operators, missing registrations, and unsupported modes are exercised only by synthetic calls or authority-test table mutation. The table is not query-controlled. Any new caller or payload-mode migration must re-verify these separate routing claims. Label calls likewise use the independent labelPayloadPolicy at root or existing-plan admission; both label rows are mixedPreserve and retain mixed payload columns without entering this bespoke guard. Scalar arithmetic is also migrated: requireFloatArithmeticPolicy authorizes its root and existing-plan mixedFloatOnly entries, and finishScalarArithmetic narrows mixed rows before selecting its established projection boundary; neither route invokes the bespoke dispatcher on a live Mixed input.",
       "evidence": {
         "guard": [
           "if policy != mixedBespoke"
@@ -15,10 +15,12 @@
           "requireMixedPlanPolicy"
         ],
         "cited": [
+          "finishScalarArithmetic",
           "labelPayloadPolicy",
           "lowerWithMixedOperandPolicy",
           "mathPayloadPreparation",
           "prepareMathValueInput",
+          "requireFloatArithmeticPolicy",
           "requireMixedPlanPolicy"
         ]
       }

--- a/test/rejection-parity/catalogue/internal__promql__scalar_arithmetic.go__finishScalarArithmetic.json
+++ b/test/rejection-parity/catalogue/internal__promql__scalar_arithmetic.go__finishScalarArithmetic.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/scalar_arithmetic.go:finishScalarArithmetic#3c7a287d",
+      "message": "promql: unknown scalar arithmetic projection boundary %d",
+      "class": "internal",
+      "rationale": "The only production callers are lowerVectorScalar and lowerArithmeticOverMixedExpHistogramSetOp. They supply scalarArithmeticGuarded and scalarArithmeticCanonical respectively as source constants, never as query-derived data. No parsed query can choose a different projection boundary; this error protects the internal finalizer contract and rejects before inspecting the input.",
+      "evidence": {
+        "guard": [
+          "if boundary != scalarArithmeticGuarded \u0026\u0026 boundary != scalarArithmeticCanonical"
+        ],
+        "callers": [
+          "lowerArithmeticOverMixedExpHistogramSetOp",
+          "lowerVectorScalar"
+        ],
+        "cited": [
+          "lowerArithmeticOverMixedExpHistogramSetOp",
+          "lowerVectorScalar"
+        ]
+      }
+    }
+  ]
+}

--- a/test/rejection-parity/catalogue/internal__promql__scalar_arithmetic.go__requireFloatArithmeticPolicy.json
+++ b/test/rejection-parity/catalogue/internal__promql__scalar_arithmetic.go__requireFloatArithmeticPolicy.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "head": "promql",
+      "site": "internal/promql/scalar_arithmetic.go:requireFloatArithmeticPolicy#efa3d4e1",
+      "message": "promql: mixed operand is not admitted for %s at %s",
+      "class": "internal",
+      "rationale": "This is the private scalar-arithmetic registration invariant, not rejection of an admitted query shape. lowerArithmeticRoot supplies the root site before loading the union. finishScalarArithmetic supplies root for the canonical boundary or existing-plan for a guarded mixed operand. Both scalar-arithmetic family/site pairs are registered as mixedFloatOnly in the private production table; neither the site nor the policy is query-controlled. Ordinary float operands bypass the mixed existing-plan check. Missing registrations and other payload modes are reached only through synthetic calls or temporary table mutation in authority tests; a future admission change must reassess this classification.",
+      "evidence": {
+        "guard": [
+          "if mixedOperandPolicies[key] != mixedFloatOnly"
+        ],
+        "callers": [
+          "finishScalarArithmetic",
+          "lowerArithmeticRoot"
+        ],
+        "cited": [
+          "finishScalarArithmetic",
+          "lowerArithmeticRoot"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Refs #3277.

Share the scalar-arithmetic value projection across direct mixed roots and ordinary lowered operands. Only the arithmetic root and existing-plan policy rows migrate to executable FloatOnly behavior; comparisons, scaling, scalar reduction, and label-sort policies are unchanged.

The direct-root policy check still precedes the original union loader. Existing-plan authorization still follows operand lowering and applies only to Mixed inputs. Both routes complete union shadow resolution before histogram removal, then retain their established projection boundaries, temporal envelopes, metric-name behavior, and collision checks.

This change is transplanted onto main 1510e30c5290a1d011a51488a8d481aa5fdfa339. It preserves both non-bool comparison narrowings from #3303, the OrderBy float-proof correction from #3311, and the current math/label policy implementations and metadata explanations. The ordinary-sort policy prototype is not included.

## Validation

- Focused race tests passed (3.124s), including 616 scalar-arithmetic projection-equivalence cases, policy/error precedence, and corrected nested-sort/sample-forwarding controls.
- All 1,161 immutable fresh-main baseline/candidate snapshots are identical: 1,159 successful raw/optimized plan, SQL, and argument records plus two unchanged lowering rejections (baseline 3.944s; candidate 4.251s). The rejected nested shapes are `abs((latency_exp_hist or num_cpus)+2)` and `-3^(latency_exp_hist or num_cpus)`; this refactor does not broaden admission.
- Optimized chDB execution and independent Prometheus parity passed for 64 arithmetic cases plus 61 corrected-sort runtime cases (43.375s).
- Strict rejection/surface metadata and code-citation checks pass. Metadata was re-derived with the catalogue generator API, preserving the current math and label rationale and adding the arithmetic authority path.

The independently verified signed-zero atan2 discrepancy remains tracked in #3306; this refactor does not change that behavior.

Closes #3336
