### PR TITLE
fix(promql): retain mixed samples through nested timestamp

### DIFF
--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -132,6 +132,9 @@ func lowerDateFn(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chplan.Node, e
 	family := mixedDateFamily
 	if c.Func.Name == timestampFunctionName {
 		family = mixedTimestampFamily
+		if chplan.RowShapeOf(inner) == chplan.MixedRowShape {
+			return lowerTimestampOverMixedPlan(inner, c.Args[0], s, ctx)
+		}
 	}
 	return guardedValueProjection(inner, c.Args[0], s, ctx, family, func(refs sampleRoleRefs) chplan.Expr {
 		inputSchema := refs.sourceMetrics(s)

--- a/internal/promql/histogram_native_timestamp.go
+++ b/internal/promql/histogram_native_timestamp.go
@@ -256,3 +256,34 @@ func projectExpHistogramEvalInstant(hist chplan.Node, s schema.Metrics, ctx lowe
 		},
 	}
 }
+
+// lowerTimestampOverMixedPlan converts every admitted mixed sample to a float
+// timestamp without reading its payload. A non-selector argument reports the
+// evaluation instant, not either arm's raw sample time. Retain names until the
+// collision guard runs over that normalized time: distinct source sample times
+// must not separate duplicate output label sets into different guard groups.
+func lowerTimestampOverMixedPlan(inner chplan.Node, arg parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
+	if err := requireMixedPlanPolicy(inner, mixedTimestampFamily); err != nil {
+		return nil, err
+	}
+	row := inner.RowType()
+	refs := sampleRoleRefs{
+		MetricName: requireSampleRole(row, chplan.RoleMetricName),
+		Attributes: requireSampleRole(row, chplan.RoleAttributes),
+		Timestamp:  requireSampleRole(row, chplan.RoleTimestamp),
+	}
+	ts := evalInstantExpr(refs.sourceMetrics(s), ctx)
+	named := &chplan.Project{
+		Roles: metricRoles(s),
+		Input: inner,
+		Projections: []chplan.Projection{
+			{Expr: refs.MetricName, Alias: s.MetricNameColumn},
+			{Expr: refs.Attributes, Alias: s.AttributesColumn},
+			{Expr: ts, Alias: s.TimestampColumn},
+			{Expr: asFloat64(dateFnExpr(timestampFunctionName, nil, ts)), Alias: s.ValueColumn},
+		},
+	}
+	return guardedValueProjection(named, arg, s, ctx, mixedTimestampFamily, func(refs sampleRoleRefs) chplan.Expr {
+		return refs.Value
+	})
+}

--- a/internal/promql/timestamp_nested_mixed_chdb_test.go
+++ b/internal/promql/timestamp_nested_mixed_chdb_test.go
@@ -1,0 +1,103 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"golang.org/x/tools/txtar"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+func TestTimestampNestedMixedRowsAndShadowParity_ChDB(t *testing.T) {
+	const fixturePermissions = 0o600
+	for _, shadow := range []bool{false, true} {
+		for _, histFirst := range []bool{false, true} {
+			for _, sort := range []string{"", "sort_by_label", "sort_by_label_desc"} {
+				for _, modifier := range []string{"", " offset 1s", " @ 1767225600"} {
+					for _, step := range []time.Duration{0, time.Second} {
+						t.Run(fmt.Sprintf("shadow=%v/histFirst=%v/sort=%s/modifier=%s/step=%s", shadow, histFirst, sort, modifier, step), func(t *testing.T) {
+							hist, float, seed := foHistMetric, foFloatMetric, foSeed
+							labels := []map[string]string{{"series": "f1", "bucket": "b1"}, {"series": "f2", "bucket": "b1"}, {"series": "f3", "bucket": "b3"}, {"series": "h1", "bucket": "b1"}, {"series": "h2", "bucket": "b2"}}
+							if shadow {
+								hist, float, seed = tkShadowHistMetric, tkShadowFloatMetric, tkShadowSeed
+								labels = []map[string]string{{"series": "dup"}, {"series": "solo"}}
+							}
+							left, right := float+modifier, hist+modifier
+							if histFirst {
+								left, right = right, left
+							}
+							operand := left + " or " + right
+							if sort != "" {
+								operand = sort + "(" + operand + `, "series")`
+							}
+							query := "timestamp(" + operand + ")"
+							rows := [][]any{}
+							times := []time.Time{foEvalTS}
+							if step > 0 {
+								times = append(times, foEvalTS.Add(step))
+							}
+							for _, at := range times {
+								for _, label := range labels {
+									rows = append(rows, []any{"", label, at.Format(time.RFC3339), at.Unix()})
+								}
+							}
+							expected, err := json.Marshal(rows)
+							if err != nil {
+								t.Fatal(err)
+							}
+							endpoint := "/api/v1/query"
+							if step > 0 {
+								endpoint = "/api/v1/query_range"
+							}
+							archive := &txtar.Archive{Files: []txtar.File{
+								{Name: "query.promql", Data: []byte(query + "\n")},
+								{Name: "parity", Data: []byte("oracle: prometheus\nendpoint: " + endpoint + "\nscope: full\n")},
+								{Name: "seed", Data: []byte(seed)},
+								{Name: "expected_rows", Data: expected},
+							}}
+							path := filepath.Join(t.TempDir(), "timestamp_mixed.txtar")
+							if err := os.WriteFile(path, txtar.Format(archive), fixturePermissions); err != nil {
+								t.Fatal(err)
+							}
+							fixture, err := spec.Load(path)
+							if err != nil {
+								t.Fatal(err)
+							}
+							expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(query)
+							if err != nil {
+								t.Fatal(err)
+							}
+							plan, err := promql.LowerAtRange(context.Background(), expr, schema.DefaultOTelMetrics(), foEvalTS, foEvalTS.Add(step), step)
+							if err != nil {
+								t.Fatal(err)
+							}
+							if chplan.RowShapeOf(plan) != chplan.SampleRowShape {
+								t.Fatal("timestamp must return floats, not retain histogram output payload")
+							}
+							plan = spec.AssertScanTimeBoundAccepts(t, plan)
+							sql, args, err := chsql.Emit(context.Background(), plan)
+							if err != nil {
+								t.Fatal(err)
+							}
+							actual := spec.RunRoundTripSQL(t, fixture, sql, args)
+							spec.RunParity(t, fixture, spec.ParityEval{Start: foEvalTS, End: foEvalTS.Add(step), Step: step}, actual)
+						})
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/promql/timestamp_nested_mixed_collision_chdb_test.go
+++ b/internal/promql/timestamp_nested_mixed_collision_chdb_test.go
@@ -1,0 +1,103 @@
+//go:build chdb
+
+package promql
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+	"github.com/tsouza/cerberus/test/spec"
+	oracle "github.com/tsouza/cerberus/test/spec/parityoracle/promql"
+)
+
+const nestedTimestampCollisionSeed = `
+CREATE TABLE otel_metrics_histogram (
+ MetricName String, Attributes Map(String,String), ResourceAttributes Map(String,String) DEFAULT map(), ServiceName LowCardinality(String) DEFAULT '', TimeUnix DateTime64(9), Count UInt64, Sum Float64, BucketCounts Array(UInt64), ExplicitBounds Array(Float64)
+) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+CREATE TABLE otel_metrics_exponential_histogram (
+ MetricName String, Attributes Map(String,String), ResourceAttributes Map(String,String) DEFAULT map(), ServiceName LowCardinality(String) DEFAULT '', TimeUnix DateTime64(9), Count UInt64, Sum Float64, Scale Int32, ZeroCount UInt64, PositiveOffset Int32, PositiveBucketCounts Array(UInt64), NegativeOffset Int32, NegativeBucketCounts Array(UInt64)
+) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram (MetricName,Attributes,TimeUnix,Count,Sum,Scale,ZeroCount,PositiveOffset,PositiveBucketCounts,NegativeOffset,NegativeBucketCounts) VALUES
+ ('collision_exp_hist',map('series','hist'),toDateTime64('2026-01-01 00:00:00',9),2,4.,0,0,0,[6],0,[]);
+CREATE TABLE otel_metrics_gauge (
+ MetricName String, Attributes Map(String,String), ResourceAttributes Map(String,String) DEFAULT map(), ServiceName LowCardinality(String) DEFAULT '', TimeUnix DateTime64(9), Value Float64
+) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+INSERT INTO otel_metrics_gauge (MetricName,Attributes,TimeUnix,Value) VALUES
+ ('collision_gauge',map('series','float'),toDateTime64('2025-12-31 23:59:59',9),42.),
+ ('collision_other_gauge',map('series','float'),toDateTime64('2025-12-31 23:59:58',9),7.);
+`
+
+func TestTimestampNestedMixedDuplicateLabelsetParity_ChDB(t *testing.T) {
+	const duplicateMessage = "vector cannot contain metrics with the same labelset"
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.AttributesColumn, custom.TimestampColumn, custom.ValueColumn = "metric_id", "label_map", "sample_time", "sample_value"
+	for _, s := range []schema.Metrics{standard, custom} {
+		for _, step := range []time.Duration{0, time.Second} {
+			for _, histFirst := range []bool{false, true} {
+				for _, sort := range []string{"sort_by_label", "sort_by_label_desc"} {
+					t.Run(fmt.Sprintf("%s/%s/histFirst=%v/%s", s.ValueColumn, step, histFirst, sort), func(t *testing.T) {
+						left, right := `{__name__=~"collision_gauge|collision_other_gauge"}`, "collision_exp_hist"
+						if histFirst {
+							left, right = right, left
+						}
+						query := "timestamp(" + sort + "(" + left + " or " + right + `, "series"))`
+						seeded := []oracle.Series{
+							{Labels: map[string]string{"__name__": "collision_exp_hist", "series": "hist"}, Points: []oracle.Point{{TMillis: at.Add(-time.Second).UnixMilli(), Histogram: &oracle.Histogram{Count: 2, Sum: 4, Scale: 0, PositiveBuckets: []float64{6}}}}},
+							{Labels: map[string]string{"__name__": "collision_gauge", "series": "float"}, Points: []oracle.Point{{TMillis: at.Add(-2 * time.Second).UnixMilli(), Value: 42}}},
+							{Labels: map[string]string{"__name__": "collision_other_gauge", "series": "float"}, Points: []oracle.Point{{TMillis: at.Add(-3 * time.Second).UnixMilli(), Value: 7}}},
+						}
+						_, err := oracle.Evaluate(t, seeded, oracle.Query{Expr: query, Start: at, End: at.Add(step), Step: step})
+						if err == nil || !strings.Contains(err.Error(), duplicateMessage) {
+							t.Fatalf("reference must reject duplicate label sets: %v", err)
+						}
+						expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(query)
+						if err != nil {
+							t.Fatal(err)
+						}
+						plan, err := LowerAtRange(context.Background(), expr, s, at, at.Add(step), step)
+						if err != nil {
+							t.Fatal(err)
+						}
+						plan = spec.AssertScanTimeBoundAccepts(t, plan)
+						sql, args, err := chsql.Emit(context.Background(), plan)
+						if err != nil {
+							t.Fatal(err)
+						}
+						sql = testsql.NestMapWhere(testsql.NestMapOrderBy(testsql.RewriteMapProjections(sql)))
+						db := spec.OpenChDB(t)
+						seed := strings.NewReplacer("MetricName", s.MetricNameColumn, "Attributes", s.AttributesColumn, "TimeUnix", s.TimestampColumn, "Value", s.ValueColumn).Replace(nestedTimestampCollisionSeed)
+						// ResourceAttributes is not a configurable sample-label column.
+						seed = strings.ReplaceAll(seed, "Resource"+s.AttributesColumn, "ResourceAttributes")
+						for _, stmt := range testsql.SplitStatements(seed) {
+							if _, err := db.Exec(stmt); err != nil {
+								t.Fatal(err)
+							}
+						}
+						rows, err := db.Query(sql, args...)
+						if err == nil {
+							for rows.Next() {
+							}
+							err = rows.Err()
+							if closeErr := rows.Close(); err == nil {
+								err = closeErr
+							}
+						}
+						if err == nil || !strings.Contains(err.Error(), duplicateMessage) {
+							t.Fatalf("timestamp accepted duplicate output labels: %v", err)
+						}
+					})
+				}
+			}
+		}
+	}
+}

--- a/internal/promql/timestamp_nested_mixed_test.go
+++ b/internal/promql/timestamp_nested_mixed_test.go
@@ -61,7 +61,7 @@ func TestTimestampMixedPlanNormalizesRolesBeforeGuard(t *testing.T) {
 				if chplan.RowShapeOf(named) != chplan.SampleRowShape || len(named.Projections) != len(metricRoles(s)) {
 					t.Fatal("conversion did not replace mixed payload with canonical floats")
 				}
-				var ts chplan.Expr = anchorBaseExpr(evalAnchor{End: at})
+				ts := anchorBaseExpr(evalAnchor{End: at})
 				if step > 0 {
 					ts = &chplan.ColumnRef{Name: "input_time"}
 				}

--- a/internal/promql/timestamp_nested_mixed_test.go
+++ b/internal/promql/timestamp_nested_mixed_test.go
@@ -1,0 +1,144 @@
+package promql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+func TestTimestampMixedPlanNormalizesRolesBeforeGuard(t *testing.T) {
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.AttributesColumn, custom.TimestampColumn, custom.ValueColumn = "metric_id", "label_map", "sample_time", "sample_value"
+	for _, s := range []schema.Metrics{standard, custom} {
+		for _, step := range []time.Duration{0, time.Second} {
+			t.Run(fmt.Sprintf("%s/%s", s.ValueColumn, step), func(t *testing.T) {
+				columns := []chplan.Column{
+					{Name: "input_name", Role: chplan.RoleMetricName},
+					{Name: "input_labels", Role: chplan.RoleAttributes},
+					{Name: "input_time", Role: chplan.RoleTimestamp},
+					{Name: "unread_placeholder", Role: chplan.RoleValue},
+					{Name: "input_kind", Role: chplan.RoleDiscriminator},
+				}
+				inner := sampleForwardTestInput(append(columns, chplan.HistogramPayloadColumns()...)...)
+				arg, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(`sort_by_label(latency_exp_hist or num_cpus, "job")`)
+				if err != nil {
+					t.Fatal(err)
+				}
+				at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+				ctx := lowerCtx{start: at, end: at, step: step}
+				plan, err := lowerTimestampOverMixedPlan(inner, arg, s, ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				output, ok := plan.(*chplan.Project)
+				if !ok {
+					t.Fatalf("output = %T", plan)
+				}
+				if chplan.RowShapeOf(output) != chplan.SampleRowShape {
+					t.Fatal("timestamp output must be float samples")
+				}
+				name, ok := output.Projections[0].Expr.(*chplan.LitString)
+				if !ok || name.V != "" {
+					t.Fatal("output retained metric name")
+				}
+				guard, ok := output.Input.(*chplan.Aggregate)
+				if !ok || guard.Having == nil {
+					t.Fatalf("name drop missing collision guard: %T", output.Input)
+				}
+				named, ok := guard.Input.(*chplan.Project)
+				if !ok || named.Input != inner {
+					t.Fatal("conversion must retain exact original mixed operand")
+				}
+				if chplan.RowShapeOf(named) != chplan.SampleRowShape || len(named.Projections) != len(metricRoles(s)) {
+					t.Fatal("conversion did not replace mixed payload with canonical floats")
+				}
+				var ts chplan.Expr = anchorBaseExpr(evalAnchor{End: at})
+				if step > 0 {
+					ts = &chplan.ColumnRef{Name: "input_time"}
+				}
+				want := &chplan.Project{Input: inner, Roles: metricRoles(s), Projections: []chplan.Projection{
+					{Expr: &chplan.ColumnRef{Name: "input_name"}, Alias: s.MetricNameColumn},
+					{Expr: &chplan.ColumnRef{Name: "input_labels"}, Alias: s.AttributesColumn},
+					{Expr: ts, Alias: s.TimestampColumn},
+					{Expr: asFloat64(dateFnExpr(timestampFunctionName, nil, ts)), Alias: s.ValueColumn},
+				}}
+				if !named.Equal(want) {
+					t.Fatal("conversion changed role-derived names or evaluated a payload")
+				}
+			})
+		}
+	}
+}
+
+func TestTimestampMixedPlanAuthorizationPrecedesRoleResolution(t *testing.T) {
+	key := mixedWrapperKey{family: mixedTimestampFamily, site: mixedPlanAdmission}
+	old := mixedOperandPolicies[key]
+	for _, mode := range []mixedOperandPolicy{mixedReject, mixedFloatOnly, mixedPreserve} {
+		t.Run(fmt.Sprint(mode), func(t *testing.T) {
+			mixedOperandPolicies[key] = mode
+			t.Cleanup(func() { mixedOperandPolicies[key] = old })
+			plan, err := lowerTimestampOverMixedPlan(&chplan.VectorSetOp{Mixed: true}, nil, schema.DefaultOTelMetrics(), lowerCtx{})
+			if plan != nil || err == nil {
+				t.Fatalf("denied malformed input reached conversion: %T %v", plan, err)
+			}
+		})
+	}
+}
+
+func TestTimestampNestedMixedRetainsOriginalOperand(t *testing.T) {
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.AttributesColumn, custom.TimestampColumn, custom.ValueColumn = "metric_id", "label_map", "sample_time", "sample_value"
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+	for _, s := range []schema.Metrics{standard, custom} {
+		for _, step := range []time.Duration{0, time.Second} {
+			for _, sort := range []string{"sort_by_label", "sort_by_label_desc"} {
+				for _, union := range []string{"latency_exp_hist or num_cpus", "num_cpus or latency_exp_hist"} {
+					t.Run(fmt.Sprintf("%s/%s/%s/%s", s.ValueColumn, step, sort, union), func(t *testing.T) {
+						operand := sort + "(" + union + `, "job")`
+						lowerQuery := func(query string) chplan.Node {
+							expr, err := p.ParseExpr(query)
+							if err != nil {
+								t.Fatal(err)
+							}
+							plan, err := LowerAtRange(context.Background(), expr, s, at, at.Add(step), step)
+							if err != nil {
+								t.Fatal(err)
+							}
+							return plan
+						}
+						original := lowerQuery(operand)
+						plan := lowerQuery("timestamp(" + operand + ")")
+						found := false
+						chplan.Walk(plan, func(n chplan.Node) bool {
+							if f, ok := n.(*chplan.Filter); ok && chplan.IsMixedFloatNarrowing(f) {
+								t.Fatal("timestamp discarded histogram samples")
+							}
+							if n.Equal(original) {
+								found = true
+							}
+							return true
+						})
+						if !found {
+							t.Fatal("timestamp replaced its original operand")
+						}
+						optimized := spec.AssertScanTimeBoundAccepts(t, plan)
+						if _, _, err := chsql.Emit(context.Background(), optimized); err != nil {
+							t.Fatal(err)
+						}
+					})
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3302.

Part of #3277.

## What changed

- preserve every already-admitted mixed row through nested `timestamp(...)`
- resolve metric-name, attributes, and timestamp columns by semantic role before projecting the canonical float result
- normalize non-selector timestamp results to the evaluation instant before duplicate-label collision detection
- retain the original union shadowing and mixed-plan authorization boundary

The old generic path treated the mixed relation as float-only and lost histogram rows. The new path reads no sample payload: it converts both sample kinds to the timestamp value Prometheus defines for a non-selector argument, then applies the existing name-drop collision guard.

## Verification

- exact untagged race tests passed for role normalization, authorization ordering, and preservation of the original operand
- exact chDB plus independent-Prometheus-oracle tests passed: 2 top-level tests and 88 matrix subtests
- coverage includes both union orientations, both label-sort directions, direct controls, shadow collisions, duplicate output labelsets, instant/range evaluation, offsets, `@` modifiers, and custom schema column names

The original reproduction returned three rows where Prometheus returned five. The regression suite pins every retained row and the normalization-before-collision behavior against the independent Prometheus engine.

Closes #3302
