### PR TITLE
fix(promql): serialize nested mixed count_values samples by kind

### DIFF
--- a/internal/promql/count_values_mixed_chdb_test.go
+++ b/internal/promql/count_values_mixed_chdb_test.go
@@ -1,0 +1,168 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+	oracle "github.com/tsouza/cerberus/test/spec/parityoracle/promql"
+)
+
+func TestCountValuesNestedMixedSerialization_ChDB(t *testing.T) {
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.AttributesColumn = "metric_id", "label_map"
+	custom.TimestampColumn, custom.ValueColumn = "sample_time", "sample_value"
+	for _, s := range []schema.Metrics{standard, custom} {
+		for _, shadow := range []bool{false, true} {
+			for _, histFirst := range []bool{false, true} {
+				for _, step := range []time.Duration{0, time.Second} {
+					for _, grouping := range []string{"", " by (series)"} {
+						t.Run(fmt.Sprintf("%s/shadow=%v/histFirst=%v/%s/%s", s.ValueColumn, shadow, histFirst, step, grouping), func(t *testing.T) {
+							seed, series, histMetric, floatMetric := countValuesMixedSeed(shadow)
+							left, right := floatMetric, histMetric
+							if histFirst {
+								left, right = right, left
+							}
+							operand := left + " or " + right
+							query := `count_values("v", sort_by_label(` + operand + `, "series"))` + grouping
+							assertCountValuesMixedParity(t, query, seed, series, s, step)
+							if s.ValueColumn == standard.ValueColumn && !shadow && step == 0 && grouping == "" {
+								assertCountValuesMixedParity(t, `count_values("v", `+operand+`)`, seed, series, s, step)
+								assertCountValuesMixedParity(t, `abs(`+query+`)`, seed, series, s, step)
+								emptyOperand := left + `{series="missing"} or ` + right + `{series="missing"}`
+								assertCountValuesMixedParity(t, `count_values("v", sort_by_label(`+emptyOperand+`, "series"))`, seed, series, s, step)
+								if !histFirst {
+									assertCountValuesMixedParity(t, query+" without (series)", seed, series, s, step)
+								}
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}
+
+func countValuesMixedSeed(shadow bool) (string, []oracle.Series, string, string) {
+	at := cvMixedEvalTS.Add(-time.Second).UnixMilli()
+	floatSeries := func(metric, name string, value float64) oracle.Series {
+		return oracle.Series{Labels: map[string]string{"__name__": metric, "series": name}, Points: []oracle.Point{{TMillis: at, Value: value}}}
+	}
+	histSeries := func(metric, name string, count, sum, bucketCount float64) oracle.Series {
+		return oracle.Series{Labels: map[string]string{"__name__": metric, "series": name}, Points: []oracle.Point{{TMillis: at, Histogram: &oracle.Histogram{Count: count, Sum: sum, PositiveBuckets: []float64{bucketCount}}}}}
+	}
+	if shadow {
+		return tkShadowSeed, []oracle.Series{
+			histSeries(tkShadowHistMetric, "dup", 2, 4, 6),
+			floatSeries(tkShadowFloatMetric, "dup", 42),
+			floatSeries(tkShadowFloatMetric, "solo", 7),
+		}, tkShadowHistMetric, tkShadowFloatMetric
+	}
+	// A real zero must remain distinct from the histogram's placeholder Value.
+	seed := strings.Replace(cvMixedSeed, "9.0);", "0.0);", 1)
+	return seed, []oracle.Series{
+		histSeries(cvMixedHistMetric, "h1", 5, 10, 5),
+		floatSeries(cvMixedFloatMetric, "f1", 3),
+		floatSeries(cvMixedFloatMetric, "f2", 3),
+		floatSeries(cvMixedFloatMetric, "f3", 0),
+	}, cvMixedHistMetric, cvMixedFloatMetric
+}
+
+func assertCountValuesMixedParity(t *testing.T, query, seed string, series []oracle.Series, s schema.Metrics, step time.Duration) {
+	t.Helper()
+	reference, err := oracle.Evaluate(t, series, oracle.Query{Expr: query, Start: cvMixedEvalTS, End: cvMixedEvalTS.Add(step), Step: step})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := func(labels map[string]string, stamp int64, value float64) string {
+		encoded, err := json.Marshal(labels)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return fmt.Sprintf("%s/%d/%g", encoded, stamp, value)
+	}
+	want := []string{}
+	for _, sample := range reference {
+		if sample.Histogram != nil {
+			t.Fatal("count_values reference returned a histogram")
+		}
+		want = append(want, record(sample.Labels, sample.TMillis, sample.Value))
+	}
+	slices.Sort(want)
+	seed = strings.NewReplacer("MetricName", s.MetricNameColumn, "Attributes", s.AttributesColumn, "TimeUnix", s.TimestampColumn, "Value", s.ValueColumn).Replace(seed)
+	seed = strings.ReplaceAll(seed, "Resource"+s.AttributesColumn, "ResourceAttributes")
+	for _, optimized := range []bool{false, true} {
+		t.Run(fmt.Sprintf("optimized=%v", optimized), func(t *testing.T) {
+			expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := promql.LowerAtRange(context.Background(), expr, s, cvMixedEvalTS, cvMixedEvalTS.Add(step), step)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if optimized {
+				plan = spec.AssertScanTimeBoundAccepts(t, plan)
+			}
+			col := func(name string) chplan.Expr { return &chplan.ColumnRef{Name: name} }
+			projection := &chplan.Project{Input: plan, Projections: []chplan.Projection{
+				{Expr: &chplan.FuncCall{Fn: chplan.FnToJSONString, Args: []chplan.Expr{col(s.AttributesColumn)}}, Alias: "labels"},
+				{Expr: &chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{col(s.TimestampColumn)}}, Alias: "stamp"},
+				{Expr: col(s.ValueColumn), Alias: "count"},
+			}}
+			sql, args, err := chsql.Emit(context.Background(), projection)
+			if err != nil {
+				t.Fatal(err)
+			}
+			db := spec.OpenChDB(t)
+			spec.ApplySeed(t, db, seed)
+			rows, err := db.Query(sql, args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = rows.Close() }()
+			got := []string{}
+			for rows.Next() {
+				var labelsJSON, stamp string
+				var value float64
+				if err := rows.Scan(&labelsJSON, &stamp, &value); err != nil {
+					t.Fatal(err)
+				}
+				labels := map[string]string{}
+				if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {
+					t.Fatal(err)
+				}
+				at := cvMixedEvalTS
+				if step > 0 {
+					at, err = time.Parse("2006-01-02 15:04:05.999999999", stamp)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				got = append(got, record(labels, at.UnixMilli(), value))
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatal(err)
+			}
+			slices.Sort(got)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("%s: got %v, reference %v", query, got, want)
+			}
+		})
+	}
+}

--- a/internal/promql/count_values_mixed_test.go
+++ b/internal/promql/count_values_mixed_test.go
@@ -1,0 +1,106 @@
+package promql
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestCountValuesMixedSerializationPlan(t *testing.T) {
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.AttributesColumn = "metric_id", "label_map"
+	custom.TimestampColumn, custom.ValueColumn = "sample_time", "sample_value"
+	for _, s := range []schema.Metrics{standard, custom} {
+		for _, mixed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/mixed=%v", s.ValueColumn, mixed), func(t *testing.T) {
+				operand := "num_cpus"
+				if mixed {
+					operand = `sort_by_label(latency_exp_hist or num_cpus, "series")`
+				}
+				plan := lowerCountValuesMixedTest(t, `count_values("v", `+operand+`)`, s)
+				if chplan.RowShapeOf(plan) != chplan.SampleRowShape || plan.RowType().HasHistogramPayload() {
+					t.Fatal("count_values must return ordinary float counts")
+				}
+				var aggregate *chplan.Aggregate
+				var valueKey chplan.Expr
+				chplan.Walk(plan, func(node chplan.Node) bool {
+					if agg, ok := node.(*chplan.Aggregate); ok {
+						for i, alias := range agg.GroupByAliases {
+							if alias == "cv_val" {
+								aggregate, valueKey = agg, agg.GroupBy[i]
+							}
+						}
+					}
+					return true
+				})
+				if aggregate == nil {
+					t.Fatal("missing value-label grouping")
+				}
+				floatKey := promFixedFloatStringExpr(&chplan.ColumnRef{Name: s.ValueColumn})
+				if !mixed {
+					if !reflect.DeepEqual(valueKey, floatKey) {
+						t.Fatal("ordinary float serialization changed")
+					}
+					return
+				}
+				if _, ok := aggregate.Input.(*chplan.OrderBy); !ok || !aggregate.Input.RowType().HasHistogramPayload() {
+					t.Fatal("serialization must consume the complete shadow-resolved mixed operand")
+				}
+				conditional, ok := valueKey.(*chplan.FuncCall)
+				const conditionalArity = 3
+				if !ok || conditional.Fn != chplan.FnIf || len(conditional.Args) != conditionalArity {
+					t.Fatalf("mixed key must choose a serializer, got %T", valueKey)
+				}
+				wantKind := &chplan.Binary{
+					Op:    chplan.OpEq,
+					Left:  &chplan.ColumnRef{Name: chplan.MixedDiscriminatorColumn},
+					Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+				}
+				if !reflect.DeepEqual(conditional.Args[0], wantKind) ||
+					!reflect.DeepEqual(conditional.Args[1], floatKey) ||
+					!reflect.DeepEqual(conditional.Args[2], nativeHistogramStringExpr(s)) {
+					t.Fatal("mixed value-label key does not use the sample-kind serializers")
+				}
+			})
+		}
+	}
+}
+
+func TestCountValuesMixedAdmissionRemainsRequired(t *testing.T) {
+	key := mixedWrapperKey{family: mixedCountValuesFamily, site: mixedPlanAdmission}
+	saved := mixedOperandPolicies[key]
+	delete(mixedOperandPolicies, key)
+	t.Cleanup(func() { mixedOperandPolicies[key] = saved })
+	expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(`count_values("v", sort_by_label(latency_exp_hist or num_cpus, "series"))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Unix(0, 0)
+	plan, err := LowerAt(context.Background(), expr, schema.DefaultOTelMetrics(), at, at)
+	if plan != nil || err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for count-values at existing-plan") {
+		t.Fatalf("missing admission: plan=%T error=%v", plan, err)
+	}
+}
+
+func lowerCountValuesMixedTest(t *testing.T, query string, s schema.Metrics) chplan.Node {
+	t.Helper()
+	expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Unix(0, 0)
+	plan, err := LowerAt(context.Background(), expr, s, at, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -5484,11 +5484,26 @@ func lowerCountValues(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (
 	if err := requireMixedPlanPolicy(input, mixedCountValuesFamily); err != nil {
 		return nil, err
 	}
+	valueKey := promFixedFloatStringExpr(&chplan.ColumnRef{Name: s.ValueColumn})
+	if chplan.RowShapeOf(input) == chplan.MixedRowShape {
+		// Shadow resolution belongs to the completed operand. Serialize each
+		// surviving sample by its kind: histogram placeholder Values are not
+		// real floats and must never enter the float value-label group.
+		valueKey = &chplan.FuncCall{Fn: chplan.FnIf, Args: []chplan.Expr{
+			&chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: chplan.MixedDiscriminatorColumn},
+				Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+			},
+			valueKey,
+			nativeHistogramStringExpr(s),
+		}}
+	}
 	return lowerCountValuesOverPlan(
 		a,
 		label,
 		input,
-		promFixedFloatStringExpr(&chplan.ColumnRef{Name: s.ValueColumn}),
+		valueKey,
 		s,
 		ctx,
 	), nil


### PR DESCRIPTION
## Summary

- choose the nested mixed `count_values` serializer from the live sample discriminator
- keep ordinary float serialization and the existing direct-root, histogram, and subquery kernels unchanged
- cover structural admission plus default/custom schemas, instant/range evaluation, `by`/`without`, empty input, shadow collisions, real float zero, and both union orientations

## Verification

- `go test -timeout 3m -race -count=1 -run '^(TestCountValuesMixedSerializationPlan|TestCountValuesMixedAdmissionRemainsRequired)$' ./internal/promql`
- `go test -timeout 12m -tags chdb -count=1 -run '^TestCountValuesNestedMixedSerialization_ChDB$' ./internal/promql` (704.714s)

Closes #3345
