### PR TITLE
fix(promql): preserve mixed group semantics in nested sum and avg

### DIFF
--- a/internal/promql/float_aggregate_input_test.go
+++ b/internal/promql/float_aggregate_input_test.go
@@ -113,6 +113,15 @@ func TestFloatAggregateNarrowingLeavesOtherFamilies(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if fn == "sum" || fn == "avg" {
+				// Sum/avg now partition sample kinds rather than discarding the
+				// histogram side. Only their float reduction narrows to floats.
+				union, ok := plan.(*chplan.VectorSetOp)
+				if !ok || !union.MixedDropCollisions || chplan.RowShapeOf(union.Left) != chplan.HistogramRowShape || chplan.RowShapeOf(plan) != chplan.MixedRowShape {
+					t.Fatalf("%s lost histogram group semantics: %T", fn, plan)
+				}
+				return
+			}
 			chplan.Walk(plan, func(node chplan.Node) bool {
 				if filter, ok := node.(*chplan.Filter); ok && chplan.IsMixedFloatNarrowing(filter) {
 					t.Fatalf("%s acquired float-only semantics", fn)

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -5334,6 +5334,9 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 	if err := requireMixedPlanPolicy(input, mixedAggregateFamily(a.Op)); err != nil {
 		return nil, err
 	}
+	if expHistogramAggOpIsMergeable(a.Op) && chplan.RowShapeOf(input) == chplan.MixedRowShape {
+		return lowerSumOrAvgOverMixedPlan(a, input, s, ctx)
+	}
 	// Authorize the original Mixed relation before discarding histogram rows.
 	// Float-only reductions must not aggregate their placeholder Value column;
 	// narrowing this already-lowered relation preserves union shadow precedence.

--- a/internal/promql/sum_avg_mixed_input.go
+++ b/internal/promql/sum_avg_mixed_input.go
@@ -1,0 +1,28 @@
+package promql
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+// lowerSumOrAvgOverMixedPlan reduces an already-authorized mixed relation.
+// Partition only after its union and wrappers have resolved sample membership;
+// reducing placeholder Values would lose histogram-only groups and retain groups
+// which Prometheus removes because they contain both sample kinds.
+func lowerSumOrAvgOverMixedPlan(a *parser.AggregateExpr, input chplan.Node, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	// Histogram reductions group by timestamp even for instant queries. Normalize
+	// their input to one evaluation instant, never separate source scrape times.
+	histInput := nativeHistogramProjection(mixedDiscriminatorFilter(input, mixedDiscriminatorHistogram),
+		&chplan.ColumnRef{Name: s.MetricNameColumn}, evalInstantExpr(s, ctx), histogramProjectionSchema(s))
+	histBranch, err := lowerExpHistogramSumOrAvgOverPlan(a, histInput, s, ctx.resourceBounds.HistogramMergeMaxCostUnits)
+	if err != nil {
+		return nil, err
+	}
+	floatBranch, err := lowerPlainAggOverMixedFloatArm(a, wrapMixedFloatPartition(input, s), s, ctx)
+	if err != nil {
+		return nil, err
+	}
+	return combineMixedAggregateBranches(histBranch, floatBranch, s, ctx.step > 0), nil
+}

--- a/internal/promql/sum_avg_mixed_input_chdb_test.go
+++ b/internal/promql/sum_avg_mixed_input_chdb_test.go
@@ -1,0 +1,141 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"golang.org/x/tools/txtar"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+// Histograms have unequal source timestamps. Every grouping mode must reduce
+// them at the evaluation instant rather than creating one group per scrape.
+const mixedSumAvgSeed = `
+CREATE TABLE otel_metrics_histogram (MetricName String, Attributes Map(String,String), ResourceAttributes Map(String,String) DEFAULT map(), ServiceName LowCardinality(String) DEFAULT '', TimeUnix DateTime64(9), Count UInt64, Sum Float64, BucketCounts Array(UInt64), ExplicitBounds Array(Float64)) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+CREATE TABLE otel_metrics_exponential_histogram (MetricName String, Attributes Map(String,String), ResourceAttributes Map(String,String) DEFAULT map(), ServiceName LowCardinality(String) DEFAULT '', TimeUnix DateTime64(9), Count UInt64, Sum Float64, Scale Int32, ZeroCount UInt64, PositiveOffset Int32, PositiveBucketCounts Array(UInt64), NegativeOffset Int32, NegativeBucketCounts Array(UInt64)) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram (MetricName,Attributes,TimeUnix,Count,Sum,Scale,ZeroCount,PositiveOffset,PositiveBucketCounts,NegativeOffset,NegativeBucketCounts) VALUES
+ ('group_exp_hist',map('series','dup','bucket','mixed'),toDateTime64('2025-12-31 23:59:57',9),2,4,0,0,0,[2],0,[]),
+ ('group_exp_hist',map('series','h1','bucket','hist'),toDateTime64('2025-12-31 23:59:58',9),2,4,0,0,0,[2],0,[]),
+ ('group_exp_hist',map('series','h2','bucket','hist'),toDateTime64('2025-12-31 23:59:59',9),4,8,0,0,0,[4],0,[]);
+CREATE TABLE otel_metrics_gauge (MetricName String, Attributes Map(String,String), ResourceAttributes Map(String,String) DEFAULT map(), ServiceName LowCardinality(String) DEFAULT '', TimeUnix DateTime64(9), Value Float64) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+INSERT INTO otel_metrics_gauge (MetricName,Attributes,TimeUnix,Value) VALUES
+ ('group_gauge',map('series','dup','bucket','mixed'),toDateTime64('2026-01-01 00:00:00',9),99),
+ ('group_gauge',map('series','f0','bucket','mixed'),toDateTime64('2026-01-01 00:00:00',9),10),
+ ('group_gauge',map('series','f1','bucket','float'),toDateTime64('2026-01-01 00:00:00',9),6),
+ ('group_gauge',map('series','f2','bucket','float'),toDateTime64('2026-01-01 00:00:00',9),10);
+`
+
+func TestSumAvgNestedMixedGroupParity_ChDB(t *testing.T) {
+	const (
+		fixturePermissions    = 0o600
+		histogramCountSum     = 6.0
+		histogramValueSum     = 12.0
+		floatGroupSum         = 16.0
+		shadowedFloatGroupSum = 109.0
+		pureGroupSize         = 2
+	)
+	for _, op := range []string{"sum", "avg"} {
+		for _, histFirst := range []bool{false, true} {
+			for _, wrapper := range []string{"sort_by_label", "sort_by_label_desc"} {
+				for _, step := range []time.Duration{0, time.Second} {
+					for _, grouping := range []string{"", " by(bucket)", " without(series)", "empty"} {
+						t.Run(fmt.Sprintf("%s/%v/%s/%s/%s", op, histFirst, wrapper, step, grouping), func(t *testing.T) {
+							hist, floats := "group_exp_hist", "group_gauge"
+							clause := grouping
+							if grouping == "empty" {
+								hist += `{series="missing"}`
+								floats += `{series="missing"}`
+								clause = ""
+							}
+							left, right := floats, hist
+							if histFirst {
+								left, right = right, left
+							}
+							query := op + clause + "(" + wrapper + "(" + left + " or " + right + `,"series"))`
+							rows := [][]any{}
+							for at := foEvalTS; !at.After(foEvalTS.Add(step)); at = at.Add(step) {
+								if grouping != "" && grouping != "empty" {
+									hCount, hSum, floatValue, mixedValue := histogramCountSum, histogramValueSum, floatGroupSum, shadowedFloatGroupSum
+									if op == "avg" {
+										hCount /= pureGroupSize
+										hSum /= pureGroupSize
+										floatValue /= pureGroupSize
+										mixedValue /= pureGroupSize
+									}
+									rows = append(rows, []any{"", map[string]string{"bucket": "hist"}, at.Format(time.RFC3339), 0, hCount, hSum, 0, 0, 0, 0, []float64{hCount}, 0, []any{}, 1})
+									floatRow := func(bucket string, value float64) []any {
+										return []any{"", map[string]string{"bucket": bucket}, at.Format(time.RFC3339), value, 0, 0, 0, 0, 0, 0, []any{}, 0, []any{}, 0}
+									}
+									rows = append(rows, floatRow("float", floatValue))
+									if !histFirst {
+										rows = append(rows, floatRow("mixed", mixedValue))
+									}
+								}
+								if step == 0 {
+									break
+								}
+							}
+							want, err := json.Marshal(rows)
+							if err != nil {
+								t.Fatal(err)
+							}
+							endpoint := "/api/v1/query"
+							if step > 0 {
+								endpoint = "/api/v1/query_range"
+							}
+							archive := &txtar.Archive{Files: []txtar.File{
+								{Name: "query.promql", Data: []byte(query + "\n")},
+								{Name: "seed", Data: []byte(mixedSumAvgSeed)},
+								{Name: "expected_rows", Data: want},
+								{Name: "parity", Data: []byte("oracle: prometheus\nendpoint: " + endpoint + "\nscope: full\n")},
+							}}
+							path := filepath.Join(t.TempDir(), "sum_avg.txtar")
+							if err := os.WriteFile(path, txtar.Format(archive), fixturePermissions); err != nil {
+								t.Fatal(err)
+							}
+							fixture, err := spec.Load(path)
+							if err != nil {
+								t.Fatal(err)
+							}
+							expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(query)
+							if err != nil {
+								t.Fatal(err)
+							}
+							plan, err := promql.LowerAtRange(context.Background(), expr, schema.DefaultOTelMetrics(), foEvalTS, foEvalTS.Add(step), step)
+							if err != nil {
+								t.Fatal(err)
+							}
+							for _, optimized := range []bool{false, true} {
+								t.Run(fmt.Sprintf("optimized=%v", optimized), func(t *testing.T) {
+									n := chplan.CloneNode(plan)
+									if optimized {
+										n = spec.AssertScanTimeBoundAccepts(t, n)
+									}
+									sql, args, err := chsql.Emit(context.Background(), n)
+									if err != nil {
+										t.Fatal(err)
+									}
+									actual := spec.RunRoundTripSQL(t, fixture, sql, args)
+									spec.RunParity(t, fixture, spec.ParityEval{Start: foEvalTS, End: foEvalTS.Add(step), Step: step}, actual)
+								})
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/promql/sum_avg_mixed_input_test.go
+++ b/internal/promql/sum_avg_mixed_input_test.go
@@ -1,0 +1,77 @@
+package promql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestSumAvgMixedInputKeepsTypePartitions(t *testing.T) {
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.AttributesColumn, custom.TimestampColumn, custom.ValueColumn = "metric_id", "labels_map", "sample_time", "sample_value"
+	for _, s := range []schema.Metrics{standard, custom} {
+		for _, step := range []time.Duration{0, time.Second} {
+			for _, op := range []string{"sum", "avg"} {
+				for _, operand := range []string{`sort_by_label(latency_exp_hist or num_cpus,"job")`, `sort_by_label_desc(num_cpus or latency_exp_hist,"job")`} {
+					t.Run(fmt.Sprintf("%s/%s/%s/%s", s.ValueColumn, step, op, operand), func(t *testing.T) {
+						lowerQuery := func(q string) chplan.Node {
+							e, err := p.ParseExpr(q)
+							if err != nil {
+								t.Fatal(err)
+							}
+							n, err := LowerAtRange(context.Background(), e, s, at, at.Add(step), step)
+							if err != nil {
+								t.Fatal(err)
+							}
+							return n
+						}
+						original := lowerQuery(operand)
+						got := lowerQuery(op + " by(job)(" + operand + ")")
+						union, ok := got.(*chplan.VectorSetOp)
+						if !ok || !union.Mixed || !union.MixedDropCollisions || union.StepAligned != (step > 0) {
+							t.Fatalf("sum/avg must drop mixed groups after separate reductions: %T", got)
+						}
+						for _, branch := range []chplan.Node{union.Left, union.Right} {
+							found := false
+							chplan.Walk(branch, func(n chplan.Node) bool {
+								if n.Equal(original) {
+									found = true
+								}
+								return true
+							})
+							if !found {
+								t.Fatal("partition replaced the already-shadowed operand")
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestSumAvgMixedAuthorizationPrecedesPartition(t *testing.T) {
+	key := mixedWrapperKey{family: mixedSumAvgFamily, site: mixedPlanAdmission}
+	old := mixedOperandPolicies[key]
+	delete(mixedOperandPolicies, key)
+	t.Cleanup(func() { mixedOperandPolicies[key] = old })
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	for _, op := range []string{"sum", "avg"} {
+		e, err := p.ParseExpr(op + `(sort_by_label(latency_exp_hist or num_cpus,"job"))`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n, err := Lower(context.Background(), e, schema.DefaultOTelMetrics()); n != nil || err == nil {
+			t.Fatalf("missing policy admitted %s: %T %v", op, n, err)
+		}
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_sum.go__lowerExpHistogramSumOrAvgOverPlan.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_sum.go__lowerExpHistogramSumOrAvgOverPlan.json
@@ -5,7 +5,7 @@
       "site": "internal/promql/histogram_native_sum.go:lowerExpHistogramSumOrAvgOverPlan#7a3163a0",
       "message": "promql: internal invariant violated: nested native-histogram aggregation input is %T with %s row shape",
       "class": "internal",
-      "rationale": "mergeableExpHistogramAggregate plus recursive histogram recognition admits lowerExpHistogramValuedShape's call only over the HistogramRowShape it itself returned. lowerSumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346, histogram_native_mixed_or_aggregate.go) is the second caller: it passes either histNode directly — lowerExpHistogramSetOpOperand's own postcondition already guarantees HistogramRowShape — or mixedOrShadowUnless's chplan.VectorSetOp{Histogram: true} wrapping it, which chplan.RowShapeOf also reports as HistogramRowShape, so this guard stays unreachable via that path too. Cerberus issue #2581 added a third caller, lowerSumOrAvgMixedOrSubqueryFoldFn (histogram_native_mixed_or_subquery_aggregate_range_fn.go): it calls shadowResolveMixedExpHistogramOperands directly — the SAME helper lowerSumOrAvgOverMixedExpHistogramSetOp calls internally — and passes its histForAgg return value straight through, so the identical HistogramRowShape postcondition holds for this caller too. Cerberus issue #2715 added a fourth caller, lowerSumOrAvgMixedOrSubqueryFoldFnRange (same file) — the true query_range fan-out sibling of lowerSumOrAvgMixedOrSubqueryFoldFn, calling shadowResolveMixedExpHistogramOperands the identical way and passing histForAgg straight through, so the same postcondition holds for it too. Cerberus issue #3265 added a fifth caller, lowerSumOrAvgOverMixedOrSubqueryFoldFn (histogram_native_mixed_or_subquery_outer_aggregate_fold.go): it also calls shadowResolveMixedExpHistogramOperands directly, but unlike the two callers above it does not pass histForAgg straight through — it first folds histForAgg over the outer window via lowerExpHistogramRangeFnOverSubqueryInput, and passes THAT return value on. lowerExpHistogramRangeFnOverSubqueryInput's own contract (\"keeps the subquery matrix on the public thirteen-column histogram contract\") guarantees a HistogramRowShape result — the same contract the ordinary bare-selector fold (lowerExpHistogramRangeFnOverSubquery) already relies on to feed this same guard — so the identical postcondition holds for this caller too.",
+      "rationale": "mergeableExpHistogramAggregate plus recursive histogram recognition admits lowerExpHistogramValuedShape's call only over the HistogramRowShape it itself returned. lowerSumOrAvgOverMixedExpHistogramSetOp (cerberus issue #2346, histogram_native_mixed_or_aggregate.go) is the second caller: it passes either histNode directly — lowerExpHistogramSetOpOperand's own postcondition already guarantees HistogramRowShape — or mixedOrShadowUnless's chplan.VectorSetOp{Histogram: true} wrapping it, which chplan.RowShapeOf also reports as HistogramRowShape, so this guard stays unreachable via that path too. Cerberus issue #2581 added a third caller, lowerSumOrAvgMixedOrSubqueryFoldFn (histogram_native_mixed_or_subquery_aggregate_range_fn.go): it calls shadowResolveMixedExpHistogramOperands directly — the SAME helper lowerSumOrAvgOverMixedExpHistogramSetOp calls internally — and passes its histForAgg return value straight through, so the identical HistogramRowShape postcondition holds for this caller too. Cerberus issue #2715 added a fourth caller, lowerSumOrAvgMixedOrSubqueryFoldFnRange (same file) — the true query_range fan-out sibling of lowerSumOrAvgMixedOrSubqueryFoldFn, calling shadowResolveMixedExpHistogramOperands the identical way and passing histForAgg straight through, so the same postcondition holds for it too. Cerberus issue #3265 added a fifth caller, lowerSumOrAvgOverMixedOrSubqueryFoldFn (histogram_native_mixed_or_subquery_outer_aggregate_fold.go): it also calls shadowResolveMixedExpHistogramOperands directly, but unlike the two callers above it does not pass histForAgg straight through — it first folds histForAgg over the outer window via lowerExpHistogramRangeFnOverSubqueryInput, and passes THAT return value on. lowerExpHistogramRangeFnOverSubqueryInput's own contract (\"keeps the subquery matrix on the public thirteen-column histogram contract\") guarantees a HistogramRowShape result — the same contract the ordinary bare-selector fold (lowerExpHistogramRangeFnOverSubquery) already relies on to feed this same guard — so the identical postcondition holds for this caller too. The sixth caller, lowerSumOrAvgOverMixedPlan, is dispatched by lowerAggregate only after mixed-policy authorization and chplan.RowShapeOf(input) == chplan.MixedRowShape for sum or avg. It partitions the already-resolved relation by the histogram discriminator with mixedDiscriminatorFilter, then nativeHistogramProjection reprojects that partition onto HistogramRowShape before calling this reducer. It passes the resolved ctx.resourceBounds.HistogramMergeMaxCostUnits as the merge cost. Thus neither query syntax nor configuration can supply a wrong-shape plan to this internal helper.",
       "evidence": {
         "guard": [
           "if chplan.RowShapeOf(input) != chplan.HistogramRowShape"
@@ -15,9 +15,11 @@
           "lowerSumOrAvgMixedOrSubqueryFoldFn",
           "lowerSumOrAvgMixedOrSubqueryFoldFnRange",
           "lowerSumOrAvgOverMixedExpHistogramSetOp",
-          "lowerSumOrAvgOverMixedOrSubqueryFoldFn"
+          "lowerSumOrAvgOverMixedOrSubqueryFoldFn",
+          "lowerSumOrAvgOverMixedPlan"
         ],
         "cited": [
+          "lowerAggregate",
           "lowerExpHistogramRangeFnOverSubquery",
           "lowerExpHistogramRangeFnOverSubqueryInput",
           "lowerExpHistogramSetOpOperand",
@@ -26,8 +28,11 @@
           "lowerSumOrAvgMixedOrSubqueryFoldFnRange",
           "lowerSumOrAvgOverMixedExpHistogramSetOp",
           "lowerSumOrAvgOverMixedOrSubqueryFoldFn",
+          "lowerSumOrAvgOverMixedPlan",
           "mergeableExpHistogramAggregate",
+          "mixedDiscriminatorFilter",
           "mixedOrShadowUnless",
+          "nativeHistogramProjection",
           "shadowResolveMixedExpHistogramOperands"
         ]
       }


### PR DESCRIPTION
Fixes #3297.

Part of #3277.

## What changed

- authorize an already-lowered mixed relation before inspecting its shape
- route `sum` and `avg` over that relation through the existing histogram reducer, float reducer, and mixed-group collision-drop union
- normalize histogram rows to the evaluation timestamp before grouping, so instant and range evaluations do not split a Prometheus group by source scrape time
- retain the float-only narrowing behavior for the other aggregate families

This preserves the already-resolved wrapper and set-operator membership. It prevents histogram placeholder `Value` fields from entering ordinary float aggregation while keeping histogram-only and float-only groups and dropping groups containing both sample kinds, matching Prometheus.

## Verification

- 157 focused unit subtests passed
- five existing direct raw/optimized golden cases remained unchanged
- 64 independent-oracle scenarios passed for each of `sum` and `avg`, with raw and optimized SQL checked in every scenario (128 executions total)
- coverage includes both union orientations, ascending/descending label-order wrappers, instant/range evaluation, grouped/ungrouped/without aggregation, empty input, pure-type groups, mixed groups, and shadow collisions

The original current-`main` reproduction returned `sum=7` and `avg=3.5`; Prometheus returned an empty vector for both. The regression matrix pins the corrected result against the independent Prometheus engine.

Closes #3297
