### PR TITLE
refactor(promql): reconcile mixed-wrapper schema consumers

### DIFF
--- a/internal/api/loki/absent_over_time_grid_test.go
+++ b/internal/api/loki/absent_over_time_grid_test.go
@@ -48,7 +48,10 @@ func TestAbsentOverTimeRangeQuery_GridIsRequestGrid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse+lower %q: %v", q, err)
 	}
-	plan = l.ProjectSamples(plan, meta)
+	plan, err = l.ProjectSamples(plan, meta)
+	if err != nil {
+		t.Fatalf("project samples: %v", err)
+	}
 	plan = optimizer.Default().Run(context.Background(), plan)
 
 	// Guard: confirm the optimized plan's only grid carrier is
@@ -98,7 +101,10 @@ func TestAbsentOverTimeInstantQuery_StillReportsNoGrid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse+lower %q: %v", q, err)
 	}
-	plan = l.ProjectSamples(plan, meta)
+	plan, err = l.ProjectSamples(plan, meta)
+	if err != nil {
+		t.Fatalf("project samples: %v", err)
+	}
 	plan = optimizer.Default().Run(context.Background(), plan)
 
 	if _, _, step := solver.GridOf(plan); step != 0 {

--- a/internal/api/prom/handler.go
+++ b/internal/api/prom/handler.go
@@ -1624,15 +1624,24 @@ func errContainsStage(msg, stage string) bool {
 // chplan.ProjectExposesCanonical check distinguishes these "value-rewrite"
 // Projects from the canonical-shape Projects upstream lowerings (LWR,
 // instant fns over `temperature`, etc.) emit.
-func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
+func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) (chplan.Node, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("prom: sample projection: nil plan")
+	}
+	row := plan.RowType()
+	kind := row.SampleKind()
+	if kind == chplan.SampleKindOpaque || kind == chplan.SampleKindInvalid {
+		return nil, fmt.Errorf("prom: sample projection: cannot publish %s schema", kind)
+	}
+
 	// A histogram-VALUED plan already publishes the full wire contract:
 	// the canonical quartet FIRST, then the nine chplan.Histogram*Column
 	// outputs that internal/chclient's cursor binds when it probes the
 	// result set's final column. Re-projecting the quartet on top would
 	// drop those nine, un-latch the probe, and hand every native-histogram
 	// answer back as the placeholder float — so the correct wrapper here
-	// is no wrapper at all. RowShapeOf is the one classifier for "what
-	// does this node publish"; see chplan.HistogramRowShape.
+	// is no wrapper at all. The node's physical schema is the classifier
+	// for what the node actually publishes.
 	//
 	// A Mixed plan (chplan.MixedRowShape, cerberus issue #2330 — `or`
 	// between a float-valued and a histogram-valued operand) needs the
@@ -1643,48 +1652,156 @@ func wrapWithSampleProjection(plan chplan.Node, s schema.Metrics) chplan.Node {
 	// histogram columns AND the discriminator — the cursor would then
 	// fall back to the plain four-column shape and silently answer every
 	// row as its (possibly placeholder) Value.
-	switch chplan.RowShapeOf(plan) {
-	case chplan.HistogramRowShape, chplan.MixedRowShape:
-		return plan
+	if kind == chplan.SampleKindHistogram || kind == chplan.SampleKindMixed {
+		projected, want, err := projectSamplePayload(plan, row, s, kind)
+		if err != nil {
+			return nil, err
+		}
+		if row.Equal(want) {
+			return plan, nil
+		}
+		return projected, nil
+	}
+
+	attributes, err := requiredSampleRole(row, chplan.RoleAttributes, "attributes")
+	if err != nil {
+		return nil, err
+	}
+	value, err := requiredSampleRole(row, chplan.RoleValue, "value")
+	if err != nil {
+		return nil, err
+	}
+	metricName, hasMetricName := row.Find(chplan.RoleMetricName)
+	timestamp, hasTimestamp := row.Find(chplan.RoleTimestamp)
+	anchor, hasAnchor := row.Find(chplan.RoleAnchor)
+
+	var metricNameProjection chplan.Projection
+	if hasMetricName {
+		metricNameProjection = sampleColumnProjection(metricName, s.MetricNameColumn)
+	} else {
+		metricNameProjection = chplan.Projection{
+			Expr:  &chplan.LitString{V: ""},
+			Alias: s.MetricNameColumn,
+		}
+	}
+
+	var timestampProjection chplan.Projection
+	cols := sampleColumns(s)
+	// TimeUnix source: a matrix-shape RangeWindow exposes a real per-row
+	// timestamp under the literal column `anchor_ts`, which the emitter
+	// keeps offset-SHIFTED (the window/rate math keys off the shifted
+	// window edge). PromQL's `offset` shifts only WHICH samples a reducing
+	// window reads, not the timestamp the result is reported at, so for a
+	// reducing rate/increase/*_over_time window with a non-zero offset the
+	// reported timestamp is anchor_ts + Offset (the unshifted request
+	// grid); reading raw `anchor_ts` here re-shifted every offset matrix
+	// query's output past this handler's projection, invisible to the spec
+	// goldens (which never wrap in this projection). A raw range vector /
+	// subquery (Identity) reports each sample at its ACTUAL, offset-shifted
+	// time, so it is left un-relabeled. Matrix schemas also publish a
+	// RoleTimestamp column, but RoleAnchor must win: it is the result grid,
+	// while RoleTimestamp is the source sample time.
+	if isMatrixRangeWindow(plan, cols) {
+		if !hasAnchor || anchor.Name == "" {
+			return nil, fmt.Errorf("prom: sample projection: matrix schema is missing anchor role")
+		}
+		timestampProjection = sampleColumnProjection(anchor, s.TimestampColumn)
+		if off, relabel := matrixWindowOffset(plan, cols); relabel {
+			timestampProjection = chplan.Projection{
+				Expr:  chplan.OffsetReanchoredColumnExpr(anchor.Name, off),
+				Alias: s.TimestampColumn,
+			}
+		}
+	} else if hasTimestamp {
+		timestampProjection = sampleColumnProjection(timestamp, s.TimestampColumn)
+	} else if hasAnchor {
+		timestampProjection = sampleColumnProjection(anchor, s.TimestampColumn)
+	} else {
+		timestampProjection = chplan.Projection{
+			Expr:  synthesizedAnchor(),
+			Alias: s.TimestampColumn,
+		}
 	}
 	projections := []chplan.Projection{
-		{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}},
-		{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}},
-		{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}},
-		{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},
+		metricNameProjection,
+		sampleColumnProjection(attributes, s.AttributesColumn),
+		timestampProjection,
+		sampleColumnProjection(value, s.ValueColumn),
 	}
-	cols := sampleColumns(s)
-	if chplan.IsDerivedShape(plan, cols) {
-		// TimeUnix source: a matrix-shape RangeWindow exposes a real per-row
-		// timestamp under the literal column `anchor_ts`, which the emitter
-		// keeps offset-SHIFTED (the window/rate math keys off the shifted
-		// window edge). PromQL's `offset` shifts only WHICH samples a reducing
-		// window reads, not the timestamp the result is reported at, so for a
-		// reducing rate/increase/*_over_time window with a non-zero offset the
-		// reported timestamp is anchor_ts + Offset (the unshifted request
-		// grid); reading raw `anchor_ts` here re-shifted every offset matrix
-		// query's output past this handler's projection, invisible to the spec
-		// goldens (which never wrap in this projection). A raw range vector /
-		// subquery (Identity) reports each sample at its ACTUAL, offset-shifted
-		// time, so it is left un-relabeled. The instant case synthesises via
-		// now64().
-		var tsExpr chplan.Expr
-		if isMatrixRangeWindow(plan, cols) {
-			tsExpr = &chplan.ColumnRef{Name: chplan.RangeWindowAnchorColumn}
-			if off, relabel := matrixWindowOffset(plan, cols); relabel {
-				tsExpr = chplan.OffsetReanchoredAnchorExpr(off)
-			}
-		} else {
-			tsExpr = synthesizedAnchor()
-		}
-		projections = []chplan.Projection{
-			{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn},
-			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
-			{Expr: tsExpr, Alias: s.TimestampColumn},
-			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
-		}
+	roles := []chplan.Column{
+		{Name: s.MetricNameColumn, Role: chplan.RoleMetricName},
+		{Name: s.AttributesColumn, Role: chplan.RoleAttributes},
+		{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+		{Name: s.ValueColumn, Role: chplan.RoleValue},
 	}
-	return &chplan.Project{Input: plan, Projections: projections}
+	return &chplan.Project{Input: plan, Projections: projections, Roles: roles}, nil
+}
+
+func sampleColumnProjection(column chplan.Column, outputName string) chplan.Projection {
+	projection := chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}}
+	if column.Name != outputName {
+		projection.Alias = outputName
+	}
+	return projection
+}
+
+func requiredSampleRole(row chplan.Schema, role chplan.ColumnRole, label string) (chplan.Column, error) {
+	column, ok := row.Find(role)
+	if !ok || column.Name == "" {
+		return chplan.Column{}, fmt.Errorf("prom: sample projection: %s schema is missing %s role", row.SampleKind(), label)
+	}
+	return column, nil
+}
+
+func projectSamplePayload(
+	plan chplan.Node,
+	row chplan.Schema,
+	s schema.Metrics,
+	kind chplan.SampleKind,
+) (chplan.Node, chplan.Schema, error) {
+	roles := []struct {
+		role  chplan.ColumnRole
+		label string
+		name  string
+	}{
+		{chplan.RoleMetricName, "metric-name", s.MetricNameColumn},
+		{chplan.RoleAttributes, "attributes", s.AttributesColumn},
+		{chplan.RoleTimestamp, "timestamp", s.TimestampColumn},
+		{chplan.RoleValue, "value", s.ValueColumn},
+	}
+	want := chplan.Schema{Columns: make([]chplan.Column, 0, len(roles)+len(chplan.HistogramPayloadColumns())+1)}
+	projections := make([]chplan.Projection, 0, cap(want.Columns))
+	for _, required := range roles {
+		column, err := requiredSampleRole(row, required.role, required.label)
+		if err != nil {
+			return nil, chplan.Schema{}, err
+		}
+		projections = append(projections, chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: column.Name},
+			Alias: required.name,
+		})
+		want.Columns = append(want.Columns, chplan.Column{Name: required.name, Role: required.role})
+	}
+	for _, field := range chplan.HistogramPayloadColumns() {
+		column, ok := row.ByName(field.Name)
+		if !ok || column.Role != chplan.RoleHistogramField {
+			return nil, chplan.Schema{}, fmt.Errorf("prom: sample projection: %s schema is missing histogram field %q", kind, field.Name)
+		}
+		projections = append(projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}, Alias: field.Name})
+		want.Columns = append(want.Columns, field)
+	}
+	if kind == chplan.SampleKindMixed {
+		discriminator, err := requiredSampleRole(row, chplan.RoleDiscriminator, "discriminator")
+		if err != nil {
+			return nil, chplan.Schema{}, err
+		}
+		projections = append(projections, chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: discriminator.Name},
+			Alias: chplan.MixedDiscriminatorColumn,
+		})
+		want.Columns = append(want.Columns, chplan.Column{Name: chplan.MixedDiscriminatorColumn, Role: chplan.RoleDiscriminator})
+	}
+	return &chplan.Project{Input: plan, Projections: projections, Roles: want.Columns}, want, nil
 }
 
 // isMatrixRangeWindow reports whether the plan root is a matrix-shape

--- a/internal/api/prom/lang.go
+++ b/internal/api/prom/lang.go
@@ -201,7 +201,7 @@ func engineGuards(guards []promql.ScalarGuard) []engine.Guard {
 // matrixFromCursor's streaming pivot wants is deliberately NOT added at
 // this seam; see RangeSeriesOrder's doc comment for why it has to land
 // later, at emit time, route-A only.
-func (l *lang) ProjectSamples(plan chplan.Node, _ engine.Meta) chplan.Node {
+func (l *lang) ProjectSamples(plan chplan.Node, _ engine.Meta) (chplan.Node, error) {
 	return wrapWithSampleProjection(plan, l.Schema)
 }
 

--- a/internal/api/prom/lang_test.go
+++ b/internal/api/prom/lang_test.go
@@ -15,6 +15,33 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
+func mustProjectSamples(t testing.TB, l *lang, plan chplan.Node, meta engine.Meta) chplan.Node {
+	t.Helper()
+	projected, err := l.ProjectSamples(plan, meta)
+	if err != nil {
+		t.Fatalf("ProjectSamples: %v", err)
+	}
+	return projected
+}
+
+func sampleRoleColumns(s schema.Metrics) []chplan.Column {
+	return []chplan.Column{
+		{Name: s.MetricNameColumn, Role: chplan.RoleMetricName},
+		{Name: s.AttributesColumn, Role: chplan.RoleAttributes},
+		{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+		{Name: s.ValueColumn, Role: chplan.RoleValue},
+	}
+}
+
+func closedSampleScan(s schema.Metrics, table string) *chplan.Scan {
+	roles := sampleRoleColumns(s)
+	columns := make([]string, len(roles))
+	for i, role := range roles {
+		columns[i] = role.Name
+	}
+	return &chplan.Scan{Table: table, Columns: columns, Roles: roles}
+}
+
 // langForTest is shared scaffolding: a Lang built with the same
 // experimental-functions parser options as the real Handler so the
 // test surfaces match prod, plus a fixed eval window so `@ start() /
@@ -154,8 +181,8 @@ func TestLang_ProjectSamples_WrapsCanonicalShape(t *testing.T) {
 	t.Parallel()
 
 	l := langForTest()
-	plan := &chplan.Scan{Table: l.Schema.GaugeTable}
-	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+	plan := closedSampleScan(l.Schema, l.Schema.GaugeTable)
+	wrapped := mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true})
 
 	proj, ok := wrapped.(*chplan.Project)
 	if !ok {

--- a/internal/api/prom/matrix_walk_aggregate_test.go
+++ b/internal/api/prom/matrix_walk_aggregate_test.go
@@ -15,18 +15,26 @@ import (
 func matrixWindowUnder(s schema.Metrics, offset time.Duration) *chplan.Project {
 	return &chplan.Project{
 		Input: &chplan.RangeWindow{
-			Input:      &chplan.Scan{Table: "otel_metrics_gauge"},
-			OuterRange: time.Hour,
-			Range:      5 * time.Minute,
-			Step:       time.Minute,
-			Offset:     offset,
-			GroupBy:    []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+			Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+			OuterRange:      time.Hour,
+			Range:           5 * time.Minute,
+			Step:            time.Minute,
+			Offset:          offset,
+			TimestampColumn: s.TimestampColumn,
+			ValueColumn:     s.ValueColumn,
+			GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
 		},
 		Projections: []chplan.Projection{
 			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
 			{Expr: &chplan.ColumnRef{Name: chplan.RangeWindowAnchorColumn}},
 			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}},
+		},
+		Roles: []chplan.Column{
+			{Name: s.AttributesColumn, Role: chplan.RoleAttributes},
+			{Name: chplan.RangeWindowAnchorColumn, Role: chplan.RoleAnchor},
+			{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+			{Name: s.ValueColumn, Role: chplan.RoleValue},
 		},
 	}
 }
@@ -113,7 +121,11 @@ func TestMatrixWalks_CrossShapePreservingAggregate(t *testing.T) {
 
 	// The wrapper is what consumes both answers, so pin the column it
 	// actually projects into the timestamp slot.
-	wrapped, ok := wrapWithSampleProjection(guarded, s).(*chplan.Project)
+	wrappedNode, err := wrapWithSampleProjection(guarded, s)
+	if err != nil {
+		t.Fatalf("wrapWithSampleProjection: %v", err)
+	}
+	wrapped, ok := wrappedNode.(*chplan.Project)
 	if !ok {
 		t.Fatalf("wrapWithSampleProjection returned %T, want *chplan.Project", wrapped)
 	}

--- a/internal/api/prom/metadata.go
+++ b/internal/api/prom/metadata.go
@@ -1539,7 +1539,10 @@ func (h *Handler) seriesMatcherSQL(ctx context.Context, matcher string, start, e
 	if err != nil {
 		return "", nil, 0, &apiError{Kind: ErrBadData, Err: err, Status: http.StatusBadRequest}
 	}
-	plan = wrapWithSampleProjection(plan, h.Schema)
+	plan, err = wrapWithSampleProjection(plan, h.Schema)
+	if err != nil {
+		return "", nil, 0, &apiError{Kind: ErrInternal, Err: err, Status: http.StatusInternalServerError}
+	}
 	plan = h.Optimizer.Run(ctx, plan)
 	sql, args, physicalScans, err = chsql.EmitCounted(ctx, plan)
 	if err != nil {

--- a/internal/api/prom/native_projection_test.go
+++ b/internal/api/prom/native_projection_test.go
@@ -30,7 +30,7 @@ func TestWrapSampleProjection_NativeRangeWindowIsDerivedMatrix(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 
 	native := &chplan.RangeWindowGridNative{
-		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Input:           closedSampleScan(s, "otel_metrics_gauge"),
 		Func:            "rate",
 		Range:           5 * time.Minute,
 		Step:            time.Minute,
@@ -48,7 +48,11 @@ func TestWrapSampleProjection_NativeRangeWindowIsDerivedMatrix(t *testing.T) {
 		t.Fatal("RangeWindowGridNative must be matrix-shape (exposes per-row anchor_ts)")
 	}
 
-	wrapped, ok := wrapWithSampleProjection(native, s).(*chplan.Project)
+	wrappedNode, err := wrapWithSampleProjection(native, s)
+	if err != nil {
+		t.Fatalf("wrapWithSampleProjection: %v", err)
+	}
+	wrapped, ok := wrappedNode.(*chplan.Project)
 	if !ok {
 		t.Fatalf("wrapWithSampleProjection returned %T, want *chplan.Project", wrapped)
 	}
@@ -96,7 +100,7 @@ func TestWrapSampleProjection_NativeRangeWindowOffsetNotReshifted(t *testing.T) 
 	s := schema.DefaultOTelMetrics()
 
 	native := &chplan.RangeWindowGridNative{
-		Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+		Input:           closedSampleScan(s, "otel_metrics_gauge"),
 		Func:            "rate",
 		Range:           5 * time.Minute,
 		Step:            time.Minute,
@@ -108,7 +112,11 @@ func TestWrapSampleProjection_NativeRangeWindowOffsetNotReshifted(t *testing.T) 
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
 	}
 
-	wrapped, ok := wrapWithSampleProjection(native, s).(*chplan.Project)
+	wrappedNode, err := wrapWithSampleProjection(native, s)
+	if err != nil {
+		t.Fatalf("wrapWithSampleProjection: %v", err)
+	}
+	wrapped, ok := wrappedNode.(*chplan.Project)
 	if !ok {
 		t.Fatalf("wrapWithSampleProjection returned %T, want *chplan.Project", wrapped)
 	}
@@ -141,7 +149,7 @@ func TestWrapSampleProjection_HistogramProjectionPassesThrough(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 
 	hp := &chplan.HistogramProjection{
-		Input:                      &chplan.Scan{Table: s.ExpHistogramTable},
+		Input:                      closedSampleScan(s, s.ExpHistogramTable),
 		CountColumn:                s.CountColumn,
 		SumColumn:                  s.SumColumn,
 		ScaleColumn:                s.ScaleColumn,
@@ -164,7 +172,11 @@ func TestWrapSampleProjection_HistogramProjectionPassesThrough(t *testing.T) {
 	if got := chplan.RowShapeOf(hp); got != chplan.HistogramRowShape {
 		t.Fatalf("RowShapeOf(HistogramProjection) = %s, want histogram", got)
 	}
-	if wrapped := wrapWithSampleProjection(hp, s); wrapped != chplan.Node(hp) {
+	wrapped, err := wrapWithSampleProjection(hp, s)
+	if err != nil {
+		t.Fatalf("wrapWithSampleProjection: %v", err)
+	}
+	if wrapped != chplan.Node(hp) {
 		t.Fatalf("wrapWithSampleProjection wrapped a histogram-shaped root in %T; it must pass through unchanged", wrapped)
 	}
 }

--- a/internal/api/prom/native_range_grid_test.go
+++ b/internal/api/prom/native_range_grid_test.go
@@ -68,7 +68,7 @@ func planForRangeQuery(t *testing.T, q string, lowerers promql.RangeLowerers) ch
 	// The engine wraps every PromQL plan with the Sample projection before it
 	// optimizes and classifies, so the classified plan is rooted on a Project.
 	l := &lang{Schema: s}
-	plan = l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+	plan = mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true})
 
 	return optimizer.Default().Run(context.Background(), plan)
 }
@@ -162,7 +162,7 @@ func TestRangeQueryGrid_InstantQueryStillReportsNoGrid(t *testing.T) {
 		t.Fatalf("lower: %v", err)
 	}
 	l := &lang{Schema: s}
-	optimized := optimizer.Default().Run(context.Background(), l.ProjectSamples(plan, engine.Meta{IsMetric: true}))
+	optimized := optimizer.Default().Run(context.Background(), mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true}))
 
 	if _, _, step := solver.GridOf(optimized); step != 0 {
 		t.Errorf("instant query reports step %s, want 0 — the Planner's instant guard would stop firing", step)

--- a/internal/api/prom/range_name_anchor_test.go
+++ b/internal/api/prom/range_name_anchor_test.go
@@ -1,0 +1,67 @@
+package prom
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+func TestRangeNamePreservingPlansPublishMatrixAnchor(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		query         string
+		wantTimestamp chplan.Expr
+	}{
+		{
+			name:          "first over offset selector",
+			query:         "first_over_time(http_requests_total[5m] offset 1m)",
+			wantTimestamp: chplan.OffsetReanchoredAnchorExpr(time.Minute),
+		},
+		{
+			name:          "last over offset selector",
+			query:         "last_over_time(http_requests_total[5m] offset 1m)",
+			wantTimestamp: chplan.OffsetReanchoredAnchorExpr(time.Minute),
+		},
+		{
+			name:          "first over subquery",
+			query:         "first_over_time(http_requests_total[10m:1m])",
+			wantTimestamp: &chplan.ColumnRef{Name: chplan.RangeWindowAnchorColumn},
+		},
+		{
+			name:          "last over subquery",
+			query:         "last_over_time(http_requests_total[10m:1m])",
+			wantTimestamp: &chplan.ColumnRef{Name: chplan.RangeWindowAnchorColumn},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := langForTest()
+			l.Step = time.Minute
+			plan, meta, err := l.Parse(context.Background(), tc.query)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tc.query, err)
+			}
+			anchor, ok := plan.RowType().Find(chplan.RoleAnchor)
+			if !ok || anchor.Name == "" {
+				t.Fatalf("Parse(%q) schema = %#v, want named anchor role", tc.query, plan.RowType())
+			}
+
+			wrapped, err := l.ProjectSamples(plan, meta)
+			if err != nil {
+				t.Fatalf("ProjectSamples(%q): %v", tc.query, err)
+			}
+			projected, ok := wrapped.(*chplan.Project)
+			if !ok {
+				t.Fatalf("ProjectSamples(%q) = %T, want *chplan.Project", tc.query, wrapped)
+			}
+			if got := projected.Projections[2].Expr; !got.Equal(tc.wantTimestamp) {
+				t.Errorf("ProjectSamples(%q) timestamp = %#v, want %#v", tc.query, got, tc.wantTimestamp)
+			}
+		})
+	}
+}

--- a/internal/api/prom/sample_projection_schema_test.go
+++ b/internal/api/prom/sample_projection_schema_test.go
@@ -1,0 +1,131 @@
+package prom
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func schemaProject(columns []chplan.Column) *chplan.Project {
+	projections := make([]chplan.Projection, len(columns))
+	for i, column := range columns {
+		projections[i] = chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: column.Name},
+			Alias: column.Name,
+		}
+	}
+	return &chplan.Project{Input: &chplan.OneRow{}, Projections: projections, Roles: columns}
+}
+
+func TestWrapWithSampleProjectionOrdersHistogramContractByRoles(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	columns := []chplan.Column{
+		{Name: "source_value", Role: chplan.RoleValue},
+		{Name: "source_time", Role: chplan.RoleTimestamp},
+		{Name: "source_labels", Role: chplan.RoleAttributes},
+		{Name: "source_name", Role: chplan.RoleMetricName},
+	}
+	columns = append(columns, chplan.HistogramPayloadColumns()...)
+	input := schemaProject(columns)
+
+	wrapped, err := wrapWithSampleProjection(input, s)
+	if err != nil {
+		t.Fatalf("wrapWithSampleProjection: %v", err)
+	}
+	projected, ok := wrapped.(*chplan.Project)
+	if !ok || projected == input {
+		t.Fatalf("wrapped histogram = %T, want a role-ordered *chplan.Project", wrapped)
+	}
+	if got := projected.RowType().SampleKind(); got != chplan.SampleKindHistogram {
+		t.Fatalf("wrapped kind = %s, want histogram", got)
+	}
+	want := append(sampleRoleColumns(s), chplan.HistogramPayloadColumns()...)
+	if got := projected.RowType(); !got.Equal(chplan.Schema{Columns: want}) {
+		t.Fatalf("wrapped schema = %#v, want %#v", got, want)
+	}
+	for i, source := range []string{"source_name", "source_labels", "source_time", "source_value"} {
+		ref, ok := projected.Projections[i].Expr.(*chplan.ColumnRef)
+		if !ok || ref.Name != source {
+			t.Fatalf("projection[%d] = %#v, want ColumnRef{%q}", i, projected.Projections[i].Expr, source)
+		}
+	}
+}
+
+func TestWrapWithSampleProjectionRealiasesMixedDiscriminator(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	columns := append(slices.Clone(sampleRoleColumns(s)), chplan.HistogramPayloadColumns()...)
+	columns = append(columns, chplan.Column{Name: "source_kind", Role: chplan.RoleDiscriminator})
+
+	wrapped, err := wrapWithSampleProjection(schemaProject(columns), s)
+	if err != nil {
+		t.Fatalf("wrapWithSampleProjection: %v", err)
+	}
+	projected, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("wrapped mixed = %T, want *chplan.Project", wrapped)
+	}
+	last := projected.Projections[len(projected.Projections)-1]
+	ref, ok := last.Expr.(*chplan.ColumnRef)
+	if !ok || ref.Name != "source_kind" || last.Alias != chplan.MixedDiscriminatorColumn {
+		t.Fatalf("mixed discriminator projection = %#v, want source_kind AS %s", last, chplan.MixedDiscriminatorColumn)
+	}
+	if got := projected.RowType().SampleKind(); got != chplan.SampleKindMixed {
+		t.Fatalf("wrapped kind = %s, want mixed", got)
+	}
+}
+
+func TestWrapWithSampleProjectionUsesCustomAnchorRole(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	input := schemaProject([]chplan.Column{
+		{Name: "source_labels", Role: chplan.RoleAttributes},
+		{Name: "source_anchor", Role: chplan.RoleAnchor},
+		{Name: "source_value", Role: chplan.RoleValue},
+	})
+
+	wrapped, err := wrapWithSampleProjection(input, s)
+	if err != nil {
+		t.Fatalf("wrapWithSampleProjection: %v", err)
+	}
+	projected, ok := wrapped.(*chplan.Project)
+	if !ok {
+		t.Fatalf("wrapped anchor schema = %T, want *chplan.Project", wrapped)
+	}
+	ref, ok := projected.Projections[2].Expr.(*chplan.ColumnRef)
+	if !ok || ref.Name != "source_anchor" {
+		t.Fatalf("timestamp projection = %#v, want ColumnRef{source_anchor}", projected.Projections[2].Expr)
+	}
+}
+
+func TestWrapWithSampleProjectionRejectsUntrustedSchemas(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	partialHistogram := append(slices.Clone(sampleRoleColumns(s)), chplan.HistogramPayloadColumns()[:1]...)
+	duplicateValue := append(slices.Clone(sampleRoleColumns(s)), chplan.Column{Name: "other_value", Role: chplan.RoleValue})
+
+	for _, tc := range []struct {
+		name string
+		plan chplan.Node
+		kind string
+	}{
+		{name: "opaque", plan: schemaProject([]chplan.Column{{Name: "private"}}), kind: "opaque"},
+		{name: "open", plan: &chplan.Scan{Table: "samples", Roles: sampleRoleColumns(s)}, kind: "opaque"},
+		{name: "partial_histogram", plan: schemaProject(partialHistogram), kind: "invalid"},
+		{name: "duplicate_value", plan: schemaProject(duplicateValue), kind: "invalid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped, err := wrapWithSampleProjection(tc.plan, s)
+			if err == nil || wrapped != nil {
+				t.Fatalf("wrapWithSampleProjection = (%T, %v), want nil error result", wrapped, err)
+			}
+			if !strings.Contains(err.Error(), tc.kind) {
+				t.Fatalf("error = %q, want %q schema classification", err, tc.kind)
+			}
+		})
+	}
+}

--- a/internal/api/tempo/explain.go
+++ b/internal/api/tempo/explain.go
@@ -167,9 +167,9 @@ func (r *explainRouter) Compare(_ context.Context, m *chplan.MetricsCompare) err
 // ProjectSamples keeps the matrix wrap parseMetrics already applied (a metrics
 // plan is Sample-shaped on emit) and defers to the embedded search projection
 // for plain search plans.
-func (l *explainLang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
+func (l *explainLang) ProjectSamples(plan chplan.Node, meta engine.Meta) (chplan.Node, error) {
 	if meta.IsMetric {
-		return plan
+		return plan, nil
 	}
 	return l.traceqlLang.ProjectSamples(plan, meta)
 }

--- a/internal/api/tempo/lang.go
+++ b/internal/api/tempo/lang.go
@@ -128,7 +128,7 @@ func (l *traceqlLang) Parse(ctx context.Context, query string) (chplan.Node, eng
 	}, nil
 }
 
-func (l *traceqlLang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
+func (l *traceqlLang) ProjectSamples(plan chplan.Node, meta engine.Meta) (chplan.Node, error) {
 	// Tempo's wrap-projection inspects the inner plan shape
 	// (Scan / StructuralJoin / Aggregate / Project) and materialises
 	// the canonical (MetricName, Attributes, TimeUnix, Value) tuple.
@@ -137,5 +137,5 @@ func (l *traceqlLang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.
 	// trace-view UI consumes (TraceId / SpanId / ParentSpanId /
 	// SpanKind / StatusCode + SpanAttributes); the search-path
 	// branches use the leaner canonical projection unchanged.
-	return wrapWithSampleProjection(plan, l.schema, meta)
+	return wrapWithSampleProjection(plan, l.schema, meta), nil
 }

--- a/internal/api/tempo/metrics_query_range.go
+++ b/internal/api/tempo/metrics_query_range.go
@@ -219,8 +219,8 @@ func (metricsLang) Parse(_ context.Context, _ string) (chplan.Node, engine.Meta,
 	return nil, engine.Meta{}, errors.New("metricsLang: Parse not supported; use Engine.QueryPlan with a pre-wrapped plan")
 }
 
-func (metricsLang) ProjectSamples(plan chplan.Node, _ engine.Meta) chplan.Node {
-	return plan
+func (metricsLang) ProjectSamples(plan chplan.Node, _ engine.Meta) (chplan.Node, error) {
+	return plan, nil
 }
 
 // alignMetricsWindow snaps a metrics-range window to the step grid the

--- a/internal/chplan/clone_test.go
+++ b/internal/chplan/clone_test.go
@@ -127,7 +127,7 @@ func allNodeKinds() []chplan.Node {
 			ZeroCountColumn: "ZeroCount", ZeroThresholdColumn: "ZeroThreshold",
 			PositiveOffsetColumn: "PositiveOffset", PositiveBucketCountsColumn: "PositiveBucketCounts",
 			NegativeOffsetColumn: "NegativeOffset", NegativeBucketCountsColumn: "NegativeBucketCounts",
-			MetricNameColumn: "MetricName", AttributesColumn: "Attributes", TimestampColumn: "TimeUnix",
+			MetricNameColumn: "MetricName", AttributesColumn: "Attributes", TimestampColumn: "TimeUnix", ValueColumn: "Value",
 		},
 		&chplan.MetricsAggregate{Attr: expr, GroupBy: []chplan.Expr{expr}, GroupByAliases: []string{"g0"}, GroupByDisplayNames: []string{"g"}, Quantiles: []float64{0.5}, Inner: leaf},
 		&chplan.MetricsCompare{Selection: expr, Pairs: expr, RootLookup: leaf, Inner: leaf, TraceIDColumn: "TraceId"},

--- a/internal/chplan/equal_invariants_test.go
+++ b/internal/chplan/equal_invariants_test.go
@@ -2468,6 +2468,7 @@ func TestHistogramProjection_Equal_Positive(t *testing.T) {
 			MetricNameColumn:           "MetricName",
 			AttributesColumn:           "Attributes",
 			TimestampColumn:            "TimeUnix",
+			ValueColumn:                "Value",
 		}
 	}
 	if !build().Equal(build()) {
@@ -2481,6 +2482,15 @@ func TestHistogramProjection_Equal_Negative_CountColumn(t *testing.T) {
 	b := &chplan.HistogramProjection{Input: &chplan.Scan{Table: "t"}, CountColumn: "Other"}
 	if a.Equal(b) {
 		t.Errorf("different CountColumn should not be Equal")
+	}
+}
+
+func TestHistogramProjection_Equal_Negative_ValueColumn(t *testing.T) {
+	t.Parallel()
+	a := &chplan.HistogramProjection{Input: &chplan.Scan{Table: "t"}, ValueColumn: "Value"}
+	b := &chplan.HistogramProjection{Input: &chplan.Scan{Table: "t"}, ValueColumn: "Other"}
+	if a.Equal(b) {
+		t.Errorf("different ValueColumn should not be Equal")
 	}
 }
 

--- a/internal/chplan/filter.go
+++ b/internal/chplan/filter.go
@@ -3,34 +3,13 @@ package chplan
 // Filter applies a predicate to its input rows, equivalent to a SQL WHERE
 // clause. Stacking multiple Filter nodes is permitted; the optimizer fuses
 // them via the conjunction-flattening rule.
-//
-// Histogram marks Input as histogram-valued (chplan.RowShapeOf(Input) ==
-// chplan.HistogramRowShape), mirroring [InfoJoin.Histogram] and
-// [VectorSetOp.Histogram]. Filter's own emitted SELECT is a bare passthrough
-// of every column its input publishes (`SELECT * FROM (<input>) WHERE …`,
-// or the fused PREWHERE/WHERE form directly over a Scan), so a Filter over
-// a histogram-valued input keeps publishing the full thirteen-column
-// contract — [RowShapeOf] must report [HistogramRowShape] for it or a wire
-// consumer re-projects down to the canonical quartet and silently drops the
-// nine histogram columns (cerberus issue #2518, `limit_ratio(r, v)` over a
-// bare exp-histogram selector: unlike topk/bottomk, which drop histogram
-// samples, limit_ratio keeps every series its hash-based sampler selects —
-// float or histogram — unchanged). Defaults to false everywhere else, so
-// every pre-existing Filter construction site is unaffected.
-//
-// Mixed is Histogram's sibling for a MIXED float/histogram-valued input
-// (chplan.RowShapeOf(Input) == chplan.MixedRowShape) — `limit_ratio(r, v)`
-// over `v` a mixed float/histogram `or` (cerberus issue #2613). Filter's own
-// emission is unaffected either way (still a bare passthrough), so setting
-// Mixed changes nothing about the rendered SQL; it exists purely so
-// [RowShapeOf] reports the right contract to whatever sits above this
-// Filter. Histogram and Mixed are mutually exclusive — an Input is one row
-// shape or the other, never both.
+// Its emitted SELECT is a bare passthrough of every column Input publishes,
+// so [Filter.RowType] is always Input's physical schema. Predicate truth can
+// refine which rows are live, including selecting none, but never changes the
+// output column contract.
 type Filter struct {
 	Input     Node
 	Predicate Expr
-	Histogram bool
-	Mixed     bool
 }
 
 func (*Filter) planNode() {}
@@ -42,6 +21,5 @@ func (f *Filter) Equal(other Node) bool {
 	if !ok {
 		return false
 	}
-	return f.Predicate.Equal(o.Predicate) && f.Input.Equal(o.Input) &&
-		f.Histogram == o.Histogram && f.Mixed == o.Mixed
+	return f.Predicate.Equal(o.Predicate) && f.Input.Equal(o.Input)
 }

--- a/internal/chplan/histogram_projection.go
+++ b/internal/chplan/histogram_projection.go
@@ -67,9 +67,9 @@ const (
 // lowering to whatever column names it needs downstream (typically
 // including the series' MetricName / Attributes / Timestamp).
 //
-// MetricNameColumn, AttributesColumn, TimestampColumn are bookkeeping
-// surfaced for the wrapping Sample-row projection the caller applies
-// downstream, mirroring the identically-named fields on
+// MetricNameColumn, AttributesColumn, TimestampColumn, and ValueColumn are
+// bookkeeping surfaced for the wrapping Sample-row projection the caller
+// applies downstream, mirroring the identically-named fields on
 // HistogramQuantileNative — the emitter itself does not read them.
 type HistogramProjection struct {
 	Input Node
@@ -90,6 +90,7 @@ type HistogramProjection struct {
 	MetricNameColumn string
 	AttributesColumn string
 	TimestampColumn  string
+	ValueColumn      string
 }
 
 func (*HistogramProjection) planNode() {}
@@ -113,6 +114,7 @@ func (h *HistogramProjection) Equal(other Node) bool {
 		h.MetricNameColumn != o.MetricNameColumn ||
 		h.AttributesColumn != o.AttributesColumn ||
 		h.TimestampColumn != o.TimestampColumn ||
+		h.ValueColumn != o.ValueColumn ||
 		len(h.GroupBy) != len(o.GroupBy) ||
 		len(h.GroupByAliases) != len(o.GroupByAliases) {
 		return false

--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -20,9 +20,15 @@ const RangeWindowAnchorColumn = "anchor_ts"
 // back with this. Offset enters with its sign (a negative/forward offset
 // subtracts). Shared so the two call sites cannot drift.
 func OffsetReanchoredAnchorExpr(offset time.Duration) Expr {
+	return OffsetReanchoredColumnExpr(RangeWindowAnchorColumn, offset)
+}
+
+// OffsetReanchoredColumnExpr builds the offset-reanchoring expression for a
+// schema-declared anchor column, including a non-canonical alias.
+func OffsetReanchoredColumnExpr(column string, offset time.Duration) Expr {
 	return &Binary{
 		Op:   OpAdd,
-		Left: &ColumnRef{Name: RangeWindowAnchorColumn},
+		Left: &ColumnRef{Name: column},
 		Right: &FuncCall{
 			Fn:   FnToIntervalNanosecond,
 			Args: []Expr{&LitInt{V: offset.Nanoseconds()}},

--- a/internal/chplan/reanchor.go
+++ b/internal/chplan/reanchor.go
@@ -171,10 +171,8 @@ func reanchor(n Node, start, end time.Time) (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		// Predicate is off-grid immutable: share. Copy-on-write from *v
-		// rather than a composite literal, per clone.go's rule — a literal
-		// here dropped Histogram / Mixed, so RowShapeOf read a re-anchored
-		// shard's histogram-valued Filter as plain float rows.
+		// Predicate is off-grid immutable: share it. Copy-on-write from *v
+		// rather than a composite literal, per clone.go's whole-struct rule.
 		c := *v
 		c.Input = input
 		return &c, nil

--- a/internal/chplan/reanchor_fields_test.go
+++ b/internal/chplan/reanchor_fields_test.go
@@ -42,14 +42,10 @@ var reanchorGridFields = map[string]bool{
 // arm, so a sharded (route B) classic-histogram plan lost its `le` and
 // finite-bounds restrictions and evaluated the quantile over the unrestricted
 // bucket ladder — a different answer from route A, with nothing failing.
-// `Filter.Histogram` / `Filter.Mixed` were dropped the same way, so RowShapeOf
-// read a re-anchored histogram-valued Filter as plain float rows. clone.go's
-// doc states the rule both arms broke: start from `c := *v`, never from a
-// literal enumerating the fields the author happened to know about.
-//
-// Filling by reflection is what makes this a class guard rather than a
-// fixture: a newly added field is covered the moment it is declared, with no
-// test edit, and a new arm written as a literal fails here immediately.
+// Filter metadata was dropped by the same pattern in the past. This class
+// guard makes every new field covered at the moment it is declared, with no
+// test edit, and makes a new arm written as a literal fail immediately.
+
 func TestReanchorRangeCarriesEveryNonGridField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chplan/row_shape.go
+++ b/internal/chplan/row_shape.go
@@ -1,160 +1,36 @@
 package chplan
 
-// RowShape names the column set a node publishes to whatever sits directly
-// above it, for the one consumer that has to build that "whatever": a
-// projection which forwards its input's columns unchanged and rewrites
-// exactly one of them.
-//
-// Such a forwarder cannot list a fixed set of columns. A projection names
-// its outputs by REFERENCE, and ClickHouse resolves every reference against
-// the scope the subquery below it actually exposes — naming a column that
-// scope does not carry is rejected outright with code 47, `Unknown
-// expression identifier`, and OMITTING one the layer above still reads
-// silently deletes it from the wire. Both failures are 502s or empty
-// panels at the HTTP edge, never a plan-level error, so the forwarder has
-// to DERIVE the set from its input rather than declare it.
-//
-// The three shapes a PromQL forwarder can be handed:
-//
-//   - [SampleRowShape] — the canonical four-column sample row
-//     `(MetricName, Attributes, Timestamp, Value)`. Only the NAMES are
-//     the contract: a Scan reads all four off storage, a Filter or Limit
-//     passes its input's through untouched, and an aggregation
-//     re-publishes them from group keys (`? AS MetricName`, the group map
-//     as `Attributes`, an evaluation-time `TimeUnix`) — which is why an
-//     [Aggregate] is never the node a forwarder sits directly on, its
-//     lowering always caps it with exactly that Project.
-//     [RangeWindowStaleResample] and RangeLWR likewise emit all four by
-//     construction. What each name CONTAINS is a separate question, and
-//     [IsDerivedShape] is what answers it.
-//   - [GridWindowRowShape] — one row per (series, ANCHOR). A window that
-//     materialises a query_range grid publishes that grid axis TWICE: once
-//     under [RangeWindowAnchorColumn], which api/prom's matrix wrapper
-//     reads back to bucket each series' points, and once under the schema
-//     timestamp column, which a step-aligned vector↔vector join reads off
-//     each arm. There is no `MetricName`: a range window computes a
-//     DERIVED sample, and PromQL drops `__name__` from those, so the
-//     window's emitter never selects the column at all. A forwarder that
-//     drops either timestamp column breaks the layer above it; one that
-//     references `MetricName` gets code 47.
-//   - [ReducedWindowRowShape] — one row per series, already reduced to a
-//     single point. There is no per-row timestamp to forward at all and no
-//     `MetricName`; only the group keys and the value survive.
-//
-// The classifier exists because the two windowed shapes were previously
-// recognised by asserting ONE concrete node kind at each consumer. That
-// spelling answers "is this a *RangeWindow", not "what does my input
-// expose", and the two questions came apart the moment a second node grew
-// the same row shape: [RangeWindowGridNative] publishes byte-for-byte the
-// columns a matrix [RangeWindow] does, so every `label_replace` /
-// `label_join` / `abs` over a range-mode `rate()` on the ts_grid path fell
-// through to the canonical branch and emitted a reference to a
-// `MetricName` its own subquery never exposed. Deriving the shape here
-// means a future node inherits the right branch by publishing the right
-// columns, not by being added to a list at each consumer.
-//
-// This answers a DIFFERENT question from [IsDerivedShape], which asks only
-// whether `MetricName` is absent and walks through the transparent nodes
-// to find out. Here the caller sits directly on the node it is projecting
-// over and needs the timestamp columns too, which "derived" does not
-// distinguish.
+// RowShape summarizes a node's physical output schema in the sample
+// vocabulary. It is diagnostic: it does not prove which sample kinds remain
+// live after filtering, or whether a wrapper should preserve metric names.
+// Consumers that need specific columns must resolve and validate their roles.
 type RowShape int
 
 const (
-	// SampleRowShape is the canonical `(MetricName, Attributes, Timestamp,
-	// Value)` row. It is the answer for every node that is not a range
-	// window, which is what makes it the zero value: a forwarder that
-	// cannot recognise its input is safest assuming the shape the vast
-	// majority of plans carry.
+	// SampleRowShape covers canonical samples and is also the documentation
+	// default for opaque, incomplete, open, or invalid outputs. It is not a
+	// float-only proof.
 	SampleRowShape RowShape = iota
 
-	// GridWindowRowShape is the matrix window row: `(group keys…,
-	// RangeWindowAnchorColumn, Timestamp, Value)` and no `MetricName`.
+	// GridWindowRowShape carries attributes, a value, and a per-step anchor.
+	// A metric-name column may also be present.
 	GridWindowRowShape
 
-	// ReducedWindowRowShape is the instant window row: `(group keys…,
-	// Value)` — no timestamp of any kind and no `MetricName`.
+	// ReducedWindowRowShape carries attributes and a value without a timestamp
+	// or anchor. A metric-name column may also survive grouping.
 	ReducedWindowRowShape
 
-	// HistogramRowShape is [HistogramProjection]'s row: `(group keys…,
-	// Histogram*Column…)` — nine named histogram columns instead of a
-	// `Value`, and no `MetricName` of its own (a wrapping Project adds
-	// one, the same way HistogramQuantileNative's wrapping Project
-	// does). It answers TRUE to every `shape != SampleRowShape` check
-	// the PromQL forwarders (projectValueOverInner,
-	// projectAttributesOverInner) make, so it would take their WINDOWED
-	// branch — which is wrong, not merely unhandled: that branch
-	// forwards `Value`, and a HistogramProjection publishes `Value`
-	// only as the placeholder it binds alongside the nine real
-	// Histogram*Column outputs. The projection would therefore succeed
-	// in ClickHouse and answer 0, dropping the histogram. Neither
-	// forwarder builds a column list a histogram-shaped row satisfies,
-	// so a histogram-valued lowering that needs them must teach them
-	// this shape first; until then both assert against it on entry
-	// (internal/promql/histogram_shape_guard.go). See also the doc
-	// comment on HistogramProjection.
-	//
-	// Three lowerings build this node today (internal/promql's
-	// histogram_native_bare.go, histogram_native_sum.go and
-	// histogram_native_range_fn.go). Generic forwarders still cannot
-	// consume it directly, and issue #2296 asked whether every wrapping
-	// shape PromQL can put around a histogram-valued result reaches one of
-	// them anyway. It does not: histogram-aware label transforms
-	// (label_replace / label_join) and scalar/histogram or
-	// histogram/histogram arithmetic recognise their operand directly,
-	// composing `sum`/`avg` over an ALREADY histogram-valued result (for
-	// example `sum(rate(m_exp_hist[5m]))`) is recognised recursively by
-	// internal/promql's mergeableExpHistogramAggregate before it would ever
-	// reach a forwarder, and float-only functions drop every histogram
-	// sample and re-project an empty canonical float shape (#2245 closed
-	// #2296 on that basis). Every remaining wrapping shape stays behind
-	// expHistogramSelectorRouting until it grows its own histogram-aware
-	// lowering or an extension to that recognizer set.
-	//
-	// [VectorSetOp] / [NaryVectorSetOp] also answer this shape when their
-	// own Histogram field is set — internal/promql's
-	// lowerExpHistogramSetOp builds one from two HistogramProjection
-	// operands for `and`/`or`/`unless` (cerberus issue #2324). Unlike the
-	// three lowerings above, neither node IS a HistogramProjection; the
-	// chsql emitter widens their projection to the same nine-column
-	// output because both arms publish it under the fixed
-	// Histogram*Column aliases regardless. [RowShapeOf] reports the
-	// SHAPE a node's own SELECT publishes, not which Go type built it, so
-	// this is still the correct answer here.
-	//
-	// [InfoJoin] answers it too when its own Histogram field is set —
-	// internal/promql's lowerInfo builds one when `info(v[, …])`'s base
-	// vector v is histogram-valued (cerberus issue #2509): reference
-	// Prometheus's info() preserves a histogram sample in the base vector
-	// rather than dropping it, so the join's own SELECT widens to carry
-	// Input's nine Histogram*Column outputs through alongside the
-	// canonical quartet. See [InfoJoin]'s own doc comment.
+	// HistogramRowShape carries the complete canonical histogram payload.
+	// Additional columns do not change the physical payload classification.
 	HistogramRowShape
 
-	// MixedRowShape is [VectorSetOp]'s answer when its Mixed field is
-	// set — internal/promql's lowerMixedExpHistogramSetOp builds one for
-	// `or` between a float-valued operand and a histogram-valued operand
-	// (cerberus issue #2330). The SELECT it publishes is the canonical
-	// quartet, the nine Histogram*Column outputs, AND a trailing
-	// discriminator column (unlike [HistogramRowShape]'s thirteen), so a
-	// generic forwarder that reads `Value` unconditionally — the same
-	// hazard [HistogramRowShape]'s doc comment describes — is just as
-	// wrong here: on a histogram-shaped ROW within this result, Value is
-	// still only the placeholder [HistogramProjection] always carries.
-	// [assertValueShapedInput] (internal/promql/histogram_shape_guard.go)
-	// panics on this shape for exactly that reason. Every consumer that
-	// builds a Mixed-shaped node keeps it at the query ROOT — see that
-	// lowering's own doc comment for why nesting one under another
-	// PromQL wrapper is deliberately left unrecognised (falls through to
-	// the pre-existing exp-histogram-selector rejection) rather than
-	// silently forwarding a column whose meaning depends on a per-row
-	// discriminator no generic consumer reads.
+	// MixedRowShape carries canonical float and histogram payloads plus one
+	// discriminator. A float-narrowing Filter retains this physical shape even
+	// when its live rows are proven float-only.
 	MixedRowShape
 )
 
-// String names the shape for test and error output. The names are the
-// constant names minus the stutter, so a failure message reads as the
-// vocabulary the doc comment uses.
+// String names the shape for diagnostics without exposing enum ordinals.
 func (s RowShape) String() string {
 	switch s {
 	case GridWindowRowShape:
@@ -171,188 +47,11 @@ func (s RowShape) String() string {
 	return "unknown"
 }
 
-// RowShapeOf reports which [RowShape] n publishes.
-//
-// A matrix [RangeWindow] (`OuterRange > 0`) fans its samples across the
-// anchors of a materialised grid and emits one row per (series, anchor);
-// an instant one has already reduced each series to a single row.
-// [RangeWindowGridNative] is ALWAYS the matrix case — the lowering builds it
-// only in range mode, with `Step > 0` and both `Start` and `End` pinned
-// (see its doc comment), so it has no instant form to distinguish. Its
-// instant sibling, [RangeWindowGridNativeInstant], is a SEPARATE node type
-// for exactly that reason — reusing this one for the single-anchor shape
-// would have made this classifier (and the several other consumers that key
-// off RangeWindowGridNative meaning "matrix") silently wrong.
-//
-// Every other node publishes all four canonical names, either by passing
-// its input's through or by re-projecting them, so [SampleRowShape] is
-// both the remaining answer and the safe default for a node this
-// classifier has never seen.
-//
-// The classifier deliberately does NOT walk into children: its callers
-// project directly over n, so the shape that matters is the one n's own
-// SELECT exposes. The one apparent exception, [*Project], is not a
-// walk-into-children case either — it reads only the Project's OWN
-// projection list (never its Input) to see whether n's own SELECT
-// republishes [MixedDiscriminatorColumn] as an output, the same
-// derive-from-what-this-node-actually-selects approach every other case
-// here uses. internal/promql's `label_replace`/`label_join` composition
-// over a mixed `or` (cerberus issue #2449) is the one lowering that ends
-// in a Project forwarding that column: [projectAttributesOverInner]'s
-// MixedRowShape branch and [guardLabelRewriteCollision]'s matching
-// re-projection (both label_fns.go / duplicate_labelset_guard.go) always
-// carry it through by construction, so a Project publishing it really is
-// still Mixed-shaped, not merely built from one. No other lowering in
-// the tree ever names an output [MixedDiscriminatorColumn], so this
-// cannot misclassify a Project nothing here wrote.
+// RowShapeOf folds the node's own compositional schema. There is no independent
+// node-kind classifier or Filter/TopK shape declaration to override it.
 func RowShapeOf(n Node) RowShape {
-	switch v := n.(type) {
-	case *Project:
-		for _, proj := range v.Projections {
-			if ProjectionOutputsColumn(proj, MixedDiscriminatorColumn) {
-				return MixedRowShape
-			}
-		}
-	case *RangeWindow:
-		if v.OuterRange > 0 {
-			return GridWindowRowShape
-		}
-		return ReducedWindowRowShape
-	case *RangeWindowGridNative:
-		return GridWindowRowShape
-	case *RangeWindowGridNativeInstant:
-		// The instant-shaped native lowering publishes one row per series
-		// with no per-row anchor timestamp at all — the query's single eval
-		// instant is reported externally, not as a SQL column — exactly the
-		// [ReducedWindowRowShape] contract the fan-out's own instant emit
-		// (RangeWindow with OuterRange == 0) already publishes.
-		return ReducedWindowRowShape
-	case *HistogramProjection:
-		return HistogramRowShape
-	case *VectorSetOp:
-		if v.Histogram {
-			return HistogramRowShape
-		}
-		if v.Mixed {
-			return MixedRowShape
-		}
-	case *NaryVectorSetOp:
-		if v.Histogram {
-			return HistogramRowShape
-		}
-	case *InfoJoin:
-		if v.Histogram {
-			return HistogramRowShape
-		}
-	case *TopK:
-		// limitk over a histogram-valued input (cerberus issue #2518):
-		// Histogram is only ever set alongside an empty Columns list (see
-		// [TopK]'s doc comment), so the outer SELECT is a bare `SELECT *`
-		// forwarding Input's own thirteen-column shape verbatim.
-		if v.Histogram {
-			return HistogramRowShape
-		}
-		// limitk/limit_ratio over a MIXED float/histogram input (cerberus
-		// issue #2613) — same passthrough reasoning, fourteen columns.
-		if v.Mixed {
-			return MixedRowShape
-		}
-	case *Filter:
-		// limit_ratio over a histogram-valued input (cerberus issue
-		// #2518): Filter's own SELECT is always a passthrough of every
-		// column Input publishes, so a histogram-valued Input keeps
-		// publishing the full thirteen-column shape through the WHERE.
-		if v.Histogram {
-			return HistogramRowShape
-		}
-		// limit_ratio over a MIXED float/histogram input (cerberus issue
-		// #2613) — same passthrough, fourteen columns.
-		if v.Mixed {
-			return MixedRowShape
-		}
-	case *HistogramVectorJoin:
-		// Its own SELECT exposes `_hq_L_*`/`_hq_R_*` aliases, not the
-		// canonical four names at all — no generic forwarder is ever
-		// placed directly over it (internal/promql's
-		// histogram_native_binop_card.go always wraps it in an
-		// explicit-column Project first), so SampleRowShape here is a
-		// documentation default rather than a claim about live columns.
-		// A hypothetical future direct consumer referencing `Value` or
-		// `MetricName` against it fails loudly with ClickHouse code 47
-		// rather than silently reading the wrong data — see
-		// [IsDerivedShape]'s HistogramVectorJoin arm for the same
-		// reasoning from the MetricName side.
+	if n == nil {
 		return SampleRowShape
-	case *HistogramFloatVectorJoin:
-		// Its own SELECT genuinely does publish the canonical
-		// MetricName/Attributes/TimeUnix names plus the nine fixed
-		// Histogram*Column fields — unlike HistogramVectorJoin's
-		// `_hq_L_*`/`_hq_R_*`-prefixed shape above — but ALSO an extra
-		// Value column no HistogramRowShape consumer expects, so
-		// neither fixed shape is an exact fit. SampleRowShape here is
-		// likewise a documentation default rather than a claim about
-		// live columns: no generic forwarder is ever placed directly
-		// over it — the calling lowering (internal/promql's
-		// histogram_native_float_vector_scaling_binop.go) always wraps
-		// it in an explicit-column Project first, exactly as
-		// HistogramVectorJoin's callers do.
-		return SampleRowShape
-	case *MixedVectorJoin:
-		// Its own SELECT publishes `_mvj_L_*`/`_mvj_R_*`-prefixed aliases
-		// (internal/chsql/mixed_vector_join.go), not any of the fixed
-		// shapes above — like HistogramVectorJoin/HistogramFloatVectorJoin
-		// above, SampleRowShape here is a documentation default rather
-		// than a claim about live columns: no generic forwarder is ever
-		// placed directly over it. internal/promql's
-		// histogram_native_mixed_or_vector_arithmetic.go always wraps it
-		// in an explicit-column Filter+Project before any consumer sees
-		// it; THAT Project is what RowShapeOf's own *Project case above
-		// classifies as MixedRowShape (MUL/DIV) or leaves as the plain
-		// canonical SampleRowShape (ADD/SUB, whose kept rows are always
-		// float-valued — see that file's header for why).
-		return SampleRowShape
-	case *RangeWindowStaleResample:
-		// Spelled out because it is the third `RangeWindow*` node and the
-		// one most likely to be swept in here by analogy. Its emitter
-		// publishes `[MetricName, Attributes, anchor_ts AS TimeUnix,
-		// Value]` — byte-for-byte what the RangeLWR it substitutes for
-		// publishes — so the canonical row genuinely IS its answer, and
-		// letting it fall through would leave that looking like an
-		// oversight.
-		return SampleRowShape
-	case *OrderBy:
-		// emitOrderBy renders `SELECT * FROM (<input>) ORDER BY ...` — a
-		// genuine passthrough of every column its input publishes, sort
-		// keys included. Its own SELECT therefore exposes exactly the
-		// shape its input does, whichever one that is (a plain sample
-		// selector's OrderBy, PromQL `sort_by_label()`'s ordinary case,
-		// stays SampleRowShape through the default branch below; wrapping
-		// a [HistogramProjection] — PromQL `sort_by_label()` /
-		// `sort_by_label_desc()` over an exp-histogram-valued vector,
-		// cerberus issue #2462 — must report HistogramRowShape or the
-		// wire layer's wrapWithSampleProjection re-projects only the
-		// canonical quartet and silently drops the nine histogram
-		// columns). Forwarding is recursive so a further OrderBy over an
-		// OrderBy (never built today) still resolves correctly.
-		return RowShapeOf(v.Input)
-	case *UnionAll:
-		// A UnionAll positionally combines its arms into ONE result set, so
-		// their row shape has to already agree for the SQL itself to be
-		// valid -- every construction site pairs same-shaped arms (the
-		// PromQL histogram companion-suffix routing's two Sample-shaped
-		// Scans; NativeRateLowerer's instant temporality-union split,
-		// cerberus issue #2843, whose native and fan-out arms both answer
-		// ReducedWindowRowShape). Reporting the first arm's own shape is
-		// therefore both correct and recursive, mirroring *OrderBy's
-		// passthrough above -- rather than silently defaulting to
-		// SampleRowShape (the wrong answer for a windowed union: a
-		// forwarder placed directly over one would then reference a
-		// MetricName / Timestamp column neither arm publishes, a live
-		// ClickHouse code 47).
-		if len(v.Inputs) == 0 {
-			return SampleRowShape
-		}
-		return RowShapeOf(v.Inputs[0])
 	}
-	return SampleRowShape
+	return RowShapeFromSchema(n.RowType())
 }

--- a/internal/chplan/row_shape_test.go
+++ b/internal/chplan/row_shape_test.go
@@ -1,246 +1,28 @@
 package chplan_test
 
 import (
-	"reflect"
 	"testing"
-	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
-// rowShapeVerdicts is the expected chplan.RowShapeOf answer for one
-// populated instance of every Node kind — the instances in allNodeKinds(),
-// whose RangeWindow carries `OuterRange: time.Hour` and is therefore the
-// MATRIX form.
-//
-// The verdict is a statement about the columns that kind's own SELECT
-// exposes to the projection directly above it, and both PromQL forwarders
-// (projectAttributesOverInner, projectValueOverInner) build their column
-// list from this one answer. A wrong verdict is not a stylistic
-// disagreement: it is either a ClickHouse code 47 for a column the scope
-// does not carry, or a column silently missing from the wire.
-//
-// TestRowShapeOf_CoversEveryNodeKind derives the key set from the package's
-// planNode() implementers, so a new Node kind cannot be added without
-// deciding its row shape here.
-var rowShapeVerdicts = map[string]chplan.RowShape{
-	// The two windows that publish a query_range grid: one row per
-	// (series, anchor), the anchor under both its own name and the
-	// timestamp column, and no MetricName.
-	"RangeWindow":           chplan.GridWindowRowShape,
-	"RangeWindowGridNative": chplan.GridWindowRowShape,
-
-	// The instant-mode native lowering: one row per series already reduced
-	// to a single point, mirroring the fan-out's own instant RangeWindow
-	// (OuterRange == 0) shape rather than its matrix sibling above.
-	"RangeWindowGridNativeInstant": chplan.ReducedWindowRowShape,
-
-	// Everything else republishes the canonical four names, whether by
-	// passing its input's through or by projecting them itself.
-	"AbsentOverTime": chplan.SampleRowShape,
-	"Aggregate":      chplan.SampleRowShape,
-	// Same reasoning as Aggregate above: never a direct forwarder target
-	// (its lowering always caps it with wrapAggregateForSample's Project),
-	// so this is a documentation default, not a claim about live columns.
-	"RangeWindowGridNativeVectorAgg": chplan.SampleRowShape,
-	"CrossJoin":                      chplan.SampleRowShape,
-	"Filter":                         chplan.SampleRowShape,
-	"HistogramQuantile":              chplan.SampleRowShape,
-	"HistogramQuantileNative":        chplan.SampleRowShape,
-	"HistogramProjection":            chplan.HistogramRowShape,
-	"HistogramVectorJoin":            chplan.SampleRowShape,
-	"HistogramFloatVectorJoin":       chplan.SampleRowShape,
-	"InfoJoin":                       chplan.SampleRowShape,
-	"Limit":                          chplan.SampleRowShape,
-	"MetricsAggregate":               chplan.SampleRowShape,
-	"MetricsCompare":                 chplan.SampleRowShape,
-	"MetricsHistogramOverTime":       chplan.SampleRowShape,
-	"MetricsSecondStage":             chplan.SampleRowShape,
-	"MixedVectorJoin":                chplan.SampleRowShape,
-	"NaryVectorSetOp":                chplan.SampleRowShape,
-	"NestedSetAnnotate":              chplan.SampleRowShape,
-	"OneRow":                         chplan.SampleRowShape,
-	"OrderBy":                        chplan.SampleRowShape,
-	"Project":                        chplan.SampleRowShape,
-	"RangeBucketFanout":              chplan.SampleRowShape,
-	"RangeBucketGridNative":          chplan.SampleRowShape,
-	"RangeLWR":                       chplan.SampleRowShape,
-	"RangeWindowStaleResample":       chplan.SampleRowShape,
-	"Scan":                           chplan.SampleRowShape,
-	"SearchTraceLimit":               chplan.SampleRowShape,
-	"SetOperation":                   chplan.SampleRowShape,
-	"StepGrid":                       chplan.SampleRowShape,
-	"StructuralJoin":                 chplan.SampleRowShape,
-	"TopK":                           chplan.SampleRowShape,
-	"UnionAll":                       chplan.SampleRowShape,
-	"VectorJoin":                     chplan.SampleRowShape,
-	"VectorSetOp":                    chplan.SampleRowShape,
-}
-
-// TestRowShapeOf_CoversEveryNodeKind is the ratchet: a Node kind added to
-// the IR without a recorded row shape fails here, because a forwarder
-// placed over it would silently take the canonical branch by default.
-func TestRowShapeOf_CoversEveryNodeKind(t *testing.T) {
-	t.Parallel()
-
-	covered := make(map[string]bool, len(rowShapeVerdicts))
-	for kind := range rowShapeVerdicts {
-		covered[kind] = true
+func TestRowShapeOfNil(t *testing.T) {
+	if got := chplan.RowShapeOf(nil); got != chplan.SampleRowShape {
+		t.Fatalf("nil shape = %s; want sample default", got)
 	}
-	assertCoversEveryNodeKind(t, covered, "rowShapeVerdicts",
-		"record the row shape its emitter publishes and, if it is not the canonical "+
-			"sample row, add an arm to chplan.RowShapeOf")
 }
 
-// TestRowShapeOf_ClassifiesEveryNodeKind runs the classifier over one
-// populated instance of every Node kind and compares against the recorded
-// verdict, naming the kind on a mismatch.
-func TestRowShapeOf_ClassifiesEveryNodeKind(t *testing.T) {
-	t.Parallel()
-
+// allNodeKinds is source-derived from the sealed Node implementations. The
+// fold therefore acquires no second node-kind inventory as the IR grows.
+func TestRowShapeOfFoldsEveryNodeSchema(t *testing.T) {
 	for _, node := range allNodeKinds() {
-		kind := reflect.TypeOf(node).Elem().Name()
-		want, recorded := rowShapeVerdicts[kind]
-		if !recorded {
-			// Reported by TestRowShapeOf_CoversEveryNodeKind; skipping the
-			// comparison keeps this failure from duplicating that one.
-			continue
-		}
+		want := chplan.RowShapeFromSchema(node.RowType())
 		if got := chplan.RowShapeOf(node); got != want {
-			t.Errorf("RowShapeOf(*%s) = %s, want %s — a projection forwarding over %s "+
-				"builds its column list from this answer, so the wrong one is a live "+
-				"code 47 or a column dropped from the wire",
-				kind, got, want, kind)
+			t.Errorf("RowShapeOf(%T) = %s, schema fold = %s", node, got, want)
 		}
 	}
 }
 
-// TestRowShapeOf_RangeWindowSplitsOnOuterRange pins the one discrimination
-// allNodeKinds() cannot express, because it holds a single RangeWindow
-// instance: the SAME node kind answers differently depending on whether it
-// materialises a query_range grid.
-//
-// A matrix window (OuterRange > 0) emits one row per (series, anchor) and
-// has both timestamp names to forward; an instant one has already collapsed
-// each series to a single row and has no timestamp at all. Collapsing the
-// two would make an instant `rate(m[5m])` under a label rewrite forward
-// columns its scope does not expose.
-func TestRowShapeOf_RangeWindowSplitsOnOuterRange(t *testing.T) {
-	t.Parallel()
-
-	base := chplan.RangeWindow{
-		Input: &chplan.Scan{Table: "otel_metrics_sum"},
-		Func:  "rate", Range: 5 * time.Minute, Step: time.Minute,
-		Start: time.Unix(1000, 0).UTC(), End: time.Unix(4600, 0).UTC(),
-	}
-
-	instant := base
-	if got := chplan.RowShapeOf(&instant); got != chplan.ReducedWindowRowShape {
-		t.Errorf("RowShapeOf(instant RangeWindow) = %s, want %s", got, chplan.ReducedWindowRowShape)
-	}
-
-	matrix := base
-	matrix.OuterRange = time.Hour
-	if got := chplan.RowShapeOf(&matrix); got != chplan.GridWindowRowShape {
-		t.Errorf("RowShapeOf(matrix RangeWindow) = %s, want %s", got, chplan.GridWindowRowShape)
-	}
-}
-
-// TestRowShapeOf_UnionAllReportsFirstArmShape pins cerberus issue #2843's
-// fix: a UnionAll answers its first arm's own RowShapeOf, not the
-// SampleRowShape default the generic (Scan, Scan) stub in allNodeKinds()
-// happens to also produce. NativeRateLowerer's instant temporality-union
-// split (cerberus issue #2843) returns a raw two-arm UnionAll of
-// ReducedWindowRowShape nodes with NO wrapping Project — unlike the matrix
-// arm's derivedRateArm — specifically so a forwarder placed directly over it
-// (e.g. `abs(rate(...))`) reads the correct answer here rather than
-// defaulting to SampleRowShape and referencing a Timestamp column neither
-// arm publishes (a live ClickHouse code 47).
-func TestRowShapeOf_UnionAllReportsFirstArmShape(t *testing.T) {
-	t.Parallel()
-
-	reducedArm := &chplan.RangeWindow{
-		Input: &chplan.Scan{Table: "otel_metrics_sum"},
-		Func:  "rate", Range: 5 * time.Minute,
-		Start: time.Unix(1000, 0).UTC(), End: time.Unix(4600, 0).UTC(),
-	}
-	union := &chplan.UnionAll{Inputs: []chplan.Node{
-		&chplan.RangeWindowGridNativeInstant{
-			Input: &chplan.Scan{Table: "otel_metrics_sum"}, Func: "rate",
-			Range: 5 * time.Minute, Anchor: time.Unix(4600, 0).UTC(),
-			TimestampColumn: "TimeUnix", ValueColumn: "Value",
-		},
-		reducedArm,
-	}}
-	if got := chplan.RowShapeOf(union); got != chplan.ReducedWindowRowShape {
-		t.Errorf("RowShapeOf(reduced-shape UnionAll) = %s, want %s", got, chplan.ReducedWindowRowShape)
-	}
-
-	if got := chplan.RowShapeOf(&chplan.UnionAll{}); got != chplan.SampleRowShape {
-		t.Errorf("RowShapeOf(empty UnionAll) = %s, want %s", got, chplan.SampleRowShape)
-	}
-}
-
-// TestRowShapeOf_VectorSetOpFlags pins the two boolean flags
-// chplan.RowShapeOf reads off a *VectorSetOp directly, since
-// allNodeKinds() only exercises the zero-value instance (both flags
-// false, SampleRowShape — already covered by
-// TestRowShapeOf_ClassifiesEveryNodeKind). Histogram is #2324's
-// both-arms-histogram flag; Mixed is #2330's exactly-one-arm-histogram
-// sibling — the two are mutually exclusive in practice (chsql's
-// validateVectorSetOpCols rejects both set), but RowShapeOf itself
-// checks Histogram first, so this also pins that ordering doesn't
-// accidentally mask Mixed.
-func TestRowShapeOf_VectorSetOpFlags(t *testing.T) {
-	t.Parallel()
-
-	base := chplan.VectorSetOp{
-		Left: &chplan.Scan{Table: "otel_metrics_sum"}, Right: &chplan.Scan{Table: "otel_metrics_sum"},
-		Op: chplan.VectorSetOr,
-	}
-
-	histogram := base
-	histogram.Histogram = true
-	if got := chplan.RowShapeOf(&histogram); got != chplan.HistogramRowShape {
-		t.Errorf("RowShapeOf(VectorSetOp{Histogram: true}) = %s, want %s", got, chplan.HistogramRowShape)
-	}
-
-	mixed := base
-	mixed.Mixed = true
-	if got := chplan.RowShapeOf(&mixed); got != chplan.MixedRowShape {
-		t.Errorf("RowShapeOf(VectorSetOp{Mixed: true}) = %s, want %s", got, chplan.MixedRowShape)
-	}
-}
-
-// TestRowShapeOf_FilterAndTopKMixedFlag pins the same Mixed flag on
-// *Filter and *TopK (cerberus issue #2613): limitk/limit_ratio (TopK) and
-// limit_ratio's own Filter wrapper both preserve a mixed float/histogram
-// input's row shape unchanged, since their own SELECT is always a bare
-// passthrough of whatever Input publishes — see each case's own doc
-// comment in row_shape.go. allNodeKinds() only exercises the zero-value
-// instance of each (both flags false), so this is these two nodes' only
-// coverage of the Mixed branch, mirroring
-// TestRowShapeOf_VectorSetOpFlags's identical role for *VectorSetOp.
-func TestRowShapeOf_FilterAndTopKMixedFlag(t *testing.T) {
-	t.Parallel()
-
-	stubInput := &chplan.Scan{Table: "otel_metrics_sum"}
-
-	filter := &chplan.Filter{Input: stubInput, Mixed: true}
-	if got := chplan.RowShapeOf(filter); got != chplan.MixedRowShape {
-		t.Errorf("RowShapeOf(Filter{Mixed: true}) = %s, want %s", got, chplan.MixedRowShape)
-	}
-
-	topK := &chplan.TopK{Input: stubInput, K: 1, Mixed: true}
-	if got := chplan.RowShapeOf(topK); got != chplan.MixedRowShape {
-		t.Errorf("RowShapeOf(TopK{Mixed: true}) = %s, want %s", got, chplan.MixedRowShape)
-	}
-}
-
-// TestRowShapeString pins the names the failure messages above are written
-// against, including the answer for a value outside the declared set — a
-// forwarder reading a corrupt shape should say so rather than print an
-// integer.
 func TestRowShapeString(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chplan/schema.go
+++ b/internal/chplan/schema.go
@@ -34,6 +34,38 @@ type Schema struct {
 	Open    bool
 }
 
+// SampleKind classifies a closed output schema by the sample payload it
+// publishes. Opaque and invalid are deliberately separate: opaque means the
+// schema makes no complete sample claim, while invalid means it makes a
+// contradictory or ambiguous one that consumers must reject.
+type SampleKind uint8
+
+const (
+	SampleKindOpaque SampleKind = iota
+	SampleKindFloat
+	SampleKindHistogram
+	SampleKindMixed
+	SampleKindInvalid
+)
+
+// String renders the sample-kind vocabulary used by invariant diagnostics.
+func (k SampleKind) String() string {
+	switch k {
+	case SampleKindOpaque:
+		return "opaque"
+	case SampleKindFloat:
+		return "float"
+	case SampleKindHistogram:
+		return "histogram"
+	case SampleKindMixed:
+		return "mixed"
+	case SampleKindInvalid:
+		return "invalid"
+	default:
+		return "unknown"
+	}
+}
+
 // Find returns the first column carrying role, in declaration order.
 func (s Schema) Find(role ColumnRole) (Column, bool) {
 	for _, c := range s.Columns {
@@ -157,6 +189,110 @@ func (s Schema) HasHistogramPayload() bool {
 		}
 	}
 	return true
+}
+
+// SampleKind validates and classifies the public sample contract. Public
+// roles must be named and unambiguous, and histogram fields must be the
+// complete canonical payload. Names on opaque or other-role columns never
+// create a sample contract, but they may not shadow a public sample output.
+// Structurally valid open schemas remain opaque because undeclared outputs can
+// invalidate an otherwise plausible contract.
+func (s Schema) SampleKind() SampleKind {
+	const samplePublicRoleCount = int(RoleDiscriminator) + 1
+	const histogramPayloadColumnCount = 9
+
+	var roleCount [samplePublicRoleCount]int
+	var histogramSeen [histogramPayloadColumnCount]bool
+	canonicalHistogram := histogramColumns()
+	for _, column := range s.Columns {
+		if !samplePublicRole(column.Role) {
+			continue
+		}
+		if column.Name == "" {
+			return SampleKindInvalid
+		}
+		nameCount := 0
+		for _, candidate := range s.Columns {
+			if candidate.Name == column.Name {
+				nameCount++
+			}
+		}
+		if nameCount != 1 {
+			return SampleKindInvalid
+		}
+		roleCount[column.Role]++
+		if column.Role == RoleHistogramField {
+			matched := false
+			for i, field := range canonicalHistogram {
+				if column.Name == field.Name {
+					histogramSeen[i] = true
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return SampleKindInvalid
+			}
+		}
+	}
+
+	for _, role := range [...]ColumnRole{
+		RoleMetricName,
+		RoleAttributes,
+		RoleTimestamp,
+		RoleAnchor,
+		RoleValue,
+		RoleDiscriminator,
+	} {
+		if roleCount[role] > 1 {
+			return SampleKindInvalid
+		}
+	}
+
+	hasHistogram := roleCount[RoleHistogramField] != 0
+	hasDiscriminator := roleCount[RoleDiscriminator] != 0
+	if hasHistogram {
+		if roleCount[RoleHistogramField] != len(canonicalHistogram) {
+			return SampleKindInvalid
+		}
+		for _, seen := range histogramSeen {
+			if !seen {
+				return SampleKindInvalid
+			}
+		}
+	} else if hasDiscriminator {
+		return SampleKindInvalid
+	}
+
+	if hasDiscriminator {
+		for _, role := range [...]ColumnRole{RoleMetricName, RoleAttributes, RoleTimestamp, RoleValue} {
+			if roleCount[role] != 1 {
+				return SampleKindInvalid
+			}
+		}
+	}
+	if s.Open {
+		return SampleKindOpaque
+	}
+	if hasDiscriminator {
+		return SampleKindMixed
+	}
+	if hasHistogram {
+		return SampleKindHistogram
+	}
+	if roleCount[RoleValue] == 1 {
+		return SampleKindFloat
+	}
+	return SampleKindOpaque
+}
+
+func samplePublicRole(role ColumnRole) bool {
+	switch role {
+	case RoleMetricName, RoleAttributes, RoleTimestamp, RoleAnchor, RoleValue, RoleHistogramField, RoleDiscriminator:
+		return true
+	default:
+		return false
+	}
 }
 
 // RowShapeFromSchema folds physical columns into the legacy sample vocabulary.

--- a/internal/chplan/schema.go
+++ b/internal/chplan/schema.go
@@ -286,6 +286,33 @@ func (s Schema) SampleKind() SampleKind {
 	return SampleKindOpaque
 }
 
+// LiveSampleKind refines a node's physical sample schema with the only
+// value-domain proof represented in the plan: a discriminator-zero filter over
+// a mixed payload contains float rows only while retaining the mixed columns.
+// Filter and OrderBy preserve that proof; every other node is a proof barrier.
+func LiveSampleKind(n Node) SampleKind {
+	if n == nil {
+		return SampleKindOpaque
+	}
+	kind := n.RowType().SampleKind()
+	if kind != SampleKindMixed {
+		return kind
+	}
+	for {
+		if IsMixedFloatNarrowing(n) {
+			return SampleKindFloat
+		}
+		switch node := n.(type) {
+		case *Filter:
+			n = node.Input
+		case *OrderBy:
+			n = node.Input
+		default:
+			return kind
+		}
+	}
+}
+
 func samplePublicRole(role ColumnRole) bool {
 	switch role {
 	case RoleMetricName, RoleAttributes, RoleTimestamp, RoleAnchor, RoleValue, RoleHistogramField, RoleDiscriminator:
@@ -295,21 +322,24 @@ func samplePublicRole(role ColumnRole) bool {
 	}
 }
 
-// RowShapeFromSchema folds physical columns into the legacy sample vocabulary.
-// Opaque relational outputs have no sample contract and retain its default.
+// RowShapeFromSchema folds a validated physical sample contract into the
+// diagnostic row-shape vocabulary. Opaque, open, incomplete, and invalid
+// schemas retain the sample default; that default is not proof of live floats.
 func RowShapeFromSchema(s Schema) RowShape {
-	switch {
-	case s.Has(RoleDiscriminator):
+	switch s.SampleKind() {
+	case SampleKindMixed:
 		return MixedRowShape
-	case s.Has(RoleHistogramField):
+	case SampleKindHistogram:
 		return HistogramRowShape
-	case s.Has(RoleAnchor) && !s.Has(RoleMetricName):
-		return GridWindowRowShape
-	case s.Has(RoleValue) && !s.Has(RoleMetricName) && !s.Has(RoleTimestamp) && !s.Has(RoleAnchor):
-		return ReducedWindowRowShape
-	default:
-		return SampleRowShape
+	case SampleKindFloat:
+		if s.Has(RoleAttributes) && s.Has(RoleAnchor) {
+			return GridWindowRowShape
+		}
+		if s.Has(RoleAttributes) && !s.Has(RoleTimestamp) && !s.Has(RoleAnchor) {
+			return ReducedWindowRowShape
+		}
 	}
+	return SampleRowShape
 }
 
 // IsMixedFloatNarrowing reports an explicit discriminator filter that retains

--- a/internal/chplan/schema_nodes.go
+++ b/internal/chplan/schema_nodes.go
@@ -135,7 +135,8 @@ func (v *InfoJoin) RowType() Schema {
 }
 
 func (h *HistogramProjection) RowType() Schema {
-	out := groupSchema(h.Input.RowType(), h.GroupBy, h.GroupByAliases, nil)
+	roles := sampleSchema(h.MetricNameColumn, h.AttributesColumn, h.TimestampColumn, h.ValueColumn)
+	out := groupSchema(h.Input.RowType(), h.GroupBy, h.GroupByAliases, roles.Columns)
 	out.Columns = append(out.Columns, histogramColumns()...)
 	return out
 }

--- a/internal/chplan/schema_shape_test.go
+++ b/internal/chplan/schema_shape_test.go
@@ -1,0 +1,141 @@
+package chplan
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestRowShapeFromValidatedSchema(t *testing.T) {
+	name := Column{Name: "metric", Role: RoleMetricName}
+	attributes := Column{Name: "labels", Role: RoleAttributes}
+	timestamp := Column{Name: "sample_time", Role: RoleTimestamp}
+	anchor := Column{Name: "step", Role: RoleAnchor}
+	value := Column{Name: "value", Role: RoleValue}
+	discriminator := Column{Name: "sample_kind", Role: RoleDiscriminator}
+	float := []Column{name, attributes, timestamp, value}
+	histogram := HistogramPayloadColumns()
+	mixed := append(slices.Clone(float), histogram...)
+	mixed = append(mixed, discriminator)
+
+	for _, tc := range []struct {
+		name   string
+		schema Schema
+		want   RowShape
+	}{
+		{name: "empty", schema: Schema{}, want: SampleRowShape},
+		{name: "strict_float", schema: Schema{Columns: float}, want: SampleRowShape},
+		{name: "strict_reduced", schema: Schema{Columns: []Column{attributes, value}}, want: ReducedWindowRowShape},
+		{name: "named_reduced", schema: Schema{Columns: []Column{name, attributes, value}}, want: ReducedWindowRowShape},
+		{name: "strict_grid", schema: Schema{Columns: []Column{attributes, anchor, timestamp, value}}, want: GridWindowRowShape},
+		{name: "named_grid", schema: Schema{Columns: []Column{name, attributes, anchor, timestamp, value}}, want: GridWindowRowShape},
+		{name: "partial_value", schema: Schema{Columns: []Column{value}}, want: SampleRowShape},
+		{name: "partial_anchor", schema: Schema{Columns: []Column{anchor}}, want: SampleRowShape},
+		{name: "histogram", schema: Schema{Columns: histogram}, want: HistogramRowShape},
+		{name: "histogram_with_float_columns", schema: Schema{Columns: append(slices.Clone(float), histogram...)}, want: HistogramRowShape},
+		{name: "mixed", schema: Schema{Columns: mixed}, want: MixedRowShape},
+		{name: "opaque_join", schema: Schema{Columns: []Column{{Name: "_hq_L_HistogramCount"}, {Name: "_mvj_R_Value"}}}, want: SampleRowShape},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RowShapeFromSchema(tc.schema); got != tc.want {
+				t.Fatalf("RowShapeFromSchema = %s, want %s; schema=%#v", got, tc.want, tc.schema)
+			}
+		})
+	}
+}
+
+func TestRowShapeFromSchemaRejectsUnvalidatedContracts(t *testing.T) {
+	attributes := Column{Name: "labels", Role: RoleAttributes}
+	anchor := Column{Name: "step", Role: RoleAnchor}
+	value := Column{Name: "value", Role: RoleValue}
+	discriminator := Column{Name: "sample_kind", Role: RoleDiscriminator}
+	histogram := HistogramPayloadColumns()
+	partialHistogram := slices.Clone(histogram[1:])
+
+	for _, tc := range []struct {
+		name   string
+		schema Schema
+	}{
+		{name: "open_reduced", schema: Schema{Open: true, Columns: []Column{attributes, value}}},
+		{name: "open_grid", schema: Schema{Open: true, Columns: []Column{attributes, anchor, value}}},
+		{name: "open_histogram", schema: Schema{Open: true, Columns: histogram}},
+		{name: "partial_histogram", schema: Schema{Columns: partialHistogram}},
+		{name: "orphan_discriminator", schema: Schema{Columns: []Column{attributes, value, discriminator}}},
+		{name: "duplicate_value_role", schema: Schema{Columns: []Column{attributes, value, {Name: "other_value", Role: RoleValue}}}},
+		{name: "unnamed_value", schema: Schema{Columns: []Column{attributes, {Role: RoleValue}}}},
+		{name: "ambiguous_value_name", schema: Schema{Columns: []Column{attributes, value, {Name: value.Name}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RowShapeFromSchema(tc.schema); got != SampleRowShape {
+				t.Fatalf("RowShapeFromSchema = %s, want sample default; schema=%#v", got, tc.schema)
+			}
+		})
+	}
+}
+
+func TestRowShapeOfUsesPhysicalSchemaNotLiveKind(t *testing.T) {
+	roles := []Column{
+		{Name: "metric", Role: RoleMetricName},
+		{Name: "labels", Role: RoleAttributes},
+		{Name: "sample_time", Role: RoleTimestamp},
+		{Name: "value", Role: RoleValue},
+	}
+	roles = append(roles, HistogramPayloadColumns()...)
+	roles = append(roles, Column{Name: MixedDiscriminatorColumn, Role: RoleDiscriminator})
+	names := make([]string, len(roles))
+	for i, role := range roles {
+		names[i] = role.Name
+	}
+	mixed := &Scan{Table: "mixed", Columns: names, Roles: roles}
+	narrowed := &Filter{
+		Input: mixed,
+		Predicate: &Binary{
+			Op:    OpEq,
+			Left:  &ColumnRef{Name: MixedDiscriminatorColumn},
+			Right: &LitInt{V: 0},
+		},
+	}
+	if got := LiveSampleKind(narrowed); got != SampleKindFloat {
+		t.Fatalf("LiveSampleKind(narrowed) = %s, want float", got)
+	}
+	if got := RowShapeOf(narrowed); got != MixedRowShape {
+		t.Fatalf("RowShapeOf(narrowed) = %s, want physical mixed shape", got)
+	}
+}
+
+func TestRowShapeOfReconcilesOpaqueAndHistogramJoins(t *testing.T) {
+	const (
+		metric     = "metric"
+		attributes = "labels"
+		timestamp  = "sample_time"
+		value      = "value"
+	)
+	for _, tc := range []struct {
+		name string
+		node Node
+		want RowShape
+	}{
+		{
+			name: "histogram_vector_join",
+			node: &HistogramVectorJoin{MetricNameColumn: metric, AttributesColumn: attributes, TimestampColumn: timestamp},
+			want: SampleRowShape,
+		},
+		{
+			name: "mixed_vector_join",
+			node: &MixedVectorJoin{MetricNameColumn: metric, AttributesColumn: attributes, TimestampColumn: timestamp, ValueColumn: value},
+			want: SampleRowShape,
+		},
+		{
+			name: "histogram_float_vector_join",
+			node: &HistogramFloatVectorJoin{MetricNameColumn: metric, AttributesColumn: attributes, TimestampColumn: timestamp, ValueColumn: value},
+			want: HistogramRowShape,
+		},
+		{name: "empty_union", node: &UnionAll{}, want: SampleRowShape},
+		{name: "opaque_default", node: &OneRow{}, want: SampleRowShape},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RowShapeOf(tc.node); got != tc.want {
+				t.Fatalf("RowShapeOf(%T) = %s, want %s; schema=%#v", tc.node, got, tc.want, tc.node.RowType())
+			}
+		})
+	}
+}

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -106,6 +106,34 @@ func TestRowTypeEveryNode(t *testing.T) {
 	assertCoversEverySealedKind(t, nodeMarkerMethod, covered, "RowType cases", "add an output-schema assertion")
 }
 
+func TestHistogramProjectionRowTypeDeclaresCanonicalRoles(t *testing.T) {
+	t.Parallel()
+
+	h := &HistogramProjection{
+		Input: &OneRow{},
+		GroupBy: []Expr{
+			&LitString{V: "metric"},
+			&LitString{V: "labels"},
+			&LitString{V: "time"},
+			&LitFloat{V: 0},
+		},
+		GroupByAliases:   []string{"source_name", "source_labels", "source_time", "source_value"},
+		MetricNameColumn: "source_name",
+		AttributesColumn: "source_labels",
+		TimestampColumn:  "source_time",
+		ValueColumn:      "source_value",
+	}
+
+	want := sampleSchema("source_name", "source_labels", "source_time", "source_value")
+	want.Columns = append(want.Columns, histogramColumns()...)
+	if got := h.RowType(); !got.Equal(want) {
+		t.Fatalf("HistogramProjection.RowType() = %#v, want %#v", got, want)
+	}
+	if got := h.RowType().SampleKind(); got != SampleKindHistogram {
+		t.Fatalf("HistogramProjection sample kind = %s, want %s", got, SampleKindHistogram)
+	}
+}
+
 func TestRowTypeDeclarations(t *testing.T) {
 	roles := []Column{{"renamed_value", RoleValue}, {"renamed_labels", RoleAttributes}}
 	p := &Project{Input: &OneRow{}, Roles: roles, Projections: []Projection{{Expr: &LitInt{V: 1}, Alias: "renamed_value"}}}
@@ -217,6 +245,66 @@ func TestRowTypeWindowBranches(t *testing.T) {
 	}
 }
 
+func TestRowTypeMatrixAnchorSurvivesSchemaPreservingWrappers(t *testing.T) {
+	input := &Scan{
+		Columns: []string{"labels", "time", "value"},
+		Roles: []Column{
+			{Name: "labels", Role: RoleAttributes},
+			{Name: "time", Role: RoleTimestamp},
+			{Name: "value", Role: RoleValue},
+		},
+	}
+	window := &RangeWindow{
+		Input:           input,
+		OuterRange:      time.Hour,
+		GroupBy:         []Expr{&ColumnRef{Name: "labels"}},
+		TimestampColumn: "time",
+		ValueColumn:     "value",
+	}
+	project := &Project{
+		Input: window,
+		Projections: []Projection{
+			{Expr: &ColumnRef{Name: "labels"}},
+			{Expr: &ColumnRef{Name: RangeWindowAnchorColumn}},
+			{Expr: &ColumnRef{Name: "time"}},
+			{Expr: &ColumnRef{Name: "value"}},
+		},
+		Roles: input.Roles,
+	}
+	aggregate := &Aggregate{
+		Input: project,
+		GroupBy: []Expr{
+			&ColumnRef{Name: "labels"},
+			&ColumnRef{Name: RangeWindowAnchorColumn},
+			&ColumnRef{Name: "time"},
+		},
+		GroupByAliases: []string{"labels", RangeWindowAnchorColumn, "time"},
+		AggFuncs:       []AggFunc{{Fn: FnAny, Args: []Expr{&ColumnRef{Name: "value"}}, Alias: "value"}},
+		Roles:          input.Roles,
+	}
+
+	want := Schema{Columns: []Column{
+		{Name: "labels", Role: RoleAttributes},
+		{Name: RangeWindowAnchorColumn, Role: RoleAnchor},
+		{Name: "time", Role: RoleTimestamp},
+		{Name: "value", Role: RoleValue},
+	}}
+	for _, tc := range []struct {
+		name string
+		node Node
+	}{
+		{name: "range_window", node: window},
+		{name: "project", node: project},
+		{name: "aggregate", node: aggregate},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.node.RowType(); !got.Equal(want) {
+				t.Fatalf("RowType = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
 func TestRowTypeMixedFloatNarrowing(t *testing.T) {
 	mixed := &Scan{Columns: []string{MixedDiscriminatorColumn}, Roles: []Column{{MixedDiscriminatorColumn, RoleDiscriminator}}}
 	filter := &Filter{Input: mixed, Predicate: &Binary{Op: OpEq, Left: &ColumnRef{Name: MixedDiscriminatorColumn}, Right: &LitInt{V: 0}}}
@@ -257,6 +345,49 @@ func TestRowTypeMixedFloatNarrowing(t *testing.T) {
 	filter.Predicate.(*Binary).Left = &ColumnRef{Name: MixedDiscriminatorColumn}
 	if IsMixedFloatNarrowing(filter) {
 		t.Fatal("filtering one of two independent discriminators accepted")
+	}
+}
+
+func TestLiveSampleKindCarriesOnlyRepresentedFloatProof(t *testing.T) {
+	floatColumns := []Column{
+		{Name: "MetricName", Role: RoleMetricName},
+		{Name: "Attributes", Role: RoleAttributes},
+		{Name: "TimeUnix", Role: RoleTimestamp},
+		{Name: "Value", Role: RoleValue},
+	}
+	mixedColumns := append(slices.Clone(floatColumns), HistogramPayloadColumns()...)
+	mixedColumns = append(mixedColumns, Column{Name: MixedDiscriminatorColumn, Role: RoleDiscriminator})
+	names := make([]string, len(mixedColumns))
+	for i, column := range mixedColumns {
+		names[i] = column.Name
+	}
+	mixed := &Scan{Table: "mixed", Columns: names, Roles: mixedColumns}
+	narrowed := &Filter{
+		Input: mixed,
+		Predicate: &Binary{
+			Op:    OpEq,
+			Left:  &ColumnRef{Name: MixedDiscriminatorColumn},
+			Right: &LitInt{V: 0},
+		},
+	}
+
+	for _, tc := range []struct {
+		name string
+		node Node
+		want SampleKind
+	}{
+		{name: "nil", want: SampleKindOpaque},
+		{name: "mixed", node: mixed, want: SampleKindMixed},
+		{name: "narrowed", node: narrowed, want: SampleKindFloat},
+		{name: "filtered_narrowing", node: &Filter{Input: narrowed, Predicate: &LitBool{V: true}}, want: SampleKindFloat},
+		{name: "ordered_narrowing", node: &OrderBy{Input: narrowed}, want: SampleKindFloat},
+		{name: "project_barrier", node: &Project{Input: narrowed}, want: SampleKindMixed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LiveSampleKind(tc.node); got != tc.want {
+				t.Fatalf("LiveSampleKind = %s, want %s", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -284,6 +284,118 @@ func TestRowTypeCanonicalHistogramPayload(t *testing.T) {
 	}
 }
 
+func TestSchemaSampleKind(t *testing.T) {
+	floatRoles := []Column{
+		{"source_name", RoleMetricName},
+		{"source_labels", RoleAttributes},
+		{"source_time", RoleTimestamp},
+		{"source_value", RoleValue},
+	}
+	histogram := HistogramPayloadColumns()
+	mixed := append(slices.Clone(floatRoles), histogram...)
+	mixed = append(mixed, Column{"source_kind", RoleDiscriminator})
+	reorderedMixed := slices.Clone(mixed)
+	slices.Reverse(reorderedMixed)
+
+	for _, tc := range []struct {
+		name string
+		row  Schema
+		want SampleKind
+	}{
+		{name: "float_custom_names", row: Schema{Columns: floatRoles}, want: SampleKindFloat},
+		{name: "reduced_float", row: Schema{Columns: []Column{{"source_value", RoleValue}}}, want: SampleKindFloat},
+		{name: "pure_histogram", row: Schema{Columns: histogram}, want: SampleKindHistogram},
+		{name: "histogram_with_placeholder", row: Schema{Columns: append(slices.Clone(floatRoles), histogram...)}, want: SampleKindHistogram},
+		{name: "mixed", row: Schema{Columns: mixed}, want: SampleKindMixed},
+		{name: "mixed_reordered", row: Schema{Columns: reorderedMixed}, want: SampleKindMixed},
+		{name: "opaque", row: Schema{Columns: []Column{{Name: "private"}}}, want: SampleKindOpaque},
+		{name: "open_float", row: Schema{Columns: floatRoles, Open: true}, want: SampleKindOpaque},
+		{name: "trace_roles", row: Schema{Columns: []Column{{"trace", RoleTraceID}, {"span", RoleSpanID}}}, want: SampleKindOpaque},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.row.SampleKind(); got != tc.want {
+				t.Fatalf("SampleKind = %s, want %s; schema=%#v", got, tc.want, tc.row)
+			}
+		})
+	}
+}
+
+func TestSchemaSampleKindRejectsMalformedContracts(t *testing.T) {
+	floatRoles := []Column{{"labels", RoleAttributes}, {"value", RoleValue}}
+	histogram := HistogramPayloadColumns()
+	kind := Column{"source_kind", RoleDiscriminator}
+
+	type sampleKindCase struct {
+		name    string
+		columns []Column
+	}
+	cases := []sampleKindCase{
+		{name: "orphan_discriminator", columns: append(slices.Clone(floatRoles), kind)},
+		{name: "duplicate_value_role", columns: append(slices.Clone(floatRoles), Column{"other_value", RoleValue})},
+		{name: "unnamed_value", columns: []Column{{Role: RoleValue}}},
+		{name: "shadowed_value", columns: append(slices.Clone(floatRoles), Column{Name: "value"})},
+		{name: "duplicate_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), kind, Column{"other_kind", RoleDiscriminator})},
+		{name: "unnamed_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), Column{Role: RoleDiscriminator})},
+		{name: "shadowed_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), kind, Column{Name: kind.Name})},
+		{name: "noncanonical_histogram_role", columns: append(slices.Clone(floatRoles), Column{"raw_count", RoleHistogramField})},
+	}
+	for i, role := range floatRoles {
+		missing := slices.Delete(slices.Clone(floatRoles), i, i+1)
+		columns := append(missing, histogram...)
+		columns = append(columns, kind)
+		cases = append(cases, sampleKindCase{name: "mixed_missing/" + role.Name, columns: columns})
+	}
+	for i, field := range histogram {
+		missing := slices.Delete(slices.Clone(histogram), i, i+1)
+		wrongRole := slices.Clone(histogram)
+		wrongRole[i].Role = RoleOpaque
+		duplicate := append(slices.Clone(histogram), field)
+		shadowed := append(slices.Clone(histogram), Column{Name: field.Name})
+		cases = append(
+			cases,
+			sampleKindCase{name: "missing/" + field.Name, columns: missing},
+			sampleKindCase{name: "wrong_role/" + field.Name, columns: wrongRole},
+			sampleKindCase{name: "duplicate/" + field.Name, columns: duplicate},
+			sampleKindCase{name: "shadowed/" + field.Name, columns: shadowed},
+		)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (Schema{Columns: tc.columns}).SampleKind(); got != SampleKindInvalid {
+				t.Fatalf("SampleKind = %s, want %s; schema=%#v", got, SampleKindInvalid, tc.columns)
+			}
+		})
+	}
+}
+
+func TestSchemaSampleKindUsesRolesNotSampleNames(t *testing.T) {
+	for _, field := range HistogramPayloadColumns() {
+		row := Schema{Columns: []Column{{Name: field.Name, Role: RoleValue}}}
+		if got := row.SampleKind(); got != SampleKindFloat {
+			t.Fatalf("value named %q classified as %s, want %s", field.Name, got, SampleKindFloat)
+		}
+	}
+}
+
+func TestSampleKindString(t *testing.T) {
+	for _, tc := range []struct {
+		kind SampleKind
+		want string
+	}{
+		{SampleKindOpaque, "opaque"},
+		{SampleKindFloat, "float"},
+		{SampleKindHistogram, "histogram"},
+		{SampleKindMixed, "mixed"},
+		{SampleKindInvalid, "invalid"},
+		{SampleKindInvalid + 1, "unknown"},
+	} {
+		if got := tc.kind.String(); got != tc.want {
+			t.Errorf("SampleKind(%d).String() = %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+}
+
 func TestRowTypeOpenCrossJoin(t *testing.T) {
 	left := &Scan{Roles: []Column{{"known", RoleAttributes}}}
 	right := &Scan{Columns: []string{"known", "maybe"}, Roles: []Column{{"known", RoleAttributes}, {"maybe", RoleTimestamp}}}

--- a/internal/chplan/topk.go
+++ b/internal/chplan/topk.go
@@ -40,6 +40,9 @@ package chplan
 // (MetricName / Attributes / TimeUnix / Value) so downstream
 // consumers (chDB roundtrip runner, handler projection) see a
 // fixed-arity column list rather than the opaque-arity `*`.
+// [TopK.RowType] derives the resulting schema from Input and this list, so a
+// wildcard preserves Input's whole physical schema while an explicit list
+// carries only the selected columns and their existing roles.
 //
 // `KExpr` is the computed-K variant: a chplan subtree whose evaluation
 // yields the K integer at execution time. When non-nil, the emitter
@@ -63,35 +66,6 @@ package chplan
 // numbered in whatever order CH encounters them — the same arbitrary
 // selection the literal-K `LIMIT K BY <By>` shape makes. The ranking
 // variants (topk/bottomk) keep `Unordered == false`.
-//
-// `Histogram` marks Input as histogram-valued (chplan.RowShapeOf(Input) ==
-// chplan.HistogramRowShape), mirroring [InfoJoin.Histogram] and
-// [VectorSetOp.Histogram]. Only `limitk` ever sets it: reference
-// Prometheus's LIMITK arm of aggregationK (promql/engine.go) pushes every
-// selected series' sample — float or histogram — onto the group heap
-// unchanged, with no `s.H != nil` branch anywhere in its control flow,
-// unlike TOPK/BOTTOMK's explicit ignore-and-annotate branch just above it
-// in the same function; topk/bottomk therefore never set this field (a
-// purely histogram-valued input is intercepted upstream and folded to an
-// empty result — see histogram_native_drop_aggregation.go). When Histogram
-// is true, `Columns` is always empty (`SELECT *`), so the outer SELECT
-// forwards Input's full thirteen-column contract instead of declaring only
-// the canonical Sample quartet — [RowShapeOf] must report
-// [HistogramRowShape] for such a TopK or a wire consumer re-projects down
-// to the quartet and silently drops the nine histogram columns (cerberus
-// issue #2518). Defaults to false everywhere else, so every pre-existing
-// TopK construction site (topk/bottomk, and limitk over a float-valued
-// input) is unaffected.
-//
-// Mixed is Histogram's sibling for `limitk`/`limit_ratio` over a MIXED
-// float/histogram-valued input (cerberus issue #2613) — a mixed float/
-// histogram `or`, same trigger shape as [VectorSetOp.Mixed]. Reference
-// Prometheus's LIMITK/LIMIT_RATIO push every selected sample onto the
-// heap/sampler regardless of type, exactly as for the pure-histogram case
-// above, so the same "preserve, never drop" treatment applies. Like
-// Histogram, Mixed is only ever set alongside an empty `Columns` — the
-// outer SELECT stays a bare passthrough of Input's fourteen-column Mixed
-// contract. Histogram and Mixed are mutually exclusive.
 type TopK struct {
 	Input     Node
 	K         int64
@@ -101,8 +75,6 @@ type TopK struct {
 	Desc      bool     // true = topk (DESC), false = bottomk (ASC)
 	Unordered bool     // true = limitk (no ORDER BY, arbitrary K-per-group)
 	Columns   []string // explicit outer SELECT column list; empty = `SELECT *`
-	Histogram bool     // true = limitk over a histogram-valued input (see doc above)
-	Mixed     bool     // true = limitk/limit_ratio over a mixed float/histogram input (see doc above)
 }
 
 func (*TopK) planNode() {}
@@ -117,7 +89,6 @@ func (t *TopK) Children() []Node {
 func (t *TopK) Equal(other Node) bool {
 	o, ok := other.(*TopK)
 	if !ok || t.K != o.K || t.Desc != o.Desc || t.Unordered != o.Unordered ||
-		t.Histogram != o.Histogram || t.Mixed != o.Mixed ||
 		len(t.By) != len(o.By) || len(t.Columns) != len(o.Columns) {
 		return false
 	}

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -3349,8 +3349,8 @@ func TestValidateVectorJoinCols_EachEmptyErrors(t *testing.T) {
 	t.Parallel()
 	base := func() *chplan.VectorJoin {
 		return &chplan.VectorJoin{
-			Left:             &chplan.Scan{Table: "otel_metrics_sum"},
-			Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+			Left:             vectorSetOpTestScan("otel_metrics_sum"),
+			Right:            vectorSetOpTestScan("otel_metrics_sum"),
 			Op:               chplan.OpAdd,
 			Match:            chplan.VectorMatch{Labels: []string{"job"}, On: true},
 			MetricNameColumn: "MetricName",
@@ -3399,8 +3399,8 @@ func TestValidateVectorSetOpCols_EachEmptyErrors(t *testing.T) {
 	t.Parallel()
 	base := func() *chplan.VectorSetOp {
 		return &chplan.VectorSetOp{
-			Left:             &chplan.Scan{Table: "otel_metrics_sum"},
-			Right:            &chplan.Scan{Table: "otel_metrics_sum"},
+			Left:             vectorSetOpTestScan("otel_metrics_sum"),
+			Right:            vectorSetOpTestScan("otel_metrics_sum"),
 			Op:               chplan.VectorSetAnd,
 			Match:            chplan.VectorMatch{On: true},
 			MetricNameColumn: "MetricName",

--- a/internal/chsql/nary_vector_set_op.go
+++ b/internal/chsql/nary_vector_set_op.go
@@ -79,7 +79,10 @@ func (e *emitter) emitNaryVectorSetOp(s *chplan.NaryVectorSetOp) error {
 		if err != nil {
 			return err
 		}
-		canonical := naryVectorSetOpCanonicalArmFrag(s, arm, armFrag)
+		canonical, err := naryVectorSetOpCanonicalArmFrag(s, arm, armFrag)
+		if err != nil {
+			return err
+		}
 		sideArms[i] = naryVectorSetOpSideArmFrag(s, canonical, i)
 	}
 
@@ -192,7 +195,7 @@ func naryVectorSetOpOutputCols(s *chplan.NaryVectorSetOp) []Frag {
 // missing MetricName / TimeUnix synthesised exactly as the binary path
 // does, so a flattened chain emits byte-identical arm projections to the
 // nested form it replaces.
-func naryVectorSetOpCanonicalArmFrag(s *chplan.NaryVectorSetOp, arm chplan.Node, armFrag Frag) Frag {
+func naryVectorSetOpCanonicalArmFrag(s *chplan.NaryVectorSetOp, arm chplan.Node, armFrag Frag) (Frag, error) {
 	view := &chplan.VectorSetOp{
 		Op:               s.Op,
 		Match:            s.Match,
@@ -225,6 +228,22 @@ func (e *emitter) validateNaryVectorSetOpShape(s *chplan.NaryVectorSetOp) error 
 		return fmt.Errorf("%w: NaryVectorSetOp.ValueColumn unset", ErrUnsupported)
 	case s.Op != chplan.VectorSetOr && s.Op != chplan.VectorSetAnd:
 		return fmt.Errorf("%w: NaryVectorSetOp op %q is not associative", ErrUnsupported, s.Op)
+	}
+	declared := chplan.SampleKindFloat
+	if s.Histogram {
+		declared = chplan.SampleKindHistogram
+	}
+	for i, arm := range s.Arms {
+		kind, err := vectorSetOpArmSampleKind(arm)
+		if err != nil {
+			return err
+		}
+		if kind != declared {
+			return fmt.Errorf(
+				"%w: NaryVectorSetOp declares %s output but arm %d has %s live schema",
+				ErrUnsupported, declared, i, kind,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/chsql/nary_vector_set_op_test.go
+++ b/internal/chsql/nary_vector_set_op_test.go
@@ -11,14 +11,33 @@ import (
 
 func narySetOpArm(table string) chplan.Node {
 	return &chplan.Project{
-		Input: &chplan.Scan{Table: table},
+		Input: setOpTestScan(table),
 		Projections: []chplan.Projection{
 			{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "MetricName"},
 			{Expr: &chplan.ColumnRef{Name: "Attributes"}, Alias: "Attributes"},
 			{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "TimeUnix"},
 			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
 		},
+		Roles: setOpTestRoles(),
 	}
+}
+
+func setOpTestRoles() []chplan.Column {
+	return []chplan.Column{
+		{Name: "MetricName", Role: chplan.RoleMetricName},
+		{Name: "Attributes", Role: chplan.RoleAttributes},
+		{Name: "TimeUnix", Role: chplan.RoleTimestamp},
+		{Name: "Value", Role: chplan.RoleValue},
+	}
+}
+
+func setOpTestScan(table string) *chplan.Scan {
+	roles := setOpTestRoles()
+	columns := make([]string, len(roles))
+	for i, role := range roles {
+		columns[i] = role.Name
+	}
+	return &chplan.Scan{Table: table, Columns: columns, Roles: roles}
 }
 
 func naryOp(op chplan.VectorSetOpKind, tables ...string) *chplan.NaryVectorSetOp {

--- a/internal/chsql/vector_set_op.go
+++ b/internal/chsql/vector_set_op.go
@@ -142,8 +142,14 @@ func (e *emitter) emitVectorSetOp(s *chplan.VectorSetOp) error {
 	// the per-arm canonical projection covers both that case and the
 	// matrix-shape mismatch surfaced by the dashboard sweep
 	// (otelcol dashboard's "refused / send-failed / dropped" panels).
-	leftArm := vectorSetOpCanonicalArmFrag(s, s.Left, leftFrag)
-	rightArm := vectorSetOpCanonicalArmFrag(s, s.Right, rightFrag)
+	leftArm, err := vectorSetOpCanonicalArmFrag(s, s.Left, leftFrag)
+	if err != nil {
+		return err
+	}
+	rightArm, err := vectorSetOpCanonicalArmFrag(s, s.Right, rightFrag)
+	if err != nil {
+		return err
+	}
 
 	switch s.Op {
 	case chplan.VectorSetAnd:
@@ -295,8 +301,14 @@ func (e *emitter) emitMixedVectorSetOp(s *chplan.VectorSetOp) error {
 		return err
 	}
 
-	leftArm := mixedVectorSetOpArmFrag(s, s.Left, leftFrag)
-	rightArm := mixedVectorSetOpArmFrag(s, s.Right, rightFrag)
+	leftArm, err := mixedVectorSetOpArmFrag(s, s.Left, leftFrag)
+	if err != nil {
+		return err
+	}
+	rightArm, err := mixedVectorSetOpArmFrag(s, s.Right, rightFrag)
+	if err != nil {
+		return err
+	}
 
 	sideArmL := mixedVectorSetOpSideArmFrag(s, leftArm, 0)
 	sideArmR := mixedVectorSetOpSideArmFrag(s, rightArm, 1)
@@ -377,28 +389,41 @@ func mixedVectorSetOpOutputCols(s *chplan.VectorSetOp) []Frag {
 //   - Anything else (float-shaped): the arm publishes Value for real and
 //     nine typed placeholders standing in for the histogram columns it
 //     doesn't have; discriminator is synthesised as 0.
-func mixedVectorSetOpArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag Frag) Frag {
-	switch chplan.RowShapeOf(arm) {
-	case chplan.MixedRowShape:
+func mixedVectorSetOpArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag Frag) (Frag, error) {
+	kind, err := vectorSetOpArmSampleKind(arm)
+	if err != nil {
+		return nil, err
+	}
+	quartet, err := vectorSetOpCanonicalQuartetFrags(s, arm)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case chplan.SampleKindMixed:
+		payload, err := vectorSetOpPayloadFrags(arm.RowType(), true)
+		if err != nil {
+			return nil, err
+		}
 		inner := NewQuery().
-			Select(mixedVectorSetOpOutputCols(s)...).
+			Select(append(quartet, payload...)...).
 			From(armFrag)
-		return inner.Frag()
-	case chplan.HistogramRowShape:
-		cols := append(vectorSetOpCanonicalQuartetFrags(s, arm), vectorSetOpHistogramCols()...)
+		return inner.Frag(), nil
+	case chplan.SampleKindHistogram:
+		cols := append(quartet, vectorSetOpHistogramCols()...)
 		cols = append(cols, As(InlineLit(setOpMixedIsHistogramTrue), setOpMixedIsHistogramCol))
 		inner := NewQuery().
 			Select(cols...).
 			From(armFrag)
-		return inner.Frag()
-	default:
-		cols := append(vectorSetOpCanonicalQuartetFrags(s, arm), mixedVectorSetOpHistogramPlaceholderCols()...)
+		return inner.Frag(), nil
+	case chplan.SampleKindFloat:
+		cols := append(quartet, mixedVectorSetOpHistogramPlaceholderCols()...)
 		cols = append(cols, As(InlineLit(setOpMixedIsHistogramFalse), setOpMixedIsHistogramCol))
 		inner := NewQuery().
 			Select(cols...).
 			From(armFrag)
-		return inner.Frag()
+		return inner.Frag(), nil
 	}
+	return nil, fmt.Errorf("%w: mixed VectorSetOp arm has %s sample kind", ErrUnsupported, kind)
 }
 
 // mixedVectorSetOpHistogramPlaceholderCols returns the nine
@@ -511,8 +536,15 @@ func mixedVectorSetOpSideArmFrag(s *chplan.VectorSetOp, armFrag Frag, side int) 
 // The Attributes / Value columns are always referenced by name (every
 // derived emitter still passes Attributes + the schema-named
 // ValueColumn through).
-func vectorSetOpCanonicalArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag Frag) Frag {
-	cols := vectorSetOpCanonicalQuartetFrags(s, arm)
+func vectorSetOpCanonicalArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag Frag) (Frag, error) {
+	kind, err := vectorSetOpArmSampleKind(arm)
+	if err != nil {
+		return nil, err
+	}
+	cols, err := vectorSetOpCanonicalQuartetFrags(s, arm)
+	if err != nil {
+		return nil, err
+	}
 	// Widen by THIS ARM's own row shape, not s.Histogram: for a
 	// homogeneous set op (both arms histogram, or both float) the two
 	// answers agree, but a MIXED `and`/`unless` (cerberus issue #2325 —
@@ -527,10 +559,10 @@ func vectorSetOpCanonicalArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag
 	// one it does (histogram side, harmlessly unused downstream) would
 	// desync from reality. In the homogeneous cases this is
 	// byte-identical to the old s.Histogram check.
-	switch chplan.RowShapeOf(arm) {
-	case chplan.HistogramRowShape:
+	switch kind {
+	case chplan.SampleKindHistogram:
 		cols = append(cols, vectorSetOpHistogramCols()...)
-	case chplan.MixedRowShape:
+	case chplan.SampleKindMixed:
 		// cerberus issue #2555: this arm is itself an already-Mixed
 		// VectorSetOp (a nested mixedExpHistogramSetOp resolved as its
 		// own operand). When this arm is the FORWARDED side of an
@@ -539,13 +571,16 @@ func vectorSetOpCanonicalArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag
 		// makes them resolvable there. When this arm is the non-forwarded
 		// side, the extra columns are harmlessly unused, exactly like the
 		// Histogram case above.
-		cols = append(cols, vectorSetOpHistogramCols()...)
-		cols = append(cols, Col(setOpMixedIsHistogramCol))
+		payload, err := vectorSetOpPayloadFrags(arm.RowType(), true)
+		if err != nil {
+			return nil, err
+		}
+		cols = append(cols, payload...)
 	}
 	inner := NewQuery().
 		Select(cols...).
 		From(armFrag)
-	return inner.Frag()
+	return inner.Frag(), nil
 }
 
 // vectorSetOpCanonicalQuartetFrags returns the four canonical-shape Frags
@@ -556,33 +591,84 @@ func vectorSetOpCanonicalArmFrag(s *chplan.VectorSetOp, arm chplan.Node, armFrag
 // [mixedVectorSetOpArmFrag] (cerberus issue #2330) can reuse the exact
 // same derived/matrix-shape resolution the symmetric Histogram /
 // float-only paths already use, instead of re-deriving it.
-func vectorSetOpCanonicalQuartetFrags(s *chplan.VectorSetOp, arm chplan.Node) []Frag {
-	derived := chplan.IsDerivedShape(arm, vectorSetOpSampleColumns(s))
-	armTsCol, matrix := vectorSetOpArmTimestampCol(arm, s)
+func vectorSetOpCanonicalQuartetFrags(s *chplan.VectorSetOp, arm chplan.Node) ([]Frag, error) {
+	row := arm.RowType()
+	attributes, err := vectorSetOpRequiredRole(row, chplan.RoleAttributes, "attributes")
+	if err != nil {
+		return nil, err
+	}
+	value, err := vectorSetOpRequiredRole(row, chplan.RoleValue, "value")
+	if err != nil {
+		return nil, err
+	}
 
 	var metricNameFrag Frag
-	if derived {
+	metricName, hasMetricName := row.Find(chplan.RoleMetricName)
+	if !hasMetricName {
 		metricNameFrag = As(Lit(""), s.MetricNameColumn)
 	} else {
-		metricNameFrag = Col(s.MetricNameColumn)
+		metricNameFrag = vectorSetOpAliasedColumn(metricName.Name, s.MetricNameColumn)
 	}
 
 	var timeFrag Frag
-	switch {
-	case derived && !matrix:
+	timestamp, hasTimestamp := row.Find(chplan.RoleTimestamp)
+	anchor, hasAnchor := row.Find(chplan.RoleAnchor)
+	if hasTimestamp {
+		timeFrag = vectorSetOpAliasedColumn(timestamp.Name, s.TimestampColumn)
+	} else if hasAnchor {
+		timeFrag = vectorSetOpAliasedColumn(anchor.Name, s.TimestampColumn)
+	} else if armTsCol, matrix := vectorSetOpArmTimestampCol(arm, s); matrix {
+		timeFrag = vectorSetOpAliasedColumn(armTsCol, s.TimestampColumn)
+	} else {
 		timeFrag = As(vectorSetOpSynthesizedAnchorFrag(), s.TimestampColumn)
-	case matrix && armTsCol != s.TimestampColumn:
-		timeFrag = As(Col(armTsCol), s.TimestampColumn)
-	default:
-		timeFrag = Col(s.TimestampColumn)
 	}
 
 	return []Frag{
 		metricNameFrag,
-		Col(s.AttributesColumn),
+		vectorSetOpAliasedColumn(attributes.Name, s.AttributesColumn),
 		timeFrag,
-		Col(s.ValueColumn),
+		vectorSetOpAliasedColumn(value.Name, s.ValueColumn),
+	}, nil
+}
+
+func vectorSetOpArmSampleKind(arm chplan.Node) (chplan.SampleKind, error) {
+	if arm == nil {
+		return chplan.SampleKindInvalid, fmt.Errorf("%w: VectorSetOp arm is nil", ErrUnsupported)
 	}
+	kind := chplan.LiveSampleKind(arm)
+	switch kind {
+	case chplan.SampleKindFloat, chplan.SampleKindHistogram, chplan.SampleKindMixed:
+		return kind, nil
+	default:
+		return kind, fmt.Errorf("%w: VectorSetOp arm has %s sample schema", ErrUnsupported, kind)
+	}
+}
+
+func vectorSetOpRequiredRole(row chplan.Schema, role chplan.ColumnRole, label string) (chplan.Column, error) {
+	column, ok := row.Find(role)
+	if !ok || column.Name == "" {
+		return chplan.Column{}, fmt.Errorf("%w: VectorSetOp arm is missing %s role", ErrUnsupported, label)
+	}
+	return column, nil
+}
+
+func vectorSetOpAliasedColumn(source, target string) Frag {
+	if source == target {
+		return Col(source)
+	}
+	return As(Col(source), target)
+}
+
+func vectorSetOpPayloadFrags(row chplan.Schema, discriminator bool) ([]Frag, error) {
+	cols := vectorSetOpHistogramCols()
+	if !discriminator {
+		return cols, nil
+	}
+	column, err := vectorSetOpRequiredRole(row, chplan.RoleDiscriminator, "discriminator")
+	if err != nil {
+		return nil, err
+	}
+	return append(cols, vectorSetOpAliasedColumn(column.Name, setOpMixedIsHistogramCol)), nil
 }
 
 // vectorSetOpHistogramCols returns the nine chplan.Histogram*Column
@@ -791,6 +877,35 @@ func (e *emitter) validateVectorSetOpCols(s *chplan.VectorSetOp) error {
 		// drop the colliding key, or refuse the query. Emitting one of
 		// them silently would make the plan's own intent unreadable.
 		return fmt.Errorf("%w: VectorSetOp.MixedDropCollisions and .MixedAbortOnCollision are mutually exclusive", ErrUnsupported)
+	}
+	return validateVectorSetOpSampleKinds(s)
+}
+
+func validateVectorSetOpSampleKinds(s *chplan.VectorSetOp) error {
+	left, err := vectorSetOpArmSampleKind(s.Left)
+	if err != nil {
+		return err
+	}
+	right, err := vectorSetOpArmSampleKind(s.Right)
+	if err != nil {
+		return err
+	}
+
+	actual := left
+	if s.Op == chplan.VectorSetOr && left != right {
+		actual = chplan.SampleKindMixed
+	}
+	declared := chplan.SampleKindFloat
+	if s.Histogram {
+		declared = chplan.SampleKindHistogram
+	} else if s.Mixed {
+		declared = chplan.SampleKindMixed
+	}
+	if actual != declared {
+		return fmt.Errorf(
+			"%w: VectorSetOp declares %s output but its live arm schemas produce %s",
+			ErrUnsupported, declared, actual,
+		)
 	}
 	return nil
 }

--- a/internal/chsql/vector_set_op_arm_scope_test.go
+++ b/internal/chsql/vector_set_op_arm_scope_test.go
@@ -31,7 +31,11 @@ const canonicalTimestampColumn = "TimeUnix"
 // `Timestamp`.
 func setOpArmMatrixRangeWindow(table string) chplan.Node {
 	rw := &chplan.RangeWindow{
-		Input:           &chplan.Scan{Table: table},
+		Input: &chplan.Scan{Table: table, Roles: []chplan.Column{
+			{Name: "ResourceAttributes", Role: chplan.RoleAttributes},
+			{Name: logsTimestampColumn, Role: chplan.RoleTimestamp},
+			{Name: "Value", Role: chplan.RoleValue},
+		}},
 		Func:            "rate",
 		Range:           5 * time.Minute,
 		Step:            time.Minute,
@@ -48,6 +52,7 @@ func setOpArmMatrixRangeWindow(table string) chplan.Node {
 			{Expr: &chplan.ColumnRef{Name: "anchor_ts"}, Alias: canonicalTimestampColumn},
 			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
 		},
+		Roles: setOpTestRoles(),
 	}
 }
 

--- a/internal/chsql/vector_set_op_mixed_drop_collisions_test.go
+++ b/internal/chsql/vector_set_op_mixed_drop_collisions_test.go
@@ -15,7 +15,7 @@ import (
 // arm, a float-shaped arm, and the survival rule under test.
 func mixedDropCollisionsPlan(drop bool) *chplan.VectorSetOp {
 	histArm := &chplan.HistogramProjection{
-		Input:                      &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
+		Input:                      vectorSetOpTestScan("otel_metrics_exponential_histogram"),
 		CountColumn:                "Count",
 		SumColumn:                  "Sum",
 		ScaleColumn:                "Scale",
@@ -27,15 +27,23 @@ func mixedDropCollisionsPlan(drop bool) *chplan.VectorSetOp {
 		MetricNameColumn:           "MetricName",
 		AttributesColumn:           "Attributes",
 		TimestampColumn:            "TimeUnix",
+		GroupBy: []chplan.Expr{
+			&chplan.ColumnRef{Name: "MetricName"},
+			&chplan.ColumnRef{Name: "Attributes"},
+			&chplan.ColumnRef{Name: "TimeUnix"},
+			&chplan.LitFloat{V: 0},
+		},
+		GroupByAliases: []string{"MetricName", "Attributes", "TimeUnix", "Value"},
 	}
 	floatArm := &chplan.Project{
-		Input: &chplan.Scan{Table: "otel_metrics_gauge"},
+		Input: vectorSetOpTestScan("otel_metrics_gauge"),
 		Projections: []chplan.Projection{
 			{Expr: &chplan.ColumnRef{Name: "MetricName"}, Alias: "MetricName"},
 			{Expr: &chplan.ColumnRef{Name: "Attributes"}, Alias: "Attributes"},
 			{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "TimeUnix"},
 			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
 		},
+		Roles: vectorSetOpTestRoles(),
 	}
 	return &chplan.VectorSetOp{
 		Left:                histArm,
@@ -49,6 +57,24 @@ func mixedDropCollisionsPlan(drop bool) *chplan.VectorSetOp {
 		TimestampColumn:     "TimeUnix",
 		ValueColumn:         "Value",
 	}
+}
+
+func vectorSetOpTestRoles() []chplan.Column {
+	return []chplan.Column{
+		{Name: "MetricName", Role: chplan.RoleMetricName},
+		{Name: "Attributes", Role: chplan.RoleAttributes},
+		{Name: "TimeUnix", Role: chplan.RoleTimestamp},
+		{Name: "Value", Role: chplan.RoleValue},
+	}
+}
+
+func vectorSetOpTestScan(table string) *chplan.Scan {
+	roles := vectorSetOpTestRoles()
+	columns := make([]string, len(roles))
+	for i, role := range roles {
+		columns[i] = role.Name
+	}
+	return &chplan.Scan{Table: table, Columns: columns, Roles: roles}
 }
 
 // TestEmitMixedVectorSetOp_DropCollisionsSurvivalRule pins the ONE thing

--- a/internal/chsql/vector_set_op_mixed_histogram_test.go
+++ b/internal/chsql/vector_set_op_mixed_histogram_test.go
@@ -19,7 +19,7 @@ import (
 // faithful stand-in for a real lowering's output.
 func mixedSetOpHistogramArm() *chplan.HistogramProjection {
 	return &chplan.HistogramProjection{
-		Input:                      &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
+		Input:                      setOpTestScan("otel_metrics_exponential_histogram"),
 		CountColumn:                "Count",
 		SumColumn:                  "Sum",
 		ScaleColumn:                "Scale",
@@ -43,7 +43,7 @@ func mixedSetOpHistogramArm() *chplan.HistogramProjection {
 // Value) quartet as real physical columns, standing in for
 // histogram_quantile()'s own float-valued output.
 func mixedSetOpFloatArm() *chplan.Scan {
-	return &chplan.Scan{Table: "otel_metrics_gauge"}
+	return setOpTestScan("otel_metrics_gauge")
 }
 
 func mixedSetOp(op chplan.VectorSetOpKind, left, right chplan.Node, histogram bool) *chplan.VectorSetOp {

--- a/internal/chsql/vector_set_op_schema_test.go
+++ b/internal/chsql/vector_set_op_schema_test.go
@@ -1,0 +1,180 @@
+package chsql_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+func setOpSchemaProject(columns []chplan.Column) chplan.Node {
+	projections := make([]chplan.Projection, len(columns))
+	for i, column := range columns {
+		projections[i] = chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: column.Name},
+			Alias: column.Name,
+		}
+	}
+	return &chplan.Project{Input: &chplan.OneRow{}, Projections: projections, Roles: columns}
+}
+
+func schemaRoutedSetOp(left, right chplan.Node) *chplan.VectorSetOp {
+	return &chplan.VectorSetOp{
+		Left: left, Right: right, Op: chplan.VectorSetOr,
+		MetricNameColumn: "MetricName", AttributesColumn: "Attributes",
+		TimestampColumn: "TimeUnix", ValueColumn: "Value",
+	}
+}
+
+func TestEmitVectorSetOpCanonicalizesCustomRoleNames(t *testing.T) {
+	t.Parallel()
+	custom := []chplan.Column{
+		{Name: "source_name", Role: chplan.RoleMetricName},
+		{Name: "source_labels", Role: chplan.RoleAttributes},
+		{Name: "source_time", Role: chplan.RoleTimestamp},
+		{Name: "source_value", Role: chplan.RoleValue},
+	}
+
+	sql, _, err := chsql.Emit(context.Background(), schemaRoutedSetOp(
+		setOpSchemaProject(custom),
+		setOpSchemaProject(custom),
+	))
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"`source_name` AS `MetricName`",
+		"`source_labels` AS `Attributes`",
+		"`source_time` AS `TimeUnix`",
+		"`source_value` AS `Value`",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("SQL missing role alias %q: %s", want, sql)
+		}
+	}
+}
+
+func TestEmitVectorSetOpCanonicalizesCustomAnchorRole(t *testing.T) {
+	t.Parallel()
+	custom := []chplan.Column{
+		{Name: "source_labels", Role: chplan.RoleAttributes},
+		{Name: "source_anchor", Role: chplan.RoleAnchor},
+		{Name: "source_value", Role: chplan.RoleValue},
+	}
+
+	sql, _, err := chsql.Emit(context.Background(), schemaRoutedSetOp(
+		setOpSchemaProject(custom),
+		setOpSchemaProject(custom),
+	))
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if want := "`source_anchor` AS `TimeUnix`"; !strings.Contains(sql, want) {
+		t.Fatalf("SQL missing anchor role alias %q: %s", want, sql)
+	}
+}
+
+func TestEmitVectorSetOpRejectsOpaqueAndInvalidArms(t *testing.T) {
+	t.Parallel()
+	valid := setOpSchemaProject(setOpTestRoles())
+	invalid := append(setOpTestRoles(), chplan.Column{Name: "other_value", Role: chplan.RoleValue})
+
+	for _, tc := range []struct {
+		name string
+		arm  chplan.Node
+	}{
+		{name: "opaque", arm: setOpSchemaProject([]chplan.Column{{Name: "private"}})},
+		{name: "open", arm: &chplan.Scan{Table: "samples", Roles: setOpTestRoles()}},
+		{name: "invalid", arm: setOpSchemaProject(invalid)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := chsql.Emit(context.Background(), schemaRoutedSetOp(tc.arm, valid))
+			if !errors.Is(err, chsql.ErrUnsupported) {
+				t.Fatalf("Emit = %v, want ErrUnsupported", err)
+			}
+		})
+	}
+}
+
+func TestEmitVectorSetOpRejectsOutputKindFlagMismatch(t *testing.T) {
+	t.Parallel()
+	floatArm := setOpSchemaProject(setOpTestRoles())
+	histogramColumns := append(setOpTestRoles(), chplan.HistogramPayloadColumns()...)
+	histogramArm := setOpSchemaProject(histogramColumns)
+	mixedColumns := append(slices.Clone(histogramColumns), chplan.Column{
+		Name: chplan.MixedDiscriminatorColumn,
+		Role: chplan.RoleDiscriminator,
+	})
+	mixedArm := setOpSchemaProject(mixedColumns)
+
+	for _, tc := range []struct {
+		name string
+		plan *chplan.VectorSetOp
+	}{
+		{name: "plain_or_histograms", plan: schemaRoutedSetOp(histogramArm, histogramArm)},
+		{name: "histogram_or_floats", plan: func() *chplan.VectorSetOp {
+			plan := schemaRoutedSetOp(floatArm, floatArm)
+			plan.Histogram = true
+			return plan
+		}()},
+		{name: "plain_and_forwarded_mixed", plan: func() *chplan.VectorSetOp {
+			plan := schemaRoutedSetOp(mixedArm, floatArm)
+			plan.Op = chplan.VectorSetAnd
+			return plan
+		}()},
+		{name: "mixed_or_floats", plan: func() *chplan.VectorSetOp {
+			plan := schemaRoutedSetOp(floatArm, floatArm)
+			plan.Mixed = true
+			return plan
+		}()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, _, err := chsql.Emit(context.Background(), tc.plan); !errors.Is(err, chsql.ErrUnsupported) {
+				t.Fatalf("Emit = %v, want ErrUnsupported", err)
+			}
+		})
+	}
+}
+
+func TestEmitNaryVectorSetOpPropagatesUntrustedArm(t *testing.T) {
+	t.Parallel()
+	n := naryOp(chplan.VectorSetOr, "a", "b")
+	n.Arms[1] = setOpSchemaProject([]chplan.Column{{Name: "private"}})
+	if _, _, err := chsql.Emit(context.Background(), n); !errors.Is(err, chsql.ErrUnsupported) {
+		t.Fatalf("Emit = %v, want ErrUnsupported", err)
+	}
+}
+
+func TestEmitNaryVectorSetOpRejectsArmKindFlagMismatch(t *testing.T) {
+	t.Parallel()
+	histogramColumns := append(setOpTestRoles(), chplan.HistogramPayloadColumns()...)
+	mixedColumns := append(slices.Clone(histogramColumns), chplan.Column{
+		Name: chplan.MixedDiscriminatorColumn,
+		Role: chplan.RoleDiscriminator,
+	})
+
+	for _, tc := range []struct {
+		name      string
+		arm       chplan.Node
+		histogram bool
+	}{
+		{name: "plain_with_histogram", arm: setOpSchemaProject(histogramColumns)},
+		{name: "plain_with_mixed", arm: setOpSchemaProject(mixedColumns)},
+		{name: "histogram_with_float", arm: setOpSchemaProject(setOpTestRoles()), histogram: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			n := naryOp(chplan.VectorSetOr, "a", "b")
+			n.Histogram = tc.histogram
+			n.Arms[1] = tc.arm
+			if _, _, err := chsql.Emit(context.Background(), n); !errors.Is(err, chsql.ErrUnsupported) {
+				t.Fatalf("Emit = %v, want ErrUnsupported", err)
+			}
+		})
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1332,7 +1332,7 @@ type Lang interface {
 	// chclient.Sample shape — (MetricName, Attributes, TimeUnix,
 	// Value). Each existing handler hand-rolls this; the adapter
 	// owns it after the port.
-	ProjectSamples(plan chplan.Node, meta Meta) chplan.Node
+	ProjectSamples(plan chplan.Node, meta Meta) (chplan.Node, error)
 }
 
 // Meta carries per-query semantic flags the engine needs but cannot
@@ -1566,7 +1566,10 @@ func (e *Engine) DryRunSQL(ctx context.Context, lang Lang, query string) (DryRun
 	}
 	dr := DryRun{Meta: meta}
 
-	plan = lang.ProjectSamples(plan, meta)
+	plan, err = lang.ProjectSamples(plan, meta)
+	if err != nil {
+		return dr, fmt.Errorf("engine: project samples: %w", err)
+	}
 	if !meta.IsTraceByID {
 		plan = e.Optimizer.Run(ctx, plan)
 	}
@@ -1621,7 +1624,10 @@ func (e *Engine) QueryPlan(ctx context.Context, lang Lang, plan chplan.Node, met
 	// Wrap-projection. The adapter owns the per-language switch
 	// (canonical vs. derived vs. structural-join shape); the engine
 	// applies it unconditionally.
-	plan = lang.ProjectSamples(plan, meta)
+	plan, err := lang.ProjectSamples(plan, meta)
+	if err != nil {
+		return Result{}, fmt.Errorf("engine: project samples: %w", err)
+	}
 
 	// Optimize — unless the adapter signalled a fetch-by-id where
 	// rewriting buys nothing. Each branch keeps the rest of the
@@ -2264,7 +2270,10 @@ func (e *Engine) QueryPlanCursor(ctx context.Context, lang Lang, plan chplan.Nod
 		return CursorResult{}, err
 	}
 
-	plan = lang.ProjectSamples(plan, meta)
+	plan, err := lang.ProjectSamples(plan, meta)
+	if err != nil {
+		return CursorResult{}, fmt.Errorf("engine: project samples: %w", err)
+	}
 	if !meta.IsTraceByID {
 		optT := telemetry.ObserveStage(telemetry.StageOptimize, lang.Name())
 		plan = e.Optimizer.Run(ctx, plan)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -20,7 +20,7 @@ import (
 type fakeLang struct {
 	name         string
 	parseFn      func(ctx context.Context, q string) (chplan.Node, engine.Meta, error)
-	projectFn    func(plan chplan.Node, meta engine.Meta) chplan.Node
+	projectFn    func(plan chplan.Node, meta engine.Meta) (chplan.Node, error)
 	parseCalls   int
 	projectCalls int
 }
@@ -35,12 +35,12 @@ func (f *fakeLang) Parse(ctx context.Context, query string) (chplan.Node, engine
 	return &chplan.Scan{Table: "otel_metrics_gauge"}, engine.Meta{IsMetric: true, ResponseShape: "prom-vector"}, nil
 }
 
-func (f *fakeLang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
+func (f *fakeLang) ProjectSamples(plan chplan.Node, meta engine.Meta) (chplan.Node, error) {
 	f.projectCalls++
 	if f.projectFn != nil {
 		return f.projectFn(plan, meta)
 	}
-	return plan
+	return plan, nil
 }
 
 // fakeQuerier captures the SQL the engine emitted and returns a fixed

--- a/internal/engine/project_samples_error_test.go
+++ b/internal/engine/project_samples_error_test.go
@@ -1,0 +1,59 @@
+package engine_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+)
+
+func TestEngineProjectSamplesErrorFailsBeforeEmitOrExecute(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("untrusted sample schema")
+	client := &fakeQuerier{}
+	lang := &fakeLang{
+		name: "promql",
+		projectFn: func(chplan.Node, engine.Meta) (chplan.Node, error) {
+			return nil, wantErr
+		},
+	}
+	eng := newEngine(client)
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "dry_run",
+			run: func() error {
+				_, err := eng.DryRunSQL(context.Background(), lang, "up")
+				return err
+			},
+		},
+		{
+			name: "query_plan",
+			run: func() error {
+				_, err := eng.QueryPlan(context.Background(), lang, &chplan.OneRow{}, engine.Meta{})
+				return err
+			},
+		},
+		{
+			name: "query_plan_cursor",
+			run: func() error {
+				_, err := eng.QueryPlanCursor(context.Background(), lang, &chplan.OneRow{}, engine.Meta{})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.run(); !errors.Is(err, wantErr) {
+				t.Fatalf("error = %v, want projection failure", err)
+			}
+		})
+	}
+	if client.calls != 0 {
+		t.Fatalf("client calls = %d, want 0", client.calls)
+	}
+}

--- a/internal/engine/routed_corpus_observe_test.go
+++ b/internal/engine/routed_corpus_observe_test.go
@@ -24,7 +24,9 @@ func (routedCorpusLang) Parse(context.Context, string) (chplan.Node, Meta, error
 	return memoWiringEligiblePlan(), Meta{IsMetric: true}, nil
 }
 
-func (routedCorpusLang) ProjectSamples(plan chplan.Node, _ Meta) chplan.Node { return plan }
+func (routedCorpusLang) ProjectSamples(plan chplan.Node, _ Meta) (chplan.Node, error) {
+	return plan, nil
+}
 
 // routedCorpusObserver records both corpus seams separately so a test can tell
 // a route-A observation from a route-B one — and catch a dispatch recorded on

--- a/internal/engine/ts_grid_scalar_subquery_test.go
+++ b/internal/engine/ts_grid_scalar_subquery_test.go
@@ -174,4 +174,6 @@ func (*tsGridStubLang) Parse(context.Context, string) (chplan.Node, Meta, error)
 	return nil, Meta{}, nil
 }
 
-func (*tsGridStubLang) ProjectSamples(plan chplan.Node, _ Meta) chplan.Node { return plan }
+func (*tsGridStubLang) ProjectSamples(plan chplan.Node, _ Meta) (chplan.Node, error) {
+	return plan, nil
+}

--- a/internal/logql/lang.go
+++ b/internal/logql/lang.go
@@ -192,7 +192,7 @@ const (
 // Body under [LogLineColumn], since a log line is a String and the
 // sample shape's fourth column is a float64 — a log stream has no
 // numeric value, so its projection carries no fourth column at all.
-func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
+func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) (chplan.Node, error) {
 	s := l.Schema
 	if meta.IsMetric {
 		// A multi-variant union (`variants(...) of (...)`) already shaped
@@ -204,7 +204,7 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 		// `ResourceAttributes` column the per-arm Project has already
 		// consumed into `Attributes`, so forward the union untouched.
 		if isVariantPlan(plan) {
-			return plan
+			return plan, nil
 		}
 		// Metric queries lower to RangeWindow / Aggregate / Filter(Aggregate),
 		// whose output is (group-keys…, <metric-value>). MetricName + TimeUnix
@@ -279,7 +279,7 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 				{Expr: tsExpr, Alias: sampleTimeUnixCol},
 				{Expr: &chplan.ColumnRef{Name: rangeAggSynthValueColumn}, Alias: sampleValueCol},
 			},
-		}
+		}, nil
 	}
 	// Log-stream query: the positional row the chclient cursor scans is
 	// (<String>, Attributes, TimeUnix[, Metadata]). A log line is a String,
@@ -378,7 +378,7 @@ func (l *Lang) ProjectSamples(plan chplan.Node, meta engine.Meta) chplan.Node {
 		Roles:       logSampleRoles(),
 		Input:       plan,
 		Projections: projections,
-	}
+	}, nil
 }
 
 // IsMetricQuery reports whether the parsed LogQL expression produces a

--- a/internal/logql/lang_test.go
+++ b/internal/logql/lang_test.go
@@ -58,7 +58,7 @@ func TestProjectSamples_MetricBranchRefsValueColumn(t *testing.T) {
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.ResourceAttributesColumn}},
 	}
 
-	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+	wrapped := mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true})
 
 	proj, ok := wrapped.(*chplan.Project)
 	if !ok {
@@ -152,7 +152,7 @@ func TestProjectSamples_VectorAggregateRefsAttributes(t *testing.T) {
 		},
 	}
 
-	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+	wrapped := mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true})
 
 	proj, ok := wrapped.(*chplan.Project)
 	if !ok {
@@ -218,7 +218,7 @@ func TestProjectSamples_MatrixRangeWindowRefsAnchorTs(t *testing.T) {
 		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.ResourceAttributesColumn}},
 	}
 
-	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+	wrapped := mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true})
 
 	proj, ok := wrapped.(*chplan.Project)
 	if !ok {
@@ -281,7 +281,7 @@ func TestProjectSamples_VectorAggregateOverMatrixForwardsTimeUnix(t *testing.T) 
 		},
 	}
 
-	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+	wrapped := mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true})
 
 	proj, ok := wrapped.(*chplan.Project)
 	if !ok {
@@ -346,7 +346,7 @@ func TestProjectSamples_VectorVectorBinopRefsAttributes(t *testing.T) {
 		ValueColumn:      "Value",
 	}
 
-	wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+	wrapped := mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true})
 
 	proj, ok := wrapped.(*chplan.Project)
 	if !ok {
@@ -406,7 +406,7 @@ func TestProjectSamples_LogQuerySurfacesDetectedLevelWhenReferenced(t *testing.T
 	// Log-stream queries lower to a Scan (or Filter(Scan)) — no inner
 	// Project layer. ProjectSamples wraps with the wire-shape projection.
 	plan := &chplan.Scan{Table: s.LogsTable}
-	wrapped := l.ProjectSamples(plan, engine.Meta{
+	wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 		IsMetric: false,
 		Extra:    map[string]any{"expr": expr},
 	})
@@ -514,7 +514,7 @@ func TestProjectSamples_BareLogQueryAlsoSurfacesDetectedLevel(t *testing.T) {
 	}
 
 	plan := &chplan.Scan{Table: s.LogsTable}
-	wrapped := l.ProjectSamples(plan, engine.Meta{
+	wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 		IsMetric: false,
 		Extra:    map[string]any{"expr": expr},
 	})
@@ -592,7 +592,7 @@ func TestProjectSamples_ParserStageQuerySurfacesDetectedLevel(t *testing.T) {
 				t.Fatalf("ParseExpr: %v", err)
 			}
 			plan := &chplan.Scan{Table: s.LogsTable}
-			wrapped := l.ProjectSamples(plan, engine.Meta{
+			wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 				IsMetric: false,
 				Extra:    map[string]any{"expr": expr},
 			})
@@ -652,7 +652,7 @@ func TestProjectSamples_LineFilterQuerySurfacesDetectedLevel(t *testing.T) {
 				t.Fatalf("ParseExpr: %v", err)
 			}
 			plan := &chplan.Scan{Table: s.LogsTable}
-			wrapped := l.ProjectSamples(plan, engine.Meta{
+			wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 				IsMetric: false,
 				Extra:    map[string]any{"expr": expr},
 			})
@@ -719,7 +719,7 @@ func TestProjectSamples_ParserStageSurfacesExtractedLabels(t *testing.T) {
 				t.Fatalf("ParseExpr: %v", err)
 			}
 			plan := &chplan.Scan{Table: s.LogsTable}
-			wrapped := l.ProjectSamples(plan, engine.Meta{
+			wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 				IsMetric: false,
 				Extra:    map[string]any{"expr": expr},
 			})
@@ -783,7 +783,7 @@ func TestProjectSamples_NoParserStage_KeepsBareResourceAttributes(t *testing.T) 
 				t.Fatalf("ParseExpr: %v", err)
 			}
 			plan := &chplan.Scan{Table: s.LogsTable}
-			wrapped := l.ProjectSamples(plan, engine.Meta{
+			wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 				IsMetric: false,
 				Extra:    map[string]any{"expr": expr},
 			})
@@ -844,7 +844,7 @@ func TestProjectSamples_LogQueryWithDetectedLevelFilterTriggersWrap(t *testing.T
 				t.Fatalf("ParseExpr: %v", err)
 			}
 			plan := &chplan.Scan{Table: s.LogsTable}
-			wrapped := l.ProjectSamples(plan, engine.Meta{
+			wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 				IsMetric: false,
 				Extra:    map[string]any{"expr": expr},
 			})
@@ -901,7 +901,7 @@ func TestProjectSamples_DropDetectedLevelSkipsWrap(t *testing.T) {
 				t.Fatalf("ParseExpr: %v", err)
 			}
 			plan := &chplan.Scan{Table: s.LogsTable}
-			wrapped := l.ProjectSamples(plan, engine.Meta{
+			wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 				IsMetric: false,
 				Extra:    map[string]any{"expr": expr},
 			})
@@ -958,7 +958,7 @@ func TestProjectSamples_DropDetectedLevelStillSurfacesWhenNotUnconditional(t *te
 				t.Fatalf("ParseExpr: %v", err)
 			}
 			plan := &chplan.Scan{Table: s.LogsTable}
-			wrapped := l.ProjectSamples(plan, engine.Meta{
+			wrapped := mustProjectSamples(t, l, plan, engine.Meta{
 				IsMetric: false,
 				Extra:    map[string]any{"expr": expr},
 			})

--- a/internal/logql/log_row_shape_test.go
+++ b/internal/logql/log_row_shape_test.go
@@ -33,7 +33,7 @@ func logStreamProjection(t *testing.T, q string, s schema.Logs) *chplan.Project 
 		t.Fatalf("ParseExpr(%q): %v", q, err)
 	}
 	l := &logql.Lang{Schema: s}
-	wrapped := l.ProjectSamples(&chplan.Scan{Table: s.LogsTable}, engine.Meta{
+	wrapped := mustProjectSamples(t, l, &chplan.Scan{Table: s.LogsTable}, engine.Meta{
 		IsMetric: false,
 		Extra:    map[string]any{"expr": expr},
 	})

--- a/internal/logql/lower_test.go
+++ b/internal/logql/lower_test.go
@@ -98,7 +98,8 @@ func TestLower(t *testing.T) {
 		})
 		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 		spec.AssertRowTypeMatchesDriver(t, optimized, roundTripResult)
-		spec.AssertRowShapeAgreement(t, plan)
+		spec.AssertPlanScanRoles(t, plan)
+		spec.AssertPlanScanRoles(t, optimized)
 
 		// A fixture carrying a `parity:` section is additionally answered
 		// by the REAL upstream Loki engine over the same seeded data, and

--- a/internal/logql/parser_merge_materialise_mutation_test.go
+++ b/internal/logql/parser_merge_materialise_mutation_test.go
@@ -173,7 +173,10 @@ func TestProjectSamples_UnpackReplacesTheLineWithTheUnpackedEntry(t *testing.T) 
 		t.Fatalf("Parse: %v", err)
 	}
 
-	projected := l.ProjectSamples(plan, meta)
+	projected, err := l.ProjectSamples(plan, meta)
+	if err != nil {
+		t.Fatalf("ProjectSamples: %v", err)
+	}
 	p, ok := projected.(*chplan.Project)
 	if !ok {
 		t.Fatalf("ProjectSamples returned %T, want *chplan.Project", projected)

--- a/internal/logql/project_samples_checked_test.go
+++ b/internal/logql/project_samples_checked_test.go
@@ -1,0 +1,18 @@
+package logql_test
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/engine"
+	"github.com/tsouza/cerberus/internal/logql"
+)
+
+func mustProjectSamples(t testing.TB, lang *logql.Lang, plan chplan.Node, meta engine.Meta) chplan.Node {
+	t.Helper()
+	projected, err := lang.ProjectSamples(plan, meta)
+	if err != nil {
+		t.Fatalf("ProjectSamples: %v", err)
+	}
+	return projected
+}

--- a/internal/logql/projection_labels_fallback_test.go
+++ b/internal/logql/projection_labels_fallback_test.go
@@ -40,7 +40,7 @@ func TestProjectSamples_LabelsWalkRejectionFallsBackToTheBareAttributes(t *testi
 		if err != nil {
 			t.Fatalf("Parse(%q): %v", q, err)
 		}
-		sqlStr, _, err := chsql.Emit(context.Background(), l.ProjectSamples(plan, meta))
+		sqlStr, _, err := chsql.Emit(context.Background(), mustProjectSamples(t, l, plan, meta))
 		if err != nil {
 			t.Fatalf("chsql.Emit(%q): %v", q, err)
 		}

--- a/internal/logql/variants_test.go
+++ b/internal/logql/variants_test.go
@@ -278,7 +278,7 @@ func TestProjectSamplesForwardsVariantPlan(t *testing.T) {
 				t.Fatalf("lower: %v", err)
 			}
 
-			wrapped := l.ProjectSamples(plan, engine.Meta{IsMetric: true})
+			wrapped := mustProjectSamples(t, l, plan, engine.Meta{IsMetric: true})
 			if wrapped != plan {
 				t.Fatalf("ProjectSamples wrapped the variant plan (%T); want it forwarded unchanged", wrapped)
 			}

--- a/internal/optimizer/field_preservation_test.go
+++ b/internal/optimizer/field_preservation_test.go
@@ -2,32 +2,26 @@ package optimizer_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/optimizer"
 )
 
 // TestConstantFold_PreservesAggFuncCombinators pins that folding an
-// aggregate's argument does not rewrite the aggregate itself.
+// aggregate's argument does not rewrite the aggregate function itself.
 //
-// The fold rebuilt every AggFunc of an Aggregate from a composite literal
-// whenever ANY expression in that Aggregate folded, and the literal did not
-// carry Combinators. `argMinIf(a, b, cond)` came out as `argMin(a, b,
-// cond)` — a three-argument argMin ClickHouse rejects outright — and
-// `groupArrayIf` as `groupArray`, which silently collects the rows the
-// condition was there to exclude.
+// The fold once rebuilt an Aggregate's AggFunc from a composite literal
+// whenever any expression folded, but failed to carry Combinators.
+// `argMinIf(a, b, cond)` became invalid three-argument `argMin(a, b, cond)`,
+// while `groupArrayIf` became `groupArray` and silently retained excluded rows.
 func TestConstantFold_PreservesAggFuncCombinators(t *testing.T) {
 	t.Parallel()
 
-	// A foldable argument: the constant-fold rules collapse a literal
-	// arithmetic Binary, which is what triggers the AggFunc rebuild.
 	foldable := &chplan.Binary{
 		Op:    chplan.OpAdd,
 		Left:  &chplan.LitInt{V: 2},
 		Right: &chplan.LitInt{V: 3},
 	}
-
 	plan := &chplan.Aggregate{
 		Input: &chplan.Scan{Table: "otel_traces"},
 		AggFuncs: []chplan.AggFunc{{
@@ -40,131 +34,16 @@ func TestConstantFold_PreservesAggFuncCombinators(t *testing.T) {
 
 	got, changed := optimizer.ConstantFoldSemantic{}.Apply(plan)
 	if !changed {
-		t.Fatal("ConstantFoldSemantic did not fire; the AggFunc rebuild this test guards never ran")
+		t.Fatal("ConstantFoldSemantic did not fire; AggFunc rebuild test guards never ran")
 	}
-
 	agg, ok := got.(*chplan.Aggregate)
 	if !ok {
 		t.Fatalf("optimized plan = %T, want *chplan.Aggregate", got)
 	}
 	if len(agg.AggFuncs) != 1 {
-		t.Fatalf("AggFuncs = %d, want 1", len(agg.AggFuncs))
+		t.Fatalf("AggFuncs length = %d, want 1", len(agg.AggFuncs))
 	}
-	if len(agg.AggFuncs[0].Combinators) != 1 {
-		t.Fatalf(
-			"AggFuncs[0].Combinators = %v, want the If combinator to survive the fold: "+
-				"argMinIf silently became argMin",
-			agg.AggFuncs[0].Combinators,
-		)
+	if len(agg.AggFuncs[0].Combinators) != 1 || agg.AggFuncs[0].Combinators[0] != chplan.CombIf {
+		t.Fatalf("AggFuncs[0].Combinators = %v, want [CombIf]", agg.AggFuncs[0].Combinators)
 	}
-}
-
-// TestFilterRewrites_PreserveHistogramRowShape pins that the three rules
-// that rebuild a chplan.Filter carry its Histogram / Mixed flags.
-//
-// chplan/filter.go makes those flags part of the node's contract: RowShapeOf
-// must report a histogram row shape for such a Filter or a wire consumer
-// silently drops the nine histogram columns. All three rules rebuilt the
-// node from a composite literal that did not carry them, contradicting the
-// `newAgg := *a` / `newRW := *r` discipline two lines below in the same
-// functions.
-func TestFilterRewrites_PreserveHistogramRowShape(t *testing.T) {
-	t.Parallel()
-
-	pred := func(name string) chplan.Expr {
-		return &chplan.Binary{
-			Op:    chplan.OpEq,
-			Left:  &chplan.ColumnRef{Name: name},
-			Right: &chplan.LitString{V: "x"},
-		}
-	}
-
-	t.Run("fusion_keeps_the_outer_filters_shape", func(t *testing.T) {
-		t.Parallel()
-
-		plan := &chplan.Filter{
-			Predicate: pred("outer"),
-			Histogram: true,
-			Mixed:     true,
-			Input: &chplan.Filter{
-				Predicate: pred("inner"),
-				Input:     &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
-			},
-		}
-
-		got, ok := optimizer.FilterFusion{}.Apply(plan)
-		if !ok {
-			t.Fatal("FilterFusion did not fire on nested Filters")
-		}
-		f, ok := got.(*chplan.Filter)
-		if !ok {
-			t.Fatalf("fused node = %T, want *chplan.Filter", got)
-		}
-		if !f.Histogram || !f.Mixed {
-			t.Errorf(
-				"fused Filter Histogram=%v Mixed=%v, want both true — the outer Filter's row shape "+
-					"is what the parent sees and it was dropped",
-				f.Histogram, f.Mixed,
-			)
-		}
-	})
-
-	t.Run("transposes_carry_the_shape_down", func(t *testing.T) {
-		t.Parallel()
-
-		for name, plan := range map[string]chplan.Node{
-			"filter_over_aggregate": &chplan.Filter{
-				Predicate: pred("Attributes"),
-				Histogram: true,
-				Mixed:     true,
-				Input: &chplan.Aggregate{
-					Input:   &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
-					GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
-				},
-			},
-			"filter_over_range_window": &chplan.Filter{
-				Predicate: pred("Attributes"),
-				Histogram: true,
-				Mixed:     true,
-				Input: &chplan.RangeWindow{
-					Input: &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
-					Range: 5 * time.Minute,
-					// The transpose only fires when the predicate reads
-					// nothing but the window's series-identifying GroupBy
-					// columns, so the fixture has to supply them.
-					GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "Attributes"}},
-				},
-			},
-		} {
-			t.Run(name, func(t *testing.T) {
-				t.Parallel()
-
-				var got chplan.Node
-				switch plan.(*chplan.Filter).Input.(type) {
-				case *chplan.Aggregate:
-					got, _ = optimizer.FilterAggregateTranspose().Apply(plan)
-				default:
-					got, _ = optimizer.FilterRangeWindowTranspose().Apply(plan)
-				}
-
-				var seen *chplan.Filter
-				chplan.Walk(got, func(n chplan.Node) bool {
-					if f, ok := n.(*chplan.Filter); ok && seen == nil {
-						seen = f
-					}
-					return true
-				})
-				if seen == nil {
-					t.Fatal("the transpose did not fire, so this case proves nothing: fix the fixture")
-				}
-				if !seen.Histogram || !seen.Mixed {
-					t.Errorf(
-						"transposed Filter Histogram=%v Mixed=%v, want both true — the flags did not "+
-							"ride down with the predicate",
-						seen.Histogram, seen.Mixed,
-					)
-				}
-			})
-		}
-	})
 }

--- a/internal/optimizer/filter_aggregate_transpose.go
+++ b/internal/optimizer/filter_aggregate_transpose.go
@@ -87,9 +87,8 @@ func transposeFilterAggregate(b Bindings) chplan.Node {
 		return nil
 	}
 
-	// Copy-on-write from f so Histogram / Mixed ride down with the
-	// predicate, matching the newAgg := *a / newRW := *r discipline just
-	// below and chplan/clone.go's rule.
+	// Copy-on-write from f so future fields ride down with the predicate,
+	// matching the newAgg := *a discipline below and chplan.CloneNode's rule.
 	newFilter := *f
 	newFilter.Input = a.Input
 	newAgg := *a

--- a/internal/optimizer/filter_fusion.go
+++ b/internal/optimizer/filter_fusion.go
@@ -18,13 +18,8 @@ func (FilterFusion) Apply(n chplan.Node) (chplan.Node, bool) {
 	if !ok {
 		return n, false
 	}
-	// Copy-on-write from the OUTER filter: its Histogram / Mixed flags are
-	// the row shape the parent already sees, and a composite literal would
-	// drop them (chplan/filter.go makes them part of the node's contract —
-	// a consumer reading HistogramRowShape off the fused node would
-	// otherwise silently lose the nine histogram columns). Same rule as
-	// chplan/clone.go states, and as the two transposes follow for the
-	// nodes they rebuild.
+	// Copy-on-write from the outer filter so future fields are preserved while
+	// only the input and predicate change, matching chplan.CloneNode's rule.
 	fused := *outer
 	fused.Input = inner.Input
 	fused.Predicate = &chplan.Binary{Op: chplan.OpAnd, Left: inner.Predicate, Right: outer.Predicate}

--- a/internal/optimizer/filter_range_window_transpose.go
+++ b/internal/optimizer/filter_range_window_transpose.go
@@ -111,9 +111,8 @@ func transposeFilterRangeWindow(b Bindings) chplan.Node {
 		return nil
 	}
 
-	// Copy-on-write from f so Histogram / Mixed ride down with the
-	// predicate, matching the newAgg := *a / newRW := *r discipline just
-	// below and chplan/clone.go's rule.
+	// Copy-on-write from f so future fields ride down with the predicate,
+	// matching the newRW := *r discipline below and chplan.CloneNode's rule.
 	newFilter := *f
 	newFilter.Input = r.Input
 	newRW := *r

--- a/internal/optimizer/flatten_vector_set_op.go
+++ b/internal/optimizer/flatten_vector_set_op.go
@@ -58,8 +58,8 @@ func (FlattenVectorSetOp) Apply(n chplan.Node) (chplan.Node, bool) {
 	// fields chplan.NaryVectorSetOp has no room for (it only threads
 	// Histogram, the symmetric both-arms case, through). Rebuilding one
 	// as an N-ary node would silently drop MixedHistogramOnLeft, which
-	// downgrades chplan.RowShapeOf's answer from MixedRowShape to the
-	// default SampleRowShape — exactly the silent-placeholder-Value
+	// downgrades the published mixed payload to the float-only contract —
+	// exactly the silent-placeholder-Value
 	// hazard [assertValueShapedInput] exists to catch, except
 	// [wrapWithSampleProjection] has no guard of its own and would
 	// happily wrap the flattened node's Value column, discarding every
@@ -92,8 +92,12 @@ func (FlattenVectorSetOp) Apply(n chplan.Node) (chplan.Node, bool) {
 	// 47 "Unknown expression identifier". Bail and leave the (already
 	// correct) nested binary VectorSetOp shape in place whenever any arm
 	// disagrees with the flag chosen for the whole chain.
+	expectedKind := chplan.SampleKindFloat
+	if binary.Histogram {
+		expectedKind = chplan.SampleKindHistogram
+	}
 	for _, arm := range arms {
-		if (chplan.RowShapeOf(arm) == chplan.HistogramRowShape) != binary.Histogram {
+		if chplan.LiveSampleKind(arm) != expectedKind {
 			return n, false
 		}
 	}

--- a/internal/optimizer/flatten_vector_set_op_test.go
+++ b/internal/optimizer/flatten_vector_set_op_test.go
@@ -21,7 +21,19 @@ func setOpCols(metric, attrs, ts, val string) func(op chplan.VectorSetOpKind, l,
 	}
 }
 
-func tableScan(name string) *chplan.Scan { return &chplan.Scan{Table: name} }
+func tableScan(name string) *chplan.Scan {
+	columns := []chplan.Column{
+		{Name: "MetricName", Role: chplan.RoleMetricName},
+		{Name: "Attributes", Role: chplan.RoleAttributes},
+		{Name: "TimeUnix", Role: chplan.RoleTimestamp},
+		{Name: "Value", Role: chplan.RoleValue},
+	}
+	names := make([]string, len(columns))
+	for i, column := range columns {
+		names[i] = column.Name
+	}
+	return &chplan.Scan{Table: name, Columns: names, Roles: columns}
+}
 
 // TestFlattenVectorSetOp_OrChainOfFour linearises
 // `((a or b) or c) or d` into one NaryVectorSetOp with four arms in
@@ -73,6 +85,24 @@ func TestFlattenVectorSetOp_AndChain(t *testing.T) {
 	}
 	if nary.Op != chplan.VectorSetAnd || len(nary.Arms) != 3 {
 		t.Fatalf("got op=%q arms=%d, want and/3", nary.Op, len(nary.Arms))
+	}
+}
+
+func TestFlattenVectorSetOp_HistogramChainUsesPhysicalSchemas(t *testing.T) {
+	t.Parallel()
+	mk := setOpCols("MetricName", "Attributes", "TimeUnix", "Value")
+	left := mk(chplan.VectorSetOr, histogramSetOpArm("a"), histogramSetOpArm("b"))
+	left.Histogram = true
+	input := mk(chplan.VectorSetOr, left, histogramSetOpArm("c"))
+	input.Histogram = true
+
+	out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), input)
+	nary, ok := out.(*chplan.NaryVectorSetOp)
+	if !ok {
+		t.Fatalf("histogram chain = %T, want *chplan.NaryVectorSetOp", out)
+	}
+	if !nary.Histogram || len(nary.Arms) != 3 {
+		t.Fatalf("histogram chain = Histogram:%v Arms:%d, want true/3", nary.Histogram, len(nary.Arms))
 	}
 }
 
@@ -276,5 +306,63 @@ func TestFlattenVectorSetOp_MixedValueTypeSkipsFlattening(t *testing.T) {
 	if chplan.RowShapeOf(out) != chplan.MixedRowShape {
 		t.Errorf("RowShapeOf(out) = %s, want %s — flattening must not downgrade the shape",
 			chplan.RowShapeOf(out), chplan.MixedRowShape)
+	}
+}
+
+func TestFlattenVectorSetOp_UntrustedArmSchemaSkipsFlattening(t *testing.T) {
+	t.Parallel()
+	mk := setOpCols("MetricName", "Attributes", "TimeUnix", "Value")
+	valid := tableScan("valid")
+	invalidRoles := []chplan.Column{
+		{Name: "Attributes", Role: chplan.RoleAttributes},
+		{Name: "Value", Role: chplan.RoleValue},
+		{Name: "other_value", Role: chplan.RoleValue},
+	}
+
+	for _, tc := range []struct {
+		name string
+		arm  chplan.Node
+	}{
+		{name: "opaque", arm: &chplan.Scan{Table: "opaque", Columns: []string{"private"}}},
+		{name: "open", arm: &chplan.Scan{Table: "open", Roles: setOpTestColumns()}},
+		{name: "invalid", arm: &chplan.Scan{
+			Table:   "invalid",
+			Columns: []string{"Attributes", "Value", "other_value"},
+			Roles:   invalidRoles,
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			input := mk(chplan.VectorSetOr, tc.arm, valid)
+			out := optimizer.New(optimizer.FlattenVectorSetOp{}).Run(context.Background(), input)
+			if _, flattened := out.(*chplan.NaryVectorSetOp); flattened {
+				t.Fatalf("%s arm was flattened despite an untrusted physical schema", tc.name)
+			}
+		})
+	}
+}
+
+func setOpTestColumns() []chplan.Column {
+	return []chplan.Column{
+		{Name: "MetricName", Role: chplan.RoleMetricName},
+		{Name: "Attributes", Role: chplan.RoleAttributes},
+		{Name: "TimeUnix", Role: chplan.RoleTimestamp},
+		{Name: "Value", Role: chplan.RoleValue},
+	}
+}
+
+func histogramSetOpArm(name string) chplan.Node {
+	columns := append(setOpTestColumns(), chplan.HistogramPayloadColumns()...)
+	projections := make([]chplan.Projection, len(columns))
+	for i, column := range columns {
+		projections[i] = chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: column.Name},
+			Alias: column.Name,
+		}
+	}
+	return &chplan.Project{
+		Input:       &chplan.Scan{Table: name},
+		Projections: projections,
+		Roles:       columns,
 	}
 }

--- a/internal/optimizer/property_stage_gen_test.go
+++ b/internal/optimizer/property_stage_gen_test.go
@@ -236,6 +236,7 @@ func setOpArm(rng *rand.Rand) chplan.Node {
 			{Expr: &chplan.ColumnRef{Name: "TimeUnix"}, Alias: "TimeUnix"},
 			{Expr: &chplan.ColumnRef{Name: "Value"}, Alias: "Value"},
 		},
+		Roles: setOpTestColumns(),
 	}
 }
 

--- a/internal/optimizer/rule_interaction_test.go
+++ b/internal/optimizer/rule_interaction_test.go
@@ -334,8 +334,33 @@ func setOp(op chplan.VectorSetOpKind, l, r chplan.Node) *chplan.VectorSetOp {
 // the flatten's arm-freezing order is what is under test.
 func orChain(arm chplan.Node) chplan.Node {
 	return setOp(chplan.VectorSetOr,
-		setOp(chplan.VectorSetOr, arm, &chplan.Scan{Table: "b"}),
-		&chplan.Scan{Table: "c"})
+		setOp(chplan.VectorSetOr, arm, tableScan("b")),
+		tableScan("c"))
+}
+
+// aggregateSetOpArm is a closed canonical Sample arm that still exposes a
+// Filter(Aggregate) pair for FilterAggregateTranspose. The aggregate keeps all
+// three identity columns and writes its reducer into the declared Value role,
+// so FlattenVectorSetOp validates the same physical contract its emitter uses.
+func aggregateSetOpArm() chplan.Node {
+	return &chplan.Filter{
+		Input: &chplan.Aggregate{
+			Input: tableScan("a"),
+			GroupBy: []chplan.Expr{
+				&chplan.ColumnRef{Name: "MetricName"},
+				&chplan.ColumnRef{Name: "Attributes"},
+				&chplan.ColumnRef{Name: "TimeUnix"},
+			},
+			GroupByAliases: []string{"MetricName", "Attributes", "TimeUnix"},
+			AggFuncs: []chplan.AggFunc{{
+				Fn:    chplan.FnSum,
+				Args:  []chplan.Expr{&chplan.ColumnRef{Name: "Value"}},
+				Alias: "Value",
+			}},
+			Roles: setOpTestColumns(),
+		},
+		Predicate: labelFilter("MetricName", "up"),
+	}
 }
 
 // pairPlans maps a pairKey to a builder for the plan shape that makes BOTH
@@ -444,7 +469,7 @@ var pairPlans = map[string]func() chplan.Node{
 	// ConstantFoldSemantic × FlattenVectorSetOp.
 	pairKey(ruleFoldSemantic, ruleFlattenSetOp): func() chplan.Node {
 		return orChain(&chplan.Filter{
-			Input: &chplan.Scan{Table: "a"},
+			Input: tableScan("a"),
 			Predicate: &chplan.Binary{
 				Op:    chplan.OpAnd,
 				Left:  trueEq(1),
@@ -531,7 +556,7 @@ var pairPlans = map[string]func() chplan.Node{
 	// ConstantFoldHeuristic × FlattenVectorSetOp.
 	pairKey(ruleFoldHeuristic, ruleFlattenSetOp): func() chplan.Node {
 		return orChain(&chplan.Filter{
-			Input: &chplan.Scan{Table: "a"},
+			Input: tableScan("a"),
 			Predicate: &chplan.Binary{
 				Op:    chplan.OpAnd,
 				Left:  &chplan.LitBool{V: true},
@@ -598,7 +623,7 @@ var pairPlans = map[string]func() chplan.Node{
 	pairKey(ruleFilterFusion, ruleFlattenSetOp): func() chplan.Node {
 		return orChain(&chplan.Filter{
 			Input: &chplan.Filter{
-				Input:     &chplan.Scan{Table: "a"},
+				Input:     tableScan("a"),
 				Predicate: labelFilter("MetricName", "up"),
 			},
 			Predicate: labelFilter("job", "api"),
@@ -639,10 +664,7 @@ var pairPlans = map[string]func() chplan.Node{
 
 	// FilterAggregateTranspose × FlattenVectorSetOp.
 	pairKey(ruleAggTranspose, ruleFlattenSetOp): func() chplan.Node {
-		return orChain(&chplan.Filter{
-			Input:     sumAgg(&chplan.Scan{Table: "a"}, "job"),
-			Predicate: labelFilter("job", "api"),
-		})
+		return orChain(aggregateSetOpArm())
 	},
 
 	// FilterRangeWindowTranspose × ProjectionPushdown.
@@ -676,7 +698,7 @@ var pairPlans = map[string]func() chplan.Node{
 	// FilterRangeWindowTranspose × FlattenVectorSetOp.
 	pairKey(ruleRWTranspose, ruleFlattenSetOp): func() chplan.Node {
 		return orChain(&chplan.Filter{
-			Input:     rateWindow(&chplan.Scan{Table: "a"}),
+			Input:     rateWindow(tableScan("a")),
 			Predicate: labelFilter("Attributes", "v1"),
 		})
 	},
@@ -692,7 +714,7 @@ var pairPlans = map[string]func() chplan.Node{
 	// ProjectionPushdown × FlattenVectorSetOp.
 	pairKey(ruleProjPushdown, ruleFlattenSetOp): func() chplan.Node {
 		return orChain(&chplan.Project{
-			Input: &chplan.Scan{Table: "a"},
+			Input: &chplan.Scan{Table: "a", Roles: setOpTestColumns()},
 			Projections: []chplan.Projection{
 				{Expr: &chplan.ColumnRef{Name: "MetricName"}},
 				{Expr: &chplan.ColumnRef{Name: "Value"}},
@@ -707,6 +729,6 @@ var pairPlans = map[string]func() chplan.Node{
 	// an arm frozen BEFORE it was stamped, and then never revisited, would
 	// diverge here.
 	pairKey(ruleNormalizeBound, ruleFlattenSetOp): func() chplan.Node {
-		return orChain(rateWindow(&chplan.Scan{Table: "a"}))
+		return orChain(rateWindow(tableScan("a")))
 	},
 }

--- a/internal/promql/binary.go
+++ b/internal/promql/binary.go
@@ -524,8 +524,8 @@ func rewriteAnchorToTimeUnix(expr chplan.Expr, s schema.Metrics) chplan.Expr {
 //
 // The resulting VectorSetOp.Histogram / Mixed flags — which shape the
 // emitter's per-arm canonicalisation and the OUTER SELECT's column list
-// both use — are decided from the ACTUAL lowered shape of each side
-// ([chplan.RowShapeOf]), not from a pre-lowering AST guess: `and` /
+// both use — are decided from the ACTUAL physical sample contract of each
+// side ([chplan.LiveSampleKind]), not from a pre-lowering AST guess: `and` /
 // `unless` forward exactly one side's rows verbatim (the other side's
 // own value type never reaches the wire, only its label signature does),
 // so the output is that FORWARDED (left) side's shape regardless of what
@@ -534,7 +534,7 @@ func rewriteAnchorToTimeUnix(expr chplan.Expr, s schema.Metrics) chplan.Expr {
 // unchanged exactly like a Histogram-shaped one already did. `or` unions
 // both sides' rows, which cerberus cannot represent when the two sides
 // disagree between the two PURE shapes (Histogram vs Sample) — the
-// whole-query row-shape decision ([chplan.RowShapeOf] feeding
+// whole-query sample-contract decision (the physical schema feeding
 // internal/api/prom/handler.go's wrapWithSampleProjection) and the
 // emitter's positional UNION ALL both assume one shape for the entire
 // result — so that mismatch is rejected explicitly rather than emitted
@@ -544,7 +544,7 @@ func rewriteAnchorToTimeUnix(expr chplan.Expr, s schema.Metrics) chplan.Expr {
 // Histogram-shaped, Sample-shaped, or another Mixed-shaped other arm the
 // same way [lowerMixedExpHistogramSetOp] already unions a pure Histogram
 // arm with a pure Sample one — internal/chsql's mixedVectorSetOpArmFrag
-// classifies each arm by its own [chplan.RowShapeOf] and forwards an
+// classifies each arm by its own [chplan.LiveSampleKind] and forwards an
 // already-Mixed arm's real per-row discriminator unchanged instead of
 // resynthesising one it doesn't need. cerberus issue #2571 widened
 // [mixedExpHistogramSetOp] itself (the recognizer this function's own
@@ -573,10 +573,16 @@ func lowerVectorSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chp
 		return nil, err
 	}
 
-	leftShape := chplan.RowShapeOf(left)
-	rightShape := chplan.RowShapeOf(right)
-	leftHistogram := leftShape == chplan.HistogramRowShape
-	rightHistogram := rightShape == chplan.HistogramRowShape
+	leftKind := chplan.LiveSampleKind(left)
+	rightKind := chplan.LiveSampleKind(right)
+	if err := requireVectorSetOpSampleKind("left", leftKind); err != nil {
+		return nil, err
+	}
+	if err := requireVectorSetOpSampleKind("right", rightKind); err != nil {
+		return nil, err
+	}
+	leftHistogram := leftKind == chplan.SampleKindHistogram
+	rightHistogram := rightKind == chplan.SampleKindHistogram
 	// cerberus issue #2555: either operand may itself already be a Mixed
 	// VectorSetOp, resolved as a NESTED operand of THIS set op via
 	// [lowerVectorSetOpOperand] rather than only at the query root. A
@@ -585,8 +591,8 @@ func lowerVectorSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chp
 	// its own third shape, distinct from a pure HistogramRowShape operand
 	// — `leftHistogram`/`rightHistogram` are both false for a Mixed
 	// operand, exactly as they would be for a plain float one.
-	leftMixed := leftShape == chplan.MixedRowShape
-	rightMixed := rightShape == chplan.MixedRowShape
+	leftMixed := leftKind == chplan.SampleKindMixed
+	rightMixed := rightKind == chplan.SampleKindMixed
 
 	match := chplan.VectorMatch{}
 	if b.VectorMatching != nil {
@@ -602,7 +608,7 @@ func lowerVectorSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chp
 			// a Mixed arm composes with any of the other two shapes (see
 			// this function's own doc comment above). Left/Right stay in
 			// source order; internal/chsql's emitter classifies each arm
-			// independently by its own chplan.RowShapeOf, so no
+			// independently by its own chplan.LiveSampleKind, so no
 			// "which side is which" flag is needed the way the
 			// construct-from-two-pure-shapes case
 			// ([lowerMixedExpHistogramSetOp]) needs MixedHistogramOnLeft.
@@ -624,7 +630,7 @@ func lowerVectorSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chp
 			// shapes — cerberus has no wire representation for a query
 			// result that is per-row float or histogram outside the
 			// Mixed contract, only one shape for the whole query (see
-			// chplan.RowShapeOf / VectorSetOp.Histogram).
+			// physical sample schema / VectorSetOp.Histogram).
 			//
 			// This is reached only when NEITHER side's operand was
 			// recognised, before lowering, as histogram-valued by
@@ -637,7 +643,7 @@ func lowerVectorSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chp
 			// histogram-valued shape arbitrarily many levels deep
 			// ([isExpHistogramForwardedThroughSetOp],
 			// histogram_native_set_op.go), closing the gap where this
-			// function's own [chplan.RowShapeOf]-based leftHistogram /
+			// function's own [chplan.LiveSampleKind]-based leftHistogram /
 			// rightHistogram computation could already see the
 			// mismatch — because the operand actually WAS lowered
 			// successfully to Histogram-shaped by
@@ -681,6 +687,15 @@ func lowerVectorSetOp(b *parser.BinaryExpr, s schema.Metrics, ctx lowerCtx) (chp
 		TimestampColumn:  s.TimestampColumn,
 		ValueColumn:      s.ValueColumn,
 	}, nil
+}
+
+func requireVectorSetOpSampleKind(side string, kind chplan.SampleKind) error {
+	switch kind {
+	case chplan.SampleKindFloat, chplan.SampleKindHistogram, chplan.SampleKindMixed:
+		return nil
+	default:
+		return fmt.Errorf("promql: vector set op %s operand has %s sample schema", side, kind)
+	}
 }
 
 // promVectorSetOpKind maps a PromQL parser set-op token to the chplan

--- a/internal/promql/count_values_mixed_test.go
+++ b/internal/promql/count_values_mixed_test.go
@@ -91,6 +91,25 @@ func TestCountValuesMixedAdmissionRemainsRequired(t *testing.T) {
 	}
 }
 
+func TestCountValuesMixedSerializationResolvesDiscriminatorRole(t *testing.T) {
+	const conditionalArity = 3
+	s := schema.DefaultOTelMetrics()
+	live, _ := mixedConsumerTestRows(s)
+	floatKey := promFixedFloatStringExpr(&chplan.ColumnRef{Name: s.ValueColumn})
+	conditional, ok := mixedCountValuesValueKey(live, floatKey, s).(*chplan.FuncCall)
+	if !ok || len(conditional.Args) != conditionalArity {
+		t.Fatalf("mixed value key = %#v", conditional)
+	}
+	predicate, ok := conditional.Args[0].(*chplan.Binary)
+	if !ok {
+		t.Fatalf("mixed discriminator predicate = %T", conditional.Args[0])
+	}
+	discriminator, ok := predicate.Left.(*chplan.ColumnRef)
+	if !ok || discriminator.Name != "source_kind" {
+		t.Fatalf("mixed discriminator = %#v, want source_kind role", predicate.Left)
+	}
+}
+
 func lowerCountValuesMixedTest(t *testing.T, query string, s schema.Metrics) chplan.Node {
 	t.Helper()
 	expr, err := parser.NewParser(parser.Options{EnableExperimentalFunctions: true}).ParseExpr(query)

--- a/internal/promql/date_fns.go
+++ b/internal/promql/date_fns.go
@@ -146,10 +146,10 @@ func projectDateFnOverInner(c *parser.Call, inner chplan.Node, s schema.Metrics,
 	family := mixedDateFamily
 	if c.Func.Name == timestampFunctionName {
 		family = mixedTimestampFamily
-		if chplan.RowShapeOf(inner) == chplan.MixedRowShape {
+		if mixedRowsNeedPreparation(inner) {
 			return lowerTimestampOverMixedPlan(inner, c.Args[0], s, ctx)
 		}
-	} else if chplan.RowShapeOf(inner) == chplan.MixedRowShape {
+	} else if mixedRowsNeedPreparation(inner) {
 		prepare, err := datePayloadPreparation(mixedPlanAdmission)
 		if err != nil {
 			return nil, err

--- a/internal/promql/float_aggregate_input_test.go
+++ b/internal/promql/float_aggregate_input_test.go
@@ -68,23 +68,52 @@ func TestFloatAggregateMixedInputNarrowing(t *testing.T) {
 	}
 }
 
-func TestFloatAggregateAuthorizationBeforeNarrowing(t *testing.T) {
+func TestFloatAggregatePlanPolicyDrivesNarrowing(t *testing.T) {
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
 	s := schema.DefaultOTelMetrics()
 	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	for _, fn := range []string{"min", "max", "stddev", "stdvar", "quantile"} {
 		t.Run(fn, func(t *testing.T) {
 			key := mixedWrapperKey{family: mixedFloatAggregateFamily, site: mixedPlanAdmission}
-			policy := mixedOperandPolicies[key]
-			delete(mixedOperandPolicies, key)
-			t.Cleanup(func() { mixedOperandPolicies[key] = policy })
 			expr, err := p.ParseExpr(floatAggregateTestQuery(fn, `sort_by_label(latency_exp_hist or num_cpus,"job")`))
 			if err != nil {
 				t.Fatal(err)
 			}
+			policy := mixedOperandPolicies[key]
 			plan, err := LowerAt(context.Background(), expr, s, at, at)
-			if plan != nil || err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for float-aggregate at existing-plan") {
-				t.Fatalf("original Mixed authorization bypassed: %T %v", plan, err)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var narrowed bool
+			chplan.Walk(plan, func(node chplan.Node) bool {
+				if filter, ok := node.(*chplan.Filter); ok && chplan.IsMixedFloatNarrowing(filter) {
+					narrowed = true
+				}
+				return true
+			})
+			if !narrowed {
+				t.Fatal("float-only plan policy did not narrow the mixed relation")
+			}
+			for _, denied := range []struct {
+				name    string
+				policy  mixedOperandPolicy
+				present bool
+			}{
+				{name: "missing"},
+				{name: "bespoke", policy: mixedBespoke, present: true},
+				{name: "preserve", policy: mixedPreserve, present: true},
+			} {
+				t.Run(denied.name, func(t *testing.T) {
+					delete(mixedOperandPolicies, key)
+					if denied.present {
+						mixedOperandPolicies[key] = denied.policy
+					}
+					t.Cleanup(func() { mixedOperandPolicies[key] = policy })
+					plan, err := LowerAt(context.Background(), expr, s, at, at)
+					if plan != nil || err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for float-aggregate at existing-plan") {
+						t.Fatalf("non-float-only policy reached aggregate: %T %v", plan, err)
+					}
+				})
 			}
 			for _, operand := range []string{"up", "latency_exp_hist"} {
 				expr, err := p.ParseExpr(floatAggregateTestQuery(fn, operand))

--- a/internal/promql/gremlins_kill_histogram_subquery_select_test.go
+++ b/internal/promql/gremlins_kill_histogram_subquery_select_test.go
@@ -13,7 +13,7 @@
 // down through isExpHistogramValuedShape and the copy therefore decided
 // nothing. The rule is now stated once, in
 // [expHistogramLoweringAvailable], where both its mutants are killable.
-// The remaining two adjudications stand:
+// The two remaining original cases now have different dispositions:
 //
 //   - histogram_native_subquery_select.go:`step < 0` (CONDITIONALS_BOUNDARY,
 //     `step < 0` -> `<= 0`). Two lines above, `if step == 0 { step =
@@ -24,22 +24,15 @@
 //     over every value except exactly 0, so no reachable input can make
 //     the two operators disagree (the same reasoning
 //     gremlins_kill_subquery_test.go's header gives for subquery.go:`step < 0`).
-//   - histogram_native_subquery_select.go:`if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
-//     (INVERT_LOGICAL, `||` -> `&&`).
-//     lowerExpHistogramValuedShape's own contract (histogram_native_float_
-//     fn.go) guarantees `matched == false` if and only if its very last
-//     fallback ran, which always returns `input == nil` — and
-//     chplan.RowShapeOf(nil) (no `case nil` in its type switch) always
-//     falls through to its non-Histogram default. So `!matched` and
-//     `RowShapeOf(input) != Histogram` are always EQUAL on every reachable
-//     input: both true together (an unmatched sub-expression) or both false
-//     together (every histogram-preserving recognizer this dispatch reaches
-//     is documented to publish HistogramRowShape whenever it returns a nil
-//     error, and a non-nil error already returns two lines above this
-//     guard). OR and AND compute the same boolean whenever their two
-//     operands are always equal.
+//   - The former compound guard was split into two explicit invariant checks:
+//     histogram_native_subquery_select.go:`if !matched` and
+//     histogram_native_subquery_select.go:`if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram`.
+//     That split retired the equivalent INVERT_LOGICAL (`||` -> `&&`) mutant.
+//     An unmatched input and a matched input with the wrong sample kind now
+//     report their distinct contract violations independently.
 //
-// All three are confirmed by manually applying the mutation and running
+// The remaining boundary case was confirmed by manually applying the mutation and
+// running
 // `go test ./internal/promql/...`: green.
 package promql
 

--- a/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
@@ -109,7 +109,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstKindDispatch(t *test
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:` —
 // the label locates the arm, the guard inside it is the mutant. This is
 // the resets/changes sibling of the last_over_time/first_over_time
-// dispatch above. Both shapes ultimately produce the same four-column canonical
+// dispatch above. Both kinds ultimately produce the same four-column canonical
 // Project, so the two paths are told apart by whether the underlying
 // Aggregate collected the Mixed-only groupArrays
 // [mixedPairCountAggs] adds.

--- a/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
@@ -56,26 +56,26 @@ func mixedDiscriminatorProjected(n chplan.Node) bool {
 	return found
 }
 
-// TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch
+// TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstKindDispatch
 // kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the
-// `if shape == chplan.HistogramRowShape` guard that opens the arm
+// `if kind == chplan.SampleKindHistogram` guard that opens the arm
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`,
 // inside lowerHistogramOrMixedSubqueryOuterFnInput. The citation names the
 // `case` label rather than the mutated guard because that guard is spelled
 // identically in all three arms of this switch, so no substring of it
 // singles one out, while the label above it does:
 //
-//	if shape == chplan.HistogramRowShape {
+//	if kind == chplan.SampleKindHistogram {
 //	    node, err = lowerSelectFnOverExpHistogramSubqueryInput(...)
 //	    ...
 //	}
 //	node, err = lowerMixedOrSubqueryLastFirstInput(...)
 //
-// A HistogramRowShape input must route to the plain histogram
+// A SampleKindHistogram input must route to the plain histogram
 // continuation (never publishes chplan.MixedDiscriminatorColumn); a
-// MixedRowShape input must route to the Mixed-aware continuation (always
+// SampleKindMixed input must route to the Mixed-aware continuation (always
 // does, via [mixedLastFirstProjection]). The negation swaps both.
-func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *testing.T) {
+func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstKindDispatch(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -84,28 +84,28 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 	sub := &parser.SubqueryExpr{Range: 5 * time.Minute, Step: time.Minute}
 	inner := &chplan.Scan{Table: "dummy"}
 
-	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.HistogramRowShape, lastOverTimeWindowFn, sub, s, ctx)
+	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, lastOverTimeWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("histogram-shape: %v", err)
+		t.Fatalf("histogram sample kind: %v", err)
 	}
 	if mixedDiscriminatorProjected(histPlan) {
-		t.Fatalf("histogram-shape last_over_time took the Mixed path (mutant `==`->`!=` at " +
+		t.Fatalf("histogram sample kind last_over_time took the Mixed path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`)")
 	}
 
-	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, lastOverTimeWindowFn, sub, s, ctx)
+	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, lastOverTimeWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("mixed-shape: %v", err)
+		t.Fatalf("mixed sample kind: %v", err)
 	}
 	if !mixedDiscriminatorProjected(mixedPlan) {
-		t.Fatalf("mixed-shape last_over_time took the Histogram path (mutant `==`->`!=` at " +
+		t.Fatalf("mixed sample kind last_over_time took the Histogram path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`)")
 	}
 }
 
-// TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch
+// TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesKindDispatch
 // kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the same
-// `if shape == chplan.HistogramRowShape` guard one arm further down,
+// `if kind == chplan.SampleKindHistogram` guard one arm further down,
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:` —
 // the label locates the arm, the guard inside it is the mutant. This is
 // the resets/changes sibling of the last_over_time/first_over_time
@@ -113,7 +113,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 // Project, so the two paths are told apart by whether the underlying
 // Aggregate collected the Mixed-only groupArrays
 // [mixedPairCountAggs] adds.
-func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t *testing.T) {
+func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesKindDispatch(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -122,37 +122,37 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t 
 	sub := &parser.SubqueryExpr{Range: 5 * time.Minute, Step: time.Minute}
 	inner := &chplan.Scan{Table: "dummy"}
 
-	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.HistogramRowShape, resetsWindowFn, sub, s, ctx)
+	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, resetsWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("histogram-shape: %v", err)
+		t.Fatalf("histogram sample kind: %v", err)
 	}
 	if mixedPairAggAlias(histPlan, mixedPairValueArrayAlias) {
-		t.Fatalf("histogram-shape resets took the Mixed path (mutant `==`->`!=` at " +
+		t.Fatalf("histogram sample kind resets took the Mixed path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`)")
 	}
 
-	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, resetsWindowFn, sub, s, ctx)
+	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, resetsWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("mixed-shape: %v", err)
+		t.Fatalf("mixed sample kind: %v", err)
 	}
 	if !mixedPairAggAlias(mixedPlan, mixedPairValueArrayAlias) {
-		t.Fatalf("mixed-shape resets took the Histogram path (mutant `==`->`!=` at " +
+		t.Fatalf("mixed sample kind resets took the Histogram path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`)")
 	}
 }
 
-// TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch kills
+// TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldKindDispatch kills
 // the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the same
-// `if shape == chplan.HistogramRowShape` guard in the third arm,
+// `if kind == chplan.SampleKindHistogram` guard in the third arm,
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:` —
 // again the label locates the arm and the guard inside it is the mutant.
 // This is the FOLD-family (rate/increase/delta/...) sibling of the two
-// dispatches above. Over a MixedRowShape input this case routes to
+// dispatches above. Over a SampleKindMixed input this case routes to
 // [lowerFurtherWrapMixedOrSubqueryFoldFn], whose own
 // [combineMixedAggregateBranches] always returns a *chplan.VectorSetOp at
 // the root — a shape the plain-histogram continuation
 // ([lowerExpHistogramRangeFnOverSubqueryInput]) never returns.
-func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch(t *testing.T) {
+func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldKindDispatch(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -161,21 +161,21 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch(t *testing.
 	sub := &parser.SubqueryExpr{Range: 5 * time.Minute, Step: time.Minute}
 	inner := &chplan.Scan{Table: "dummy"}
 
-	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.HistogramRowShape, rateWindowFn, sub, s, ctx)
+	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, rateWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("histogram-shape: %v", err)
+		t.Fatalf("histogram sample kind: %v", err)
 	}
 	if _, ok := histPlan.(*chplan.VectorSetOp); ok {
-		t.Fatalf("histogram-shape rate took the Mixed path (mutant `==`->`!=` at " +
+		t.Fatalf("histogram sample kind rate took the Mixed path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`)")
 	}
 
-	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, rateWindowFn, sub, s, ctx)
+	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, rateWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("mixed-shape: %v", err)
+		t.Fatalf("mixed sample kind: %v", err)
 	}
 	if _, ok := mixedPlan.(*chplan.VectorSetOp); !ok {
-		t.Fatalf("mixed-shape rate = %T, want *chplan.VectorSetOp (mutant `==`->`!=` at "+
+		t.Fatalf("mixed sample kind rate = %T, want *chplan.VectorSetOp (mutant `==`->`!=` at "+
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`)", mixedPlan)
 	}
 }

--- a/internal/promql/gremlins_kill_subquery_test.go
+++ b/internal/promql/gremlins_kill_subquery_test.go
@@ -299,9 +299,9 @@ func TestSubqueryInstantSafe_PiExceptionNotRejected(t *testing.T) {
 }
 
 // TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor kills the
-// CONDITIONALS_NEGATION mutant at histogram_shape_guard.go:rowsMayContainHistograms:`return !hasUnambiguousNamedRole(row, chplan.RoleValue)`.
-// A plain `or` composition has one unambiguous float value role, so the live
-// sample-kind guard must return false and allow lowering without query
+// CONDITIONALS_NEGATION mutant at histogram_shape_guard.go:rowsMayContainHistograms:`return liveSampleKind(inner) != chplan.SampleKindFloat`.
+// A plain `or` composition has a float sample kind, so the live guard must
+// return false and allow lowering without query
 // evaluation context. Negating that result wrongly sends this query through
 // the conservative histogram rejection path.
 func TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor(t *testing.T) {

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -241,21 +241,7 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // `append([]string(nil), src...) == nil` for both a nil and an empty-non-nil
 // src.
 //
-// 5. AN INTERNAL-INVARIANT ERROR PATH.
-//
-//	histogram_native_range_fn.go:`!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
-//	histogram_native_subquery_select.go:`!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
-//
-// `||` -> `&&` narrows a check that reports "internal invariant violated".
-// The two readings differ only when exactly one disjunct holds, and neither
-// half is constructible: `lowerExpHistogramValuedShape` returns a nil node
-// whenever `matched` is false, and `chplan.RowShapeOf(nil)` is the sample row
-// shape, so `!matched` always arrives together with a non-histogram shape and
-// both readings error. The complementary case — matched with a non-histogram
-// shape — is the invariant the line exists to report, and producing it would
-// require lowerExpHistogramValuedShape to break its own contract.
-//
-// 7. A `continue` WHOSE `break` BINDS TO A SWITCH, NOT TO THE LOOP.
+// 5. A `continue` WHOSE `break` BINDS TO A SWITCH, NOT TO THE LOOP.
 //
 //	duplicate_labelset_guard.go:`if mixed && mixedPayload[name] {`
 //	duplicate_labelset_guard.go:`if keyOnStep`

--- a/internal/promql/histogram_native_bare.go
+++ b/internal/promql/histogram_native_bare.go
@@ -319,5 +319,6 @@ func nativeHistogramProjection(input chplan.Node, nameExpr, tsExpr chplan.Expr, 
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
 	}
 }

--- a/internal/promql/histogram_native_binop.go
+++ b/internal/promql/histogram_native_binop.go
@@ -186,10 +186,10 @@ func lowerExpHistogramValuedOperand(expr parser.Expr, s schema.Metrics, ctx lowe
 	if !matched {
 		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram binop operand matched no known histogram-valued shape for %v", expr)
 	}
-	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+	if kind := node.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
 		return nil, fmt.Errorf(
-			"promql: internal invariant violated: exp-histogram binop operand lowering published %s row shape (%T), want %s",
-			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+			"promql: internal invariant violated: exp-histogram binop operand lowering published %s sample kind (%T), want histogram",
+			kind, node,
 		)
 	}
 	return node, nil

--- a/internal/promql/histogram_native_count.go
+++ b/internal/promql/histogram_native_count.go
@@ -117,8 +117,8 @@ func countOrGroupOverExpHistogramValue(expr parser.Expr, s schema.Metrics, ctx l
 // or a histogram. Grouping by the published evaluation timestamp keeps range
 // query anchors independent while using the same plan for instant queries.
 func lowerExpHistogramCountOrGroupOverPlan(agg *parser.AggregateExpr, input chplan.Node, s schema.Metrics) (chplan.Node, error) {
-	if chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: nested native-histogram count/group input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: nested native-histogram count/group input is %T with %s sample kind", input, kind)
 	}
 
 	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(

--- a/internal/promql/histogram_native_count_values.go
+++ b/internal/promql/histogram_native_count_values.go
@@ -38,8 +38,8 @@ func lowerExpHistogramCountValuesOverPlan(agg *parser.AggregateExpr, input chpla
 	if label == "" {
 		return nil, fmt.Errorf("promql: count_values requires a non-empty label name")
 	}
-	if chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: count_values native-histogram input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: count_values native-histogram input is %T with %s sample kind", input, kind)
 	}
 	return lowerCountValuesOverPlan(agg, label, input, nativeHistogramStringExpr(s), s, ctx), nil
 }

--- a/internal/promql/histogram_native_label_replace.go
+++ b/internal/promql/histogram_native_label_replace.go
@@ -77,12 +77,12 @@ func lowerLabelCallOverExpHistogram(call *parser.Call, s schema.Metrics, ctx low
 	// `and`/`or`/`unless` (cerberus issue #2324), and [isExpHistogramValuedShape]
 	// recognises it too, so [labelCallOverExpHistogram] matches an outer
 	// label_replace/label_join around one. Both shapes publish the exact same
-	// thirteen-column contract under the fixed Histogram*Column aliases (see
-	// [chplan.RowShapeOf]), so any node answering [chplan.HistogramRowShape]
+	// thirteen-column contract under the fixed Histogram*Column aliases, so any
+	// node whose schema classifies [chplan.SampleKindHistogram]
 	// here is a valid input to [rewriteHistogramProjectionAttributes] — a
 	// stricter Go-type assertion is what issue #2468 reports as the bug.
-	if shape := chplan.RowShapeOf(inner); shape != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram label_replace input publishes %s row shape (%T), want %s", shape, inner, chplan.HistogramRowShape)
+	if kind := inner.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram label_replace input publishes %s sample kind (%T), want histogram", kind, inner)
 	}
 	return rewriteHistogramProjectionAttributes(inner, attrs, s), nil
 }

--- a/internal/promql/histogram_native_label_replace.go
+++ b/internal/promql/histogram_native_label_replace.go
@@ -159,6 +159,7 @@ func rewriteHistogramProjectionAttributes(inner chplan.Node, attrs chplan.Expr, 
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
 	}
 }
 

--- a/internal/promql/histogram_native_mixed_or.go
+++ b/internal/promql/histogram_native_mixed_or.go
@@ -234,17 +234,18 @@ func lowerMixedExpHistogramOperands(
 	if err != nil {
 		return nil, nil, false, err
 	}
-	switch shape := chplan.RowShapeOf(floatNode); shape {
-	case chplan.SampleRowShape, chplan.GridWindowRowShape, chplan.ReducedWindowRowShape:
-		return histNode, floatNode, histOnLeft, nil
-	default:
+	row := floatNode.RowType()
+	kind := row.SampleKind()
+	if kind != chplan.SampleKindFloat {
 		return nil, nil, false, fmt.Errorf(
-			"promql: 'or' between a float-valued and a histogram-valued operand does not "+
-				"support a %s-shaped float operand, which cerberus issue #2333 does not "+
-				"cover",
-			shape,
+			"promql: 'or' between a float-valued and a histogram-valued operand has a %s float schema",
+			kind,
 		)
 	}
+	if _, _, err := resolveSampleTemporalLayout(row); err != nil {
+		return nil, nil, false, fmt.Errorf("promql: mixed 'or' float operand: %w", err)
+	}
+	return histNode, floatNode, histOnLeft, nil
 }
 
 // mixedExpHistogramMatch translates b's `on`/`ignoring` vector-matching

--- a/internal/promql/histogram_native_mixed_or_aggregate.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate.go
@@ -466,17 +466,48 @@ func lowerPlainAggOverMixedFloatArm(agg *parser.AggregateExpr, input chplan.Node
 //     [chplan.NowNanoMinusStaleness], that internal/api/prom/handler.go's
 //     synthesizedAnchor also calls), keeping the two mixed-or lowerings'
 //     instant-mode anchors identical.
-func canonicalizeMixedFloatArmForAgg(input chplan.Node, s schema.Metrics) chplan.Node {
-	if chplan.RowShapeOf(input) != chplan.ReducedWindowRowShape {
-		return input
+func canonicalizeMixedFloatArmForAgg(input chplan.Node, s schema.Metrics) (chplan.Node, error) {
+	row := input.RowType()
+	kind := row.SampleKind()
+	if kind != chplan.SampleKindFloat && kind != chplan.SampleKindMixed {
+		return nil, fmt.Errorf("promql: mixed aggregate float arm has %s sample schema", kind)
 	}
+	temporal, layout, err := resolveSampleTemporalLayout(row)
+	if err != nil {
+		return nil, fmt.Errorf("promql: mixed aggregate float arm: %w", err)
+	}
+	if temporal.timestamp != "" && temporal.attributes == s.AttributesColumn &&
+		temporal.timestamp == s.TimestampColumn && temporal.value == s.ValueColumn {
+		return input, nil
+	}
+	refs := temporal.refs()
+
+	// This adapter preserves any physical metric-name role. The aggregate
+	// above it remains the owner of PromQL's output-name policy.
+	projections := make([]chplan.Projection, 0, 5)
+	roles := make([]chplan.Column, 0, 5)
+	if refs.MetricName != nil {
+		projections = append(projections, sampleForwardColumn(refs.MetricName, s.MetricNameColumn, true))
+		roles = append(roles, chplan.Column{Name: s.MetricNameColumn, Role: chplan.RoleMetricName})
+	}
+	projections = append(projections, sampleForwardColumn(refs.Attributes, s.AttributesColumn, true))
+	roles = append(roles, chplan.Column{Name: s.AttributesColumn, Role: chplan.RoleAttributes})
+	if layout.anchored {
+		projections = append(projections, sampleForwardColumn(refs.Anchor, chplan.RangeWindowAnchorColumn, true))
+		roles = append(roles, chplan.Column{Name: chplan.RangeWindowAnchorColumn, Role: chplan.RoleAnchor})
+	}
+	if refs.Timestamp == nil {
+		projections = append(projections, chplan.Projection{Expr: chplan.NowNanoMinusStaleness(), Alias: s.TimestampColumn})
+	} else {
+		projections = append(projections, sampleForwardColumn(refs.Timestamp, s.TimestampColumn, true))
+	}
+	roles = append(roles, chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleTimestamp})
+	projections = append(projections, sampleForwardColumn(refs.Value, s.ValueColumn, true))
+	roles = append(roles, chplan.Column{Name: s.ValueColumn, Role: chplan.RoleValue})
+
 	return &chplan.Project{
-		Roles: metricRoles(s),
-		Input: input,
-		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
-			{Expr: chplan.NowNanoMinusStaleness(), Alias: s.TimestampColumn},
-			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
-		},
-	}
+		Roles:       roles,
+		Input:       input,
+		Projections: projections,
+	}, nil
 }

--- a/internal/promql/histogram_native_mixed_or_aggregate_topk.go
+++ b/internal/promql/histogram_native_mixed_or_aggregate_topk.go
@@ -104,7 +104,7 @@ func lowerTopKOverMixedExpHistogramSetOp(agg *parser.AggregateExpr, b *parser.Bi
 
 	kF, ok := tryScalarLiteral(agg.Param)
 	if !ok {
-		return buildTopKComputed(agg, s, ctx, floatForAgg, false, false)
+		return buildTopKComputed(agg, s, ctx, floatForAgg)
 	}
 	k, empty, err := topKDomain(kF)
 	if err != nil {

--- a/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go
@@ -248,8 +248,8 @@ func lowerSumOrAvgMixedOrSubquerySelectFn(shape sumOrAvgMixedOrSubqueryShape, gr
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(mixedRel) != chplan.MixedRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s row shape", mixedRel, chplan.RowShapeOf(mixedRel))
+	if kind := mixedRel.RowType().SampleKind(); kind != chplan.SampleKindMixed {
+		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s sample kind", mixedRel, kind)
 	}
 	// [lowerSelectFnOverExpHistogramSubqueryInput]'s own doc: this
 	// continuation only ever reads the Attributes/Timestamp/Value columns

--- a/internal/promql/histogram_native_mixed_or_subquery_further_setop_range_fn.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_further_setop_range_fn.go
@@ -1,6 +1,8 @@
 package promql
 
 import (
+	"fmt"
+
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -78,15 +80,17 @@ import (
 // function for the three grid modes, and for why the classic ambient-grid
 // fan-outs buried inside its own wideInner stay untouched (cerberus issue
 // #2728).
-func lowerHistogramOrMixedSubqueryOuterFnInput(inner chplan.Node, shape chplan.RowShape, windowFn string, sub *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (node chplan.Node, matched bool, err error) {
+func lowerHistogramOrMixedSubqueryOuterFnInput(inner chplan.Node, kind chplan.SampleKind, windowFn string, sub *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (node chplan.Node, matched bool, err error) {
+	if !histogramSubqueryOuterFnName(windowFn) {
+		return nil, false, nil
+	}
+	if kind != chplan.SampleKindHistogram && kind != chplan.SampleKindMixed {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: histogram subquery outer function input has %s sample kind", kind)
+	}
 	if nestedCallSubqueryShape(sub.Expr) {
 		// Widening mutates inner in place, so it must not run for a name
-		// the switch below leaves unmatched (deriv, predict_linear, …) —
-		// those fall through to the caller's own float-only-drop /
-		// rejection handling over the UNwidened relation.
-		if !histogramSubqueryOuterFnName(windowFn) {
-			return nil, false, nil
-		}
+		// the switch below leaves unmatched (deriv, predict_linear, …).
+		// The function-name gate above therefore runs before this mutation.
 		if err := widenNestedCallSubqueryInner(inner, sub, ctx); err != nil {
 			return nil, false, err
 		}
@@ -96,21 +100,21 @@ func lowerHistogramOrMixedSubqueryOuterFnInput(inner chplan.Node, shape chplan.R
 		node, err = lowerSelectFnOverExpHistogramSubqueryInput(inner, sub, windowFn, s, ctx)
 		return node, true, err
 	case lastOverTimeWindowFn, firstOverTimeWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerSelectFnOverExpHistogramSubqueryInput(inner, sub, windowFn, s, ctx)
 			return node, true, err
 		}
 		node, err = lowerMixedOrSubqueryLastFirstInput(inner, sub, windowFn, s, ctx)
 		return node, true, err
 	case resetsWindowFn, changesWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerSelectFnOverExpHistogramSubqueryInput(inner, sub, windowFn, s, ctx)
 			return node, true, err
 		}
 		node, err = lowerMixedOrSubqueryResetsOrChangesInput(inner, sub, windowFn, s, ctx)
 		return node, true, err
 	case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerExpHistogramRangeFnOverSubqueryInput(inner, sub, windowFn, s, ctx)
 			return node, true, err
 		}

--- a/internal/promql/histogram_native_mixed_or_subquery_last_first.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_last_first.go
@@ -85,8 +85,8 @@ func lowerMixedOrSubqueryLastFirst(shape sumOrAvgMixedOrSubqueryShape, gridCtx l
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(mixedRel) != chplan.MixedRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s row shape", mixedRel, chplan.RowShapeOf(mixedRel))
+	if kind := mixedRel.RowType().SampleKind(); kind != chplan.SampleKindMixed {
+		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s sample kind", mixedRel, kind)
 	}
 	return lowerMixedOrSubqueryLastFirstInput(mixedRel, shape.sub, shape.windowFn, s, ctx)
 }

--- a/internal/promql/histogram_native_mixed_or_subquery_resets_changes.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_resets_changes.go
@@ -283,8 +283,8 @@ func lowerMixedOrSubqueryResetsOrChanges(shape sumOrAvgMixedOrSubqueryShape, gri
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(mixedRel) != chplan.MixedRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s row shape", mixedRel, chplan.RowShapeOf(mixedRel))
+	if kind := mixedRel.RowType().SampleKind(); kind != chplan.SampleKindMixed {
+		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s sample kind", mixedRel, kind)
 	}
 	return lowerMixedOrSubqueryResetsOrChangesInput(mixedRel, shape.sub, shape.windowFn, s, ctx)
 }

--- a/internal/promql/histogram_native_mixed_or_value_fn.go
+++ b/internal/promql/histogram_native_mixed_or_value_fn.go
@@ -116,6 +116,7 @@ func wrapMixedHistogramPartition(mixed chplan.Node, s schema.Metrics) *chplan.Hi
 		MetricNameColumn: s.MetricNameColumn,
 		AttributesColumn: s.AttributesColumn,
 		TimestampColumn:  s.TimestampColumn,
+		ValueColumn:      s.ValueColumn,
 	}
 }
 

--- a/internal/promql/histogram_native_mixed_or_vector_plain_arithmetic.go
+++ b/internal/promql/histogram_native_mixed_or_vector_plain_arithmetic.go
@@ -70,19 +70,43 @@ import (
 // commutative, and for group_left()/group_right() cardinality (PromQL
 // defines "many" relative to the operator's own LHS/RHS, not to which side
 // happens to be mixed).
-func widenPlainVectorToMixedShape(node chplan.Node, s schema.Metrics) chplan.Node {
+func widenPlainVectorToMixedShape(node chplan.Node, s schema.Metrics) (chplan.Node, error) {
+	row := node.RowType()
+	kind := row.SampleKind()
+	if kind != chplan.SampleKindFloat {
+		return nil, fmt.Errorf("promql: mixed join plain operand has %s sample schema", kind)
+	}
+	temporal, _, err := resolveSampleTemporalLayout(row)
+	if err != nil {
+		return nil, fmt.Errorf("promql: mixed join plain operand: %w", err)
+	}
+	refs := temporal.refs()
+
 	zeroFloat := func() chplan.Expr { return &chplan.LitFloat{V: 0} }
 	zeroInt := func() chplan.Expr { return &chplan.LitInt{V: 0} }
 	emptyBuckets := func() chplan.Expr { return &chplan.FuncCall{Fn: chplan.FnEmptyArrayFloat64} }
+	metricName := chplan.Projection{Expr: &chplan.LitString{V: ""}, Alias: s.MetricNameColumn}
+	if refs.MetricName != nil {
+		// The widening adapter preserves a physical name when one exists;
+		// the arithmetic/comparison result owns any later drop-name policy.
+		metricName = sampleForwardColumn(refs.MetricName, s.MetricNameColumn, true)
+	}
+	timestamp := chplan.Projection{Expr: chplan.NowNanoMinusStaleness(), Alias: s.TimestampColumn}
+	if refs.Timestamp != nil {
+		timestamp = sampleForwardColumn(refs.Timestamp, s.TimestampColumn, true)
+	}
+	roles := append([]chplan.Column(nil), metricRoles(s)...)
+	roles = append(roles, chplan.HistogramPayloadColumns()...)
+	roles = append(roles, chplan.Column{Name: mixedDiscriminatorColumn, Role: chplan.RoleDiscriminator})
 
 	return &chplan.Project{
-		Roles: metricRoles(s),
+		Roles: roles,
 		Input: node,
 		Projections: []chplan.Projection{
-			{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
-			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
-			{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
-			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+			metricName,
+			sampleForwardColumn(refs.Attributes, s.AttributesColumn, true),
+			timestamp,
+			sampleForwardColumn(refs.Value, s.ValueColumn, true),
 			{Expr: zeroFloat(), Alias: chplan.HistogramCountColumn},
 			{Expr: zeroFloat(), Alias: chplan.HistogramSumColumn},
 			{Expr: zeroInt(), Alias: chplan.HistogramScaleColumn},
@@ -94,7 +118,7 @@ func widenPlainVectorToMixedShape(node chplan.Node, s schema.Metrics) chplan.Nod
 			{Expr: emptyBuckets(), Alias: chplan.HistogramNegativeBucketCountsColumn},
 			{Expr: &chplan.LitInt{V: mixedDiscriminatorFloat}, Alias: mixedDiscriminatorColumn},
 		},
-	}
+	}, nil
 }
 
 // lowerPlainOperandForMixedJoin lowers plainExpr through the ordinary
@@ -118,15 +142,11 @@ func lowerPlainOperandForMixedJoin(plainExpr parser.Expr, s schema.Metrics, ctx 
 	if err != nil {
 		return nil, err
 	}
-	switch shape := chplan.RowShapeOf(plainNode); shape {
-	case chplan.SampleRowShape, chplan.GridWindowRowShape, chplan.ReducedWindowRowShape:
-		return widenPlainVectorToMixedShape(plainNode, s), nil
-	default:
-		return nil, fmt.Errorf(
-			"promql: a mixed float/histogram 'or' operand paired with a %s-shaped operand "+
-				"is not supported", shape,
-		)
+	widened, err := widenPlainVectorToMixedShape(plainNode, s)
+	if err != nil {
+		return nil, err
 	}
+	return widened, nil
 }
 
 // vectorPlainArithmeticOverMixedExpHistogramSetOp recognises `<mixed or>

--- a/internal/promql/histogram_native_range_fn.go
+++ b/internal/promql/histogram_native_range_fn.go
@@ -284,8 +284,11 @@ func lowerExpHistogramRangeFnOverSubquery(shape histogramSubqueryRangeShape, s s
 	if err != nil {
 		return nil, err
 	}
-	if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if !matched {
+		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input matched no histogram-valued shape for %v", sub.Expr)
+	}
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input is %T with %s sample kind", input, kind)
 	}
 	node, err := lowerExpHistogramRangeFnOverSubqueryInput(input, sub, shape.windowFn, s, ctx)
 	if err != nil {

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -284,8 +284,8 @@ func isExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx)
 // keep=false incompatible-types result; otherwise the capping
 // histogram-shaped node is rewritten to scale it.
 //
-// The histogram side is asserted by ROW SHAPE
-// ([chplan.RowShapeOf] == [chplan.HistogramRowShape]), not by literal Go
+// The histogram side is asserted by validated schema kind
+// ([chplan.Schema.SampleKind] == [chplan.SampleKindHistogram]), not by literal Go
 // type: [isExpHistogramValuedShape] — the very predicate
 // [expHistogramScalarBinop] / [expHistogramDroppingScalarBinop] gate on to
 // decide the histogram side is even eligible — reports true for a
@@ -314,10 +314,10 @@ func lowerExpHistogramScalarBinop(histSide parser.Expr, op chplan.BinaryOp, scal
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+	if kind := node.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
 		return nil, fmt.Errorf(
-			"promql: internal invariant violated: exp-histogram scalar-binop operand lowering published %s row shape (%T), want %s",
-			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+			"promql: internal invariant violated: exp-histogram scalar-binop operand lowering published %s sample kind (%T), want histogram",
+			kind, node,
 		)
 	}
 	if drop {

--- a/internal/promql/histogram_native_set_op.go
+++ b/internal/promql/histogram_native_set_op.go
@@ -151,10 +151,10 @@ func lowerExpHistogramSetOpOperand(expr parser.Expr, s schema.Metrics, ctx lower
 	if !matched {
 		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram set-op operand matched no known histogram-valued shape for %v", expr)
 	}
-	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+	if kind := node.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
 		return nil, fmt.Errorf(
-			"promql: internal invariant violated: exp-histogram set-op operand lowering published %s row shape (%T), want %s",
-			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+			"promql: internal invariant violated: exp-histogram set-op operand lowering published %s sample kind (%T), want histogram",
+			kind, node,
 		)
 	}
 	return node, nil
@@ -249,10 +249,10 @@ func lowerExpHistogramValuedOrForwardedOperand(expr parser.Expr, s schema.Metric
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+	if kind := node.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
 		return nil, fmt.Errorf(
-			"promql: internal invariant violated: exp-histogram-forwarding set-op operand lowering published %s row shape (%T), want %s",
-			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+			"promql: internal invariant violated: exp-histogram-forwarding set-op operand lowering published %s sample kind (%T), want histogram",
+			kind, node,
 		)
 	}
 	return node, nil

--- a/internal/promql/histogram_native_subquery_call_subquery.go
+++ b/internal/promql/histogram_native_subquery_call_subquery.go
@@ -1,6 +1,7 @@
 package promql
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
@@ -200,37 +201,43 @@ func guardedCallSubqueryFanout(
 // `<fn>(<inner-sub>)[<outer-range>:<step>]`, mirroring
 // [lowerHistogramOrMixedSubqueryOuterFnInput]'s own switch vocabulary rung
 // for rung. wideInner is already lowered (the widened inner subquery's own
-// relation) and shape is its already-computed row shape.
+// relation) and kind is its already-validated sample schema contract.
 func lowerHistogramOrMixedCallSubqueryInput(
 	wideInner chplan.Node,
-	shape chplan.RowShape,
+	kind chplan.SampleKind,
 	windowFn string,
 	outerSub, innerSub *parser.SubqueryExpr,
 	step time.Duration,
 	s schema.Metrics,
 	ctx lowerCtx,
 ) (node chplan.Node, matched bool, err error) {
+	if !histogramSubqueryOuterFnName(windowFn) {
+		return nil, false, nil
+	}
+	if kind != chplan.SampleKindHistogram && kind != chplan.SampleKindMixed {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: histogram call-subquery input has %s sample kind", kind)
+	}
 	grid := histogramCallSubqueryGrid{outerSub: outerSub, innerRange: innerSub.Range, step: step}
 	switch windowFn {
 	case countOverTimeWindowFn, presentOverTimeWindowFn, tsOfFirstOverTimeExpHistFn, tsOfLastOverTimeExpHistFn:
 		node, err = lowerSelectFnOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 		return node, true, err
 	case lastOverTimeWindowFn, firstOverTimeWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerSelectFnOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 			return node, true, err
 		}
 		node, err = lowerMixedLastFirstOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 		return node, true, err
 	case resetsWindowFn, changesWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerSelectFnOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 			return node, true, err
 		}
 		node, err = lowerMixedResetsOrChangesOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 		return node, true, err
 	case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerExpHistogramFoldOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 			return node, true, err
 		}

--- a/internal/promql/histogram_native_subquery_select.go
+++ b/internal/promql/histogram_native_subquery_select.go
@@ -179,8 +179,11 @@ func lowerSelectFnOverExpHistogramSubquery(shape histogramSubquerySelectShape, s
 	if err != nil {
 		return nil, err
 	}
-	if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if !matched {
+		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input matched no histogram-valued shape for %v", sub.Expr)
+	}
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input is %T with %s sample kind", input, kind)
 	}
 	node, err := lowerSelectFnOverExpHistogramSubqueryInput(input, sub, shape.windowFn, s, ctx)
 	if err != nil {

--- a/internal/promql/histogram_native_sum.go
+++ b/internal/promql/histogram_native_sum.go
@@ -293,8 +293,8 @@ func expHistogramGroupMergeFanout(perSeries chplan.Node, anchor *chplan.ColumnRe
 // ceiling (ctx.resourceBounds.HistogramMergeMaxCostUnits, cerberus issue
 // #2667), passed straight through to [expHistogramMergeSortStage].
 func lowerExpHistogramSumOrAvgOverPlan(agg *parser.AggregateExpr, input chplan.Node, s schema.Metrics, maxCostUnits int64) (chplan.Node, error) {
-	if chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: nested native-histogram aggregation input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: nested native-histogram aggregation input is %T with %s sample kind", input, kind)
 	}
 
 	histSchema := histogramProjectionSchema(s)

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -1924,14 +1924,14 @@ func lowerHistogramQuantileHistogramValuedArg(
 	if err != nil {
 		return nil, true, err
 	}
-	// RowShapeOf, not a *chplan.HistogramProjection type assertion: a
+	// SampleKind, not a *chplan.HistogramProjection type assertion: a
 	// set-op operand (histogram_native_set_op.go) answers histogram-valued
 	// as a *chplan.VectorSetOp with Histogram=true, publishing the
 	// identical nine-column contract under a different node type.
-	// RowShapeOf is this package's own shared test for "is this the
-	// thirteen-column histogram row shape" across every such producer.
-	if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
-		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
+	// the schema classifier validates the complete histogram contract across
+	// every such producer.
+	if kind := hist.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering produced %s sample kind (%T), want histogram", kind, hist)
 	}
 	return lowerHistogramQuantileNativeOverProjection(hist, phi, s), true, nil
 }

--- a/internal/promql/histogram_shape_guard.go
+++ b/internal/promql/histogram_shape_guard.go
@@ -33,137 +33,25 @@ func mixedRowsNeedPreparation(inner chplan.Node) bool {
 	return completeHistogram && discriminated && !mixedFloatRowsProven(inner)
 }
 
+// liveSampleKind refines the physical schema contract with the only
+// value-domain proof represented in the plan: a discriminator-zero filter over
+// a mixed payload contains float rows only while retaining all mixed columns.
+func liveSampleKind(inner chplan.Node) chplan.SampleKind {
+	if inner == nil {
+		return chplan.SampleKindOpaque
+	}
+	kind := inner.RowType().SampleKind()
+	if kind == chplan.SampleKindMixed && mixedFloatRowsProven(inner) {
+		return chplan.SampleKindFloat
+	}
+	return kind
+}
+
 // rowsMayContainHistograms answers which payload path a subquery must take.
 // A discriminator-zero proof makes a physically mixed relation safe for the
 // float path without changing its columns. Unknown or malformed schemas stay
 // on the conservative path: callers must never erase a possible histogram by
 // projecting the ordinary float envelope over a relation they cannot prove.
 func rowsMayContainHistograms(inner chplan.Node) bool {
-	row := inner.RowType()
-	if row.Open {
-		return true
-	}
-	completeHistogram, discriminated, valid := inspectLiveSamplePayload(row)
-	if !valid {
-		return true
-	}
-	if !liveSampleRolesAreUnambiguous(row) {
-		return true
-	}
-	if completeHistogram {
-		if !discriminated {
-			return true
-		}
-		return !mixedFloatRowsProven(inner)
-	}
-	return !hasUnambiguousNamedRole(row, chplan.RoleValue)
-}
-
-func liveSampleRolesAreUnambiguous(row chplan.Schema) bool {
-	for _, role := range [...]chplan.ColumnRole{
-		chplan.RoleMetricName,
-		chplan.RoleAttributes,
-		chplan.RoleTimestamp,
-		chplan.RoleAnchor,
-		chplan.RoleValue,
-		chplan.RoleDiscriminator,
-	} {
-		if !roleIsUnambiguousWhenPresent(row, role) {
-			return false
-		}
-	}
-	return true
-}
-
-// inspectLiveSamplePayload validates the public histogram/discriminator
-// envelope without panicking. The lowering pipeline can then conservatively
-// retain an unrecognised payload and let its histogram-aware continuation
-// report the established error, rather than silently selecting the float path.
-func inspectLiveSamplePayload(row chplan.Schema) (completeHistogram, discriminated, valid bool) {
-	valid = true
-	histogramFields := chplan.HistogramPayloadColumns()
-	sawHistogramContract := false
-	completeHistogram = true
-	for _, field := range histogramFields {
-		count := 0
-		for _, column := range row.Columns {
-			if column.Name != field.Name {
-				continue
-			}
-			sawHistogramContract = true
-			if column.Role != chplan.RoleHistogramField {
-				valid = false
-				continue
-			}
-			count++
-			if count != 1 {
-				valid = false
-			}
-		}
-		if count != 1 {
-			completeHistogram = false
-		}
-	}
-	for _, column := range row.Columns {
-		if column.Role != chplan.RoleHistogramField {
-			continue
-		}
-		sawHistogramContract = true
-		canonicalName := false
-		for _, field := range histogramFields {
-			if column.Name == field.Name {
-				canonicalName = true
-				break
-			}
-		}
-		if !canonicalName {
-			valid = false
-		}
-	}
-	if sawHistogramContract && !completeHistogram {
-		valid = false
-	}
-
-	discriminated = row.Has(chplan.RoleDiscriminator)
-	if !roleIsUnambiguousWhenPresent(row, chplan.RoleDiscriminator) {
-		valid = false
-	}
-	if discriminated && !completeHistogram {
-		valid = false
-	}
-	if completeHistogram && discriminated && !hasUnambiguousNamedRole(row, chplan.RoleValue) {
-		valid = false
-	}
-	return completeHistogram, discriminated, valid
-}
-
-func hasUnambiguousNamedRole(row chplan.Schema, role chplan.ColumnRole) bool {
-	found := false
-	name := ""
-	for _, column := range row.Columns {
-		if column.Role != role {
-			continue
-		}
-		if found || column.Name == "" {
-			return false
-		}
-		found = true
-		name = column.Name
-	}
-	if !found {
-		return false
-	}
-	for _, column := range row.Columns {
-		if column.Name == name && column.Role != role {
-			return false
-		}
-	}
-	return true
-}
-
-func roleIsUnambiguousWhenPresent(row chplan.Schema, role chplan.ColumnRole) bool {
-	if !row.Has(role) {
-		return true
-	}
-	return hasUnambiguousNamedRole(row, role)
+	return liveSampleKind(inner) != chplan.SampleKindFloat
 }

--- a/internal/promql/histogram_shape_guard.go
+++ b/internal/promql/histogram_shape_guard.go
@@ -37,14 +37,7 @@ func mixedRowsNeedPreparation(inner chplan.Node) bool {
 // value-domain proof represented in the plan: a discriminator-zero filter over
 // a mixed payload contains float rows only while retaining all mixed columns.
 func liveSampleKind(inner chplan.Node) chplan.SampleKind {
-	if inner == nil {
-		return chplan.SampleKindOpaque
-	}
-	kind := inner.RowType().SampleKind()
-	if kind == chplan.SampleKindMixed && mixedFloatRowsProven(inner) {
-		return chplan.SampleKindFloat
-	}
-	return kind
+	return chplan.LiveSampleKind(inner)
 }
 
 // rowsMayContainHistograms answers which payload path a subquery must take.

--- a/internal/promql/histogram_shape_guard_test.go
+++ b/internal/promql/histogram_shape_guard_test.go
@@ -22,18 +22,13 @@ import (
 
 // histogramShapedInput returns a minimal plan node that publishes
 // chplan.HistogramRowShape.
-func histogramShapedInput() chplan.Node {
-	return &chplan.HistogramProjection{
-		Input:                      &chplan.Scan{Table: "otel_metrics_exponential_histogram"},
-		CountColumn:                "Count",
-		SumColumn:                  "Sum",
-		ScaleColumn:                "Scale",
-		ZeroCountColumn:            "ZeroCount",
-		PositiveOffsetColumn:       "PositiveOffset",
-		PositiveBucketCountsColumn: "PositiveBucketCounts",
-		NegativeOffsetColumn:       "NegativeOffset",
-		NegativeBucketCountsColumn: "NegativeBucketCounts",
-	}
+func histogramShapedInput(s schema.Metrics) chplan.Node {
+	return nativeHistogramProjection(
+		sampleForwardTestInput(metricRoles(s)...),
+		&chplan.ColumnRef{Name: s.MetricNameColumn},
+		&chplan.ColumnRef{Name: s.TimestampColumn},
+		s,
+	)
 }
 
 func TestProjectForwarders_PanicOnHistogramShapedInput(t *testing.T) {
@@ -45,13 +40,13 @@ func TestProjectForwarders_PanicOnHistogramShapedInput(t *testing.T) {
 		{
 			name: "projectValueOverInner",
 			call: func() {
-				projectValueOverInner(histogramShapedInput(), s, sampleProjectionLayout{canonical: true}, func(sampleRoleRefs) chplan.Expr { return &chplan.LitFloat{V: 1} })
+				projectValueOverInner(histogramShapedInput(s), s, sampleProjectionLayout{canonical: true}, func(sampleRoleRefs) chplan.Expr { return &chplan.LitFloat{V: 1} })
 			},
 		},
 		{
 			name: "projectAttributesOverInner",
 			call: func() {
-				mustProjectAttributesOverInner(t, histogramShapedInput(), s, func(refs sampleRoleRefs) chplan.Expr { return refs.Attributes })
+				mustProjectAttributesOverInner(t, histogramShapedInput(s), s, func(refs sampleRoleRefs) chplan.Expr { return refs.Attributes })
 			},
 		},
 	}
@@ -80,7 +75,7 @@ func TestProjectForwarders_PanicOnHistogramShapedInput(t *testing.T) {
 // someone widened the condition by accident.
 func TestProjectForwarders_AcceptEveryNonHistogramShape(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
-	scan := &chplan.Scan{Table: "otel_metrics_gauge", Roles: metricRoles(s)}
+	scan := sampleForwardTestInput(metricRoles(s)...)
 	inputs := []struct {
 		name  string
 		node  chplan.Node

--- a/internal/promql/histogram_value_fns.go
+++ b/internal/promql/histogram_value_fns.go
@@ -266,15 +266,15 @@ func lowerHistogramValueFnHistogramValuedArg(
 	if err != nil {
 		return nil, true, err
 	}
-	// RowShapeOf, not a *chplan.HistogramProjection type assertion: a
+	// SampleKind, not a *chplan.HistogramProjection type assertion: a
 	// set-op operand (histogram_native_set_op.go) answers histogram-valued
 	// as a *chplan.VectorSetOp with Histogram=true, publishing the
 	// identical nine-column contract under a different node type, and
-	// RowShapeOf is this package's own shared test for "is this the
-	// thirteen-column histogram row shape" across every such producer
+	// the schema classifier is the shared validation of that histogram
+	// contract across every such producer
 	// (mirrors lowerExpHistogramCountOrGroupOverPlan's identical check).
-	if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
-		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
+	if kind := hist.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering produced %s sample kind (%T), want histogram", kind, hist)
 	}
 	node, err = lowerHistogramValueFnOverProjection(c, hist, s, ctx)
 	return node, true, err

--- a/internal/promql/info_fn.go
+++ b/internal/promql/info_fn.go
@@ -259,8 +259,8 @@ func lowerInfoNonStaticBase(
 // lowerInfoJoin builds the enrichment join over an already-lowered base
 // arm. Split out of lowerInfo so the ignore-set carve-out can feed it
 // either the whole base vector or just its enrichable arm. histogramBase
-// marks input as histogram-valued (chplan.RowShapeOf(input) ==
-// chplan.HistogramRowShape) — see chplan.InfoJoin.Histogram's doc comment.
+// records the source-derived histogram-valued proof computed before lowering;
+// see chplan.InfoJoin.Histogram's doc comment.
 func lowerInfoJoin(input chplan.Node, histogramBase bool, nameMatchers, dataMatchers []*labels.Matcher, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	infoNode, err := lowerInfoMetric(nameMatchers, dataMatchers, s, ctx)
 	if err != nil {

--- a/internal/promql/instant_fns.go
+++ b/internal/promql/instant_fns.go
@@ -438,13 +438,13 @@ func projectValueOverInner(inner chplan.Node, s schema.Metrics, layout samplePro
 		func(refs sampleRoleRefs) sampleRoleRewrite { return sampleRoleRewrite{value: build(refs)} })
 }
 
-// legacySampleProjectionLayout preserves the existing temporal/materialization
-// boundary until the legacy shape contract is reconciled. It must not choose
-// a wrapper's name or payload policy, and it never supplies input column names.
+// legacySampleProjectionLayout derives the input's temporal envelope from its
+// physical roles. It must not choose a wrapper's name or payload policy, and it
+// never supplies input column names.
 func legacySampleProjectionLayout(inner chplan.Node) sampleProjectionLayout {
-	shape := chplan.RowShapeOf(inner)
-	return sampleProjectionLayout{
-		canonical: shape != chplan.GridWindowRowShape && shape != chplan.ReducedWindowRowShape,
-		anchored:  shape == chplan.GridWindowRowShape,
+	_, layout, err := resolveSampleTemporalLayout(inner.RowType())
+	if err != nil {
+		panic(err.Error())
 	}
+	return layout
 }

--- a/internal/promql/label_forwarding_contract_test.go
+++ b/internal/promql/label_forwarding_contract_test.go
@@ -48,9 +48,9 @@ func TestAttributeRewriteUnnamedFloatPhysicalColumns(t *testing.T) {
 				{name: "opaque_attributes", columns: []chplan.Column{{Name: s.AttributesColumn}, timestamp, value}, wantPanic: true},
 				{name: "opaque_timestamp", columns: []chplan.Column{attributes, {Name: s.TimestampColumn}, value}, wantPanic: true},
 				{name: "opaque_value", columns: []chplan.Column{attributes, timestamp, {Name: s.ValueColumn}}, wantPanic: true},
-				{name: "histogram_payload_retains_legacy_boundary", columns: append([]chplan.Column{attributes, anchor, timestamp, value}, chplan.HistogramPayloadColumns()...), wantPanic: true},
-				{name: "histogram_helper_retains_legacy_boundary", columns: []chplan.Column{attributes, timestamp, value, {Name: chplan.HistogramCountColumn, Role: chplan.RoleHistogramField}}, wantPanic: true},
-				{name: "discriminator_retains_legacy_boundary", columns: []chplan.Column{attributes, timestamp, value, {Name: "sample_kind", Role: chplan.RoleDiscriminator}}, wantPanic: true},
+				{name: "histogram_payload_is_not_value_forwardable", columns: append([]chplan.Column{attributes, anchor, timestamp, value}, chplan.HistogramPayloadColumns()...), wantPanic: true},
+				{name: "partial_histogram_is_not_value_forwardable", columns: []chplan.Column{attributes, timestamp, value, {Name: chplan.HistogramCountColumn, Role: chplan.RoleHistogramField}}, wantPanic: true},
+				{name: "orphan_discriminator_is_not_value_forwardable", columns: []chplan.Column{attributes, timestamp, value, {Name: "sample_kind", Role: chplan.RoleDiscriminator}}, wantPanic: true},
 			} {
 				t.Run(tc.name, func(t *testing.T) {
 					scan := &chplan.Scan{Roles: slices.Clone(tc.columns)}
@@ -60,9 +60,6 @@ func TestAttributeRewriteUnnamedFloatPhysicalColumns(t *testing.T) {
 							scan.Columns = append(scan.Columns, column.Name)
 							inner.Projections = append(inner.Projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}})
 						}
-					}
-					if got := chplan.RowShapeOf(inner); got != chplan.SampleRowShape {
-						t.Fatalf("fixture legacy shape = %v, want Sample", got)
 					}
 					var newAttrs chplan.Expr
 					var project *chplan.Project

--- a/internal/promql/limitk_exp_histogram_test.go
+++ b/internal/promql/limitk_exp_histogram_test.go
@@ -71,12 +71,11 @@ func TestLower_ExpHistogram_LimitKAndLimitRatioPreserveSamples(t *testing.T) {
 	}
 }
 
-// TestLower_ExpHistogram_LimitKEmptyKStaysHistogramShaped pins the K < 1
+// TestLower_ExpHistogram_LimitKEmptyKStaysHistogramShaped pins K < 1
 // degenerate fold (topKDomain's "empty" case, shared with topk/bottomk):
-// limitk still recognises a histogram-valued input first, so the
-// resulting constant-false chplan.Filter still reports HistogramRowShape
-// — the SQL stays column-set-compatible with its histogram-valued
-// Input even though the predicate keeps zero rows.
+// limitk still recognises the histogram-valued input first, so the resulting
+// constant-false Filter retains its histogram physical schema even though
+// its predicate keeps zero rows.
 func TestLower_ExpHistogram_LimitKEmptyKStaysHistogramShaped(t *testing.T) {
 	t.Parallel()
 
@@ -88,24 +87,18 @@ func TestLower_ExpHistogram_LimitKEmptyKStaysHistogramShaped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LowerAt: %v", err)
 	}
-	filter, ok := plan.(*chplan.Filter)
+	_, ok := plan.(*chplan.Filter)
 	if !ok {
 		t.Fatalf("plan is %T, want *chplan.Filter", plan)
-	}
-	if !filter.Histogram {
-		t.Fatalf("Filter.Histogram = false, want true")
 	}
 	if shape := chplan.RowShapeOf(plan); shape != chplan.HistogramRowShape {
 		t.Fatalf("RowShapeOf(plan) = %s, want histogram", shape)
 	}
 }
 
-// TestLower_ExpHistogram_TopKBottomKUnaffected pins that topk/bottomk's
-// existing histogram-DROPPING treatment (histogram_native_drop_
-// aggregation.go) is unchanged by #2518's fix: a purely histogram-valued
-// input still folds to an empty float-shaped result, never a
-// chplan.TopK.Histogram-marked plan — only limitk/limit_ratio preserve
-// the histogram shape.
+// TestLower_ExpHistogram_TopKBottomKUnaffected pins topk/bottomk's
+// histogram-dropping treatment. Only limitk/limit_ratio preserve histogram
+// samples.
 func TestLower_ExpHistogram_TopKBottomKUnaffected(t *testing.T) {
 	t.Parallel()
 

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -5336,7 +5336,7 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 	if err != nil {
 		return nil, err
 	}
-	if expHistogramAggOpIsMergeable(a.Op) && chplan.RowShapeOf(input) == chplan.MixedRowShape {
+	if expHistogramAggOpIsMergeable(a.Op) && mixedRowsNeedPreparation(input) {
 		return lowerSumOrAvgOverMixedPlan(a, input, s, ctx)
 	}
 	// Authorize the original Mixed relation before discarding histogram rows.
@@ -5483,14 +5483,14 @@ func lowerCountValues(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (
 		return nil, err
 	}
 	valueKey := promFixedFloatStringExpr(&chplan.ColumnRef{Name: s.ValueColumn})
-	if chplan.RowShapeOf(input) == chplan.MixedRowShape {
+	if mixedRowsNeedPreparation(input) {
 		// Shadow resolution belongs to the completed operand. Serialize each
 		// surviving sample by its kind: histogram placeholder Values are not
 		// real floats and must never enter the float value-label group.
 		valueKey = &chplan.FuncCall{Fn: chplan.FnIf, Args: []chplan.Expr{
 			&chplan.Binary{
 				Op:    chplan.OpEq,
-				Left:  &chplan.ColumnRef{Name: chplan.MixedDiscriminatorColumn},
+				Left:  requireSampleRole(input.RowType(), chplan.RoleDiscriminator),
 				Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
 			},
 			valueKey,
@@ -5826,7 +5826,7 @@ func lowerLimitKInput(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.
 	if err != nil {
 		return nil, false, false, err
 	}
-	mixed := chplan.RowShapeOf(input) == chplan.MixedRowShape
+	mixed := mixedRowsNeedPreparation(input)
 	if mixed {
 		transform, policyErr := executeMixedSelectorPolicy(mixedLimitFamily, mixedPlanAdmission)
 		if policyErr != nil {

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -5487,15 +5487,7 @@ func lowerCountValues(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (
 		// Shadow resolution belongs to the completed operand. Serialize each
 		// surviving sample by its kind: histogram placeholder Values are not
 		// real floats and must never enter the float value-label group.
-		valueKey = &chplan.FuncCall{Fn: chplan.FnIf, Args: []chplan.Expr{
-			&chplan.Binary{
-				Op:    chplan.OpEq,
-				Left:  requireSampleRole(input.RowType(), chplan.RoleDiscriminator),
-				Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
-			},
-			valueKey,
-			nativeHistogramStringExpr(s),
-		}}
+		valueKey = mixedCountValuesValueKey(input, valueKey, s)
 	}
 	return lowerCountValuesOverPlan(
 		a,
@@ -5505,6 +5497,18 @@ func lowerCountValues(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (
 		s,
 		ctx,
 	), nil
+}
+
+func mixedCountValuesValueKey(input chplan.Node, floatKey chplan.Expr, s schema.Metrics) chplan.Expr {
+	return &chplan.FuncCall{Fn: chplan.FnIf, Args: []chplan.Expr{
+		&chplan.Binary{
+			Op:    chplan.OpEq,
+			Left:  requireSampleRole(input.RowType(), chplan.RoleDiscriminator),
+			Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+		},
+		floatKey,
+		nativeHistogramStringExpr(s),
+	}}
 }
 
 // lowerCountValuesOverPlan applies the shared count_values grouping and

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -4349,12 +4349,14 @@ func appendNameGroupKey(rw *chplan.RangeWindow, s schema.Metrics) *chplan.Column
 // in the `anchor_ts` column; the instant shape doesn't expose a real
 // TimeUnix at all (the SQL emits only Attributes + Value), so the
 // projection synthesises one via the same `now64() - 5s` expression
-// the handler uses for derived-shape Projects. The outer
-// `wrapWithSampleProjection` canonical branch reads back the
-// `s.TimestampColumn` alias verbatim either way.
+// the handler uses for derived-shape Projects. A matrix projection also
+// forwards the raw anchor after the canonical quartet. The HTTP adapter walks
+// through this wrapper to recover the underlying matrix window, so its schema
+// must keep the anchor role the adapter then selects as the result grid.
 func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name chplan.Expr) chplan.Node {
 	var tsExpr chplan.Expr
-	if rw.OuterRange > 0 || rw.DownsampleTier {
+	matrix := rw.OuterRange > 0 || rw.DownsampleTier
+	if matrix {
 		// The matrix RangeWindow keeps anchor_ts offset-SHIFTED for the
 		// window/reduce math; PromQL reports a reducing window's result on the
 		// UNSHIFTED grid, so add Offset back (matching the emitter's
@@ -4397,16 +4399,24 @@ func wrapRangeWindowPreserveName(rw *chplan.RangeWindow, s schema.Metrics, name 
 		// anchor, so we stamp `now64(9) - toIntervalNanosecond(5e9)`.
 		tsExpr = chplan.NowNanoMinusStaleness()
 	}
-	return &chplan.Project{
-		Roles: metricRoles(s),
-		Input: rw,
-		Projections: []chplan.Projection{
-			{Expr: name, Alias: s.MetricNameColumn},
-			{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
-			{Expr: tsExpr, Alias: s.TimestampColumn},
-			{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
-		},
+	projections := []chplan.Projection{
+		{Expr: name, Alias: s.MetricNameColumn},
+		{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+		{Expr: tsExpr, Alias: s.TimestampColumn},
+		{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
 	}
+	roles := metricRoles(s)
+	if matrix {
+		projections = append(projections, chplan.Projection{
+			Expr:  &chplan.ColumnRef{Name: chplan.RangeWindowAnchorColumn},
+			Alias: chplan.RangeWindowAnchorColumn,
+		})
+		roles = append(roles, chplan.Column{
+			Name: chplan.RangeWindowAnchorColumn,
+			Role: chplan.RoleAnchor,
+		})
+	}
+	return &chplan.Project{Roles: roles, Input: rw, Projections: projections}
 }
 
 // rangeFnCollidesOnNameDrop reports whether a range-function call can
@@ -5328,22 +5338,12 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 	}
 
 	family := mixedAggregateFamily(a.Op)
-	if family == mixedCountGroupFamily {
-		input, err = preserveMixedPlan(input, family)
-	} else {
-		err = requireMixedPlanPolicy(input, family)
-	}
+	input, err = prepareMixedAggregatePlan(input, family)
 	if err != nil {
 		return nil, err
 	}
 	if expHistogramAggOpIsMergeable(a.Op) && mixedRowsNeedPreparation(input) {
 		return lowerSumOrAvgOverMixedPlan(a, input, s, ctx)
-	}
-	// Authorize the original Mixed relation before discarding histogram rows.
-	// Float-only reductions must not aggregate their placeholder Value column;
-	// narrowing this already-lowered relation preserves union shadow precedence.
-	if expHistogramAggDropsHistogramSamples(a.Op) {
-		input = mixedRowsFloatOnly(input)
 	}
 	wrapped, err := lowerPlainAggregateOverInput(a, input, s, ctx, ordinaryPlainAggregateLayout)
 	if err != nil {
@@ -5755,7 +5755,7 @@ func topKDomain(kF float64) (k int64, empty bool, err error) {
 // stable across evaluation steps, so the same series survive at every
 // anchor — matching Prom's per-step-but-deterministic behaviour.
 func lowerLimitRatio(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
-	input, histogram, mixed, err := lowerLimitKInput(a.Expr, s, ctx)
+	input, err := lowerLimitKInput(a.Expr, s, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -5771,12 +5771,12 @@ func lowerLimitRatio(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (c
 	if err != nil {
 		return nil, err
 	}
-	return &chplan.Filter{Input: input, Predicate: pred, Histogram: histogram, Mixed: mixed}, nil
+	return &chplan.Filter{Input: input, Predicate: pred}, nil
 }
 
 // lowerLimitKInput lowers the input vector shared by limitk (both the
-// literal-K and computed-K paths) and limit_ratio, reporting whether the
-// input is histogram-valued.
+// literal-K and computed-K paths) and limit_ratio while preserving its
+// physical sample payload.
 //
 // Reference Prometheus's LIMITK and LIMIT_RATIO arms of aggregationK
 // (promql/engine.go) build every Sample — float or histogram — from
@@ -5788,12 +5788,12 @@ func lowerLimitRatio(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (c
 // limitk/limit_ratio therefore needs the recognise-and-PRESERVE treatment
 // [lowerSortByLabel]'s fix (cerberus issue #2462) established, not the
 // recognise-and-drop treatment topk/bottomk use — cerberus issue #2518.
-func lowerLimitKInput(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, bool, bool, error) {
+func lowerLimitKInput(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	if hist, ok, err := lowerExpHistogramValuedShape(expr, s, ctx); ok {
 		if err != nil {
-			return nil, false, false, err
+			return nil, err
 		}
-		return hist, true, false, nil
+		return hist, nil
 	}
 	// A mixed float/histogram `or` operand (cerberus issue #2613) —
 	// `limitk(K, <hist> or <float>)` / `limit_ratio(R, <hist> or <float>)`.
@@ -5807,13 +5807,13 @@ func lowerLimitKInput(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.
 	if b, ok := mixedExpHistogramSetOp(expr, s, ctx); ok {
 		transform, err := executeMixedSelectorPolicy(mixedLimitFamily, mixedOperandAdmission)
 		if err != nil {
-			return nil, false, false, err
+			return nil, err
 		}
 		mixed, err := lowerMixedExpHistogramSetOp(b, s, ctx)
 		if err != nil {
-			return nil, false, false, err
+			return nil, err
 		}
-		return transform(mixed), false, true, nil
+		return transform(mixed), nil
 	}
 	// A nested drop-family shape (cerberus issue #2528) — e.g.
 	// `limitk(3, demo_latency_exp_hist + 0)`. The result is already the
@@ -5822,23 +5822,22 @@ func lowerLimitKInput(expr parser.Expr, s schema.Metrics, ctx lowerCtx) (chplan.
 	// "was the input histogram-shaped" contract.
 	if dropped, ok, err := lowerExpHistogramDroppingShape(expr, s, ctx); ok {
 		if err != nil {
-			return nil, false, false, err
+			return nil, err
 		}
-		return dropped, false, false, nil
+		return dropped, nil
 	}
 	input, err := lower(expr, s, ctx)
 	if err != nil {
-		return nil, false, false, err
+		return nil, err
 	}
-	mixed := mixedRowsNeedPreparation(input)
-	if mixed {
+	if mixedRowsNeedPreparation(input) {
 		transform, policyErr := executeMixedSelectorPolicy(mixedLimitFamily, mixedPlanAdmission)
 		if policyErr != nil {
-			return nil, false, false, policyErr
+			return nil, policyErr
 		}
 		input = transform(input)
 	}
-	return input, false, mixed, nil
+	return input, nil
 }
 
 // limitKOrRatioOverExpHistogram recognises `limitk(K, <exp-hist shape>)` /
@@ -6320,7 +6319,7 @@ func lowerLimitK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chpla
 		return nil, err
 	}
 
-	input, histogram, mixed, err := lowerLimitKInput(a.Expr, s, ctx)
+	input, err := lowerLimitKInput(a.Expr, s, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -6332,33 +6331,17 @@ func lowerLimitK(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (chpla
 		return &chplan.Filter{
 			Input:     input,
 			Predicate: &chplan.LitBool{V: false},
-			Histogram: histogram,
-			Mixed:     mixed,
 		}, nil
 	}
 
 	by := topKPartition(a, s, ctx)
-
-	// A histogram-valued OR mixed-valued input always forces `SELECT *`:
-	// the explicit canonical-quartet column list topKOutputColumns would
-	// otherwise declare drops the columns the input actually publishes
-	// (nine Histogram*Column outputs, or the fourteen-column Mixed
-	// contract — see [chplan.TopK]'s doc comment). topKOutputColumns has
-	// no way to tell either apart from a canonical input on its own, so
-	// `histogram`/`mixed` are the explicit signals that override it.
-	columns := topKOutputColumns(input, s)
-	if histogram || mixed {
-		columns = nil
-	}
 
 	return &chplan.TopK{
 		Input:     input,
 		K:         k,
 		By:        by,
 		Unordered: true,
-		Columns:   columns,
-		Histogram: histogram,
-		Mixed:     mixed,
+		Columns:   limitKOutputColumns(input, s),
 	}, nil
 }
 
@@ -6456,6 +6439,19 @@ func topKOutputColumns(input chplan.Node, s schema.Metrics) []string {
 	}
 }
 
+// limitKOutputColumns preserves every public payload column selected by
+// limitk. Ordinary float inputs retain the established explicit quartet;
+// histogram and mixed schemas use SELECT * so their payload and discriminator
+// pass through unchanged. The decision comes from the input's declared
+// physical roles rather than a duplicate flag on TopK.
+func limitKOutputColumns(input chplan.Node, s schema.Metrics) []string {
+	row := input.RowType()
+	if row.Has(chplan.RoleHistogramField) || row.Has(chplan.RoleDiscriminator) {
+		return nil
+	}
+	return topKOutputColumns(input, s)
+}
+
 // lowerTopKComputed lowers `topk`/`bottomk`/`limitk` with a K that is
 // any scalar-valued PromQL expression rather than a foldable literal —
 // `topk(scalar(<vector>), v)`, `topk(scalar(x) * 2, v)`,
@@ -6484,11 +6480,10 @@ func lowerTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) 
 	// aggregation.go), so `input` here is never histogram-valued for
 	// them and the plain [lower] dispatch is unchanged for that path.
 	var input chplan.Node
-	var histogram, mixed bool
 	var transform mixedPlanTransform
 	var err error
 	if a.Op == parser.LIMITK {
-		input, histogram, mixed, err = lowerLimitKInput(a.Expr, s, ctx)
+		input, err = lowerLimitKInput(a.Expr, s, ctx)
 	} else {
 		transform, err = executeMixedSelectorPolicy(mixedTopKFamily, mixedPlanAdmission)
 		if err == nil {
@@ -6501,7 +6496,7 @@ func lowerTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) 
 	if a.Op != parser.LIMITK {
 		input = transform(input)
 	}
-	return buildTopKComputed(a, s, ctx, input, histogram, mixed)
+	return buildTopKComputed(a, s, ctx, input)
 }
 
 // buildTopKComputed builds the computed-K topk/bottomk/limitk node over
@@ -6511,10 +6506,8 @@ func lowerTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) 
 // K-domain / partition / column-shape rules over the mixed `or`'s
 // shadow-resolved float arm instead of a freshly lowered `a.Expr` — the
 // only difference between the two callers is which chplan.Node `input`
-// names. `histogram` is always false for the mixed-or caller (topk/
-// bottomk never preserve a histogram-valued input — see
-// [lowerTopKComputed]'s own comment).
-func buildTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx, input chplan.Node, histogram, mixed bool) (chplan.Node, error) {
+// names.
+func buildTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx, input chplan.Node) (chplan.Node, error) {
 	// The K domain is reference Prometheus's, and reference applies it to
 	// the parameter's whole per-step value series before it aggregates
 	// anything. A computed K has no value until the query runs, and the
@@ -6548,21 +6541,16 @@ func buildTopKComputed(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx, 
 		},
 	}
 
-	// See lowerLimitK's matching comment: a histogram-valued OR
-	// mixed-valued input always forces `SELECT *` rather than the
-	// explicit canonical-quartet column list.
 	columns := topKOutputColumns(input, s)
-	if histogram || mixed {
-		columns = nil
+	if a.Op == parser.LIMITK {
+		columns = limitKOutputColumns(input, s)
 	}
 
 	t := &chplan.TopK{
-		Input:     input,
-		KExpr:     kExpr,
-		By:        topKPartition(a, s, ctx),
-		Columns:   columns,
-		Histogram: histogram,
-		Mixed:     mixed,
+		Input:   input,
+		KExpr:   kExpr,
+		By:      topKPartition(a, s, ctx),
+		Columns: columns,
 	}
 	if a.Op == parser.LIMITK {
 		// limitk keeps K arbitrary series per group — no ranking, so the

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -219,7 +219,8 @@ func TestLower(t *testing.T) {
 		})
 		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 		spec.AssertRowTypeMatchesDriver(t, optimized, roundTripResult)
-		spec.AssertRowShapeAgreement(t, plan)
+		spec.AssertPlanScanRoles(t, plan)
+		spec.AssertPlanScanRoles(t, optimized)
 
 		// A fixture carrying a `parity:` section is additionally answered
 		// by the REAL upstream Prometheus engine over the same seeded

--- a/internal/promql/mixed_consumer_inventory_test.go
+++ b/internal/promql/mixed_consumer_inventory_test.go
@@ -1,0 +1,84 @@
+package promql
+
+import (
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Mixed-wrapper consumers decide from mixedRowsNeedPreparation, which keeps
+// physical payload separate from the live-row proof. The three remaining
+// RowShapeOf comparisons are histogram-recognizer postconditions covered by
+// #3349; adding another site means a consumer regressed to legacy inference.
+func TestMixedWrapperLegacyShapeInventory(t *testing.T) {
+	want := []string{
+		"histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerSumOrAvgMixedOrSubquerySelectFn",
+		"histogram_native_mixed_or_subquery_last_first.go:lowerMixedOrSubqueryLastFirstInput",
+		"histogram_native_mixed_or_subquery_resets_changes.go:lowerMixedOrSubqueryResetsOrChanges",
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	var got []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := goparser.ParseFile(fset, name, nil, goparser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil {
+				continue
+			}
+			found := false
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				binary, ok := node.(*ast.BinaryExpr)
+				if ok && mixedRowShapeComparison(binary) {
+					found = true
+				}
+				return true
+			})
+			if found {
+				got = append(got, name+":"+function.Name.Name)
+			}
+		}
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RowShapeOf mixed comparisons =\n  %s\nwant\n  %s", strings.Join(got, "\n  "), strings.Join(want, "\n  "))
+	}
+}
+
+func mixedRowShapeComparison(binary *ast.BinaryExpr) bool {
+	if binary.Op != token.EQL && binary.Op != token.NEQ {
+		return false
+	}
+	return rowShapeOfCall(binary.X) && mixedRowShapeIdent(binary.Y) ||
+		rowShapeOfCall(binary.Y) && mixedRowShapeIdent(binary.X)
+}
+
+func rowShapeOfCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "RowShapeOf"
+}
+
+func mixedRowShapeIdent(expr ast.Expr) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "MixedRowShape"
+}

--- a/internal/promql/mixed_consumer_inventory_test.go
+++ b/internal/promql/mixed_consumer_inventory_test.go
@@ -12,15 +12,11 @@ import (
 )
 
 // Mixed-wrapper consumers decide from mixedRowsNeedPreparation, which keeps
-// physical payload separate from the live-row proof. The three remaining
-// RowShapeOf comparisons are histogram-recognizer postconditions covered by
-// #3349; adding another site means a consumer regressed to legacy inference.
+// physical payload separate from the live-row proof. No production consumer
+// compares RowShapeOf with MixedRowShape; adding a site means a consumer
+// regressed to legacy inference.
 func TestMixedWrapperLegacyShapeInventory(t *testing.T) {
-	want := []string{
-		"histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerSumOrAvgMixedOrSubquerySelectFn",
-		"histogram_native_mixed_or_subquery_last_first.go:lowerMixedOrSubqueryLastFirstInput",
-		"histogram_native_mixed_or_subquery_resets_changes.go:lowerMixedOrSubqueryResetsOrChanges",
-	}
+	var want []string
 	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/promql/mixed_consumer_live_kind_test.go
+++ b/internal/promql/mixed_consumer_live_kind_test.go
@@ -1,0 +1,128 @@
+package promql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestMixedConsumersConsultPolicyOnlyForLiveMixedRows(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	live, floatRows := mixedConsumerTestRows(s)
+	arg := mustParse(t, "up")
+	year := mustParse(t, "year(up)").(*parser.Call)
+	timestamp := mustParse(t, "timestamp(up)").(*parser.Call)
+
+	tests := []struct {
+		name string
+		key  mixedWrapperKey
+		run  func(chplan.Node) (chplan.Node, error)
+	}{
+		{
+			name: "preserve",
+			key:  mixedWrapperKey{family: mixedCountGroupFamily, site: mixedPlanAdmission},
+			run: func(input chplan.Node) (chplan.Node, error) {
+				return preserveMixedPlan(input, mixedCountGroupFamily)
+			},
+		},
+		{
+			name: "scalar",
+			key:  mixedWrapperKey{family: mixedScalarFamily, site: mixedPlanAdmission},
+			run:  scalarFloatRows,
+		},
+		{
+			name: "scalar_arithmetic",
+			key:  mixedWrapperKey{family: mixedArithmeticFamily, site: mixedPlanAdmission},
+			run: func(input chplan.Node) (chplan.Node, error) {
+				return finishScalarArithmetic(input, arg, s, lowerCtx{}, chplan.OpAdd, 1, false, scalarArithmeticGuarded)
+			},
+		},
+		{
+			name: "scalar_comparison",
+			key:  mixedWrapperKey{family: mixedComparisonFamily, site: mixedPlanAdmission},
+			run: func(input chplan.Node) (chplan.Node, error) {
+				return finishScalarComparison(input, arg, s, lowerCtx{}, chplan.OpGt, 1, false, false, scalarComparisonGuarded)
+			},
+		},
+		{
+			name: "date",
+			key:  mixedWrapperKey{family: mixedDateFamily, site: mixedPlanAdmission},
+			run: func(input chplan.Node) (chplan.Node, error) {
+				return projectDateFnOverInner(year, input, s, lowerCtx{})
+			},
+		},
+		{
+			name: "timestamp",
+			key:  mixedWrapperKey{family: mixedTimestampFamily, site: mixedPlanAdmission},
+			run: func(input chplan.Node) (chplan.Node, error) {
+				return projectDateFnOverInner(timestamp, input, s, lowerCtx{})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy, ok := mixedOperandPolicies[tc.key]
+			if !ok {
+				t.Fatal("fixture policy is missing")
+			}
+			delete(mixedOperandPolicies, tc.key)
+			t.Cleanup(func() { mixedOperandPolicies[tc.key] = policy })
+
+			if plan, err := tc.run(live); plan != nil || err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted") {
+				t.Fatalf("live mixed input bypassed policy: plan=%T error=%v", plan, err)
+			}
+			plan, err := tc.run(floatRows)
+			if plan == nil || err != nil {
+				t.Fatalf("proven float rows consulted mixed policy: plan=%T error=%v", plan, err)
+			}
+		})
+	}
+}
+
+func TestTimestampConsumerPreservesLiveMixedRowsAndAcceptsFloatProof(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	live, floatRows := mixedConsumerTestRows(s)
+	call := mustParse(t, "timestamp(up)").(*parser.Call)
+	for _, tc := range []struct {
+		name       string
+		input      chplan.Node
+		wantNarrow int
+	}{
+		{name: "live_mixed", input: live},
+		{name: "float_proof", input: floatRows, wantNarrow: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := projectDateFnOverInner(call, tc.input, s, lowerCtx{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			narrow := 0
+			chplan.Walk(plan, func(node chplan.Node) bool {
+				if chplan.IsMixedFloatNarrowing(node) {
+					narrow++
+				}
+				return true
+			})
+			if narrow != tc.wantNarrow {
+				t.Fatalf("float narrowing count = %d, want %d", narrow, tc.wantNarrow)
+			}
+		})
+	}
+}
+
+func mixedConsumerTestRows(s schema.Metrics) (chplan.Node, chplan.Node) {
+	columns := append(metricRoles(s), chplan.HistogramPayloadColumns()...)
+	columns = append(columns, chplan.Column{Name: "source_kind", Role: chplan.RoleDiscriminator})
+	live := sampleForwardTestInput(columns...)
+	floatRows := &chplan.Filter{Input: live, Predicate: &chplan.Binary{
+		Op:    chplan.OpEq,
+		Left:  &chplan.ColumnRef{Name: "source_kind"},
+		Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
+	}}
+	return live, floatRows
+}

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -214,7 +214,7 @@ func lowerWithMixedPreservePolicy(family mixedWrapperFamily, site mixedAdmission
 }
 
 func preserveMixedPlan(inner chplan.Node, family mixedWrapperFamily) (chplan.Node, error) {
-	if chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+	if !mixedRowsNeedPreparation(inner) {
 		return inner, nil
 	}
 	return lowerWithMixedPreservePolicy(family, mixedPlanAdmission, func() (chplan.Node, error) { return inner, nil })

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -97,9 +97,11 @@ type mixedWrapperKey struct {
 //
 // Bespoke entries select a family-specific payload transformation. Sum/avg, for
 // example, partitions and recombines a mixed plan; count/group instead preserve
-// that plan for their payload-neutral reduction. Scalar arithmetic's root and
-// existing-plan entries execute the float-only policy through its shared value
-// kernel, preserving each projection boundary.
+// that plan for their payload-neutral reduction. Float aggregates remain bespoke
+// at the root, where their mixed union needs shadow resolution, while their
+// existing-plan entries execute the shared float-only transform after that
+// resolution. Scalar arithmetic follows the same policy-driven narrowing while
+// preserving each projection boundary.
 var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedLeafFamily, mixedRootAdmission}:              mixedBespoke,
 	{mixedSumAvgFamily, mixedRootAdmission}:            mixedBespoke,
@@ -148,7 +150,7 @@ var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedVectorComparisonFamily, mixedPlanAdmission}:  mixedBespoke,
 	{mixedSumAvgFamily, mixedPlanAdmission}:            mixedBespoke,
 	{mixedCountGroupFamily, mixedPlanAdmission}:        mixedPreserve,
-	{mixedFloatAggregateFamily, mixedPlanAdmission}:    mixedBespoke,
+	{mixedFloatAggregateFamily, mixedPlanAdmission}:    mixedFloatOnly,
 	{mixedTopKFamily, mixedPlanAdmission}:              mixedFloatOnly,
 	{mixedCountValuesFamily, mixedPlanAdmission}:       mixedBespoke,
 }
@@ -194,6 +196,30 @@ func mixedPlanTransformForPolicy(policy mixedOperandPolicy) mixedPlanTransform {
 		return mixedRowsFloatOnly
 	}
 	return preserveMixedPlanTransform
+}
+
+// prepareMixedAggregatePlan applies the registered existing-plan policy for
+// the aggregate families which reach lowerAggregate's generic input path.
+// Keeping this switch closed prevents a new aggregate family from inheriting a
+// plausible payload transform merely because somebody added a table entry.
+func prepareMixedAggregatePlan(inner chplan.Node, family mixedWrapperFamily) (chplan.Node, error) {
+	if !mixedRowsNeedPreparation(inner) {
+		return inner, nil
+	}
+
+	expected := mixedPolicyClosed
+	switch family {
+	case mixedSumAvgFamily:
+		expected = mixedBespoke
+	case mixedCountGroupFamily:
+		expected = mixedPreserve
+	case mixedFloatAggregateFamily:
+		expected = mixedFloatOnly
+	}
+	if err := requireMixedPlanPolicy(inner, family, expected); err != nil {
+		return nil, err
+	}
+	return mixedPlanTransformForPolicy(expected)(inner), nil
 }
 
 func requireMixedBespokePolicy(key mixedWrapperKey, policy mixedOperandPolicy) error {

--- a/internal/promql/mixed_operand_policy_test.go
+++ b/internal/promql/mixed_operand_policy_test.go
@@ -204,6 +204,9 @@ func TestMixedOperandPolicyAdmissionInventory(t *testing.T) {
 			case mixedLabelFamily, mixedSortByLabelFamily, mixedCountGroupFamily, mixedLimitFamily:
 				wantPolicy = mixedPreserve
 			}
+			if key == (mixedWrapperKey{family: mixedFloatAggregateFamily, site: mixedPlanAdmission}) {
+				wantPolicy = mixedFloatOnly
+			}
 			if got := mixedOperandPolicies[key]; got != wantPolicy {
 				t.Errorf("admission %v = %v, want %v", key, got, wantPolicy)
 			}

--- a/internal/promql/mixed_physical_payload_test.go
+++ b/internal/promql/mixed_physical_payload_test.go
@@ -35,23 +35,25 @@ func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.
 		input                chplan.Node
 		physicalMixed        bool
 		floatProven          bool
+		physicalKind         chplan.SampleKind
+		liveKind             chplan.SampleKind
 		legacyShape          chplan.RowShape
 		needsPreparation     bool
 		mayContainHistograms bool
 	}{
-		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleRowShape, false, false},
-		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.HistogramRowShape, false, true},
-		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleRowShape, true, true},
-		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleRowShape, false, false},
-		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleRowShape, false, false},
-		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleRowShape, false, false},
-		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleRowShape, false, false},
-		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleRowShape, false, false},
-		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.MixedRowShape, true, true},
-		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleRowShape, true, true},
-		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleRowShape, true, true},
-		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleRowShape, true, true},
-		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.MixedRowShape, false, false},
+		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.SampleKindHistogram, chplan.SampleKindHistogram, chplan.HistogramRowShape, false, true},
+		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
+		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.MixedRowShape, true, true},
+		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
+		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
+		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
+		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.MixedRowShape, false, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			row := tc.input.RowType()
@@ -61,6 +63,12 @@ func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.
 			}
 			if got := mixedFloatRowsProven(tc.input); got != tc.floatProven {
 				t.Fatalf("float proof=%v, want %v", got, tc.floatProven)
+			}
+			if got := row.SampleKind(); got != tc.physicalKind {
+				t.Fatalf("physical sample kind=%s, want %s", got, tc.physicalKind)
+			}
+			if got := liveSampleKind(tc.input); got != tc.liveKind {
+				t.Fatalf("live sample kind=%s, want %s", got, tc.liveKind)
 			}
 			if got := chplan.RowShapeOf(tc.input); got != tc.legacyShape {
 				t.Fatalf("legacy shape=%s, want %s", got, tc.legacyShape)

--- a/internal/promql/mixed_physical_payload_test.go
+++ b/internal/promql/mixed_physical_payload_test.go
@@ -11,87 +11,69 @@ import (
 	"github.com/tsouza/cerberus/internal/schema"
 )
 
-func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.T) {
+func TestMixedRowsNeedPreparationSeparatesPhysicalPayloadAndLiveProof(t *testing.T) {
+	t.Parallel()
 	s := schema.DefaultOTelMetrics()
 	mixedColumns := append(metricRoles(s), chplan.HistogramPayloadColumns()...)
-	mixedColumns = append(mixedColumns, chplan.Column{Name: "source_kind", Role: chplan.RoleDiscriminator})
+	mixedColumns = append(mixedColumns, chplan.Column{Name: mixedDiscriminatorColumn, Role: chplan.RoleDiscriminator})
 	mixed := sampleForwardTestInput(mixedColumns...)
 	floatRows := &chplan.Filter{Input: mixed, Predicate: &chplan.Binary{
 		Op:    chplan.OpEq,
-		Left:  &chplan.ColumnRef{Name: "source_kind"},
+		Left:  &chplan.ColumnRef{Name: mixedDiscriminatorColumn},
 		Right: &chplan.LitInt{V: mixedDiscriminatorFloat},
 	}}
-	legacyMixedFloat := &chplan.Filter{
-		Input:     sampleForwardTestInput(metricRoles(s)...),
-		Predicate: &chplan.LitBool{V: true},
-		Mixed:     true,
-	}
 	emptyRankedSelector := &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: false}}
 	nonemptyRankedSelector := &chplan.TopK{Input: floatRows, Columns: topKOutputColumns(floatRows, s)}
-	preservingSelector := &chplan.TopK{Input: mixed, Mixed: true}
+	preservingSelector := &chplan.TopK{Input: mixed}
 
 	for _, tc := range []struct {
 		name                 string
 		input                chplan.Node
-		physicalMixed        bool
-		floatProven          bool
 		physicalKind         chplan.SampleKind
 		liveKind             chplan.SampleKind
-		legacyShape          chplan.RowShape
 		needsPreparation     bool
 		mayContainHistograms bool
 	}{
-		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
-		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.SampleKindHistogram, chplan.SampleKindHistogram, chplan.HistogramRowShape, false, true},
-		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
-		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
-		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
-		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
-		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
-		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
-		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.MixedRowShape, true, true},
-		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
-		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
-		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
-		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.MixedRowShape, false, false},
+		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), chplan.SampleKindFloat, chplan.SampleKindFloat, false, false},
+		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, chplan.SampleKindHistogram, chplan.SampleKindHistogram, false, true},
+		{"physical_mixed", mixed, chplan.SampleKindMixed, chplan.SampleKindMixed, true, true},
+		{"float_proof_preserves_physical_mixed", floatRows, chplan.SampleKindMixed, chplan.SampleKindFloat, false, false},
+		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, chplan.SampleKindMixed, chplan.SampleKindFloat, false, false},
+		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, chplan.SampleKindMixed, chplan.SampleKindFloat, false, false},
+		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, chplan.SampleKindMixed, chplan.SampleKindFloat, false, false},
+		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, chplan.SampleKindFloat, chplan.SampleKindFloat, false, false},
+		{"preserving_selector_keeps_live_mixed", preservingSelector, chplan.SampleKindMixed, chplan.SampleKindMixed, true, true},
+		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, chplan.SampleKindMixed, chplan.SampleKindMixed, true, true},
+		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, chplan.SampleKindMixed, chplan.SampleKindMixed, true, true},
+		{"project_barrier", &chplan.Project{Input: mixed}, chplan.SampleKindMixed, chplan.SampleKindMixed, true, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			row := tc.input.RowType()
-			physicalMixed := row.HasHistogramPayload() && row.Has(chplan.RoleDiscriminator)
-			if physicalMixed != tc.physicalMixed {
-				t.Fatalf("physical mixed=%v, want %v; schema=%#v", physicalMixed, tc.physicalMixed, row)
-			}
-			if got := mixedFloatRowsProven(tc.input); got != tc.floatProven {
-				t.Fatalf("float proof=%v, want %v", got, tc.floatProven)
-			}
 			if got := row.SampleKind(); got != tc.physicalKind {
-				t.Fatalf("physical sample kind=%s, want %s", got, tc.physicalKind)
+				t.Errorf("physical sample kind = %s, want %s; schema=%#v", got, tc.physicalKind, row)
 			}
 			if got := liveSampleKind(tc.input); got != tc.liveKind {
-				t.Fatalf("live sample kind=%s, want %s", got, tc.liveKind)
-			}
-			if got := chplan.RowShapeOf(tc.input); got != tc.legacyShape {
-				t.Fatalf("legacy shape=%s, want %s", got, tc.legacyShape)
+				t.Errorf("live sample kind = %s, want %s", got, tc.liveKind)
 			}
 			if got := mixedRowsNeedPreparation(tc.input); got != tc.needsPreparation {
-				t.Fatalf("needs preparation=%v, want %v", got, tc.needsPreparation)
+				t.Errorf("needs preparation = %v, want %v", got, tc.needsPreparation)
 			}
 			if got := rowsMayContainHistograms(tc.input); got != tc.mayContainHistograms {
-				t.Fatalf("may contain histograms=%v, want %v", got, tc.mayContainHistograms)
+				t.Errorf("may contain histograms = %v, want %v", got, tc.mayContainHistograms)
 			}
 
 			prepared := mixedRowsFloatOnly(tc.input)
 			if !tc.needsPreparation {
 				if prepared != tc.input {
-					t.Fatal("input without live mixed rows was narrowed")
+					t.Fatal("already-compatible input was wrapped")
 				}
 				return
 			}
 			if !prepared.RowType().Equal(row) {
-				t.Fatalf("preparation changed physical schema: got %#v, want %#v", prepared.RowType(), row)
+				t.Fatalf("narrowing changed physical schema: got %#v, want %#v", prepared.RowType(), row)
 			}
 			if !chplan.IsMixedFloatNarrowing(prepared) {
-				t.Fatalf("prepared plan is not a float discriminator proof: %#v", prepared)
+				t.Fatal("preparation did not create an explicit float-row proof")
 			}
 			if mixedRowsFloatOnly(prepared) != prepared {
 				t.Fatal("float preparation is not idempotent")
@@ -246,8 +228,8 @@ func TestRowsMayContainHistogramsUsesRolesAcrossSampleEnvelopes(t *testing.T) {
 			value,
 			{Role: role},
 		}}
-		if liveSampleRolesAreUnambiguous(unnamed) {
-			t.Fatalf("unnamed role %d was accepted: %#v", role, unnamed)
+		if got := unnamed.SampleKind(); got != chplan.SampleKindInvalid {
+			t.Fatalf("unnamed role %d classified as %s, want invalid: %#v", role, got, unnamed)
 		}
 		for _, input := range []chplan.Node{
 			sampleForwardTestInput(

--- a/internal/promql/plain_aggregate_kernel.go
+++ b/internal/promql/plain_aggregate_kernel.go
@@ -23,7 +23,11 @@ const (
 // Admission and quantile-domain guards belong to the respective callers.
 func lowerPlainAggregateOverInput(a *parser.AggregateExpr, input chplan.Node, s schema.Metrics, ctx lowerCtx, layout plainAggregateLayout) (chplan.Node, error) {
 	if layout == mixedPlainAggregateLayout {
-		input = canonicalizeMixedFloatArmForAgg(input, s)
+		var err error
+		input, err = canonicalizeMixedFloatArmForAgg(input, s)
+		if err != nil {
+			return nil, err
+		}
 	}
 	groupBy, err := aggregateGroupBy(a, s)
 	if err != nil {

--- a/internal/promql/presence_kernel_test.go
+++ b/internal/promql/presence_kernel_test.go
@@ -84,7 +84,11 @@ func TestPresenceKernelLayouts(t *testing.T) {
 			for _, op := range []parser.ItemType{parser.COUNT, parser.GROUP} {
 				for _, layout := range []plainAggregateLayout{ordinaryPlainAggregateLayout, mixedPlainAggregateLayout} {
 					t.Run(fmt.Sprintf("%v/%v/%s/%v", custom, step, op, layout), func(t *testing.T) {
-						input := &chplan.VectorSetOp{Mixed: true}
+						input := &chplan.VectorSetOp{
+							Mixed: true, MetricNameColumn: s.MetricNameColumn,
+							AttributesColumn: s.AttributesColumn, TimestampColumn: s.TimestampColumn,
+							ValueColumn: s.ValueColumn,
+						}
 						expr := &parser.AggregateExpr{Op: op, Grouping: []string{"job", "instance"}}
 						plan, err := lowerPlainAggregateOverInput(expr, input, s, lowerCtx{step: step}, layout)
 						if err != nil {
@@ -132,9 +136,22 @@ func TestPresenceKernelLayouts(t *testing.T) {
 func TestPresenceKernelCanonicalizationAndNativeGrid(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 	a := &parser.AggregateExpr{Op: parser.COUNT}
+	source := sampleForwardTestInput(metricRoles(s)...)
+	newReduced := func() *chplan.RangeWindow {
+		return &chplan.RangeWindow{
+			Input: source, ValueColumn: s.ValueColumn,
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+		}
+	}
+	newGrid := func() *chplan.RangeWindowGridNative {
+		return &chplan.RangeWindowGridNative{
+			Input: source, TimestampColumn: s.TimestampColumn, ValueColumn: s.ValueColumn,
+			GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+		}
+	}
 	t.Run("quantile-cannot-bypass-domain-guard", func(t *testing.T) {
 		quantile := &parser.AggregateExpr{Op: parser.QUANTILE, Param: &parser.NumberLiteral{Val: -1}}
-		plan, err := lowerPlainAggregateOverInput(quantile, &chplan.RangeWindowGridNative{}, s, lowerCtx{step: time.Minute, lowerers: RangeLowerers{VectorAgg: true}}, ordinaryPlainAggregateLayout)
+		plan, err := lowerPlainAggregateOverInput(quantile, newGrid(), s, lowerCtx{step: time.Minute, lowerers: RangeLowerers{VectorAgg: true}}, ordinaryPlainAggregateLayout)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -144,7 +161,7 @@ func TestPresenceKernelCanonicalizationAndNativeGrid(t *testing.T) {
 	})
 	for _, layout := range []plainAggregateLayout{ordinaryPlainAggregateLayout, mixedPlainAggregateLayout} {
 		t.Run(fmt.Sprint(layout), func(t *testing.T) {
-			reduced := &chplan.RangeWindow{}
+			reduced := newReduced()
 			plan, err := lowerPlainAggregateOverInput(a, reduced, s, lowerCtx{}, layout)
 			if err != nil {
 				t.Fatal(err)
@@ -161,7 +178,7 @@ func TestPresenceKernelCanonicalizationAndNativeGrid(t *testing.T) {
 				}
 			}
 			for _, enabled := range []bool{false, true} {
-				grid := &chplan.RangeWindowGridNative{}
+				grid := newGrid()
 				plan, err := lowerPlainAggregateOverInput(a, grid, s, lowerCtx{step: time.Minute, lowerers: RangeLowerers{VectorAgg: enabled}}, layout)
 				if err != nil {
 					t.Fatal(err)

--- a/internal/promql/presence_kernel_test.go
+++ b/internal/promql/presence_kernel_test.go
@@ -62,7 +62,7 @@ func TestPresenceKernelPayloadPolicy(t *testing.T) {
 	if plan, err := preserveMixedPlan(&chplan.VectorSetOp{Mixed: true}, mixedCountGroupFamily); plan != nil || err == nil {
 		t.Fatal("missing plan policy admitted")
 	}
-	for _, input := range []chplan.Node{&chplan.Scan{}, &chplan.HistogramProjection{}} {
+	for _, input := range []chplan.Node{&chplan.Scan{}, &chplan.HistogramProjection{Input: &chplan.OneRow{}}} {
 		got, err := preserveMixedPlan(input, mixedCountGroupFamily)
 		if got != input || err != nil {
 			t.Fatalf("ordinary input %T consulted mixed policy: plan=%T err=%v", input, got, err)

--- a/internal/promql/sample_forward.go
+++ b/internal/promql/sample_forward.go
@@ -51,6 +51,91 @@ type sampleRoleRewrite struct {
 	value      chplan.Expr
 }
 
+type sampleTemporalRoles struct {
+	metricName string
+	attributes string
+	timestamp  string
+	anchor     string
+	value      string
+}
+
+func (r sampleTemporalRoles) refs() sampleRoleRefs {
+	refs := sampleRoleRefs{
+		Attributes: &chplan.ColumnRef{Name: r.attributes},
+		Value:      &chplan.ColumnRef{Name: r.value},
+	}
+	if r.metricName != "" {
+		refs.MetricName = &chplan.ColumnRef{Name: r.metricName}
+	}
+	if r.timestamp != "" {
+		refs.Timestamp = &chplan.ColumnRef{Name: r.timestamp}
+	}
+	if r.anchor != "" {
+		refs.Anchor = &chplan.ColumnRef{Name: r.anchor}
+	}
+	return refs
+}
+
+// resolveSampleTemporalLayout validates the physical roles that describe one
+// sample's identity and temporal envelope. It deliberately says nothing about
+// whether a caller preserves MetricName or rewrites Value: those are wrapper
+// policies, while this helper answers only which live columns carry the roles.
+func resolveSampleTemporalLayout(row chplan.Schema) (sampleTemporalRoles, sampleProjectionLayout, error) {
+	if row.Open {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, fmt.Errorf("promql: temporal sample layout requires a closed schema")
+	}
+	if row.SampleKind() == chplan.SampleKindInvalid {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, fmt.Errorf("promql: temporal sample layout has an invalid sample schema")
+	}
+
+	attributes, _, err := resolveOptionalSampleRoleName(row, chplan.RoleAttributes)
+	if err != nil {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, err
+	}
+	if attributes == "" {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, fmt.Errorf("promql: temporal sample layout is missing the attributes role")
+	}
+	value, _, err := resolveOptionalSampleRoleName(row, chplan.RoleValue)
+	if err != nil {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, err
+	}
+	if value == "" {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, fmt.Errorf("promql: temporal sample layout is missing the value role")
+	}
+	metricName, hasMetricName, err := resolveOptionalSampleRoleName(row, chplan.RoleMetricName)
+	if err != nil {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, err
+	}
+	timestamp, hasTimestamp, err := resolveOptionalSampleRoleName(row, chplan.RoleTimestamp)
+	if err != nil {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, err
+	}
+	anchor, hasAnchor, err := resolveOptionalSampleRoleName(row, chplan.RoleAnchor)
+	if err != nil {
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, err
+	}
+
+	roles := sampleTemporalRoles{
+		metricName: metricName,
+		attributes: attributes,
+		timestamp:  timestamp,
+		anchor:     anchor,
+		value:      value,
+	}
+	switch {
+	case hasAnchor && hasTimestamp:
+		return roles, sampleProjectionLayout{anchored: true}, nil
+	case hasAnchor:
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, fmt.Errorf("promql: temporal sample layout anchor role requires a timestamp role")
+	case hasTimestamp:
+		return roles, sampleProjectionLayout{canonical: true}, nil
+	case hasMetricName:
+		return sampleTemporalRoles{}, sampleProjectionLayout{}, fmt.Errorf("promql: temporal sample layout metric-name role requires a timestamp role")
+	default:
+		return roles, sampleProjectionLayout{}, nil
+	}
+}
+
 // sourceMetrics adapts existing expression builders that take configured names.
 // The copy is input-only: public output aliases still use the caller's schema.
 func (r sampleRoleRefs) sourceMetrics(s schema.Metrics) schema.Metrics {
@@ -204,25 +289,44 @@ func resolveSampleRoleRefs(row chplan.Schema, s schema.Metrics, policy samplePro
 }
 
 func requireSampleRole(row chplan.Schema, role chplan.ColumnRole) *chplan.ColumnRef {
+	ref, ok, err := resolveOptionalSampleRole(row, role)
+	if err != nil {
+		panic(err.Error())
+	}
+	if !ok {
+		panic(fmt.Sprintf("promql: sample forwarder is missing required role %d", role))
+	}
+	return ref
+}
+
+func resolveOptionalSampleRole(row chplan.Schema, role chplan.ColumnRole) (*chplan.ColumnRef, bool, error) {
+	name, ok, err := resolveOptionalSampleRoleName(row, role)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return &chplan.ColumnRef{Name: name}, true, nil
+}
+
+func resolveOptionalSampleRoleName(row chplan.Schema, role chplan.ColumnRole) (string, bool, error) {
 	var name string
 	for _, column := range row.Columns {
 		if column.Role != role {
 			continue
 		}
 		if name != "" || column.Name == "" {
-			panic(fmt.Sprintf("promql: sample forwarder requires one named column for role %d", role))
+			return "", false, fmt.Errorf("promql: temporal sample layout requires one named column for role %d", role)
 		}
 		name = column.Name
 	}
 	if name == "" {
-		panic(fmt.Sprintf("promql: sample forwarder is missing required role %d", role))
+		return "", false, nil
 	}
 	for _, column := range row.Columns {
 		if column.Name == name && column.Role != role {
-			panic(fmt.Sprintf("promql: sample forwarder role %d has ambiguous output name %q", role, name))
+			return "", false, fmt.Errorf("promql: temporal sample layout role %d has ambiguous output name %q", role, name)
 		}
 	}
-	return &chplan.ColumnRef{Name: name}
+	return name, true, nil
 }
 
 func requireUniqueNamedColumn(row chplan.Schema, want chplan.Column) {

--- a/internal/promql/sample_forward_test.go
+++ b/internal/promql/sample_forward_test.go
@@ -69,6 +69,83 @@ func TestSampleForwardRolesResolveBeforeRewrite(t *testing.T) {
 	}
 }
 
+func TestLegacySampleProjectionLayoutUsesTemporalRoles(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		columns []chplan.Column
+		want    sampleProjectionLayout
+	}{
+		{
+			name: "canonical renamed roles",
+			columns: []chplan.Column{
+				{Name: "source_name", Role: chplan.RoleMetricName},
+				{Name: "source_labels", Role: chplan.RoleAttributes},
+				{Name: "source_time", Role: chplan.RoleTimestamp},
+				{Name: "source_value", Role: chplan.RoleValue},
+			},
+			want: sampleProjectionLayout{canonical: true},
+		},
+		{
+			name: "grid renamed roles",
+			columns: []chplan.Column{
+				{Name: "source_labels", Role: chplan.RoleAttributes},
+				{Name: "source_anchor", Role: chplan.RoleAnchor},
+				{Name: "source_time", Role: chplan.RoleTimestamp},
+				{Name: "source_value", Role: chplan.RoleValue},
+			},
+			want: sampleProjectionLayout{anchored: true},
+		},
+		{
+			name: "reduced ignores misleading opaque names",
+			columns: []chplan.Column{
+				{Name: "source_labels", Role: chplan.RoleAttributes},
+				{Name: "TimeUnix", Role: chplan.RoleOpaque},
+				{Name: "anchor_ts", Role: chplan.RoleOpaque},
+				{Name: "source_value", Role: chplan.RoleValue},
+			},
+			want: sampleProjectionLayout{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := legacySampleProjectionLayout(sampleForwardTestInput(tc.columns...)); got != tc.want {
+				t.Fatalf("layout = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLegacySampleProjectionLayoutRejectsInvalidRoles(t *testing.T) {
+	t.Parallel()
+
+	base := []chplan.Column{
+		{Name: "source_labels", Role: chplan.RoleAttributes},
+		{Name: "source_time", Role: chplan.RoleTimestamp},
+		{Name: "source_value", Role: chplan.RoleValue},
+	}
+	for _, tc := range []struct {
+		name    string
+		columns []chplan.Column
+	}{
+		{name: "missing attributes", columns: base[1:]},
+		{name: "missing value", columns: base[:2]},
+		{name: "duplicate timestamp role", columns: append(append([]chplan.Column(nil), base...), chplan.Column{Name: "other_time", Role: chplan.RoleTimestamp})},
+		{name: "ambiguous timestamp name", columns: append(append([]chplan.Column(nil), base...), chplan.Column{Name: "source_time", Role: chplan.RoleOpaque})},
+		{name: "unnamed timestamp", columns: []chplan.Column{base[0], {Role: chplan.RoleTimestamp}, base[2]}},
+		{name: "anchor without timestamp", columns: []chplan.Column{base[0], {Name: "source_anchor", Role: chplan.RoleAnchor}, base[2]}},
+		{name: "metric name without timestamp", columns: []chplan.Column{{Name: "source_name", Role: chplan.RoleMetricName}, base[0], base[2]}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			capturePanic(t, func() {
+				legacySampleProjectionLayout(sampleForwardTestInput(tc.columns...))
+			})
+		})
+	}
+}
+
 func TestSampleForwardPreservesMixedPayload(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 	columns := append(metricRoles(s), chplan.HistogramPayloadColumns()...)

--- a/internal/promql/scalar_args.go
+++ b/internal/promql/scalar_args.go
@@ -224,7 +224,7 @@ func lowerScalarMixedOperand(build func() (chplan.Node, error)) (chplan.Node, er
 // scalarFloatRows narrows a complete nested operand only after its own shadow
 // resolution. Histogram placeholder values must never enter count()/any(Value).
 func scalarFloatRows(inner chplan.Node) (chplan.Node, error) {
-	if chplan.RowShapeOf(inner) == chplan.MixedRowShape {
+	if mixedRowsNeedPreparation(inner) {
 		if err := requireFloatScalarPolicy(mixedPlanAdmission); err != nil {
 			return nil, err
 		}

--- a/internal/promql/scalar_arithmetic.go
+++ b/internal/promql/scalar_arithmetic.go
@@ -57,7 +57,7 @@ func finishScalarArithmetic(inner chplan.Node, arg parser.Expr, s schema.Metrics
 			return nil, err
 		}
 	}
-	if boundary == scalarArithmeticGuarded && chplan.RowShapeOf(inner) == chplan.MixedRowShape {
+	if boundary == scalarArithmeticGuarded && mixedRowsNeedPreparation(inner) {
 		if err := requireFloatArithmeticPolicy(mixedPlanAdmission); err != nil {
 			return nil, err
 		}

--- a/internal/promql/scalar_comparison.go
+++ b/internal/promql/scalar_comparison.go
@@ -78,7 +78,7 @@ func finishScalarComparison(inner chplan.Node, arg parser.Expr, s schema.Metrics
 		if err := requireFloatComparisonPolicy(mixedRootAdmission); err != nil {
 			return nil, err
 		}
-	} else if chplan.RowShapeOf(inner) == chplan.MixedRowShape {
+	} else if mixedRowsNeedPreparation(inner) {
 		if err := requireFloatComparisonPolicy(mixedPlanAdmission); err != nil {
 			return nil, err
 		}

--- a/internal/promql/sort.go
+++ b/internal/promql/sort.go
@@ -93,7 +93,7 @@ func lowerSortFloatOperand(c *parser.Call, s schema.Metrics, ctx lowerCtx) (chpl
 		})
 	}
 	inner, err := lower(c.Args[0], s, ctx)
-	if err != nil || chplan.RowShapeOf(inner) != chplan.MixedRowShape {
+	if err != nil || !mixedRowsNeedPreparation(inner) {
 		return inner, err
 	}
 	return prepareSortOperand(mixedPlanAdmission, func() (chplan.Node, error) { return inner, nil })

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -1048,7 +1048,7 @@ func lowerOuterRangeFnOverSubquery(
 	// still, by [rangeFnOverExpHistogramSubquery] /
 	// [lowerExpHistogramRangeFnOverSubquery] (histogram_native_range_fn.go).
 	if rowsMayContainHistograms(inner) {
-		shape := chplan.RowShapeFromSchema(inner.RowType())
+		kind := liveSampleKind(inner)
 		// Cerberus issue #2724: inner may have reached this Histogram/Mixed
 		// shape via a further and/unless/or wrapping a mixed `or`, a bare
 		// and/unless-forwarded histogram selector, or (since cerberus issue
@@ -1063,7 +1063,7 @@ func lowerOuterRangeFnOverSubquery(
 		if err := requireMixedPlanPolicy(inner, mixedSubqueryFamily); err != nil {
 			return nil, err
 		}
-		if node, matched, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, shape, outer.Func.Name, sub, s, ctx); matched {
+		if node, matched, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, kind, outer.Func.Name, sub, s, ctx); matched {
 			return node, err
 		}
 		if !histogramSubqueryFloatOnlyDropFunc(outer.Func.Name) {
@@ -3093,7 +3093,7 @@ func lowerSubqueryOverCallSubquery(
 	// this mirrors) already gets for
 	// `<outer-fn>(<bare-histogram-selector>[range:step])`.
 	if rowsMayContainHistograms(wideInner) {
-		shape := chplan.RowShapeFromSchema(wideInner.RowType())
+		kind := liveSampleKind(wideInner)
 		// Cerberus issue #2726: wideInner may be histogram/mixed-shaped
 		// because innerSub's OWN inner expression resolved histogram-native
 		// (or a further and/unless/or wrapping one, cerberus issue #2724).
@@ -3105,7 +3105,7 @@ func lowerSubqueryOverCallSubquery(
 		if err := requireMixedPlanPolicy(wideInner, mixedSubqueryFamily); err != nil {
 			return nil, err
 		}
-		if node, matched, err := lowerHistogramOrMixedCallSubqueryInput(wideInner, shape, call.Func.Name, sub, innerSub, step, s, ctx); matched {
+		if node, matched, err := lowerHistogramOrMixedCallSubqueryInput(wideInner, kind, call.Func.Name, sub, innerSub, step, s, ctx); matched {
 			return node, err
 		}
 		if !histogramSubqueryFloatOnlyDropFunc(call.Func.Name) {

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -470,16 +470,12 @@ const (
 // whatever composes on top (an outer `*_over_time` reducer folds nothing
 // and emits nothing; `absent_over_time` reads the same emptiness and
 // correctly reports 1). It reuses the constant-false Filter idiom
-// [dropExpHistogramSamples] already establishes, and carries the
-// Histogram / Mixed passthrough flags so [chplan.RowShapeOf] still
-// classifies the capped relation by the shape its input publishes.
+// [dropExpHistogramSamples] already establishes. Filter's physical schema
+// is its Input's schema even when this predicate proves that no rows survive.
 func emptySubqueryGrid(inner chplan.Node) chplan.Node {
-	shape := chplan.RowShapeOf(inner)
 	return &chplan.Filter{
 		Input:     inner,
 		Predicate: &chplan.LitBool{V: false},
-		Histogram: shape == chplan.HistogramRowShape,
-		Mixed:     shape == chplan.MixedRowShape,
 	}
 }
 

--- a/internal/promql/temporal_layout_roles_chdb_test.go
+++ b/internal/promql/temporal_layout_roles_chdb_test.go
@@ -1,0 +1,132 @@
+//go:build chdb
+
+package promql
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/chdb-io/chdb-go/chdb/driver"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+const (
+	temporalRoleTestMetric         = "live_metric"
+	temporalRoleTestSeries         = "live_series"
+	temporalRoleTestTimestampNanos = int64(1_767_225_600_000_000_000)
+	temporalRoleTestValue          = 7.5
+)
+
+func TestTemporalRoleAdaptersExecuteRenamedInputs_ChDB(t *testing.T) {
+	s := schema.DefaultOTelMetrics()
+	s.MetricNameColumn = "public_name"
+	s.AttributesColumn = "public_labels"
+	s.TimestampColumn = "public_time"
+	s.ValueColumn = "public_value"
+	input := temporalRoleTestInput(s)
+
+	for _, tc := range []struct {
+		name          string
+		adapt         func(chplan.Node, schema.Metrics) (chplan.Node, error)
+		discriminator bool
+	}{
+		{name: "aggregate canonicalization", adapt: canonicalizeMixedFloatArmForAgg},
+		{name: "mixed join widening", adapt: widenPlainVectorToMixedShape, discriminator: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := tc.adapt(input, s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			emitted, emittedArgs, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatal(err)
+			}
+			columns := []chsql.Frag{
+				chsql.Col(s.MetricNameColumn),
+				chsql.Call(string(chplan.FnArrayElement), chsql.Col(s.AttributesColumn), chsql.Lit("series")),
+				chsql.Call(string(chplan.FnToUnixNanos), chsql.Col(s.TimestampColumn)),
+				chsql.Col(s.ValueColumn),
+			}
+			if tc.discriminator {
+				columns = append(columns, chsql.Col(mixedDiscriminatorColumn))
+			}
+			query, args := chsql.NewQuery().
+				Select(columns...).
+				From(chsql.Subquery(chsql.PreRenderedSQL{SQL: emitted, Args: emittedArgs})).
+				Build()
+
+			var (
+				metric        string
+				series        string
+				timestamp     int64
+				value         float64
+				discriminator int64
+			)
+			row := spec.OpenChDB(t).QueryRow(query, args...)
+			if tc.discriminator {
+				err = row.Scan(&metric, &series, &timestamp, &value, &discriminator)
+			} else {
+				err = row.Scan(&metric, &series, &timestamp, &value)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if metric != temporalRoleTestMetric || series != temporalRoleTestSeries ||
+				timestamp != temporalRoleTestTimestampNanos || value != temporalRoleTestValue {
+				t.Fatalf("row = (%q, %q, %d, %v), want (%q, %q, %d, %v)",
+					metric, series, timestamp, value,
+					temporalRoleTestMetric, temporalRoleTestSeries, temporalRoleTestTimestampNanos, temporalRoleTestValue)
+			}
+			if tc.discriminator && discriminator != mixedDiscriminatorFloat {
+				t.Fatalf("discriminator = %d, want %d", discriminator, mixedDiscriminatorFloat)
+			}
+		})
+	}
+}
+
+func temporalRoleTestInput(s schema.Metrics) chplan.Node {
+	const (
+		physicalMetricName = "physical_name"
+		physicalAttributes = "physical_labels"
+		physicalTimestamp  = "physical_time"
+		physicalValue      = "physical_value"
+	)
+	roles := []chplan.Column{
+		{Name: physicalMetricName, Role: chplan.RoleMetricName},
+		{Name: s.MetricNameColumn, Role: chplan.RoleOpaque},
+		{Name: physicalAttributes, Role: chplan.RoleAttributes},
+		{Name: s.AttributesColumn, Role: chplan.RoleOpaque},
+		{Name: physicalTimestamp, Role: chplan.RoleTimestamp},
+		{Name: s.TimestampColumn, Role: chplan.RoleOpaque},
+		{Name: physicalValue, Role: chplan.RoleValue},
+		{Name: s.ValueColumn, Role: chplan.RoleOpaque},
+	}
+	labelMap := func(value string) chplan.Expr {
+		return &chplan.FuncCall{Fn: chplan.FnMap, Args: []chplan.Expr{
+			&chplan.InlineString{V: "series"},
+			&chplan.LitString{V: value},
+		}}
+	}
+	timestamp := func(nanos int64) chplan.Expr {
+		return &chplan.FuncCall{Fn: chplan.FnFromUnixNanos, Args: []chplan.Expr{&chplan.LitInt{V: nanos}}}
+	}
+	return &chplan.Project{
+		Input: &chplan.OneRow{},
+		Roles: roles,
+		Projections: []chplan.Projection{
+			{Expr: &chplan.LitString{V: temporalRoleTestMetric}, Alias: physicalMetricName},
+			{Expr: &chplan.LitString{V: "decoy_metric"}, Alias: s.MetricNameColumn},
+			{Expr: labelMap(temporalRoleTestSeries), Alias: physicalAttributes},
+			{Expr: labelMap("decoy_series"), Alias: s.AttributesColumn},
+			{Expr: timestamp(temporalRoleTestTimestampNanos), Alias: physicalTimestamp},
+			{Expr: timestamp(1), Alias: s.TimestampColumn},
+			{Expr: &chplan.LitFloat{V: temporalRoleTestValue}, Alias: physicalValue},
+			{Expr: &chplan.LitFloat{V: -1}, Alias: s.ValueColumn},
+		},
+	}
+}

--- a/internal/promql/temporal_layout_roles_test.go
+++ b/internal/promql/temporal_layout_roles_test.go
@@ -1,0 +1,185 @@
+package promql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestCanonicalizeMixedFloatArmForAggResolvesPhysicalRoles(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	s.MetricNameColumn = "public_name"
+	s.AttributesColumn = "public_labels"
+	s.TimestampColumn = "public_time"
+	s.ValueColumn = "public_value"
+	input := sampleForwardTestInput(
+		chplan.Column{Name: "physical_name", Role: chplan.RoleMetricName},
+		chplan.Column{Name: s.MetricNameColumn, Role: chplan.RoleOpaque},
+		chplan.Column{Name: "physical_labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: s.AttributesColumn, Role: chplan.RoleOpaque},
+		chplan.Column{Name: "physical_time", Role: chplan.RoleTimestamp},
+		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleOpaque},
+		chplan.Column{Name: "physical_value", Role: chplan.RoleValue},
+		chplan.Column{Name: s.ValueColumn, Role: chplan.RoleOpaque},
+	)
+
+	got, err := canonicalizeMixedFloatArmForAgg(input, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, ok := got.(*chplan.Project)
+	if !ok {
+		t.Fatalf("canonicalized input = %T, want *chplan.Project", got)
+	}
+	assertTemporalProjectionRef(t, project.Projections[0], "physical_name", s.MetricNameColumn)
+	assertTemporalProjectionRef(t, project.Projections[1], "physical_labels", s.AttributesColumn)
+	assertTemporalProjectionRef(t, project.Projections[2], "physical_time", s.TimestampColumn)
+	assertTemporalProjectionRef(t, project.Projections[3], "physical_value", s.ValueColumn)
+	if row := project.RowType(); !row.Equal(chplan.Schema{Columns: metricRoles(s)}) {
+		t.Fatalf("canonicalized schema = %#v, want %#v", row, chplan.Schema{Columns: metricRoles(s)})
+	}
+}
+
+func TestCanonicalizeMixedFloatArmForAggPreservesTemporalEnvelope(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	grid := sampleForwardTestInput(
+		chplan.Column{Name: "physical_labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: "physical_anchor", Role: chplan.RoleAnchor},
+		chplan.Column{Name: "physical_time", Role: chplan.RoleTimestamp},
+		chplan.Column{Name: "physical_value", Role: chplan.RoleValue},
+	)
+	got, err := canonicalizeMixedFloatArmForAgg(grid, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := got.(*chplan.Project)
+	if len(project.Projections) != 4 {
+		t.Fatalf("grid projection count = %d, want 4", len(project.Projections))
+	}
+	assertTemporalProjectionRef(t, project.Projections[0], "physical_labels", s.AttributesColumn)
+	assertTemporalProjectionRef(t, project.Projections[1], "physical_anchor", chplan.RangeWindowAnchorColumn)
+	assertTemporalProjectionRef(t, project.Projections[2], "physical_time", s.TimestampColumn)
+	assertTemporalProjectionRef(t, project.Projections[3], "physical_value", s.ValueColumn)
+
+	reduced := sampleForwardTestInput(
+		chplan.Column{Name: "physical_labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleOpaque},
+		chplan.Column{Name: "physical_value", Role: chplan.RoleValue},
+	)
+	got, err = canonicalizeMixedFloatArmForAgg(reduced, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project = got.(*chplan.Project)
+	if len(project.Projections) != 3 {
+		t.Fatalf("reduced projection count = %d, want 3", len(project.Projections))
+	}
+	assertTemporalProjectionRef(t, project.Projections[0], "physical_labels", s.AttributesColumn)
+	if _, ok := project.Projections[1].Expr.(*chplan.Binary); !ok || project.Projections[1].Alias != s.TimestampColumn {
+		t.Fatalf("reduced timestamp projection = %#v, want synthesized %q", project.Projections[1], s.TimestampColumn)
+	}
+	assertTemporalProjectionRef(t, project.Projections[2], "physical_value", s.ValueColumn)
+
+	canonical := sampleForwardTestInput(metricRoles(s)...)
+	unchanged, err := canonicalizeMixedFloatArmForAgg(canonical, s)
+	if err != nil || unchanged != canonical {
+		t.Fatalf("already canonical input changed: plan=%T err=%v", unchanged, err)
+	}
+}
+
+func TestWidenPlainVectorToMixedShapeResolvesPhysicalRoles(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	s.MetricNameColumn = "public_name"
+	s.AttributesColumn = "public_labels"
+	s.TimestampColumn = "public_time"
+	s.ValueColumn = "public_value"
+	input := sampleForwardTestInput(
+		chplan.Column{Name: "physical_name", Role: chplan.RoleMetricName},
+		chplan.Column{Name: s.MetricNameColumn, Role: chplan.RoleOpaque},
+		chplan.Column{Name: "physical_labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: "physical_time", Role: chplan.RoleTimestamp},
+		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleOpaque},
+		chplan.Column{Name: "physical_value", Role: chplan.RoleValue},
+	)
+
+	got, err := widenPlainVectorToMixedShape(input, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := got.(*chplan.Project)
+	if len(project.Projections) != 14 {
+		t.Fatalf("projection count = %d, want 14", len(project.Projections))
+	}
+	assertTemporalProjectionRef(t, project.Projections[0], "physical_name", s.MetricNameColumn)
+	assertTemporalProjectionRef(t, project.Projections[1], "physical_labels", s.AttributesColumn)
+	assertTemporalProjectionRef(t, project.Projections[2], "physical_time", s.TimestampColumn)
+	assertTemporalProjectionRef(t, project.Projections[3], "physical_value", s.ValueColumn)
+	if kind := project.RowType().SampleKind(); kind != chplan.SampleKindMixed {
+		t.Fatalf("widened schema kind = %s, want mixed", kind)
+	}
+}
+
+func TestWidenPlainVectorToMixedShapeSynthesizesMissingIdentity(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	input := sampleForwardTestInput(
+		chplan.Column{Name: "physical_labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: s.MetricNameColumn, Role: chplan.RoleOpaque},
+		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleOpaque},
+		chplan.Column{Name: "physical_value", Role: chplan.RoleValue},
+	)
+	got, err := widenPlainVectorToMixedShape(input, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := got.(*chplan.Project)
+	name, ok := project.Projections[0].Expr.(*chplan.LitString)
+	if !ok || name.V != "" || project.Projections[0].Alias != s.MetricNameColumn {
+		t.Fatalf("derived metric-name projection = %#v", project.Projections[0])
+	}
+	if _, ok := project.Projections[2].Expr.(*chplan.Binary); !ok || project.Projections[2].Alias != s.TimestampColumn {
+		t.Fatalf("derived timestamp projection = %#v", project.Projections[2])
+	}
+}
+
+func TestTemporalConsumersRejectMalformedRoleLayouts(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	valid := metricRoles(s)
+	for _, tc := range []struct {
+		name  string
+		input chplan.Node
+	}{
+		{name: "open", input: &chplan.Scan{Roles: valid}},
+		{name: "duplicate role", input: sampleForwardTestInput(append(append([]chplan.Column(nil), valid...), chplan.Column{Name: "other_value", Role: chplan.RoleValue})...)},
+		{name: "unnamed role", input: sampleForwardTestInput(valid[0], valid[1], valid[2], chplan.Column{Role: chplan.RoleValue})},
+		{name: "incomplete anchor", input: sampleForwardTestInput(valid[1], chplan.Column{Name: "physical_anchor", Role: chplan.RoleAnchor}, valid[3])},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := canonicalizeMixedFloatArmForAgg(tc.input, s); err == nil {
+				t.Fatal("aggregate canonicalization accepted malformed roles")
+			}
+			if _, err := widenPlainVectorToMixedShape(tc.input, s); err == nil {
+				t.Fatal("mixed-join widening accepted malformed roles")
+			}
+		})
+	}
+}
+
+func assertTemporalProjectionRef(t *testing.T, projection chplan.Projection, source, alias string) {
+	t.Helper()
+	ref, ok := projection.Expr.(*chplan.ColumnRef)
+	if !ok || ref.Name != source || projection.Alias != alias {
+		t.Fatalf("projection = %#v, want ColumnRef(%q) AS %q", projection, source, alias)
+	}
+}

--- a/internal/promql/vector_set_schema_test.go
+++ b/internal/promql/vector_set_schema_test.go
@@ -1,0 +1,35 @@
+package promql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+func TestRequireVectorSetOpSampleKind(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []chplan.SampleKind{
+		chplan.SampleKindFloat,
+		chplan.SampleKindHistogram,
+		chplan.SampleKindMixed,
+	} {
+		if err := requireVectorSetOpSampleKind("left", kind); err != nil {
+			t.Errorf("requireVectorSetOpSampleKind(%s) = %v, want success", kind, err)
+		}
+	}
+	for _, kind := range []chplan.SampleKind{
+		chplan.SampleKindOpaque,
+		chplan.SampleKindInvalid,
+	} {
+		err := requireVectorSetOpSampleKind("right", kind)
+		if err == nil {
+			t.Fatalf("requireVectorSetOpSampleKind(%s) succeeded", kind)
+		}
+		for _, want := range []string{"right", kind.String()} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not contain %q", err, want)
+			}
+		}
+	}
+}

--- a/internal/traceql/lower_test.go
+++ b/internal/traceql/lower_test.go
@@ -115,7 +115,8 @@ func TestLower(t *testing.T) {
 		})
 		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 		spec.AssertRowTypeMatchesDriver(t, optimized, roundTripResult)
-		spec.AssertRowShapeAgreement(t, plan)
+		spec.AssertPlanScanRoles(t, plan)
+		spec.AssertPlanScanRoles(t, optimized)
 
 		// A fixture carrying a `parity:` section is additionally checked
 		// against the REAL upstream Tempo engine — including its own

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -110,14 +110,9 @@ func printFlags(b *strings.Builder, flags []flag) {
 	}
 }
 
-// printSampleShape renders the Histogram / Mixed pair that several node
-// kinds carry to tell the emitter which sample layout flows through
-// them: float columns, the nine native-histogram columns, or the mixed
-// 14-column shape whose trailing discriminator picks per row. Every one
-// of the three emits different SQL, so the IR has to say which it is.
-//
-// Both flags live on VectorSetOp, Filter and TopK; NaryVectorSetOp and
-// InfoJoin carry Histogram alone and pass false for mixed.
+// printSampleShape renders the Histogram / Mixed pair carried by the
+// vector-set nodes whose emitter branches genuinely depend on them.
+// NaryVectorSetOp and InfoJoin carry Histogram alone and pass false for mixed.
 func printSampleShape(b *strings.Builder, histogram, mixed bool) {
 	printFlags(b, []flag{
 		{"histogram", histogram},
@@ -165,7 +160,6 @@ func printNodeArm(b *strings.Builder, n chplan.Node, depth int, visited *[]chpla
 		}
 	case *chplan.Filter:
 		fmt.Fprintf(b, "%sFilter predicate=%s", indent, printExpr(v.Predicate))
-		printSampleShape(b, v.Histogram, v.Mixed)
 		b.WriteString("\n")
 		printChild(b, visited, v.Input, depth+1)
 	case *chplan.Project:
@@ -245,7 +239,6 @@ func printNodeArm(b *strings.Builder, n chplan.Node, depth int, visited *[]chpla
 		if len(v.Columns) > 0 {
 			fmt.Fprintf(b, " columns=[%s]", strings.Join(v.Columns, ", "))
 		}
-		printSampleShape(b, v.Histogram, v.Mixed)
 		b.WriteString("\n")
 		printChild(b, visited, v.Input, depth+1)
 		if v.KExpr != nil {

--- a/test/spec/logqlwrap/logqlwrap.go
+++ b/test/spec/logqlwrap/logqlwrap.go
@@ -61,7 +61,8 @@ func ReconstructLogStreamWrapPlan(c *spec.Case) (plan chplan.Node, ok bool, err 
 	if meta.IsMetric {
 		return nil, false, nil
 	}
-	return lang.ProjectSamples(rawPlan, meta), true, nil
+	wrapped, err := lang.ProjectSamples(rawPlan, meta)
+	return wrapped, true, err
 }
 
 func readWindowSections(c *spec.Case) (start, end time.Time, step time.Duration, err error) {

--- a/test/spec/schema.go
+++ b/test/spec/schema.go
@@ -1,16 +1,8 @@
 package spec
 
 import (
-	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
-	"path/filepath"
-	"reflect"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -89,161 +81,15 @@ func bindFixtureSchemas(plan chplan.Node, tables map[string][]string) chplan.Nod
 	return bound
 }
 
-var contractedRowShapeKinds = sync.OnceValues(func() (map[string]bool, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			break
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return nil, fmt.Errorf("cannot find repository from test working directory")
-		}
-		dir = parent
-	}
-	path := filepath.Join(dir, "internal", "chplan", "row_shape.go")
-	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-	if err != nil {
-		return nil, err
-	}
-	kinds := map[string]bool{}
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != "RowShapeOf" {
-			continue
-		}
-		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			clause, ok := n.(*ast.CaseClause)
-			if !ok {
-				return true
-			}
-			for _, expr := range clause.List {
-				pointer, ok := expr.(*ast.StarExpr)
-				if !ok {
-					continue
-				}
-				if name, ok := pointer.X.(*ast.Ident); ok {
-					kinds[name.Name] = true
-				}
-			}
-			return true
-		})
-	}
-	if len(kinds) == 0 {
-		return nil, fmt.Errorf("RowShapeOf has no contracted type-switch cases")
-	}
-	return kinds, nil
-})
-
-// AssertRowShapeAgreement derives the legacy classifier's contracted kinds
-// from its own switch. Other kinds deliberately retain a documentation default.
-func AssertRowShapeAgreement(t *testing.T, plan chplan.Node) {
+// AssertPlanScanRoles checks every storage leaf, including expression subqueries.
+// Physical schema/shape semantics have independent literal, sealed-kind-complete
+// contracts in chplan; executed fixture outputs are checked against driver metadata.
+func AssertPlanScanRoles(t *testing.T, plan chplan.Node) {
 	t.Helper()
-	kinds, err := contractedRowShapeKinds()
-	if err != nil {
-		t.Fatalf("read legacy shape contract: %v", err)
-	}
 	chplan.WalkDeep(plan, func(n chplan.Node) bool {
 		if scan, ok := n.(*chplan.Scan); ok && scan.Database != "system" && len(scan.Roles) == 0 {
 			t.Errorf("storage Scan %q/%q has no declared roles", scan.Table, scan.UnionTables)
 		}
-		kind := reflect.TypeOf(n).Elem().Name()
-		legacy := chplan.RowShapeOf(n)
-		if !kinds[kind] {
-			if legacy != chplan.SampleRowShape {
-				t.Errorf("uncontracted %s legacy shape = %s", kind, legacy)
-			}
-			return true
-		}
-		physical := chplan.RowShapeFromSchema(n.RowType())
-		reason := rowShapeDivergence(n)
-		if legacy != physical && reason == "" {
-			t.Errorf("%s legacy=%s physical=%s schema=%#v", kind, legacy, physical, n.RowType())
-		}
 		return true
 	})
-}
-
-// rowShapeDivergence describes legacy classifier branches whose contract is
-// deliberately weaker than their physical output. These predicates describe
-// actual SELECT structure; they are not fixture or node-name exemptions.
-func rowShapeDivergence(n chplan.Node) string {
-	s := n.RowType()
-	physical, legacy := chplan.RowShapeFromSchema(s), chplan.RowShapeOf(n)
-	if physical == legacy {
-		return ""
-	}
-	switch v := n.(type) {
-	case *chplan.Project:
-		if legacy != chplan.SampleRowShape || s.Has(chplan.RoleDiscriminator) {
-			return ""
-		}
-		if s.Has(chplan.RoleHistogramField) {
-			return "projection republishes histogram fields without discriminator"
-		}
-		if !s.Has(chplan.RoleMetricName) && s.Has(chplan.RoleAnchor) {
-			return "projection republishes grid outputs"
-		}
-		if !s.Has(chplan.RoleMetricName) && !s.Has(chplan.RoleTimestamp) && !s.Has(chplan.RoleAnchor) && s.Has(chplan.RoleValue) {
-			return "projection publishes scalar or reduced output"
-		}
-	case *chplan.Filter:
-		if legacy == chplan.SampleRowShape && !v.Histogram && !v.Mixed && s.Equal(v.Input.RowType()) {
-			return "unflagged filter preserves noncanonical physical columns"
-		}
-	case *chplan.TopK:
-		if legacy == chplan.SampleRowShape && !v.Histogram && !v.Mixed {
-			if len(v.Columns) == 0 && s.Equal(v.Input.RowType()) {
-				return "unflagged topk preserves noncanonical physical columns"
-			}
-			if len(v.Columns) == len(s.Columns) {
-				for i, c := range s.Columns {
-					if c.Name != v.Columns[i] {
-						return ""
-					}
-				}
-				return "topk selects a noncanonical column subset"
-			}
-		}
-	case *chplan.HistogramFloatVectorJoin:
-		if legacy == chplan.SampleRowShape && physical == chplan.HistogramRowShape && s.Has(chplan.RoleValue) && s.Has(chplan.RoleMetricName) {
-			return "float-histogram join preserves payload and float value"
-		}
-	case *chplan.RangeWindow:
-		if s.Has(chplan.RoleMetricName) && s.Has(chplan.RoleValue) && !s.Has(chplan.RoleHistogramField) && !s.Has(chplan.RoleDiscriminator) {
-			for _, key := range v.GroupBy {
-				ref, ok := key.(*chplan.ColumnRef)
-				if !ok {
-					continue
-				}
-				column, found := v.Input.RowType().ByName(ref.Name)
-				if found && column.Role == chplan.RoleMetricName && ((v.OuterRange > 0 && legacy == chplan.GridWindowRowShape) || (v.OuterRange == 0 && legacy == chplan.ReducedWindowRowShape)) {
-					return "window group keys preserve metric name"
-				}
-			}
-		}
-	case *chplan.OrderBy:
-		if legacy == chplan.RowShapeOf(v.Input) && s.Equal(v.Input.RowType()) {
-			return delegatedShapeDivergence(v.Input)
-		}
-	case *chplan.UnionAll:
-		if len(v.Inputs) > 0 && legacy == chplan.RowShapeOf(v.Inputs[0]) && s.Equal(v.Inputs[0].RowType()) {
-			return delegatedShapeDivergence(v.Inputs[0])
-		}
-	}
-	return ""
-}
-
-func delegatedShapeDivergence(input chplan.Node) string {
-	if reason := rowShapeDivergence(input); reason != "" {
-		return reason
-	}
-	kinds, err := contractedRowShapeKinds()
-	if err == nil && !kinds[reflect.TypeOf(input).Elem().Name()] && chplan.RowShapeOf(input) == chplan.SampleRowShape {
-		return "delegated documentation default from non-sample input"
-	}
-	return ""
 }

--- a/test/spec/schema_test.go
+++ b/test/spec/schema_test.go
@@ -3,7 +3,6 @@ package spec
 import (
 	"slices"
 	"testing"
-	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 )
@@ -67,49 +66,5 @@ func TestBindFixtureSchemasExpressionSubquery(t *testing.T) {
 	}
 	if len(scan.Columns) != 0 {
 		t.Fatal("binding mutated source expression subquery")
-	}
-}
-
-func TestRowShapeDivergencePredicates(t *testing.T) {
-	float := &chplan.Project{Input: &chplan.OneRow{}, Roles: []chplan.Column{{Name: "value", Role: chplan.RoleValue}}, Projections: []chplan.Projection{{Expr: &chplan.LitInt{V: 1}, Alias: "value"}}}
-	mixed := &chplan.Scan{Columns: []string{chplan.MixedDiscriminatorColumn}, Roles: []chplan.Column{{Name: chplan.MixedDiscriminatorColumn, Role: chplan.RoleDiscriminator}}}
-	cases := []struct {
-		name      string
-		node      chplan.Node
-		divergent bool
-	}{
-		{"scalar projection", float, true},
-		{"unflagged mixed filter", &chplan.Filter{Input: mixed}, true},
-		{"mixed filter declared", &chplan.Filter{Input: mixed, Mixed: true}, false},
-		{"incorrect histogram filter flag", &chplan.Filter{Input: mixed, Histogram: true}, false},
-		{"mixed projection agrees", &chplan.Project{Input: mixed, Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: chplan.MixedDiscriminatorColumn}}}}, false},
-		{"topk selects scalar", &chplan.TopK{Input: float, Columns: []string{"value"}}, true},
-		{"incorrect mixed topk flag", &chplan.TopK{Input: float, Mixed: true}, false},
-		{"orderby delegates scalar projection", &chplan.OrderBy{Input: float}, true},
-		{"union delegates scalar projection", &chplan.UnionAll{Inputs: []chplan.Node{float, float}}, true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if reason := rowShapeDivergence(tc.node); (reason != "") != tc.divergent {
-				t.Fatalf("divergence reason = %q, want divergent=%v", reason, tc.divergent)
-			}
-		})
-	}
-}
-
-func TestRowShapeNamedWindowDivergence(t *testing.T) {
-	input := &chplan.Scan{Columns: []string{"name"}, Roles: []chplan.Column{{Name: "name", Role: chplan.RoleMetricName}}}
-	window := &chplan.RangeWindow{Input: input, GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "name"}}, ValueColumn: "value", Func: "last_over_time"}
-	if rowShapeDivergence(window) == "" {
-		t.Fatal("name-preserving instant window not reconciled")
-	}
-	window.OuterRange = time.Minute
-	window.TimestampColumn = "time"
-	if rowShapeDivergence(window) == "" {
-		t.Fatal("name-preserving matrix window not reconciled")
-	}
-	window.GroupBy = nil
-	if rowShapeDivergence(window) != "" {
-		t.Fatal("ordinary grid window incorrectly treated as divergent")
 	}
 }

--- a/test/spec/traceqlwrap/traceqlwrap.go
+++ b/test/spec/traceqlwrap/traceqlwrap.go
@@ -131,5 +131,6 @@ func ReconstructSearchWrapPlan(c *spec.Case) (plan chplan.Node, ok bool, err err
 	if err != nil {
 		return nil, false, fmt.Errorf("traceql lower (wrap reconstruction): %w", err)
 	}
-	return lang.ProjectSamples(rawPlan, meta), true, nil
+	wrapped, err := lang.ProjectSamples(rawPlan, meta)
+	return wrapped, true, err
 }


### PR DESCRIPTION
## Summary

- replace legacy `RowShapeOf(...)=MixedRowShape` consumer gates with live mixed-row preparation
- let discriminator-zero proofs bypass duplicate preparation while retaining physical payload columns
- resolve mixed `count_values` discrimination from `RoleDiscriminator` instead of a fixed column name
- inventory every remaining production `RowShapeOf` mixed comparison so wrapper consumers cannot regress

## Stack

- base: #3342 (`codex/3342-live-sample-kind`)
- heavy validation runs on GitHub CI only

## Validation

- `gofumpt` on touched Go files
- `git diff --check` on touched files
- focused live-mixed versus proven-float consumer contract tests (GitHub CI)
- production legacy-shape site inventory (GitHub CI)

Closes #3348

Closes #3349
