### PR TITLE
refactor(promql): separate mixed payload from float proof

### DIFF
--- a/internal/chplan/schema_nodes.go
+++ b/internal/chplan/schema_nodes.go
@@ -26,7 +26,34 @@ func (l *Limit) RowType() Schema              { return l.Input.RowType() }
 func (o *OrderBy) RowType() Schema            { return o.Input.RowType() }
 func (s *SearchTraceLimit) RowType() Schema   { return s.Input.RowType() }
 func (m *MetricsSecondStage) RowType() Schema { return m.Input.RowType() }
-func (p *Project) RowType() Schema            { return projectSchema(p.Input.RowType(), p.Projections, p.Roles) }
+func (p *Project) RowType() Schema {
+	if projectRolesAlignWithOutputs(p.Projections, p.Roles) {
+		return Schema{Columns: slices.Clone(p.Roles)}
+	}
+	return projectSchema(p.Input.RowType(), p.Projections, p.Roles)
+}
+
+// projectRolesAlignWithOutputs recognizes the exact declaration form for a
+// closed Project schema. Names must be non-empty and unique because ByName,
+// used by projectSchema, deliberately ignores unnamed outputs and resolves a
+// duplicate declaration to its first occurrence.
+func projectRolesAlignWithOutputs(projections []Projection, roles []Column) bool {
+	if len(projections) == 0 || len(projections) != len(roles) {
+		return false
+	}
+	for i, projection := range projections {
+		name := ProjectionOutputName(projection)
+		if name == "" || roles[i].Name != name {
+			return false
+		}
+		for j := range i {
+			if roles[j].Name == name {
+				return false
+			}
+		}
+	}
+	return true
+}
 
 func (t *TopK) RowType() Schema {
 	input := t.Input.RowType()

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -126,6 +126,68 @@ func TestRowTypeDeclarations(t *testing.T) {
 	}
 }
 
+func TestProjectRowTypeAlignedDeclarations(t *testing.T) {
+	roles := []Column{{Name: "value", Role: RoleValue}, {Name: "opaque", Role: RoleOpaque}}
+	aligned := &Project{
+		Input: &OneRow{},
+		Roles: roles,
+		Projections: []Projection{
+			{Expr: &LitInt{V: 1}, Alias: "value"},
+			{Expr: &LitInt{V: 2}, Alias: "opaque"},
+		},
+	}
+	got := aligned.RowType()
+	if !got.Equal(Schema{Columns: roles}) {
+		t.Fatalf("aligned declarations: %#v", got)
+	}
+	got.Columns[0].Role = RoleOpaque
+	if aligned.Roles[0].Role != RoleValue {
+		t.Fatal("RowType schema aliases the Project role declarations")
+	}
+
+	for _, tc := range []struct {
+		name        string
+		roles       []Column
+		projections []Projection
+		want        Schema
+	}{
+		{
+			name:        "partial_roles",
+			roles:       roles[:1],
+			projections: aligned.Projections,
+			want:        Schema{Columns: []Column{roles[0], {Name: "opaque"}}},
+		},
+		{
+			name:        "mismatched_order",
+			roles:       []Column{roles[1], roles[0]},
+			projections: aligned.Projections,
+			want:        Schema{Columns: roles},
+		},
+		{
+			name:  "duplicate_names",
+			roles: []Column{{Name: "duplicate", Role: RoleValue}, {Name: "duplicate", Role: RoleAttributes}},
+			projections: []Projection{
+				{Expr: &LitInt{V: 1}, Alias: "duplicate"},
+				{Expr: &LitInt{V: 2}, Alias: "duplicate"},
+			},
+			want: Schema{Columns: []Column{{Name: "duplicate", Role: RoleValue}, {Name: "duplicate", Role: RoleValue}}},
+		},
+		{
+			name:        "unnamed_role",
+			roles:       []Column{{Role: RoleDiscriminator}},
+			projections: []Projection{{Expr: &LitInt{V: 1}}},
+			want:        Schema{Columns: []Column{{}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := &Project{Input: &OneRow{}, Roles: tc.roles, Projections: tc.projections}
+			if got := project.RowType(); !got.Equal(tc.want) {
+				t.Fatalf("RowType = %#v; want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRowTypeWindowBranches(t *testing.T) {
 	input := &Scan{Columns: []string{"labels", "time", "extra"}, Roles: []Column{{"labels", RoleAttributes}, {"time", RoleTimestamp}}}
 	r := &RangeWindow{Input: input, GroupBy: []Expr{&ColumnRef{Name: "labels"}}, ValueColumn: "value", TimestampColumn: "anchor_ts", OuterRange: time.Minute, Identity: true}

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -857,9 +857,6 @@ func lowerVectorScalar(vec parser.Expr, s schema.Metrics, op chplan.BinaryOp, sc
 	if isComparison(op) {
 		return finishScalarComparison(inner, vec, s, ctx, op, scalar, scalarOnLeft, returnBool, scalarComparisonGuarded)
 	}
-	if err := requireMixedPlanPolicy(inner, mixedScalarBinaryFamily(op, scalarOnLeft)); err != nil {
-		return nil, err
-	}
 	// Histogram-scaling operators retain their separate family authority.
 	return guardedValueProjection(inner, vec, s, ctx, mixedScalarBinaryFamily(op, scalarOnLeft), func(refs sampleRoleRefs) chplan.Expr {
 		var left, right chplan.Expr = refs.Value, &chplan.LitFloat{V: scalar}

--- a/internal/promql/histogram_shape_guard.go
+++ b/internal/promql/histogram_shape_guard.go
@@ -8,11 +8,27 @@ const mixedDiscriminatorColumn = chplan.MixedDiscriminatorColumn
 // mixedRowsFloatOnly applies the established float-wrapper admission policy.
 // Family dispatch remains unchanged here; projectSampleRoles independently
 // verifies a complete payload and an actual float-narrowing predicate before a
-// value rewrite may discard histogram columns. The legacy shape classification
-// remains until all runtime consumers are reconciled.
+// value rewrite may discard histogram columns. Physical mixed columns remain
+// present after narrowing, so an existing float-row proof makes this idempotent.
 func mixedRowsFloatOnly(inner chplan.Node) chplan.Node {
-	if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+	if !mixedRowsNeedPreparation(inner) {
 		return inner
 	}
-	return mixedDiscriminatorFilter(inner, mixedDiscriminatorFloat)
+	discriminator := requireSampleRole(inner.RowType(), chplan.RoleDiscriminator)
+	return &chplan.Filter{
+		Input: inner,
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  discriminator,
+			Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+		},
+	}
+}
+
+// mixedRowsNeedPreparation separates the physical mixed payload from the live
+// sample kinds a consumer must still handle. Payload validation runs before a
+// proof can bypass preparation, so malformed public roles fail closed.
+func mixedRowsNeedPreparation(inner chplan.Node) bool {
+	completeHistogram, discriminated := validateSamplePayload(inner.RowType())
+	return completeHistogram && discriminated && !mixedFloatRowsProven(inner)
 }

--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -173,7 +173,7 @@ func lowerMathOperand(arg parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.N
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+	if !mixedRowsNeedPreparation(inner) {
 		return inner, nil
 	}
 	if _, err := mathPayloadPreparation(mixedPlanAdmission); err != nil {
@@ -184,9 +184,9 @@ func lowerMathOperand(arg parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.N
 
 // prepareMathValueInput is deliberately later than admission: a terminal
 // literal-inverted clamp returns its original Filter(false) input unchanged.
-// Value consumers narrow here, before any bounds Filter can hide Mixed shape.
+// Value consumers narrow here after the terminal empty-result case has returned.
 func prepareMathValueInput(inner chplan.Node) (chplan.Node, error) {
-	if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+	if !mixedRowsNeedPreparation(inner) {
 		return inner, nil
 	}
 	return prepareMixedMathOperand(mixedPlanAdmission, func() (chplan.Node, error) { return inner, nil })

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -178,7 +178,7 @@ func stringArg(e parser.Expr, fnName, paramName string) (string, error) {
 // remain on their existing histogram-aware lowering path.
 func projectAttributesOverInner(inner chplan.Node, s schema.Metrics, family mixedWrapperFamily, build func(sampleRoleRefs) chplan.Expr) (*chplan.Project, error) {
 	payload := preserveMixedSamplePayload
-	if chplan.RowShapeOf(inner) == chplan.MixedRowShape && family == mixedLabelFamily {
+	if mixedRowsNeedPreparation(inner) && family == mixedLabelFamily {
 		var err error
 		payload, err = labelPayloadPolicy(mixedPlanAdmission)
 		if err != nil {

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -158,7 +158,13 @@ type mixedPlanTransform func(chplan.Node) chplan.Node
 func lowerWithMixedOperandPolicy(family mixedWrapperFamily, site mixedAdmissionSite, expected mixedOperandPolicy) (mixedPlanTransform, error) {
 	key := mixedWrapperKey{family: family, site: site}
 	policy, ok := mixedOperandPolicies[key]
-	if expected == mixedPolicyClosed || !ok || policy != expected {
+	if !ok {
+		return nil, requireMixedBespokePolicy(key, mixedReject)
+	}
+	if expected == mixedPolicyClosed {
+		return nil, requireMixedBespokePolicy(key, mixedReject)
+	}
+	if policy != expected {
 		return nil, requireMixedBespokePolicy(key, mixedReject)
 	}
 	if expected == mixedBespoke {
@@ -230,7 +236,13 @@ func requireMixedPlanPolicy(inner chplan.Node, family mixedWrapperFamily, expect
 	}
 	key := mixedWrapperKey{family: family, site: mixedPlanAdmission}
 	policy, ok := mixedOperandPolicies[key]
-	if expected == mixedPolicyClosed || !ok || policy != expected {
+	if !ok {
+		return requireMixedBespokePolicy(key, mixedReject)
+	}
+	if expected == mixedPolicyClosed {
+		return requireMixedBespokePolicy(key, mixedReject)
+	}
+	if policy != expected {
 		return requireMixedBespokePolicy(key, mixedReject)
 	}
 	if expected == mixedBespoke {

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -220,7 +220,7 @@ func preserveMixedPlan(inner chplan.Node, family mixedWrapperFamily) (chplan.Nod
 func requireMixedPlanPolicy(inner chplan.Node, family mixedWrapperFamily, expectedPolicy ...mixedOperandPolicy) error {
 	expected := mixedBespoke
 	if len(expectedPolicy) == 0 {
-		if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+		if !mixedRowsNeedPreparation(inner) {
 			return nil
 		}
 	} else if len(expectedPolicy) == 1 {

--- a/internal/promql/mixed_operand_policy_test.go
+++ b/internal/promql/mixed_operand_policy_test.go
@@ -236,6 +236,34 @@ func TestMixedOperandPolicyRejectsUnknownBeforeLowering(t *testing.T) {
 	}
 }
 
+// Deliberately non-parallel: each case installs the closed sentinel into the
+// package policy table. A successful lookup must not turn that fail-closed
+// value into an authorization merely because it equals the requested policy.
+func TestMixedOperandPolicyClosedSentinelCannotBeAuthorizedByTable(t *testing.T) {
+	t.Run("operand admission", func(t *testing.T) {
+		key := mixedWrapperKey{family: mixedMathFamily, site: mixedRootAdmission}
+		original := mixedOperandPolicies[key]
+		mixedOperandPolicies[key] = mixedPolicyClosed
+		t.Cleanup(func() { mixedOperandPolicies[key] = original })
+
+		transform, err := lowerWithMixedOperandPolicy(key.family, key.site, mixedPolicyClosed)
+		if transform != nil || err == nil {
+			t.Fatalf("closed policy admitted: transform=%v err=%v", transform != nil, err)
+		}
+	})
+
+	t.Run("plan admission", func(t *testing.T) {
+		key := mixedWrapperKey{family: mixedMathFamily, site: mixedPlanAdmission}
+		original := mixedOperandPolicies[key]
+		mixedOperandPolicies[key] = mixedPolicyClosed
+		t.Cleanup(func() { mixedOperandPolicies[key] = original })
+
+		if err := requireMixedPlanPolicy(nil, key.family, mixedPolicyClosed); err == nil {
+			t.Fatal("closed policy admitted")
+		}
+	})
+}
+
 func TestMixedOperandPolicyPreservesBespokeResultAndError(t *testing.T) {
 	for key, policy := range mixedOperandPolicies {
 		t.Run(string(key.family)+"/"+string(key.site), func(t *testing.T) {

--- a/internal/promql/mixed_operand_policy_test.go
+++ b/internal/promql/mixed_operand_policy_test.go
@@ -123,7 +123,7 @@ func TestMixedOperandPolicyAlreadyLoweredShape(t *testing.T) {
 		{"date must use its payload preparation", &chplan.VectorSetOp{Mixed: true}, mixedDateFamily, true},
 		{"math must use its payload preparation", &chplan.VectorSetOp{Mixed: true}, mixedMathFamily, true},
 		{"ordinary float unchanged", &chplan.Scan{}, "unlisted-wrapper", false},
-		{"histogram-only unchanged", &chplan.HistogramProjection{}, "unlisted-wrapper", false},
+		{"histogram-only unchanged", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, "unlisted-wrapper", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := requireMixedPlanPolicy(tc.inner, tc.family)

--- a/internal/promql/mixed_physical_payload_test.go
+++ b/internal/promql/mixed_physical_payload_test.go
@@ -1,0 +1,147 @@
+package promql
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	mixedColumns := append(metricRoles(s), chplan.HistogramPayloadColumns()...)
+	mixedColumns = append(mixedColumns, chplan.Column{Name: "source_kind", Role: chplan.RoleDiscriminator})
+	mixed := sampleForwardTestInput(mixedColumns...)
+	floatRows := &chplan.Filter{Input: mixed, Predicate: &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "source_kind"},
+		Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+	}}
+	legacyMixedFloat := &chplan.Filter{
+		Input:     sampleForwardTestInput(metricRoles(s)...),
+		Predicate: &chplan.LitBool{V: true},
+		Mixed:     true,
+	}
+	emptyRankedSelector := &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: false}}
+	nonemptyRankedSelector := &chplan.TopK{Input: floatRows, Columns: topKOutputColumns(floatRows, s)}
+	preservingSelector := &chplan.TopK{Input: mixed, Mixed: true}
+
+	for _, tc := range []struct {
+		name             string
+		input            chplan.Node
+		physicalMixed    bool
+		floatProven      bool
+		legacyShape      chplan.RowShape
+		needsPreparation bool
+	}{
+		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleRowShape, false},
+		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.HistogramRowShape, false},
+		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleRowShape, true},
+		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleRowShape, false},
+		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleRowShape, false},
+		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleRowShape, false},
+		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleRowShape, false},
+		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleRowShape, false},
+		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.MixedRowShape, true},
+		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleRowShape, true},
+		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleRowShape, true},
+		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleRowShape, true},
+		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.MixedRowShape, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row := tc.input.RowType()
+			physicalMixed := row.HasHistogramPayload() && row.Has(chplan.RoleDiscriminator)
+			if physicalMixed != tc.physicalMixed {
+				t.Fatalf("physical mixed=%v, want %v; schema=%#v", physicalMixed, tc.physicalMixed, row)
+			}
+			if got := mixedFloatRowsProven(tc.input); got != tc.floatProven {
+				t.Fatalf("float proof=%v, want %v", got, tc.floatProven)
+			}
+			if got := chplan.RowShapeOf(tc.input); got != tc.legacyShape {
+				t.Fatalf("legacy shape=%s, want %s", got, tc.legacyShape)
+			}
+			if got := mixedRowsNeedPreparation(tc.input); got != tc.needsPreparation {
+				t.Fatalf("needs preparation=%v, want %v", got, tc.needsPreparation)
+			}
+
+			prepared := mixedRowsFloatOnly(tc.input)
+			if !tc.needsPreparation {
+				if prepared != tc.input {
+					t.Fatal("input without live mixed rows was narrowed")
+				}
+				return
+			}
+			if !prepared.RowType().Equal(row) {
+				t.Fatalf("preparation changed physical schema: got %#v, want %#v", prepared.RowType(), row)
+			}
+			if !chplan.IsMixedFloatNarrowing(prepared) {
+				t.Fatalf("prepared plan is not a float discriminator proof: %#v", prepared)
+			}
+			if mixedRowsFloatOnly(prepared) != prepared {
+				t.Fatal("float preparation is not idempotent")
+			}
+		})
+	}
+}
+
+func TestMixedRowsNeedPreparationRejectsMalformedPublicPayload(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	payload := chplan.HistogramPayloadColumns()
+	kind := chplan.Column{Name: "source_kind", Role: chplan.RoleDiscriminator}
+
+	type payloadCase struct {
+		name            string
+		columns         []chplan.Column
+		preserveUnnamed bool
+	}
+	cases := []payloadCase{
+		{name: "orphan_discriminator", columns: []chplan.Column{kind}},
+		{name: "partial_histogram", columns: []chplan.Column{payload[0]}},
+		{name: "duplicate_discriminator", columns: append(slices.Clone(payload), kind, chplan.Column{Name: "other_kind", Role: chplan.RoleDiscriminator})},
+		{name: "unnamed_discriminator", columns: append(slices.Clone(payload), chplan.Column{Role: chplan.RoleDiscriminator}), preserveUnnamed: true},
+		{name: "shadowed_discriminator", columns: append(slices.Clone(payload), kind, chplan.Column{Name: kind.Name, Role: chplan.RoleOpaque})},
+	}
+	for i, field := range payload {
+		missing := slices.Delete(slices.Clone(payload), i, i+1)
+		wrongRole := slices.Clone(payload)
+		wrongRole[i].Role = chplan.RoleOpaque
+		cases = append(
+			cases,
+			payloadCase{name: "missing/" + field.Name, columns: append(slices.Clone(missing), kind)},
+			payloadCase{name: "wrong_role/" + field.Name, columns: append(wrongRole, kind)},
+			payloadCase{name: "duplicate/" + field.Name, columns: append(slices.Clone(payload), field, kind)},
+		)
+	}
+
+	for _, tc := range cases {
+		for _, narrowed := range []bool{false, true} {
+			name := "direct/" + tc.name
+			if narrowed {
+				name = "narrowed/" + tc.name
+			}
+			t.Run(name, func(t *testing.T) {
+				columns := append(metricRoles(s), tc.columns...)
+				var input chplan.Node = sampleForwardTestInput(columns...)
+				if tc.preserveUnnamed {
+					input = &chplan.Scan{Table: "samples", Roles: columns}
+				}
+				if narrowed {
+					input = &chplan.Filter{Input: input, Predicate: &chplan.Binary{
+						Op:    chplan.OpEq,
+						Left:  &chplan.ColumnRef{Name: kind.Name},
+						Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+					}}
+				}
+				capturePanic(t, func() {
+					mixedRowsNeedPreparation(input)
+				})
+			})
+		}
+	}
+
+	open := &chplan.Scan{Table: "samples", Roles: append(metricRoles(s), kind)}
+	capturePanic(t, func() {
+		mixedRowsNeedPreparation(open)
+	})
+}


### PR DESCRIPTION
## Summary

- derive physical mixed-sample classification from a complete histogram payload plus a unique discriminator role
- keep physical payload classification separate from live float-row proof, including proof through transparent plan nodes
- replace the four immediate legacy `RowShapeOf` gates with the physical-payload preparation predicate
- cover malformed public roles, custom discriminators, narrowing barriers, and ranked-selector topology
- preserve the lowering hot path with an exact-aligned, defensively cloned `Project.RowType` fast path
- remove the duplicate adjacent scale-family authorization while retaining the guarded projection's identical check

## Verification

- full race-tested `internal/chplan` and `internal/promql` packages
- exact allocation regression reproduced at 256 > 240 and restored to 234 <= 240
- focused schema tests for aligned, partial, reordered, duplicate, unnamed, opaque, and non-aliasing declarations

Closes #3343
