### PR TITLE
fix(promql): preserve nested mixed selector kinds

### DIFF
--- a/internal/api/prom/handler_chdb_mixed_selectors_test.go
+++ b/internal/api/prom/handler_chdb_mixed_selectors_test.go
@@ -32,6 +32,11 @@ CREATE TABLE otel_metrics_gauge (
  ResourceAttributes Map(String,String) DEFAULT map(), ServiceName String DEFAULT '',
  TimeUnix DateTime64(9), Value Float64
 ) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+CREATE TABLE otel_metrics_sum (
+ MetricName String, Attributes Map(String,String),
+ ResourceAttributes Map(String,String) DEFAULT map(), ServiceName String DEFAULT '',
+ TimeUnix DateTime64(9), Value Float64
+) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
 INSERT INTO otel_metrics_exponential_histogram
  (MetricName,Attributes,TimeUnix,Count,Sum,Scale,ZeroCount,PositiveOffset,PositiveBucketCounts,NegativeOffset,NegativeBucketCounts) VALUES
  ('selector_wire_exp_hist', map('series','hist'), toDateTime64('2026-01-01 00:00:00',9), 2, 3., 0, 0, 0, [2], 0, []);

--- a/internal/api/prom/handler_chdb_mixed_selectors_test.go
+++ b/internal/api/prom/handler_chdb_mixed_selectors_test.go
@@ -1,0 +1,203 @@
+//go:build chdb
+
+package prom_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/api/prom"
+	"github.com/tsouza/cerberus/internal/chclienttest"
+	"github.com/tsouza/cerberus/internal/schema"
+	oracle "github.com/tsouza/cerberus/test/spec/parityoracle/promql"
+)
+
+const selectorWireSeed = `
+CREATE TABLE otel_metrics_exponential_histogram (
+ MetricName String, Attributes Map(String,String),
+ ResourceAttributes Map(String,String) DEFAULT map(), ServiceName String DEFAULT '',
+ TimeUnix DateTime64(9), Count UInt64, Sum Float64, Scale Int32, ZeroCount UInt64,
+ PositiveOffset Int32, PositiveBucketCounts Array(UInt64), NegativeOffset Int32, NegativeBucketCounts Array(UInt64)
+) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+CREATE TABLE otel_metrics_gauge (
+ MetricName String, Attributes Map(String,String),
+ ResourceAttributes Map(String,String) DEFAULT map(), ServiceName String DEFAULT '',
+ TimeUnix DateTime64(9), Value Float64
+) ENGINE=MergeTree ORDER BY (MetricName,Attributes,TimeUnix);
+INSERT INTO otel_metrics_exponential_histogram
+ (MetricName,Attributes,TimeUnix,Count,Sum,Scale,ZeroCount,PositiveOffset,PositiveBucketCounts,NegativeOffset,NegativeBucketCounts) VALUES
+ ('selector_wire_exp_hist', map('series','hist'), toDateTime64('2026-01-01 00:00:00',9), 2, 3., 0, 0, 0, [2], 0, []);
+INSERT INTO otel_metrics_gauge (MetricName,Attributes,TimeUnix,Value) VALUES
+ ('selector_wire_gauge', map('series','float'), toDateTime64('2026-01-01 00:00:00',9), 42.);
+`
+
+func TestMixedSelectorsWireSampleKinds_ChDB(t *testing.T) {
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.TimestampColumn, custom.ValueColumn = "metric_id", "sample_time", "sample_value"
+	seeded := []oracle.Series{
+		{Labels: map[string]string{"__name__": "selector_wire_exp_hist", "series": "hist"}, Points: []oracle.Point{{TMillis: histValuedEvalTime.Add(-time.Second).UnixMilli(), Histogram: &oracle.Histogram{Count: 2, Sum: 3, PositiveBuckets: []float64{2}}}}},
+		{Labels: map[string]string{"__name__": "selector_wire_gauge", "series": "float"}, Points: []oracle.Point{{TMillis: histValuedEvalTime.Add(-time.Second).UnixMilli(), Value: 42}}},
+	}
+	for _, tc := range []struct {
+		name      string
+		op        string
+		parameter string
+		schema    schema.Metrics
+		step      time.Duration
+		histFirst bool
+	}{
+		{"topk/literal/instant/float_first", "topk", "10", standard, 0, false},
+		{"topk/computed/range/hist_first", "topk", "scalar(vector(10))", custom, time.Second, true},
+		{"bottomk/literal/range/hist_first", "bottomk", "10", custom, time.Second, true},
+		{"bottomk/computed/instant/float_first", "bottomk", "scalar(vector(10))", standard, 0, false},
+		{"limitk/literal/range/hist_first", "limitk", "10", standard, time.Second, true},
+		{"limitk/computed/instant/float_first", "limitk", "scalar(vector(10))", custom, 0, false},
+		{"limit_ratio/literal/instant/hist_first", "limit_ratio", "1", custom, 0, true},
+		{"limit_ratio/computed/range/float_first", "limit_ratio", "scalar(vector(1))", standard, time.Second, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			left, right := "selector_wire_gauge", "selector_wire_exp_hist"
+			if tc.histFirst {
+				left, right = right, left
+			}
+			query := tc.op + "(" + tc.parameter + ", sort_by_label(" + left + " or " + right + `, "series"))`
+			assertSelectorWireParity(t, tc.schema, seeded, query, tc.step)
+		})
+	}
+}
+
+func assertSelectorWireParity(t *testing.T, s schema.Metrics, seeded []oracle.Series, query string, step time.Duration) {
+	t.Helper()
+	at := histValuedEvalTime
+	reference, err := oracle.Evaluate(t, seeded, oracle.Query{Expr: query, Start: at, End: at.Add(step), Step: step})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{}
+	for _, sample := range reference {
+		key := fmt.Sprintf("%s/%s/%d", sample.Labels["__name__"], sample.Labels["series"], sample.TMillis)
+		if sample.Histogram != nil {
+			want = append(want, fmt.Sprintf("%s/hist/%g/%g", key, sample.Histogram.Count, sample.Histogram.Sum))
+		} else {
+			want = append(want, fmt.Sprintf("%s/float/%g", key, sample.Value))
+		}
+	}
+	slices.Sort(want)
+	client := chclienttest.NewChDB(t)
+	seed := strings.NewReplacer("MetricName", s.MetricNameColumn, "TimeUnix", s.TimestampColumn, "Value", s.ValueColumn).Replace(selectorWireSeed)
+	client.Seed(t, seed)
+	handler := prom.New(client, s, nil)
+	mux := http.NewServeMux()
+	handler.Mount(mux)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	params := url.Values{"query": {query}}
+	endpoint := "/api/v1/query"
+	if step == 0 {
+		params.Set("time", at.Format(time.RFC3339))
+	} else {
+		endpoint = "/api/v1/query_range"
+		params.Set("start", at.Format(time.RFC3339))
+		params.Set("end", at.Add(step).Format(time.RFC3339))
+		params.Set("step", step.String())
+	}
+	response, err := http.Get(server.URL + endpoint + "?" + params.Encode()) //nolint:noctx // test-local server
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := readBody(t, response)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("%s: status=%d body=%s", query, response.StatusCode, body)
+	}
+	got := mixedSelectorWireRows(t, body, step > 0)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s: wire=%v reference=%v", query, got, want)
+	}
+}
+
+func mixedSelectorWireRows(t *testing.T, body string, matrix bool) []string {
+	t.Helper()
+	var parsed struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric     map[string]string   `json:"metric"`
+				Value      []json.RawMessage   `json:"value"`
+				Histogram  []json.RawMessage   `json:"histogram"`
+				Values     [][]json.RawMessage `json:"values"`
+				Histograms [][]json.RawMessage `json:"histograms"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	wantType := "vector"
+	if matrix {
+		wantType = "matrix"
+	}
+	if parsed.Status != "success" || parsed.Data.ResultType != wantType {
+		t.Fatalf("invalid response: %s", body)
+	}
+	got := []string{}
+	for _, series := range parsed.Data.Result {
+		floats, histograms := series.Values, series.Histograms
+		if !matrix {
+			if len(series.Value) != 0 {
+				floats = append(floats, series.Value)
+			}
+			if len(series.Histogram) != 0 {
+				histograms = append(histograms, series.Histogram)
+			}
+		}
+		if (len(floats) == 0) == (len(histograms) == 0) {
+			t.Fatalf("seeded series must contain exactly one sample kind: %s", body)
+		}
+		for kind, points := range [][][]json.RawMessage{floats, histograms} {
+			for _, point := range points {
+				if len(point) != 2 {
+					t.Fatal("invalid wire point", point)
+				}
+				var stamp float64
+				if err := json.Unmarshal(point[0], &stamp); err != nil {
+					t.Fatal(err)
+				}
+				const millisPerSecond = 1000
+				key := fmt.Sprintf("%s/%s/%d", series.Metric["__name__"], series.Metric["series"], int64(stamp*millisPerSecond))
+				if kind == 0 {
+					var value string
+					if err := json.Unmarshal(point[1], &value); err != nil {
+						t.Fatal(err)
+					}
+					got = append(got, key+"/float/"+value)
+				} else {
+					var histogram struct {
+						Count   string  `json:"count"`
+						Sum     string  `json:"sum"`
+						Buckets [][]any `json:"buckets"`
+					}
+					if err := json.Unmarshal(point[1], &histogram); err != nil {
+						t.Fatal(err)
+					}
+					wantBuckets := [][]any{{float64(0), "1", "2", "2"}}
+					if !reflect.DeepEqual(histogram.Buckets, wantBuckets) {
+						t.Fatalf("histogram buckets=%v, want=%v", histogram.Buckets, wantBuckets)
+					}
+					got = append(got, key+"/hist/"+histogram.Count+"/"+histogram.Sum)
+				}
+			}
+		}
+	}
+	slices.Sort(got)
+	return got
+}

--- a/internal/chplan/topk.go
+++ b/internal/chplan/topk.go
@@ -23,7 +23,7 @@ package chplan
 //	SELECT <Columns> FROM (
 //	  SELECT *, row_number() OVER (PARTITION BY <By> ORDER BY <SortExpr> [DESC]) AS _rn
 //	  FROM (<input>)
-//	) WHERE _rn <= (SELECT toUInt64(`Value`) FROM (<KExpr>) LIMIT 1)
+//	) WHERE toFloat64(_rn) <= (SELECT toFloat64(`<RoleValue>`) FROM (<KExpr>) LIMIT 1)
 //
 // `Desc=true` renders `ORDER BY ... DESC` (topk). `Desc=false` renders
 // `ORDER BY ... ASC` (bottomk).
@@ -47,10 +47,10 @@ package chplan
 // CH does not accept a subquery directly in a LIMIT clause, so the
 // "per-partition top-K with computed K" semantics flow through a
 // rank-based filter. The subtree is expected to produce a single-row
-// vector shape (PromQL `scalar(<vector>)`) whose `Value` column is the
-// K integer; the emitter wraps it as `(SELECT toUInt64(Value) FROM
-// <KExpr> LIMIT 1)`. `K` and `KExpr` are mutually exclusive — set one
-// or the other, never both.
+// vector shape (PromQL `scalar(<vector>)`) with exactly one named
+// [RoleValue] column; the emitter resolves that live name and wraps it as
+// `(SELECT toFloat64(<RoleValue>) FROM <KExpr> LIMIT 1)`. `K` and `KExpr`
+// are mutually exclusive — set one or the other, never both.
 //
 // `Unordered` models PromQL's experimental `limitk(K, v)` aggregator:
 // per group, return up to K *arbitrary* series — no ranking, no value

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -747,9 +747,9 @@ func (e *emitter) emitLimit(l *chplan.Limit) error {
 // v)`), the literal-K LIMIT shape is replaced with a `row_number()
 // OVER (PARTITION BY <by> [ORDER BY <sortExpr> [DESC]]) <= K` predicate
 // because ClickHouse does not accept a subquery directly in a LIMIT
-// clause. The K subquery is wrapped as `(SELECT toFloat64(Value) FROM
-// (<k_subtree>) LIMIT 1)`, reading the `Value` column of the one-row
-// relation the lowering builds for K.
+// clause. The K subquery is wrapped as `(SELECT toFloat64(<RoleValue>) FROM
+// (<k_subtree>) LIMIT 1)`, resolving the one named value-role column from
+// the scalar materialisation's schema.
 //
 // When t.Unordered (PromQL `limitk(K, v)`), the ORDER BY is omitted
 // entirely: the result is K *arbitrary* rows per partition, no ranking.
@@ -827,7 +827,7 @@ func (e *emitter) emitTopK(t *chplan.TopK) error {
 //	SELECT <Columns> FROM (
 //	  SELECT *, row_number() OVER (PARTITION BY <By> ORDER BY <SortExpr> [DESC]) AS _rn
 //	  FROM (<input>)
-//	) WHERE toFloat64(_rn) <= (SELECT toFloat64(`Value`) FROM (<KExpr>) LIMIT 1)
+//	) WHERE toFloat64(_rn) <= (SELECT toFloat64(`<RoleValue>`) FROM (<KExpr>) LIMIT 1)
 //
 // `By` empty omits PARTITION BY (the rank fires across the whole
 // result); `SortExpr` nil (the Unordered / limitk shape) omits the

--- a/internal/chsql/emit_node.go
+++ b/internal/chsql/emit_node.go
@@ -853,6 +853,25 @@ func (e *emitter) emitTopKComputed(t *chplan.TopK) error {
 	if err != nil {
 		return err
 	}
+	kSchema := t.KExpr.RowType()
+	var kValueColumn string
+	for _, column := range kSchema.Columns {
+		if column.Role != chplan.RoleValue {
+			continue
+		}
+		if column.Name == "" || kValueColumn != "" {
+			return fmt.Errorf("chsql: computed topk requires one named scalar value column")
+		}
+		kValueColumn = column.Name
+	}
+	if kValueColumn == "" {
+		return fmt.Errorf("chsql: computed topk scalar value role is missing")
+	}
+	for _, column := range kSchema.Columns {
+		if column.Name == kValueColumn && column.Role != chplan.RoleValue {
+			return fmt.Errorf("chsql: computed topk scalar value column is ambiguous")
+		}
+	}
 
 	partitionBy := make([]Frag, 0, len(t.By))
 	for _, by := range t.By {
@@ -883,7 +902,7 @@ func (e *emitter) emitTopKComputed(t *chplan.TopK) error {
 		As(rankFrag, "_rn"),
 	)
 
-	// K subquery: `(SELECT toFloat64(Value) FROM (<k_subtree>) LIMIT 1)`.
+	// K's value name belongs to its own scalar schema, not the ranked input.
 	// The comparison stays in Float64 rather than casting K to an integer:
 	// a UInt64 cast wraps a negative K around to ~1.8e19 and lets EVERY
 	// row through, where PromQL's rule is that any K below 1 selects
@@ -893,7 +912,7 @@ func (e *emitter) emitTopKComputed(t *chplan.TopK) error {
 	// empty threshold by the lowering) keeps no row. LIMIT 1 enforces
 	// single-row scalar-subquery semantics.
 	kSelect := NewQuery().
-		Select(Call("toFloat64", Col("Value"))).
+		Select(Call("toFloat64", Col(kValueColumn))).
 		From(kSub).
 		Limit(1)
 	kSubquery := Subquery(kSelect)
@@ -905,6 +924,8 @@ func (e *emitter) emitTopKComputed(t *chplan.TopK) error {
 			cols = append(cols, Col(c))
 		}
 		outer.Select(cols...)
+	} else {
+		outer.Select(StarExcept(Star(), "_rn"))
 	}
 	return e.emitSelect(outer)
 }

--- a/internal/chsql/topk_computed_schema_test.go
+++ b/internal/chsql/topk_computed_schema_test.go
@@ -1,0 +1,49 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+func TestComputedTopKScalarValueRole(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		columns   []chplan.Column
+		wantError string
+	}{
+		{"custom", []chplan.Column{{Name: "sample_value", Role: chplan.RoleValue}}, ""},
+		{"missing", []chplan.Column{{Name: "Value"}}, "value role is missing"},
+		{"unnamed", []chplan.Column{{Role: chplan.RoleValue}}, "one named scalar value column"},
+		{"multiple", []chplan.Column{{Name: "first", Role: chplan.RoleValue}, {Name: "second", Role: chplan.RoleValue}}, "one named scalar value column"},
+		{"duplicate", []chplan.Column{{Name: "sample_value", Role: chplan.RoleValue}, {Name: "sample_value", Role: chplan.RoleValue}}, "one named scalar value column"},
+		{"ambiguous", []chplan.Column{{Name: "sample_value", Role: chplan.RoleValue}, {Name: "sample_value", Role: chplan.RoleAttributes}}, "value column is ambiguous"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := &chplan.TopK{
+				Input:     &chplan.Scan{Table: "samples"},
+				KExpr:     &chplan.Scan{Table: "scalar_input", Roles: tc.columns},
+				Unordered: true,
+			}
+			sql, _, err := chsql.Emit(context.Background(), plan)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("error=%v, want %q", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(sql, "toFloat64(`sample_value`)") {
+				t.Fatalf("scalar value schema ignored: %s", sql)
+			}
+			if !strings.Contains(sql, "* EXCEPT (`_rn`)") {
+				t.Fatalf("internal rank leaks into output: %s", sql)
+			}
+		})
+	}
+}

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -5814,7 +5814,7 @@ func lowerLimitKInput(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.
 	if err := requireMixedPlanPolicy(input, mixedLimitFamily); err != nil {
 		return nil, false, false, err
 	}
-	return input, false, false, nil
+	return input, false, chplan.RowShapeOf(input) == chplan.MixedRowShape, nil
 }
 
 // limitKOrRatioOverExpHistogram recognises `limitk(K, <exp-hist shape>)` /
@@ -6220,6 +6220,7 @@ func lowerTopK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.
 	if err := requireMixedPlanPolicy(input, mixedTopKFamily); err != nil {
 		return nil, err
 	}
+	input = mixedRowsFloatOnly(input)
 	return buildTopKLiteral(a, s, ctx, input, k, empty), nil
 }
 
@@ -6470,6 +6471,9 @@ func lowerTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) 
 	}
 	if err := requireMixedPlanPolicy(input, mixedAggregateFamily(a.Op)); err != nil {
 		return nil, err
+	}
+	if a.Op != parser.LIMITK {
+		input = mixedRowsFloatOnly(input)
 	}
 	return buildTopKComputed(a, s, ctx, input, histogram, mixed)
 }

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -6445,7 +6445,7 @@ func topKOutputColumns(input chplan.Node, s schema.Metrics) []string {
 // `pi()`, so every shape the grammar admits in K position is covered by
 // construction — there is no residual shape for a guard to reject. The
 // resulting Expr is materialised as a one-row relation because KExpr is
-// a Node slot (the emitter reads its `Value` column).
+// a Node slot (the emitter resolves its configured [chplan.RoleValue] column).
 //
 // [topKDomainExpr] applies the runtime half of the K-domain rules the
 // literal path resolves in [topKDomain].

--- a/internal/promql/selector_mixed_chdb_test.go
+++ b/internal/promql/selector_mixed_chdb_test.go
@@ -1,0 +1,215 @@
+//go:build chdb
+
+package promql_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/internal/testsql"
+	"github.com/tsouza/cerberus/test/spec"
+	oracle "github.com/tsouza/cerberus/test/spec/parityoracle/promql"
+)
+
+// K exceeds every group, making limitk's otherwise arbitrary selection exact.
+const mixedSelectorAllK = "10"
+
+func TestComputedSelectorCustomValueColumn_ChDB(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	s.ValueColumn = "sample_value"
+	for _, op := range []string{"topk", "bottomk", "limitk"} {
+		for _, step := range []time.Duration{0, time.Second} {
+			t.Run(fmt.Sprintf("%s/%s", op, step), func(t *testing.T) {
+				assertMixedSelectorParity(t, op+"(scalar(vector("+mixedSelectorAllK+")), "+foFloatMetric+")", false, s, step)
+			})
+		}
+	}
+}
+
+func TestMixedSelectorsRetainSampleKinds_ChDB(t *testing.T) {
+	standard := schema.DefaultOTelMetrics()
+	custom := standard
+	custom.MetricNameColumn, custom.TimestampColumn, custom.ValueColumn = "metric_id", "sample_time", "sample_value"
+	for _, tc := range []struct {
+		name      string
+		op        string
+		parameter string
+		schema    schema.Metrics
+		step      time.Duration
+		shadow    bool
+		histFirst bool
+	}{
+		{"topk/literal/instant/float_first", "topk", mixedSelectorAllK, standard, 0, false, false},
+		{"topk/computed/range/hist_first", "topk", "scalar(vector(" + mixedSelectorAllK + "))", custom, time.Second, false, true},
+		{"bottomk/literal/range/hist_first", "bottomk", mixedSelectorAllK, custom, time.Second, false, true},
+		{"bottomk/computed/instant/shadow_float_first", "bottomk", "scalar(vector(" + mixedSelectorAllK + "))", standard, 0, true, false},
+		{"limitk/literal/range/shadow_hist_first", "limitk", mixedSelectorAllK, standard, time.Second, true, true},
+		{"limitk/computed/instant/float_first", "limitk", "scalar(vector(" + mixedSelectorAllK + "))", custom, 0, false, false},
+		{"limit_ratio/literal/instant/hist_first", "limit_ratio", "1", custom, 0, false, true},
+		{"limit_ratio/computed/range/float_first", "limit_ratio", "scalar(vector(1))", standard, time.Second, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			operand := mixedSelectorOperand(tc.shadow, tc.histFirst)
+			query := tc.op + "(" + tc.parameter + ", sort_by_label(" + operand + `, "series")) by (bucket)`
+			assertMixedSelectorParity(t, query, tc.shadow, tc.schema, tc.step)
+		})
+	}
+}
+
+func mixedSelectorOperand(shadow, histFirst bool) string {
+	hist, float := foHistMetric, foFloatMetric
+	if shadow {
+		hist, float = tkShadowHistMetric, tkShadowFloatMetric
+	}
+	if histFirst {
+		return hist + " or " + float
+	}
+	return float + " or " + hist
+}
+
+func mixedSelectorSeed(shadow bool, s schema.Metrics) (string, []oracle.Series) {
+	hist, float, seed := foHistMetric, foFloatMetric, foSeed
+	if shadow {
+		hist, float, seed = tkShadowHistMetric, tkShadowFloatMetric, tkShadowSeed
+	}
+	at := foEvalTS.Add(-time.Second).UnixMilli()
+	histSeries := func(series, bucket string, count, sum, bucketCount float64) oracle.Series {
+		labels := map[string]string{"__name__": hist, "series": series}
+		if bucket != "" {
+			labels["bucket"] = bucket
+		}
+		return oracle.Series{Labels: labels, Points: []oracle.Point{{TMillis: at, Histogram: &oracle.Histogram{Count: count, Sum: sum, PositiveBuckets: []float64{bucketCount}}}}}
+	}
+	floatSeries := func(series, bucket string, value float64) oracle.Series {
+		labels := map[string]string{"__name__": float, "series": series}
+		if bucket != "" {
+			labels["bucket"] = bucket
+		}
+		return oracle.Series{Labels: labels, Points: []oracle.Point{{TMillis: at, Value: value}}}
+	}
+	seeded := []oracle.Series{histSeries("h1", "b1", 2, 4, 6), histSeries("h2", "b2", 3, 9, 7), floatSeries("f1", "b1", 3), floatSeries("f2", "b1", 9), floatSeries("f3", "b3", 1)}
+	if shadow {
+		seeded = []oracle.Series{histSeries("dup", "", 2, 4, 6), floatSeries("dup", "", 42), floatSeries("solo", "", 7)}
+	}
+	seed = strings.NewReplacer("MetricName", s.MetricNameColumn, "Attributes", s.AttributesColumn, "TimeUnix", s.TimestampColumn, "Value", s.ValueColumn).Replace(seed)
+	seed = strings.ReplaceAll(seed, "Resource"+s.AttributesColumn, "ResourceAttributes")
+	return seed, seeded
+}
+
+func assertMixedSelectorParity(t *testing.T, query string, shadow bool, s schema.Metrics, step time.Duration) {
+	t.Helper()
+	seed, seeded := mixedSelectorSeed(shadow, s)
+	reference, err := oracle.Evaluate(t, seeded, oracle.Query{Expr: query, Start: foEvalTS, End: foEvalTS.Add(step), Step: step})
+	if err != nil {
+		t.Fatalf("reference %s: %v", query, err)
+	}
+	want := []string{}
+	for _, sample := range reference {
+		key := fmt.Sprintf("%s/%s/%s/%d", sample.Labels["__name__"], sample.Labels["series"], sample.Labels["bucket"], sample.TMillis)
+		if sample.Histogram != nil {
+			h := sample.Histogram
+			want = append(want, fmt.Sprintf("%s/hist/%g/%g/%v", key, h.Count, h.Sum, h.PositiveBuckets))
+		} else {
+			want = append(want, fmt.Sprintf("%s/float/%g", key, sample.Value))
+		}
+	}
+	slices.Sort(want)
+	for _, optimized := range []bool{false, true} {
+		t.Run(fmt.Sprintf("optimized=%v", optimized), func(t *testing.T) {
+			t.Logf("query: %s", query)
+			expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := promql.LowerAtRange(context.Background(), expr, s, foEvalTS, foEvalTS.Add(step), step)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if optimized {
+				plan = spec.AssertScanTimeBoundAccepts(t, plan)
+			}
+			got := mixedSelectorRows(t, plan, s, seed, step)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("query %s: got %v, reference %v", query, got, want)
+			}
+		})
+	}
+}
+
+func mixedSelectorRows(t *testing.T, plan chplan.Node, s schema.Metrics, seed string, step time.Duration) []string {
+	t.Helper()
+	col := func(name string) chplan.Expr { return &chplan.ColumnRef{Name: name} }
+	str := func(expr chplan.Expr) chplan.Expr {
+		return &chplan.FuncCall{Fn: chplan.FnToString, Args: []chplan.Expr{expr}}
+	}
+	var kind, count, sum, buckets chplan.Expr = &chplan.LitInt{}, &chplan.LitFloat{}, &chplan.LitFloat{}, &chplan.LitString{V: "[]"}
+	if plan.RowType().HasHistogramPayload() {
+		kind = &chplan.LitInt{V: 1}
+		if plan.RowType().Has(chplan.RoleDiscriminator) {
+			kind = col(chplan.MixedDiscriminatorColumn)
+		}
+		count, sum, buckets = col(chplan.HistogramCountColumn), col(chplan.HistogramSumColumn), str(col(chplan.HistogramPositiveBucketCountsColumn))
+	}
+	projection := &chplan.Project{Input: plan, Projections: []chplan.Projection{
+		{Expr: col(s.MetricNameColumn), Alias: "metric"},
+		{Expr: &chplan.MapAccess{Map: col(s.AttributesColumn), Key: &chplan.LitString{V: "series"}}, Alias: "series"},
+		{Expr: &chplan.MapAccess{Map: col(s.AttributesColumn), Key: &chplan.LitString{V: "bucket"}}, Alias: "bucket"},
+		{Expr: str(col(s.TimestampColumn)), Alias: "stamp"},
+		{Expr: col(s.ValueColumn), Alias: "value"},
+		{Expr: kind, Alias: "kind"},
+		{Expr: count, Alias: "count"},
+		{Expr: sum, Alias: "sum"},
+		{Expr: buckets, Alias: "buckets"},
+	}}
+	sql, args, err := chsql.Emit(context.Background(), projection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := spec.OpenChDB(t)
+	spec.ApplySeed(t, db, seed)
+	sql = testsql.ExpandStarProjection(sql, testsql.SeedTableColumns(seed))
+	sql = testsql.NestMapWhere(testsql.NestMapOrderBy(testsql.RewriteMapProjections(sql)))
+	rows, err := db.Query(sql, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	got := []string{}
+	for rows.Next() {
+		var metric, series, bucket, stamp, positiveBuckets string
+		var value, count, sum float64
+		var kind int
+		if err := rows.Scan(&metric, &series, &bucket, &stamp, &value, &kind, &count, &sum, &positiveBuckets); err != nil {
+			t.Fatal(err)
+		}
+		at := foEvalTS
+		if step > 0 {
+			at, err = time.Parse("2006-01-02 15:04:05.999999999", stamp)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		key := fmt.Sprintf("%s/%s/%s/%d", metric, series, bucket, at.UnixMilli())
+		if kind == 1 {
+			got = append(got, fmt.Sprintf("%s/hist/%g/%g/%s", key, count, sum, positiveBuckets))
+		} else {
+			got = append(got, fmt.Sprintf("%s/float/%g", key, value))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	slices.Sort(got)
+	return got
+}

--- a/internal/promql/selector_mixed_test.go
+++ b/internal/promql/selector_mixed_test.go
@@ -1,0 +1,188 @@
+package promql
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+const mixedSelectorNestedInput = `sort_by_label(latency_exp_hist or num_cpus, "series")`
+
+func TestMixedSelectorPlanPayload(t *testing.T) {
+	for _, op := range []string{"topk", "bottomk", "limitk", "limit_ratio"} {
+		for _, k := range []string{"1", "scalar(vector(1))"} {
+			t.Run(op+"/"+k, func(t *testing.T) {
+				plan, err := lowerMixedSelectorTestQuery(t, op+"("+k+", "+mixedSelectorNestedInput+")")
+				if err != nil {
+					t.Fatal(err)
+				}
+				preserves := op == "limitk" || op == "limit_ratio"
+				if got := chplan.RowShapeOf(plan); (got == chplan.MixedRowShape) != preserves {
+					t.Fatalf("output shape=%s, preserve=%v", got, preserves)
+				}
+				if got := plan.RowType(); got.HasHistogramPayload() != preserves || got.Has(chplan.RoleDiscriminator) != preserves {
+					t.Fatalf("physical output=%#v, preserve=%v", got, preserves)
+				}
+				if preserves {
+					for _, child := range plan.Children() {
+						if chplan.IsMixedFloatNarrowing(child) {
+							t.Fatal("preserving selector narrowed its operand")
+						}
+					}
+					return
+				}
+				top, ok := plan.(*chplan.TopK)
+				if !ok || !chplan.IsMixedFloatNarrowing(top.Input) {
+					t.Fatalf("ranking must consume explicit float narrowing: %#v", plan)
+				}
+				filter := top.Input.(*chplan.Filter)
+				if _, ok := filter.Input.(*chplan.OrderBy); !ok || !filter.Input.RowType().Has(chplan.RoleDiscriminator) {
+					t.Fatal("narrowing must follow the already-lowered mixed sort")
+				}
+			})
+		}
+	}
+}
+
+// No parallel execution: each subtest restores its temporarily deleted row.
+func TestMixedSelectorIndependentPolicySites(t *testing.T) {
+	for _, op := range []string{"topk", "bottomk", "limitk", "limit_ratio"} {
+		for _, computed := range []bool{false, true} {
+			for _, nested := range []bool{false, true} {
+				family := mixedTopKFamily
+				directSite := mixedRootAdmission
+				if op == "limitk" || op == "limit_ratio" {
+					family, directSite = mixedLimitFamily, mixedOperandAdmission
+				}
+				for _, site := range []mixedAdmissionSite{directSite, mixedPlanAdmission} {
+					t.Run(fmt.Sprintf("%s/computed=%v/nested=%v/%s", op, computed, nested, site), func(t *testing.T) {
+						operand := "latency_exp_hist or num_cpus"
+						if nested {
+							operand = mixedSelectorNestedInput
+						}
+						k := "1"
+						if computed {
+							k = "scalar(vector(1))"
+						}
+						query := op + "(" + k + ", " + operand + ")"
+						if _, err := lowerMixedSelectorTestQuery(t, query); err != nil {
+							t.Fatalf("registered baseline: %v", err)
+						}
+						key := mixedWrapperKey{family: family, site: site}
+						policy, exists := mixedOperandPolicies[key]
+						if !exists {
+							t.Fatal("missing baseline policy", key)
+						}
+						delete(mixedOperandPolicies, key)
+						t.Cleanup(func() { mixedOperandPolicies[key] = policy })
+						_, err := lowerMixedSelectorTestQuery(t, query)
+						wantError := nested && site == mixedPlanAdmission || !nested && site == directSite
+						// Existing computed limitk rechecks the resulting Mixed plan.
+						wantError = wantError || op == "limitk" && computed && site == mixedPlanAdmission
+						if wantError {
+							if err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for "+string(family)+" at "+string(site)) {
+								t.Fatalf("required site did not reject: %v", err)
+							}
+						} else if err != nil {
+							t.Fatalf("unrelated policy site changed dispatch: %v", err)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestMixedSelectorParameterOrder(t *testing.T) {
+	for _, op := range []string{"topk", "bottomk", "limitk"} {
+		for _, value := range []float64{math.NaN(), math.Inf(1), math.MaxFloat64} {
+			t.Run(fmt.Sprintf("%s/%v", op, value), func(t *testing.T) {
+				agg := mixedSelectorTestAggregate(t, op+"(1, "+mixedSelectorNestedInput+")")
+				agg.Param = &parser.NumberLiteral{Val: value}
+				_, _, expected := topKDomain(value)
+				if expected == nil {
+					t.Fatal("test requires invalid literal K")
+				}
+				family := mixedAggregateFamily(agg.Op)
+				key := mixedWrapperKey{family: family, site: mixedPlanAdmission}
+				policy := mixedOperandPolicies[key]
+				delete(mixedOperandPolicies, key)
+				t.Cleanup(func() { mixedOperandPolicies[key] = policy })
+				at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+				_, err := LowerAt(context.Background(), agg, schema.DefaultOTelMetrics(), at, at)
+				if err == nil || err.Error() != expected.Error() {
+					t.Fatalf("literal K must precede operand/policy: got %v, want %v", err, expected)
+				}
+			})
+		}
+	}
+	for _, op := range []string{"topk", "bottomk", "limitk"} {
+		t.Run(op+"/computed_policy_before_parameter", func(t *testing.T) {
+			agg := mixedSelectorTestAggregate(t, op+"(scalar(vector(1)), "+mixedSelectorNestedInput+")")
+			// This malformed computed parameter must not be visited before admission.
+			agg.Param = &parser.StringLiteral{Val: "not a scalar"}
+			key := mixedWrapperKey{family: mixedAggregateFamily(agg.Op), site: mixedPlanAdmission}
+			policy := mixedOperandPolicies[key]
+			delete(mixedOperandPolicies, key)
+			t.Cleanup(func() { mixedOperandPolicies[key] = policy })
+			at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+			_, err := LowerAt(context.Background(), agg, schema.DefaultOTelMetrics(), at, at)
+			if err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted") {
+				t.Fatalf("computed admission must precede parameter building: %v", err)
+			}
+		})
+		t.Run(op+"/direct_bool_vs_literal", func(t *testing.T) {
+			agg := mixedSelectorTestAggregate(t, op+"(1, latency_exp_hist or num_cpus)")
+			agg.Expr.(*parser.BinaryExpr).ReturnBool = true
+			agg.Param = &parser.NumberLiteral{Val: math.NaN()}
+			at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+			_, err := LowerAt(context.Background(), agg, schema.DefaultOTelMetrics(), at, at)
+			if op == "limitk" {
+				_, _, expected := topKDomain(math.NaN())
+				if err == nil || err.Error() != expected.Error() {
+					t.Fatalf("limitk literal validation must precede operand loading: %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), "'bool' modifier") {
+				t.Fatalf("direct ranked adapter must retain bool-before-K ordering: %v", err)
+			}
+		})
+		t.Run(op+"/computed_operand_before_parameter", func(t *testing.T) {
+			agg := mixedSelectorTestAggregate(t, op+"(scalar(vector(1)), "+mixedSelectorNestedInput+")")
+			agg.Expr.(*parser.Call).Args[0].(*parser.BinaryExpr).ReturnBool = true
+			agg.Param = &parser.StringLiteral{Val: "not a scalar"}
+			at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+			_, err := LowerAt(context.Background(), agg, schema.DefaultOTelMetrics(), at, at)
+			if err == nil || !strings.Contains(err.Error(), "'bool' modifier") {
+				t.Fatalf("computed selector must load operand before building K: %v", err)
+			}
+		})
+	}
+}
+
+func mixedSelectorTestAggregate(t *testing.T, query string) *parser.AggregateExpr {
+	t.Helper()
+	expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	agg, ok := expr.(*parser.AggregateExpr)
+	if !ok {
+		t.Fatalf("expected aggregate, got %T", expr)
+	}
+	return agg
+}
+
+func lowerMixedSelectorTestQuery(t *testing.T, query string) (chplan.Node, error) {
+	t.Helper()
+	agg := mixedSelectorTestAggregate(t, query)
+	at := time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC)
+	return LowerAt(context.Background(), agg, schema.DefaultOTelMetrics(), at, at)
+}


### PR DESCRIPTION
## Summary

- preserve mixed float/native-histogram row shape through nested `limitk` and `limit_ratio`
- narrow nested `topk` and `bottomk` operands to float samples, matching PromQL semantics
- resolve computed selector parameters from the operand's `RoleValue` column and prevent the internal rank column from leaking
- cover plan shape, SQL schema handling, chDB parity, optimizer parity, and Prometheus wire output

## Scope

This keeps `AttributesColumn` on its supported default name. Arbitrary Map-column aliases remain independent work tracked by #3292 and are not absorbed into this fix.

## Validation

- `GOFLAGS='-run=^(TestLabelValues_MatchSelector_ChDB|TestMixedSelectorsWireSampleKinds_ChDB)$' just test-chdb`
- full CI `probe` passed with the shared catalog setup
- required source checks and the complete mutation suite passed on `fa997dbf8a051fe02a321ae7c8b672be90e76963`
- CI-only golden regeneration run [34583675530](https://github.com/tsouza/cerberus/actions/runs/34583675530) requested `migration parity solver promql chsql codegen cardinality`; the trusted planner added `logql traceql optimizer`, every resulting shard and cardinality leg passed, and publication found no generated changes

Closes #3347
