### PR TITLE
fix(promql): route subqueries by live sample kind

### DIFF
--- a/internal/chplan/schema_nodes.go
+++ b/internal/chplan/schema_nodes.go
@@ -26,7 +26,34 @@ func (l *Limit) RowType() Schema              { return l.Input.RowType() }
 func (o *OrderBy) RowType() Schema            { return o.Input.RowType() }
 func (s *SearchTraceLimit) RowType() Schema   { return s.Input.RowType() }
 func (m *MetricsSecondStage) RowType() Schema { return m.Input.RowType() }
-func (p *Project) RowType() Schema            { return projectSchema(p.Input.RowType(), p.Projections, p.Roles) }
+func (p *Project) RowType() Schema {
+	if projectRolesAlignWithOutputs(p.Projections, p.Roles) {
+		return Schema{Columns: slices.Clone(p.Roles)}
+	}
+	return projectSchema(p.Input.RowType(), p.Projections, p.Roles)
+}
+
+// projectRolesAlignWithOutputs recognizes the exact declaration form for a
+// closed Project schema. Names must be non-empty and unique because ByName,
+// used by projectSchema, deliberately ignores unnamed outputs and resolves a
+// duplicate declaration to its first occurrence.
+func projectRolesAlignWithOutputs(projections []Projection, roles []Column) bool {
+	if len(projections) == 0 || len(projections) != len(roles) {
+		return false
+	}
+	for i, projection := range projections {
+		name := ProjectionOutputName(projection)
+		if name == "" || roles[i].Name != name {
+			return false
+		}
+		for j := range i {
+			if roles[j].Name == name {
+				return false
+			}
+		}
+	}
+	return true
+}
 
 func (t *TopK) RowType() Schema {
 	input := t.Input.RowType()

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -126,6 +126,68 @@ func TestRowTypeDeclarations(t *testing.T) {
 	}
 }
 
+func TestProjectRowTypeAlignedDeclarations(t *testing.T) {
+	roles := []Column{{Name: "value", Role: RoleValue}, {Name: "opaque", Role: RoleOpaque}}
+	aligned := &Project{
+		Input: &OneRow{},
+		Roles: roles,
+		Projections: []Projection{
+			{Expr: &LitInt{V: 1}, Alias: "value"},
+			{Expr: &LitInt{V: 2}, Alias: "opaque"},
+		},
+	}
+	got := aligned.RowType()
+	if !got.Equal(Schema{Columns: roles}) {
+		t.Fatalf("aligned declarations: %#v", got)
+	}
+	got.Columns[0].Role = RoleOpaque
+	if aligned.Roles[0].Role != RoleValue {
+		t.Fatal("RowType schema aliases the Project role declarations")
+	}
+
+	for _, tc := range []struct {
+		name        string
+		roles       []Column
+		projections []Projection
+		want        Schema
+	}{
+		{
+			name:        "partial_roles",
+			roles:       roles[:1],
+			projections: aligned.Projections,
+			want:        Schema{Columns: []Column{roles[0], {Name: "opaque"}}},
+		},
+		{
+			name:        "mismatched_order",
+			roles:       []Column{roles[1], roles[0]},
+			projections: aligned.Projections,
+			want:        Schema{Columns: roles},
+		},
+		{
+			name:  "duplicate_names",
+			roles: []Column{{Name: "duplicate", Role: RoleValue}, {Name: "duplicate", Role: RoleAttributes}},
+			projections: []Projection{
+				{Expr: &LitInt{V: 1}, Alias: "duplicate"},
+				{Expr: &LitInt{V: 2}, Alias: "duplicate"},
+			},
+			want: Schema{Columns: []Column{{Name: "duplicate", Role: RoleValue}, {Name: "duplicate", Role: RoleValue}}},
+		},
+		{
+			name:        "unnamed_role",
+			roles:       []Column{{Role: RoleDiscriminator}},
+			projections: []Projection{{Expr: &LitInt{V: 1}}},
+			want:        Schema{Columns: []Column{{}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := &Project{Input: &OneRow{}, Roles: tc.roles, Projections: tc.projections}
+			if got := project.RowType(); !got.Equal(tc.want) {
+				t.Fatalf("RowType = %#v; want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRowTypeWindowBranches(t *testing.T) {
 	input := &Scan{Columns: []string{"labels", "time", "extra"}, Roles: []Column{{"labels", RoleAttributes}, {"time", RoleTimestamp}}}
 	r := &RangeWindow{Input: input, GroupBy: []Expr{&ColumnRef{Name: "labels"}}, ValueColumn: "value", TimestampColumn: "anchor_ts", OuterRange: time.Minute, Identity: true}

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -857,9 +857,6 @@ func lowerVectorScalar(vec parser.Expr, s schema.Metrics, op chplan.BinaryOp, sc
 	if isComparison(op) {
 		return finishScalarComparison(inner, vec, s, ctx, op, scalar, scalarOnLeft, returnBool, scalarComparisonGuarded)
 	}
-	if err := requireMixedPlanPolicy(inner, mixedScalarBinaryFamily(op, scalarOnLeft)); err != nil {
-		return nil, err
-	}
 	// Histogram-scaling operators retain their separate family authority.
 	return guardedValueProjection(inner, vec, s, ctx, mixedScalarBinaryFamily(op, scalarOnLeft), func(refs sampleRoleRefs) chplan.Expr {
 		var left, right chplan.Expr = refs.Value, &chplan.LitFloat{V: scalar}

--- a/internal/promql/gremlins_kill_subquery_test.go
+++ b/internal/promql/gremlins_kill_subquery_test.go
@@ -299,15 +299,11 @@ func TestSubqueryInstantSafe_PiExceptionNotRejected(t *testing.T) {
 }
 
 // TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor kills the
-// CONDITIONALS_NEGATION mutant at subquery.go:lowerSubqueryOverBinary:`if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape` — the second `==` in
-// `if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape`.
-// A plain (non-histogram, non-mixed) `or` composition must lower
-// successfully even with no query eval-time context threaded through
-// (the same !ok fallback TestSubqueryOverBinary_HistogramSetOp_NoEvalAnchorRejects,
-// subquery_and_unless_mixed_histogram_outer_test.go, pins the REJECT half
-// of). Flipping `==` to `!=` on the Mixed comparison turns the guard into
-// `shape == Histogram || shape != Mixed`, which is true for every ordinary
-// shape and wrongly rejects this query.
+// CONDITIONALS_NEGATION mutant at histogram_shape_guard.go:rowsMayContainHistograms:`return !hasUnambiguousNamedRole(row, chplan.RoleValue)`.
+// A plain `or` composition has one unambiguous float value role, so the live
+// sample-kind guard must return false and allow lowering without query
+// evaluation context. Negating that result wrongly sends this query through
+// the conservative histogram rejection path.
 func TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/promql/histogram_shape_guard.go
+++ b/internal/promql/histogram_shape_guard.go
@@ -8,11 +8,27 @@ const mixedDiscriminatorColumn = chplan.MixedDiscriminatorColumn
 // mixedRowsFloatOnly applies the established float-wrapper admission policy.
 // Family dispatch remains unchanged here; projectSampleRoles independently
 // verifies a complete payload and an actual float-narrowing predicate before a
-// value rewrite may discard histogram columns. The legacy shape classification
-// remains until all runtime consumers are reconciled.
+// value rewrite may discard histogram columns. Physical mixed columns remain
+// present after narrowing, so an existing float-row proof makes this idempotent.
 func mixedRowsFloatOnly(inner chplan.Node) chplan.Node {
-	if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+	if !mixedRowsNeedPreparation(inner) {
 		return inner
 	}
-	return mixedDiscriminatorFilter(inner, mixedDiscriminatorFloat)
+	discriminator := requireSampleRole(inner.RowType(), chplan.RoleDiscriminator)
+	return &chplan.Filter{
+		Input: inner,
+		Predicate: &chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  discriminator,
+			Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+		},
+	}
+}
+
+// mixedRowsNeedPreparation separates the physical mixed payload from the live
+// sample kinds a consumer must still handle. Payload validation runs before a
+// proof can bypass preparation, so malformed public roles fail closed.
+func mixedRowsNeedPreparation(inner chplan.Node) bool {
+	completeHistogram, discriminated := validateSamplePayload(inner.RowType())
+	return completeHistogram && discriminated && !mixedFloatRowsProven(inner)
 }

--- a/internal/promql/histogram_shape_guard.go
+++ b/internal/promql/histogram_shape_guard.go
@@ -32,3 +32,138 @@ func mixedRowsNeedPreparation(inner chplan.Node) bool {
 	completeHistogram, discriminated := validateSamplePayload(inner.RowType())
 	return completeHistogram && discriminated && !mixedFloatRowsProven(inner)
 }
+
+// rowsMayContainHistograms answers which payload path a subquery must take.
+// A discriminator-zero proof makes a physically mixed relation safe for the
+// float path without changing its columns. Unknown or malformed schemas stay
+// on the conservative path: callers must never erase a possible histogram by
+// projecting the ordinary float envelope over a relation they cannot prove.
+func rowsMayContainHistograms(inner chplan.Node) bool {
+	row := inner.RowType()
+	if row.Open {
+		return true
+	}
+	completeHistogram, discriminated, valid := inspectLiveSamplePayload(row)
+	if !valid {
+		return true
+	}
+	if !liveSampleRolesAreUnambiguous(row) {
+		return true
+	}
+	if completeHistogram {
+		if !discriminated {
+			return true
+		}
+		return !mixedFloatRowsProven(inner)
+	}
+	return !hasUnambiguousNamedRole(row, chplan.RoleValue)
+}
+
+func liveSampleRolesAreUnambiguous(row chplan.Schema) bool {
+	for _, role := range [...]chplan.ColumnRole{
+		chplan.RoleMetricName,
+		chplan.RoleAttributes,
+		chplan.RoleTimestamp,
+		chplan.RoleAnchor,
+		chplan.RoleValue,
+		chplan.RoleDiscriminator,
+	} {
+		if !roleIsUnambiguousWhenPresent(row, role) {
+			return false
+		}
+	}
+	return true
+}
+
+// inspectLiveSamplePayload validates the public histogram/discriminator
+// envelope without panicking. The lowering pipeline can then conservatively
+// retain an unrecognised payload and let its histogram-aware continuation
+// report the established error, rather than silently selecting the float path.
+func inspectLiveSamplePayload(row chplan.Schema) (completeHistogram, discriminated, valid bool) {
+	valid = true
+	histogramFields := chplan.HistogramPayloadColumns()
+	sawHistogramContract := false
+	completeHistogram = true
+	for _, field := range histogramFields {
+		count := 0
+		for _, column := range row.Columns {
+			if column.Name != field.Name {
+				continue
+			}
+			sawHistogramContract = true
+			if column.Role != chplan.RoleHistogramField {
+				valid = false
+				continue
+			}
+			count++
+			if count != 1 {
+				valid = false
+			}
+		}
+		if count != 1 {
+			completeHistogram = false
+		}
+	}
+	for _, column := range row.Columns {
+		if column.Role != chplan.RoleHistogramField {
+			continue
+		}
+		sawHistogramContract = true
+		canonicalName := false
+		for _, field := range histogramFields {
+			if column.Name == field.Name {
+				canonicalName = true
+				break
+			}
+		}
+		if !canonicalName {
+			valid = false
+		}
+	}
+	if sawHistogramContract && !completeHistogram {
+		valid = false
+	}
+
+	discriminated = row.Has(chplan.RoleDiscriminator)
+	if !roleIsUnambiguousWhenPresent(row, chplan.RoleDiscriminator) {
+		valid = false
+	}
+	if discriminated && !completeHistogram {
+		valid = false
+	}
+	if completeHistogram && discriminated && !hasUnambiguousNamedRole(row, chplan.RoleValue) {
+		valid = false
+	}
+	return completeHistogram, discriminated, valid
+}
+
+func hasUnambiguousNamedRole(row chplan.Schema, role chplan.ColumnRole) bool {
+	found := false
+	name := ""
+	for _, column := range row.Columns {
+		if column.Role != role {
+			continue
+		}
+		if found || column.Name == "" {
+			return false
+		}
+		found = true
+		name = column.Name
+	}
+	if !found {
+		return false
+	}
+	for _, column := range row.Columns {
+		if column.Name == name && column.Role != role {
+			return false
+		}
+	}
+	return true
+}
+
+func roleIsUnambiguousWhenPresent(row chplan.Schema, role chplan.ColumnRole) bool {
+	if !row.Has(role) {
+		return true
+	}
+	return hasUnambiguousNamedRole(row, role)
+}

--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -173,7 +173,7 @@ func lowerMathOperand(arg parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.N
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+	if !mixedRowsNeedPreparation(inner) {
 		return inner, nil
 	}
 	if _, err := mathPayloadPreparation(mixedPlanAdmission); err != nil {
@@ -184,9 +184,9 @@ func lowerMathOperand(arg parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.N
 
 // prepareMathValueInput is deliberately later than admission: a terminal
 // literal-inverted clamp returns its original Filter(false) input unchanged.
-// Value consumers narrow here, before any bounds Filter can hide Mixed shape.
+// Value consumers narrow here after the terminal empty-result case has returned.
 func prepareMathValueInput(inner chplan.Node) (chplan.Node, error) {
-	if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+	if !mixedRowsNeedPreparation(inner) {
 		return inner, nil
 	}
 	return prepareMixedMathOperand(mixedPlanAdmission, func() (chplan.Node, error) { return inner, nil })

--- a/internal/promql/label_fns.go
+++ b/internal/promql/label_fns.go
@@ -178,7 +178,7 @@ func stringArg(e parser.Expr, fnName, paramName string) (string, error) {
 // remain on their existing histogram-aware lowering path.
 func projectAttributesOverInner(inner chplan.Node, s schema.Metrics, family mixedWrapperFamily, build func(sampleRoleRefs) chplan.Expr) (*chplan.Project, error) {
 	payload := preserveMixedSamplePayload
-	if chplan.RowShapeOf(inner) == chplan.MixedRowShape && family == mixedLabelFamily {
+	if mixedRowsNeedPreparation(inner) && family == mixedLabelFamily {
 		var err error
 		payload, err = labelPayloadPolicy(mixedPlanAdmission)
 		if err != nil {

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -158,7 +158,13 @@ type mixedPlanTransform func(chplan.Node) chplan.Node
 func lowerWithMixedOperandPolicy(family mixedWrapperFamily, site mixedAdmissionSite, expected mixedOperandPolicy) (mixedPlanTransform, error) {
 	key := mixedWrapperKey{family: family, site: site}
 	policy, ok := mixedOperandPolicies[key]
-	if expected == mixedPolicyClosed || !ok || policy != expected {
+	if !ok {
+		return nil, requireMixedBespokePolicy(key, mixedReject)
+	}
+	if expected == mixedPolicyClosed {
+		return nil, requireMixedBespokePolicy(key, mixedReject)
+	}
+	if policy != expected {
 		return nil, requireMixedBespokePolicy(key, mixedReject)
 	}
 	if expected == mixedBespoke {
@@ -230,7 +236,13 @@ func requireMixedPlanPolicy(inner chplan.Node, family mixedWrapperFamily, expect
 	}
 	key := mixedWrapperKey{family: family, site: mixedPlanAdmission}
 	policy, ok := mixedOperandPolicies[key]
-	if expected == mixedPolicyClosed || !ok || policy != expected {
+	if !ok {
+		return requireMixedBespokePolicy(key, mixedReject)
+	}
+	if expected == mixedPolicyClosed {
+		return requireMixedBespokePolicy(key, mixedReject)
+	}
+	if policy != expected {
 		return requireMixedBespokePolicy(key, mixedReject)
 	}
 	if expected == mixedBespoke {

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -220,7 +220,7 @@ func preserveMixedPlan(inner chplan.Node, family mixedWrapperFamily) (chplan.Nod
 func requireMixedPlanPolicy(inner chplan.Node, family mixedWrapperFamily, expectedPolicy ...mixedOperandPolicy) error {
 	expected := mixedBespoke
 	if len(expectedPolicy) == 0 {
-		if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+		if !mixedRowsNeedPreparation(inner) {
 			return nil
 		}
 	} else if len(expectedPolicy) == 1 {

--- a/internal/promql/mixed_operand_policy_test.go
+++ b/internal/promql/mixed_operand_policy_test.go
@@ -236,6 +236,34 @@ func TestMixedOperandPolicyRejectsUnknownBeforeLowering(t *testing.T) {
 	}
 }
 
+// Deliberately non-parallel: each case installs the closed sentinel into the
+// package policy table. A successful lookup must not turn that fail-closed
+// value into an authorization merely because it equals the requested policy.
+func TestMixedOperandPolicyClosedSentinelCannotBeAuthorizedByTable(t *testing.T) {
+	t.Run("operand admission", func(t *testing.T) {
+		key := mixedWrapperKey{family: mixedMathFamily, site: mixedRootAdmission}
+		original := mixedOperandPolicies[key]
+		mixedOperandPolicies[key] = mixedPolicyClosed
+		t.Cleanup(func() { mixedOperandPolicies[key] = original })
+
+		transform, err := lowerWithMixedOperandPolicy(key.family, key.site, mixedPolicyClosed)
+		if transform != nil || err == nil {
+			t.Fatalf("closed policy admitted: transform=%v err=%v", transform != nil, err)
+		}
+	})
+
+	t.Run("plan admission", func(t *testing.T) {
+		key := mixedWrapperKey{family: mixedMathFamily, site: mixedPlanAdmission}
+		original := mixedOperandPolicies[key]
+		mixedOperandPolicies[key] = mixedPolicyClosed
+		t.Cleanup(func() { mixedOperandPolicies[key] = original })
+
+		if err := requireMixedPlanPolicy(nil, key.family, mixedPolicyClosed); err == nil {
+			t.Fatal("closed policy admitted")
+		}
+	})
+}
+
 func TestMixedOperandPolicyPreservesBespokeResultAndError(t *testing.T) {
 	for key, policy := range mixedOperandPolicies {
 		t.Run(string(key.family)+"/"+string(key.site), func(t *testing.T) {

--- a/internal/promql/mixed_operand_policy_test.go
+++ b/internal/promql/mixed_operand_policy_test.go
@@ -123,7 +123,7 @@ func TestMixedOperandPolicyAlreadyLoweredShape(t *testing.T) {
 		{"date must use its payload preparation", &chplan.VectorSetOp{Mixed: true}, mixedDateFamily, true},
 		{"math must use its payload preparation", &chplan.VectorSetOp{Mixed: true}, mixedMathFamily, true},
 		{"ordinary float unchanged", &chplan.Scan{}, "unlisted-wrapper", false},
-		{"histogram-only unchanged", &chplan.HistogramProjection{}, "unlisted-wrapper", false},
+		{"histogram-only unchanged", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, "unlisted-wrapper", false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := requireMixedPlanPolicy(tc.inner, tc.family)

--- a/internal/promql/mixed_physical_payload_test.go
+++ b/internal/promql/mixed_physical_payload_test.go
@@ -1,0 +1,147 @@
+package promql
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	mixedColumns := append(metricRoles(s), chplan.HistogramPayloadColumns()...)
+	mixedColumns = append(mixedColumns, chplan.Column{Name: "source_kind", Role: chplan.RoleDiscriminator})
+	mixed := sampleForwardTestInput(mixedColumns...)
+	floatRows := &chplan.Filter{Input: mixed, Predicate: &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "source_kind"},
+		Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+	}}
+	legacyMixedFloat := &chplan.Filter{
+		Input:     sampleForwardTestInput(metricRoles(s)...),
+		Predicate: &chplan.LitBool{V: true},
+		Mixed:     true,
+	}
+	emptyRankedSelector := &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: false}}
+	nonemptyRankedSelector := &chplan.TopK{Input: floatRows, Columns: topKOutputColumns(floatRows, s)}
+	preservingSelector := &chplan.TopK{Input: mixed, Mixed: true}
+
+	for _, tc := range []struct {
+		name             string
+		input            chplan.Node
+		physicalMixed    bool
+		floatProven      bool
+		legacyShape      chplan.RowShape
+		needsPreparation bool
+	}{
+		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleRowShape, false},
+		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.HistogramRowShape, false},
+		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleRowShape, true},
+		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleRowShape, false},
+		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleRowShape, false},
+		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleRowShape, false},
+		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleRowShape, false},
+		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleRowShape, false},
+		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.MixedRowShape, true},
+		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleRowShape, true},
+		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleRowShape, true},
+		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleRowShape, true},
+		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.MixedRowShape, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row := tc.input.RowType()
+			physicalMixed := row.HasHistogramPayload() && row.Has(chplan.RoleDiscriminator)
+			if physicalMixed != tc.physicalMixed {
+				t.Fatalf("physical mixed=%v, want %v; schema=%#v", physicalMixed, tc.physicalMixed, row)
+			}
+			if got := mixedFloatRowsProven(tc.input); got != tc.floatProven {
+				t.Fatalf("float proof=%v, want %v", got, tc.floatProven)
+			}
+			if got := chplan.RowShapeOf(tc.input); got != tc.legacyShape {
+				t.Fatalf("legacy shape=%s, want %s", got, tc.legacyShape)
+			}
+			if got := mixedRowsNeedPreparation(tc.input); got != tc.needsPreparation {
+				t.Fatalf("needs preparation=%v, want %v", got, tc.needsPreparation)
+			}
+
+			prepared := mixedRowsFloatOnly(tc.input)
+			if !tc.needsPreparation {
+				if prepared != tc.input {
+					t.Fatal("input without live mixed rows was narrowed")
+				}
+				return
+			}
+			if !prepared.RowType().Equal(row) {
+				t.Fatalf("preparation changed physical schema: got %#v, want %#v", prepared.RowType(), row)
+			}
+			if !chplan.IsMixedFloatNarrowing(prepared) {
+				t.Fatalf("prepared plan is not a float discriminator proof: %#v", prepared)
+			}
+			if mixedRowsFloatOnly(prepared) != prepared {
+				t.Fatal("float preparation is not idempotent")
+			}
+		})
+	}
+}
+
+func TestMixedRowsNeedPreparationRejectsMalformedPublicPayload(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	payload := chplan.HistogramPayloadColumns()
+	kind := chplan.Column{Name: "source_kind", Role: chplan.RoleDiscriminator}
+
+	type payloadCase struct {
+		name            string
+		columns         []chplan.Column
+		preserveUnnamed bool
+	}
+	cases := []payloadCase{
+		{name: "orphan_discriminator", columns: []chplan.Column{kind}},
+		{name: "partial_histogram", columns: []chplan.Column{payload[0]}},
+		{name: "duplicate_discriminator", columns: append(slices.Clone(payload), kind, chplan.Column{Name: "other_kind", Role: chplan.RoleDiscriminator})},
+		{name: "unnamed_discriminator", columns: append(slices.Clone(payload), chplan.Column{Role: chplan.RoleDiscriminator}), preserveUnnamed: true},
+		{name: "shadowed_discriminator", columns: append(slices.Clone(payload), kind, chplan.Column{Name: kind.Name, Role: chplan.RoleOpaque})},
+	}
+	for i, field := range payload {
+		missing := slices.Delete(slices.Clone(payload), i, i+1)
+		wrongRole := slices.Clone(payload)
+		wrongRole[i].Role = chplan.RoleOpaque
+		cases = append(
+			cases,
+			payloadCase{name: "missing/" + field.Name, columns: append(slices.Clone(missing), kind)},
+			payloadCase{name: "wrong_role/" + field.Name, columns: append(wrongRole, kind)},
+			payloadCase{name: "duplicate/" + field.Name, columns: append(slices.Clone(payload), field, kind)},
+		)
+	}
+
+	for _, tc := range cases {
+		for _, narrowed := range []bool{false, true} {
+			name := "direct/" + tc.name
+			if narrowed {
+				name = "narrowed/" + tc.name
+			}
+			t.Run(name, func(t *testing.T) {
+				columns := append(metricRoles(s), tc.columns...)
+				var input chplan.Node = sampleForwardTestInput(columns...)
+				if tc.preserveUnnamed {
+					input = &chplan.Scan{Table: "samples", Roles: columns}
+				}
+				if narrowed {
+					input = &chplan.Filter{Input: input, Predicate: &chplan.Binary{
+						Op:    chplan.OpEq,
+						Left:  &chplan.ColumnRef{Name: kind.Name},
+						Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+					}}
+				}
+				capturePanic(t, func() {
+					mixedRowsNeedPreparation(input)
+				})
+			})
+		}
+	}
+
+	open := &chplan.Scan{Table: "samples", Roles: append(metricRoles(s), kind)}
+	capturePanic(t, func() {
+		mixedRowsNeedPreparation(open)
+	})
+}

--- a/internal/promql/mixed_physical_payload_test.go
+++ b/internal/promql/mixed_physical_payload_test.go
@@ -3,6 +3,9 @@ package promql
 import (
 	"slices"
 	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
@@ -28,26 +31,27 @@ func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.
 	preservingSelector := &chplan.TopK{Input: mixed, Mixed: true}
 
 	for _, tc := range []struct {
-		name             string
-		input            chplan.Node
-		physicalMixed    bool
-		floatProven      bool
-		legacyShape      chplan.RowShape
-		needsPreparation bool
+		name                 string
+		input                chplan.Node
+		physicalMixed        bool
+		floatProven          bool
+		legacyShape          chplan.RowShape
+		needsPreparation     bool
+		mayContainHistograms bool
 	}{
-		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleRowShape, false},
-		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.HistogramRowShape, false},
-		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleRowShape, true},
-		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleRowShape, false},
-		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleRowShape, false},
-		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleRowShape, false},
-		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleRowShape, false},
-		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleRowShape, false},
-		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.MixedRowShape, true},
-		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleRowShape, true},
-		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleRowShape, true},
-		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleRowShape, true},
-		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.MixedRowShape, false},
+		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleRowShape, false, false},
+		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.HistogramRowShape, false, true},
+		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleRowShape, true, true},
+		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleRowShape, false, false},
+		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleRowShape, false, false},
+		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleRowShape, false, false},
+		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleRowShape, false, false},
+		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleRowShape, false, false},
+		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.MixedRowShape, true, true},
+		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleRowShape, true, true},
+		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleRowShape, true, true},
+		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleRowShape, true, true},
+		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.MixedRowShape, false, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			row := tc.input.RowType()
@@ -63,6 +67,9 @@ func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.
 			}
 			if got := mixedRowsNeedPreparation(tc.input); got != tc.needsPreparation {
 				t.Fatalf("needs preparation=%v, want %v", got, tc.needsPreparation)
+			}
+			if got := rowsMayContainHistograms(tc.input); got != tc.mayContainHistograms {
+				t.Fatalf("may contain histograms=%v, want %v", got, tc.mayContainHistograms)
 			}
 
 			prepared := mixedRowsFloatOnly(tc.input)
@@ -133,6 +140,9 @@ func TestMixedRowsNeedPreparationRejectsMalformedPublicPayload(t *testing.T) {
 						Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
 					}}
 				}
+				if !rowsMayContainHistograms(input) {
+					t.Fatal("malformed payload was routed as float-only")
+				}
 				capturePanic(t, func() {
 					mixedRowsNeedPreparation(input)
 				})
@@ -141,7 +151,168 @@ func TestMixedRowsNeedPreparationRejectsMalformedPublicPayload(t *testing.T) {
 	}
 
 	open := &chplan.Scan{Table: "samples", Roles: append(metricRoles(s), kind)}
+	if !rowsMayContainHistograms(open) {
+		t.Fatal("open mixed schema was routed as float-only")
+	}
 	capturePanic(t, func() {
 		mixedRowsNeedPreparation(open)
 	})
+
+	for _, input := range []chplan.Node{
+		&chplan.OneRow{},
+		&chplan.Scan{Table: "samples", Roles: metricRoles(s)},
+		sampleForwardTestInput(chplan.Column{Name: "opaque_value", Role: chplan.RoleOpaque}),
+		sampleForwardTestInput(chplan.Column{Role: chplan.RoleValue}),
+		sampleForwardTestInput(
+			chplan.Column{Name: "value", Role: chplan.RoleValue},
+			chplan.Column{Name: "other_value", Role: chplan.RoleValue},
+		),
+		sampleForwardTestInput(
+			chplan.Column{Name: "value", Role: chplan.RoleValue},
+			chplan.Column{Name: "value", Role: chplan.RoleOpaque},
+		),
+		&chplan.Filter{
+			Input: sampleForwardTestInput(append(slices.Clone(payload), kind)...),
+			Predicate: &chplan.Binary{
+				Op:    chplan.OpEq,
+				Left:  &chplan.ColumnRef{Name: kind.Name},
+				Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+			},
+		},
+	} {
+		if !rowsMayContainHistograms(input) {
+			t.Fatalf("unknown schema was routed as float-only: %#v", input.RowType())
+		}
+	}
+}
+
+func TestRowsMayContainHistogramsUsesRolesAcrossSampleEnvelopes(t *testing.T) {
+	value := chplan.Column{Name: "source_value", Role: chplan.RoleValue}
+	floatRows := sampleForwardTestInput(
+		chplan.Column{Name: "source_name", Role: chplan.RoleMetricName},
+		chplan.Column{Name: "source_labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: "source_time", Role: chplan.RoleTimestamp},
+		value,
+	)
+	gridRows := sampleForwardTestInput(
+		chplan.Column{Name: "source_labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: "source_anchor", Role: chplan.RoleAnchor},
+		chplan.Column{Name: "source_time", Role: chplan.RoleTimestamp},
+		value,
+	)
+	reducedRows := sampleForwardTestInput(
+		chplan.Column{Name: "group_key", Role: chplan.RoleOpaque},
+		value,
+	)
+	mixedColumns := append(slices.Clone(floatRows.RowType().Columns), chplan.HistogramPayloadColumns()...)
+	mixedColumns = append(mixedColumns, chplan.Column{Name: "source_kind", Role: chplan.RoleDiscriminator})
+	mixedRows := sampleForwardTestInput(mixedColumns...)
+	narrowedRows := &chplan.Filter{Input: mixedRows, Predicate: &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "source_kind"},
+		Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+	}}
+
+	for _, input := range []chplan.Node{floatRows, gridRows, reducedRows, narrowedRows} {
+		if rowsMayContainHistograms(input) {
+			t.Fatalf("valid float envelope was routed as histogram-capable: %#v", input.RowType())
+		}
+	}
+	for _, input := range []chplan.Node{
+		mixedRows,
+		&chplan.OrderBy{Input: mixedRows},
+		&chplan.Project{Input: narrowedRows},
+	} {
+		if !rowsMayContainHistograms(input) {
+			t.Fatalf("live or unproven mixed envelope was routed as float-only: %#v", input.RowType())
+		}
+	}
+
+	for _, role := range []chplan.ColumnRole{
+		chplan.RoleMetricName,
+		chplan.RoleAttributes,
+		chplan.RoleTimestamp,
+		chplan.RoleAnchor,
+	} {
+		for _, input := range []chplan.Node{
+			sampleForwardTestInput(value, chplan.Column{Role: role}),
+			sampleForwardTestInput(
+				value,
+				chplan.Column{Name: "first", Role: role},
+				chplan.Column{Name: "second", Role: role},
+			),
+			sampleForwardTestInput(
+				value,
+				chplan.Column{Name: "role_name", Role: role},
+				chplan.Column{Name: "role_name", Role: chplan.RoleOpaque},
+			),
+		} {
+			if !rowsMayContainHistograms(input) {
+				t.Fatalf("malformed role %d was routed as float-only: %#v", role, input.RowType())
+			}
+		}
+	}
+}
+
+func TestHistogramNativeSubqueryInnerRoutesRankedMixedRowsByLiveKind(t *testing.T) {
+	standard := schema.DefaultOTelMetrics()
+	renamed := standard
+	renamed.MetricNameColumn = "source_name"
+	renamed.AttributesColumn = "source_labels"
+	renamed.TimestampColumn = "source_time"
+	renamed.ValueColumn = "source_value"
+	at := time.Date(2026, 1, 1, 0, 10, 0, 0, time.UTC)
+
+	for _, metrics := range []schema.Metrics{standard, renamed} {
+		for _, tc := range []struct {
+			name  string
+			k     string
+			empty bool
+		}{
+			{name: "empty", k: "0", empty: true},
+			{name: "nonempty", k: "1"},
+		} {
+			t.Run(metrics.ValueColumn+"/"+tc.name, func(t *testing.T) {
+				expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(
+					"topk(" + tc.k + ", latency_exp_hist or num_cpus)[5m:1m]",
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				sub, ok := expr.(*parser.SubqueryExpr)
+				if !ok {
+					t.Fatalf("parsed expression = %T, want *parser.SubqueryExpr", expr)
+				}
+				plan, err := lowerSubquery(sub, metrics, lowerCtx{
+					start:          at,
+					end:            at,
+					lowerers:       RangeLowerers{}.withDefaults(),
+					resourceBounds: DefaultResourceBounds(),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				project, ok := plan.(*chplan.Project)
+				if !ok {
+					t.Fatalf("ranked float subquery = %T, want anchor-shaping *chplan.Project", plan)
+				}
+				if tc.empty {
+					if _, ok := project.Input.(*chplan.Filter); !ok {
+						t.Fatalf("empty ranked input = %T, want *chplan.Filter", project.Input)
+					}
+				} else {
+					if _, ok := project.Input.(*chplan.TopK); !ok {
+						t.Fatalf("nonempty ranked input = %T, want *chplan.TopK", project.Input)
+					}
+				}
+				if rowsMayContainHistograms(project.Input) {
+					t.Fatal("ranked mixed selector retained live histograms")
+				}
+				row := project.RowType()
+				if row.HasHistogramPayload() || row.Has(chplan.RoleDiscriminator) || !row.Has(chplan.RoleAnchor) {
+					t.Fatalf("ranked subquery anchor schema = %#v", row)
+				}
+			})
+		}
+	}
 }

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -108,20 +108,19 @@ func lowerSubquery(e *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (chpl
 // that error message is spelled.
 //
 // When matched, plan is returned exactly as the histogram-native
-// recognizer built it EXCEPT for its own row shape:
+// recognizer built it EXCEPT for its live sample kind:
 //
-//   - [chplan.HistogramRowShape] / [chplan.MixedRowShape] (a
-//     histogram-valued or mixed-`or` result) is returned AS-IS.
+//   - A histogram-valued or live mixed-`or` result is returned AS-IS.
 //     Re-projecting it through [subqueryAnchorShape]'s four-column
 //     Sample quartet would silently drop the nine Histogram*Column
 //     outputs (or the mixed shape's discriminator column) — the exact
 //     hazard [chplan.HistogramRowShape]'s own doc comment warns every
 //     generic forwarder about.
-//   - Anything else (the "drop" family's always-empty float quartet, a
-//     [chplan.SampleRowShape] result) gets the SAME [subqueryAnchorShape]
-//     wrap the non-histogram arithmetic siblings already apply, so a
-//     wrapping outer range-vector function can still read the
-//     `anchor_ts` alias.
+//   - Anything else (including a discriminator-zero physical mixed payload,
+//     the "drop" family's always-empty float quartet, or an ordinary sample)
+//     gets the SAME [subqueryAnchorShape] wrap the non-histogram arithmetic
+//     siblings already apply, so a wrapping outer range-vector function can
+//     still read the `anchor_ts` alias.
 //
 // A histogram-native shape reached from an OUTER range-vector function
 // wrapping this subquery (`max_over_time((m_exp_hist)[5m:1m])`) is a
@@ -165,12 +164,10 @@ func lowerHistogramNativeSubqueryInner(sub *parser.SubqueryExpr, step time.Durat
 		if err := requireMixedPlanPolicy(plan, mixedSubqueryFamily); err != nil {
 			return nil, true, err
 		}
-		switch chplan.RowShapeOf(plan) {
-		case chplan.HistogramRowShape, chplan.MixedRowShape:
+		if rowsMayContainHistograms(plan) {
 			return capEmpty(plan), true, nil
-		default:
-			return subqueryAnchorShape(capEmpty(plan), s), true, nil
 		}
+		return subqueryAnchorShape(capEmpty(plan), s), true, nil
 	}
 	// The eleven-function drop-family range-vector reducer vocabulary
 	// (max_over_time, min_over_time, deriv, predict_linear,
@@ -838,10 +835,11 @@ func lowerSubqueryOverInstantCall(
 // discriminator) and leave every consumer reading the meaningless
 // placeholder Value column instead — the exact silent-wrong-answer
 // class cerberus issue #2543 fixed for the bare-subquery-inner case.
-// The guard below is the same RowShapeOf dispatch
-// [lowerHistogramNativeSubqueryInner] already applies to its own
-// result, so a histogram/mixed-shaped set-op composes exactly like a
-// pure histogram-native subquery inner does.
+// The guard below asks the same live-sample-kind question
+// [lowerHistogramNativeSubqueryInner] applies to its own result, so a
+// histogram/mixed-valued set-op composes exactly like a pure
+// histogram-native subquery inner does without mistaking retained physical
+// payload columns for live histograms.
 func lowerSubqueryOverBinary(
 	sub *parser.SubqueryExpr,
 	b *parser.BinaryExpr,
@@ -864,12 +862,10 @@ func lowerSubqueryOverBinary(
 		if state == subqueryGridEmpty {
 			inner = emptySubqueryGrid(inner)
 		}
-		switch chplan.RowShapeOf(inner) {
-		case chplan.HistogramRowShape, chplan.MixedRowShape:
+		if rowsMayContainHistograms(inner) {
 			return inner, nil
-		default:
-			return subqueryAnchorShape(inner, s), nil
 		}
+		return subqueryAnchorShape(inner, s), nil
 	}
 
 	// Synthetic operands such as time() materialize their own StepGrid.
@@ -890,7 +886,7 @@ func lowerSubqueryOverBinary(
 	// collapsed. This branch has no grid to evaluate a per-anchor
 	// composition against even in principle, so there is no sound
 	// alternative to offer here.
-	if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape {
+	if rowsMayContainHistograms(inner) {
 		return nil, fmt.Errorf("promql: histogram-valued subquery set operator requires query eval-time context (use LowerAt)")
 	}
 	return wrapSubqueryIdentity(sub, inner, step, s, ctx)
@@ -1051,13 +1047,14 @@ func lowerOuterRangeFnOverSubquery(
 	// avg_over_time are intercepted the same way, one level earlier
 	// still, by [rangeFnOverExpHistogramSubquery] /
 	// [lowerExpHistogramRangeFnOverSubquery] (histogram_native_range_fn.go).
-	if shape := chplan.RowShapeOf(inner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape {
+	if rowsMayContainHistograms(inner) {
+		shape := chplan.RowShapeFromSchema(inner.RowType())
 		// Cerberus issue #2724: inner may have reached this Histogram/Mixed
 		// shape via a further and/unless/or wrapping a mixed `or`, a bare
 		// and/unless-forwarded histogram selector, or (since cerberus issue
 		// #3227) a bare mixed `or` — any shape [lowerSubquery]'s ordinary
-		// dispatch resolves this way, and the row shape alone says which
-		// continuation applies, so no AST recognizer is needed.
+		// dispatch resolves this way, and the validated physical row shape
+		// says which continuation applies, so no AST recognizer is needed.
 		// [lowerHistogramOrMixedSubqueryOuterFnInput] answers every one of
 		// the fifteen SELECT/FOLD-family names for it; anything else
 		// (deriv, predict_linear, ...) falls through unmatched to this
@@ -3095,7 +3092,8 @@ func lowerSubqueryOverCallSubquery(
 	// composition (lowerOuterRangeFnOverSubquery, whose identical guard
 	// this mirrors) already gets for
 	// `<outer-fn>(<bare-histogram-selector>[range:step])`.
-	if shape := chplan.RowShapeOf(wideInner); shape == chplan.HistogramRowShape || shape == chplan.MixedRowShape {
+	if rowsMayContainHistograms(wideInner) {
+		shape := chplan.RowShapeFromSchema(wideInner.RowType())
 		// Cerberus issue #2726: wideInner may be histogram/mixed-shaped
 		// because innerSub's OWN inner expression resolved histogram-native
 		// (or a further and/unless/or wrapping one, cerberus issue #2724).


### PR DESCRIPTION
## Summary

- route the five subquery payload decisions by validated live sample kind instead of legacy row-shape metadata
- keep discriminator-zero physical mixed rows on the float path while preserving histogram and unproven mixed payloads
- fail closed for open, opaque, partial, duplicate, unnamed, or shadowed sample-role schemas
- cover default and renamed schemas, empty and non-empty ranked selectors, proof propagation, and projection barriers

## Validation

- `gofumpt` and `goimports` report no formatting changes
- `git diff --check` passes
- focused tests covering the existing outer-range, no-anchor binary, mixed-family, and payload-validator paths passed before the final test-only additions
- heavy validation runs on GitHub CI as directed

## Dependency

This draft is stacked on #3359 and targets `codex/3343-physical-mixed-float-proof`. It will be retargeted to `main` after #3359 merges.

Closes #3342
