### PR TITLE
refactor(chplan): validate histogram schema contracts

### DIFF
--- a/internal/chplan/schema.go
+++ b/internal/chplan/schema.go
@@ -34,6 +34,36 @@ type Schema struct {
 	Open    bool
 }
 
+// SampleKind classifies a closed output schema by the sample payload it
+// publishes. Opaque and invalid are deliberately separate: opaque means the
+// schema makes no complete sample claim, while invalid means it makes a
+// contradictory or ambiguous one that consumers must reject.
+type SampleKind uint8
+
+const (
+	SampleKindOpaque SampleKind = iota
+	SampleKindFloat
+	SampleKindHistogram
+	SampleKindMixed
+	SampleKindInvalid
+)
+
+// String renders the sample-kind vocabulary used by invariant diagnostics.
+func (k SampleKind) String() string {
+	switch k {
+	case SampleKindFloat:
+		return "float"
+	case SampleKindHistogram:
+		return "histogram"
+	case SampleKindMixed:
+		return "mixed"
+	case SampleKindInvalid:
+		return "invalid"
+	default:
+		return "opaque"
+	}
+}
+
 // Find returns the first column carrying role, in declaration order.
 func (s Schema) Find(role ColumnRole) (Column, bool) {
 	for _, c := range s.Columns {
@@ -157,6 +187,91 @@ func (s Schema) HasHistogramPayload() bool {
 		}
 	}
 	return true
+}
+
+// SampleKind validates and classifies the public sample contract. Public
+// roles must be named and unambiguous, and histogram fields must be the
+// complete canonical payload. Names on opaque or other-role columns never
+// create a sample contract, but they may not shadow a public sample output.
+// Open schemas remain opaque because undeclared outputs can invalidate an
+// otherwise plausible contract.
+func (s Schema) SampleKind() SampleKind {
+	nameCount := make(map[string]int, len(s.Columns))
+	for _, column := range s.Columns {
+		if column.Name != "" {
+			nameCount[column.Name]++
+		}
+	}
+
+	roleCount := make(map[ColumnRole]int)
+	histogramNames := make(map[string]bool)
+	for _, column := range s.Columns {
+		if !samplePublicRole(column.Role) {
+			continue
+		}
+		if column.Name == "" || nameCount[column.Name] != 1 {
+			return SampleKindInvalid
+		}
+		roleCount[column.Role]++
+		if column.Role == RoleHistogramField {
+			histogramNames[column.Name] = true
+		}
+	}
+
+	for _, role := range [...]ColumnRole{
+		RoleMetricName,
+		RoleAttributes,
+		RoleTimestamp,
+		RoleAnchor,
+		RoleValue,
+		RoleDiscriminator,
+	} {
+		if roleCount[role] > 1 {
+			return SampleKindInvalid
+		}
+	}
+
+	hasHistogram := roleCount[RoleHistogramField] != 0
+	hasDiscriminator := roleCount[RoleDiscriminator] != 0
+	if hasHistogram {
+		canonical := histogramColumns()
+		if roleCount[RoleHistogramField] != len(canonical) {
+			return SampleKindInvalid
+		}
+		for _, field := range canonical {
+			if !histogramNames[field.Name] {
+				return SampleKindInvalid
+			}
+		}
+	} else if hasDiscriminator {
+		return SampleKindInvalid
+	}
+
+	if s.Open {
+		return SampleKindOpaque
+	}
+	if hasDiscriminator {
+		if roleCount[RoleValue] != 1 {
+			return SampleKindInvalid
+		}
+		return SampleKindMixed
+	}
+	if hasHistogram {
+		return SampleKindHistogram
+	}
+	if roleCount[RoleValue] == 1 {
+		return SampleKindFloat
+	}
+	return SampleKindOpaque
+}
+
+func samplePublicRole(role ColumnRole) bool {
+	switch role {
+	case RoleMetricName, RoleAttributes, RoleTimestamp, RoleAnchor, RoleValue, RoleHistogramField, RoleDiscriminator:
+		return true
+	default:
+		return false
+	}
 }
 
 // RowShapeFromSchema folds physical columns into the legacy sample vocabulary.

--- a/internal/chplan/schema.go
+++ b/internal/chplan/schema.go
@@ -195,8 +195,8 @@ func (s Schema) HasHistogramPayload() bool {
 // roles must be named and unambiguous, and histogram fields must be the
 // complete canonical payload. Names on opaque or other-role columns never
 // create a sample contract, but they may not shadow a public sample output.
-// Open schemas remain opaque because undeclared outputs can invalidate an
-// otherwise plausible contract.
+// Structurally valid open schemas remain opaque because undeclared outputs can
+// invalidate an otherwise plausible contract.
 func (s Schema) SampleKind() SampleKind {
 	const samplePublicRoleCount = int(RoleDiscriminator) + 1
 	const histogramPayloadColumnCount = 9
@@ -264,13 +264,17 @@ func (s Schema) SampleKind() SampleKind {
 		return SampleKindInvalid
 	}
 
+	if hasDiscriminator {
+		for _, role := range [...]ColumnRole{RoleMetricName, RoleAttributes, RoleTimestamp, RoleValue} {
+			if roleCount[role] != 1 {
+				return SampleKindInvalid
+			}
+		}
+	}
 	if s.Open {
 		return SampleKindOpaque
 	}
 	if hasDiscriminator {
-		if roleCount[RoleValue] != 1 {
-			return SampleKindInvalid
-		}
 		return SampleKindMixed
 	}
 	if hasHistogram {

--- a/internal/chplan/schema.go
+++ b/internal/chplan/schema.go
@@ -51,6 +51,8 @@ const (
 // String renders the sample-kind vocabulary used by invariant diagnostics.
 func (k SampleKind) String() string {
 	switch k {
+	case SampleKindOpaque:
+		return "opaque"
 	case SampleKindFloat:
 		return "float"
 	case SampleKindHistogram:
@@ -60,7 +62,7 @@ func (k SampleKind) String() string {
 	case SampleKindInvalid:
 		return "invalid"
 	default:
-		return "opaque"
+		return "unknown"
 	}
 }
 
@@ -196,25 +198,41 @@ func (s Schema) HasHistogramPayload() bool {
 // Open schemas remain opaque because undeclared outputs can invalidate an
 // otherwise plausible contract.
 func (s Schema) SampleKind() SampleKind {
-	nameCount := make(map[string]int, len(s.Columns))
-	for _, column := range s.Columns {
-		if column.Name != "" {
-			nameCount[column.Name]++
-		}
-	}
+	const samplePublicRoleCount = int(RoleDiscriminator) + 1
+	const histogramPayloadColumnCount = 9
 
-	roleCount := make(map[ColumnRole]int)
-	histogramNames := make(map[string]bool)
+	var roleCount [samplePublicRoleCount]int
+	var histogramSeen [histogramPayloadColumnCount]bool
+	canonicalHistogram := histogramColumns()
 	for _, column := range s.Columns {
 		if !samplePublicRole(column.Role) {
 			continue
 		}
-		if column.Name == "" || nameCount[column.Name] != 1 {
+		if column.Name == "" {
+			return SampleKindInvalid
+		}
+		nameCount := 0
+		for _, candidate := range s.Columns {
+			if candidate.Name == column.Name {
+				nameCount++
+			}
+		}
+		if nameCount != 1 {
 			return SampleKindInvalid
 		}
 		roleCount[column.Role]++
 		if column.Role == RoleHistogramField {
-			histogramNames[column.Name] = true
+			matched := false
+			for i, field := range canonicalHistogram {
+				if column.Name == field.Name {
+					histogramSeen[i] = true
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return SampleKindInvalid
+			}
 		}
 	}
 
@@ -234,12 +252,11 @@ func (s Schema) SampleKind() SampleKind {
 	hasHistogram := roleCount[RoleHistogramField] != 0
 	hasDiscriminator := roleCount[RoleDiscriminator] != 0
 	if hasHistogram {
-		canonical := histogramColumns()
-		if roleCount[RoleHistogramField] != len(canonical) {
+		if roleCount[RoleHistogramField] != len(canonicalHistogram) {
 			return SampleKindInvalid
 		}
-		for _, field := range canonical {
-			if !histogramNames[field.Name] {
+		for _, seen := range histogramSeen {
+			if !seen {
 				return SampleKindInvalid
 			}
 		}

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -294,6 +294,8 @@ func TestSchemaSampleKind(t *testing.T) {
 	histogram := HistogramPayloadColumns()
 	mixed := append(slices.Clone(floatRoles), histogram...)
 	mixed = append(mixed, Column{"source_kind", RoleDiscriminator})
+	reorderedMixed := slices.Clone(mixed)
+	slices.Reverse(reorderedMixed)
 
 	for _, tc := range []struct {
 		name string
@@ -305,6 +307,7 @@ func TestSchemaSampleKind(t *testing.T) {
 		{name: "pure_histogram", row: Schema{Columns: histogram}, want: SampleKindHistogram},
 		{name: "histogram_with_placeholder", row: Schema{Columns: append(slices.Clone(floatRoles), histogram...)}, want: SampleKindHistogram},
 		{name: "mixed", row: Schema{Columns: mixed}, want: SampleKindMixed},
+		{name: "mixed_reordered", row: Schema{Columns: reorderedMixed}, want: SampleKindMixed},
 		{name: "opaque", row: Schema{Columns: []Column{{Name: "private"}}}, want: SampleKindOpaque},
 		{name: "open_float", row: Schema{Columns: floatRoles, Open: true}, want: SampleKindOpaque},
 		{name: "trace_roles", row: Schema{Columns: []Column{{"trace", RoleTraceID}, {"span", RoleSpanID}}}, want: SampleKindOpaque},
@@ -380,7 +383,7 @@ func TestSampleKindString(t *testing.T) {
 		{SampleKindHistogram, "histogram"},
 		{SampleKindMixed, "mixed"},
 		{SampleKindInvalid, "invalid"},
-		{SampleKindInvalid + 1, "opaque"},
+		{SampleKindInvalid + 1, "unknown"},
 	} {
 		if got := tc.kind.String(); got != tc.want {
 			t.Errorf("SampleKind(%d).String() = %q, want %q", tc.kind, got, tc.want)

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -284,6 +284,110 @@ func TestRowTypeCanonicalHistogramPayload(t *testing.T) {
 	}
 }
 
+func TestSchemaSampleKind(t *testing.T) {
+	floatRoles := []Column{
+		{"source_name", RoleMetricName},
+		{"source_labels", RoleAttributes},
+		{"source_time", RoleTimestamp},
+		{"source_value", RoleValue},
+	}
+	histogram := HistogramPayloadColumns()
+	mixed := append(slices.Clone(floatRoles), histogram...)
+	mixed = append(mixed, Column{"source_kind", RoleDiscriminator})
+
+	for _, tc := range []struct {
+		name string
+		row  Schema
+		want SampleKind
+	}{
+		{name: "float_custom_names", row: Schema{Columns: floatRoles}, want: SampleKindFloat},
+		{name: "reduced_float", row: Schema{Columns: []Column{{"source_value", RoleValue}}}, want: SampleKindFloat},
+		{name: "pure_histogram", row: Schema{Columns: histogram}, want: SampleKindHistogram},
+		{name: "histogram_with_placeholder", row: Schema{Columns: append(slices.Clone(floatRoles), histogram...)}, want: SampleKindHistogram},
+		{name: "mixed", row: Schema{Columns: mixed}, want: SampleKindMixed},
+		{name: "opaque", row: Schema{Columns: []Column{{Name: "private"}}}, want: SampleKindOpaque},
+		{name: "open_float", row: Schema{Columns: floatRoles, Open: true}, want: SampleKindOpaque},
+		{name: "trace_roles", row: Schema{Columns: []Column{{"trace", RoleTraceID}, {"span", RoleSpanID}}}, want: SampleKindOpaque},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.row.SampleKind(); got != tc.want {
+				t.Fatalf("SampleKind = %s, want %s; schema=%#v", got, tc.want, tc.row)
+			}
+		})
+	}
+}
+
+func TestSchemaSampleKindRejectsMalformedContracts(t *testing.T) {
+	floatRoles := []Column{{"labels", RoleAttributes}, {"value", RoleValue}}
+	histogram := HistogramPayloadColumns()
+	kind := Column{"source_kind", RoleDiscriminator}
+
+	type sampleKindCase struct {
+		name    string
+		columns []Column
+	}
+	cases := []sampleKindCase{
+		{name: "orphan_discriminator", columns: append(slices.Clone(floatRoles), kind)},
+		{name: "mixed_without_value", columns: append(slices.Clone(histogram), kind)},
+		{name: "duplicate_value_role", columns: append(slices.Clone(floatRoles), Column{"other_value", RoleValue})},
+		{name: "unnamed_value", columns: []Column{{Role: RoleValue}}},
+		{name: "shadowed_value", columns: append(slices.Clone(floatRoles), Column{Name: "value"})},
+		{name: "duplicate_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), kind, Column{"other_kind", RoleDiscriminator})},
+		{name: "unnamed_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), Column{Role: RoleDiscriminator})},
+		{name: "shadowed_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), kind, Column{Name: kind.Name})},
+		{name: "noncanonical_histogram_role", columns: append(slices.Clone(floatRoles), Column{"raw_count", RoleHistogramField})},
+	}
+	for i, field := range histogram {
+		missing := slices.Delete(slices.Clone(histogram), i, i+1)
+		wrongRole := slices.Clone(histogram)
+		wrongRole[i].Role = RoleOpaque
+		duplicate := append(slices.Clone(histogram), field)
+		shadowed := append(slices.Clone(histogram), Column{Name: field.Name})
+		cases = append(
+			cases,
+			sampleKindCase{name: "missing/" + field.Name, columns: missing},
+			sampleKindCase{name: "wrong_role/" + field.Name, columns: wrongRole},
+			sampleKindCase{name: "duplicate/" + field.Name, columns: duplicate},
+			sampleKindCase{name: "shadowed/" + field.Name, columns: shadowed},
+		)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (Schema{Columns: tc.columns}).SampleKind(); got != SampleKindInvalid {
+				t.Fatalf("SampleKind = %s, want %s; schema=%#v", got, SampleKindInvalid, tc.columns)
+			}
+		})
+	}
+}
+
+func TestSchemaSampleKindUsesRolesNotSampleNames(t *testing.T) {
+	for _, field := range HistogramPayloadColumns() {
+		row := Schema{Columns: []Column{{Name: field.Name, Role: RoleValue}}}
+		if got := row.SampleKind(); got != SampleKindFloat {
+			t.Fatalf("value named %q classified as %s, want %s", field.Name, got, SampleKindFloat)
+		}
+	}
+}
+
+func TestSampleKindString(t *testing.T) {
+	for _, tc := range []struct {
+		kind SampleKind
+		want string
+	}{
+		{SampleKindOpaque, "opaque"},
+		{SampleKindFloat, "float"},
+		{SampleKindHistogram, "histogram"},
+		{SampleKindMixed, "mixed"},
+		{SampleKindInvalid, "invalid"},
+		{SampleKindInvalid + 1, "opaque"},
+	} {
+		if got := tc.kind.String(); got != tc.want {
+			t.Errorf("SampleKind(%d).String() = %q, want %q", tc.kind, got, tc.want)
+		}
+	}
+}
+
 func TestRowTypeOpenCrossJoin(t *testing.T) {
 	left := &Scan{Roles: []Column{{"known", RoleAttributes}}}
 	right := &Scan{Columns: []string{"known", "maybe"}, Roles: []Column{{"known", RoleAttributes}, {"maybe", RoleTimestamp}}}

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -331,7 +331,6 @@ func TestSchemaSampleKindRejectsMalformedContracts(t *testing.T) {
 	}
 	cases := []sampleKindCase{
 		{name: "orphan_discriminator", columns: append(slices.Clone(floatRoles), kind)},
-		{name: "mixed_without_value", columns: append(slices.Clone(histogram), kind)},
 		{name: "duplicate_value_role", columns: append(slices.Clone(floatRoles), Column{"other_value", RoleValue})},
 		{name: "unnamed_value", columns: []Column{{Role: RoleValue}}},
 		{name: "shadowed_value", columns: append(slices.Clone(floatRoles), Column{Name: "value"})},
@@ -339,6 +338,12 @@ func TestSchemaSampleKindRejectsMalformedContracts(t *testing.T) {
 		{name: "unnamed_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), Column{Role: RoleDiscriminator})},
 		{name: "shadowed_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), kind, Column{Name: kind.Name})},
 		{name: "noncanonical_histogram_role", columns: append(slices.Clone(floatRoles), Column{"raw_count", RoleHistogramField})},
+	}
+	for i, role := range floatRoles {
+		missing := slices.Delete(slices.Clone(floatRoles), i, i+1)
+		columns := append(missing, histogram...)
+		columns = append(columns, kind)
+		cases = append(cases, sampleKindCase{name: "mixed_missing/" + role.Name, columns: columns})
 	}
 	for i, field := range histogram {
 		missing := slices.Delete(slices.Clone(histogram), i, i+1)

--- a/internal/promql/gremlins_kill_histogram_subquery_select_test.go
+++ b/internal/promql/gremlins_kill_histogram_subquery_select_test.go
@@ -13,7 +13,7 @@
 // down through isExpHistogramValuedShape and the copy therefore decided
 // nothing. The rule is now stated once, in
 // [expHistogramLoweringAvailable], where both its mutants are killable.
-// The remaining two adjudications stand:
+// The two remaining original cases now have different dispositions:
 //
 //   - histogram_native_subquery_select.go:`step < 0` (CONDITIONALS_BOUNDARY,
 //     `step < 0` -> `<= 0`). Two lines above, `if step == 0 { step =
@@ -31,7 +31,8 @@
 //     An unmatched input and a matched input with the wrong sample kind now
 //     report their distinct contract violations independently.
 //
-// The remaining boundary cases were confirmed by manually applying the mutation and running
+// The remaining boundary case was confirmed by manually applying the mutation and
+// running
 // `go test ./internal/promql/...`: green.
 package promql
 

--- a/internal/promql/gremlins_kill_histogram_subquery_select_test.go
+++ b/internal/promql/gremlins_kill_histogram_subquery_select_test.go
@@ -24,22 +24,14 @@
 //     over every value except exactly 0, so no reachable input can make
 //     the two operators disagree (the same reasoning
 //     gremlins_kill_subquery_test.go's header gives for subquery.go:`step < 0`).
-//   - histogram_native_subquery_select.go:`if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
-//     (INVERT_LOGICAL, `||` -> `&&`).
-//     lowerExpHistogramValuedShape's own contract (histogram_native_float_
-//     fn.go) guarantees `matched == false` if and only if its very last
-//     fallback ran, which always returns `input == nil` — and
-//     chplan.RowShapeOf(nil) (no `case nil` in its type switch) always
-//     falls through to its non-Histogram default. So `!matched` and
-//     `RowShapeOf(input) != Histogram` are always EQUAL on every reachable
-//     input: both true together (an unmatched sub-expression) or both false
-//     together (every histogram-preserving recognizer this dispatch reaches
-//     is documented to publish HistogramRowShape whenever it returns a nil
-//     error, and a non-nil error already returns two lines above this
-//     guard). OR and AND compute the same boolean whenever their two
-//     operands are always equal.
+//   - The former compound guard was split into two explicit invariant checks:
+//     histogram_native_subquery_select.go:`if !matched` and
+//     histogram_native_subquery_select.go:`if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram`.
+//     That split retired the equivalent INVERT_LOGICAL (`||` -> `&&`) mutant.
+//     An unmatched input and a matched input with the wrong sample kind now
+//     report their distinct contract violations independently.
 //
-// All three are confirmed by manually applying the mutation and running
+// The remaining boundary cases were confirmed by manually applying the mutation and running
 // `go test ./internal/promql/...`: green.
 package promql
 

--- a/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
@@ -56,26 +56,26 @@ func mixedDiscriminatorProjected(n chplan.Node) bool {
 	return found
 }
 
-// TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch
+// TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstKindDispatch
 // kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the
-// `if shape == chplan.HistogramRowShape` guard that opens the arm
+// `if kind == chplan.SampleKindHistogram` guard that opens the arm
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`,
 // inside lowerHistogramOrMixedSubqueryOuterFnInput. The citation names the
 // `case` label rather than the mutated guard because that guard is spelled
 // identically in all three arms of this switch, so no substring of it
 // singles one out, while the label above it does:
 //
-//	if shape == chplan.HistogramRowShape {
+//	if kind == chplan.SampleKindHistogram {
 //	    node, err = lowerSelectFnOverExpHistogramSubqueryInput(...)
 //	    ...
 //	}
 //	node, err = lowerMixedOrSubqueryLastFirstInput(...)
 //
-// A HistogramRowShape input must route to the plain histogram
+// A SampleKindHistogram input must route to the plain histogram
 // continuation (never publishes chplan.MixedDiscriminatorColumn); a
-// MixedRowShape input must route to the Mixed-aware continuation (always
+// SampleKindMixed input must route to the Mixed-aware continuation (always
 // does, via [mixedLastFirstProjection]). The negation swaps both.
-func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *testing.T) {
+func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstKindDispatch(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -86,26 +86,26 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 
 	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, lastOverTimeWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("histogram-shape: %v", err)
+		t.Fatalf("histogram sample kind: %v", err)
 	}
 	if mixedDiscriminatorProjected(histPlan) {
-		t.Fatalf("histogram-shape last_over_time took the Mixed path (mutant `==`->`!=` at " +
+		t.Fatalf("histogram sample kind last_over_time took the Mixed path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`)")
 	}
 
 	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, lastOverTimeWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("mixed-shape: %v", err)
+		t.Fatalf("mixed sample kind: %v", err)
 	}
 	if !mixedDiscriminatorProjected(mixedPlan) {
-		t.Fatalf("mixed-shape last_over_time took the Histogram path (mutant `==`->`!=` at " +
+		t.Fatalf("mixed sample kind last_over_time took the Histogram path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`)")
 	}
 }
 
-// TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch
+// TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesKindDispatch
 // kills the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the same
-// `if shape == chplan.HistogramRowShape` guard one arm further down,
+// `if kind == chplan.SampleKindHistogram` guard one arm further down,
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:` —
 // the label locates the arm, the guard inside it is the mutant. This is
 // the resets/changes sibling of the last_over_time/first_over_time
@@ -113,7 +113,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 // Project, so the two paths are told apart by whether the underlying
 // Aggregate collected the Mixed-only groupArrays
 // [mixedPairCountAggs] adds.
-func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t *testing.T) {
+func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesKindDispatch(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -124,35 +124,35 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t 
 
 	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, resetsWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("histogram-shape: %v", err)
+		t.Fatalf("histogram sample kind: %v", err)
 	}
 	if mixedPairAggAlias(histPlan, mixedPairValueArrayAlias) {
-		t.Fatalf("histogram-shape resets took the Mixed path (mutant `==`->`!=` at " +
+		t.Fatalf("histogram sample kind resets took the Mixed path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`)")
 	}
 
 	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, resetsWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("mixed-shape: %v", err)
+		t.Fatalf("mixed sample kind: %v", err)
 	}
 	if !mixedPairAggAlias(mixedPlan, mixedPairValueArrayAlias) {
-		t.Fatalf("mixed-shape resets took the Histogram path (mutant `==`->`!=` at " +
+		t.Fatalf("mixed sample kind resets took the Histogram path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`)")
 	}
 }
 
-// TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch kills
+// TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldKindDispatch kills
 // the CONDITIONALS_NEGATION mutant (`==` -> `!=`) on the same
-// `if shape == chplan.HistogramRowShape` guard in the third arm,
+// `if kind == chplan.SampleKindHistogram` guard in the third arm,
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:` —
 // again the label locates the arm and the guard inside it is the mutant.
 // This is the FOLD-family (rate/increase/delta/...) sibling of the two
-// dispatches above. Over a MixedRowShape input this case routes to
+// dispatches above. Over a SampleKindMixed input this case routes to
 // [lowerFurtherWrapMixedOrSubqueryFoldFn], whose own
 // [combineMixedAggregateBranches] always returns a *chplan.VectorSetOp at
 // the root — a shape the plain-histogram continuation
 // ([lowerExpHistogramRangeFnOverSubqueryInput]) never returns.
-func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch(t *testing.T) {
+func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldKindDispatch(t *testing.T) {
 	t.Parallel()
 
 	s := schema.DefaultOTelMetrics()
@@ -163,19 +163,19 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch(t *testing.
 
 	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, rateWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("histogram-shape: %v", err)
+		t.Fatalf("histogram sample kind: %v", err)
 	}
 	if _, ok := histPlan.(*chplan.VectorSetOp); ok {
-		t.Fatalf("histogram-shape rate took the Mixed path (mutant `==`->`!=` at " +
+		t.Fatalf("histogram sample kind rate took the Mixed path (mutant `==`->`!=` at " +
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`)")
 	}
 
 	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, rateWindowFn, sub, s, ctx)
 	if err != nil {
-		t.Fatalf("mixed-shape: %v", err)
+		t.Fatalf("mixed sample kind: %v", err)
 	}
 	if _, ok := mixedPlan.(*chplan.VectorSetOp); !ok {
-		t.Fatalf("mixed-shape rate = %T, want *chplan.VectorSetOp (mutant `==`->`!=` at "+
+		t.Fatalf("mixed sample kind rate = %T, want *chplan.VectorSetOp (mutant `==`->`!=` at "+
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`)", mixedPlan)
 	}
 }

--- a/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
@@ -84,7 +84,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 	sub := &parser.SubqueryExpr{Range: 5 * time.Minute, Step: time.Minute}
 	inner := &chplan.Scan{Table: "dummy"}
 
-	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.HistogramRowShape, lastOverTimeWindowFn, sub, s, ctx)
+	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, lastOverTimeWindowFn, sub, s, ctx)
 	if err != nil {
 		t.Fatalf("histogram-shape: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstShapeDispatch(t *tes
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case lastOverTimeWindowFn, firstOverTimeWindowFn:`)")
 	}
 
-	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, lastOverTimeWindowFn, sub, s, ctx)
+	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, lastOverTimeWindowFn, sub, s, ctx)
 	if err != nil {
 		t.Fatalf("mixed-shape: %v", err)
 	}
@@ -122,7 +122,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t 
 	sub := &parser.SubqueryExpr{Range: 5 * time.Minute, Step: time.Minute}
 	inner := &chplan.Scan{Table: "dummy"}
 
-	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.HistogramRowShape, resetsWindowFn, sub, s, ctx)
+	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, resetsWindowFn, sub, s, ctx)
 	if err != nil {
 		t.Fatalf("histogram-shape: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_ResetsChangesShapeDispatch(t 
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:`)")
 	}
 
-	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, resetsWindowFn, sub, s, ctx)
+	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, resetsWindowFn, sub, s, ctx)
 	if err != nil {
 		t.Fatalf("mixed-shape: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch(t *testing.
 	sub := &parser.SubqueryExpr{Range: 5 * time.Minute, Step: time.Minute}
 	inner := &chplan.Scan{Table: "dummy"}
 
-	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.HistogramRowShape, rateWindowFn, sub, s, ctx)
+	histPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindHistogram, rateWindowFn, sub, s, ctx)
 	if err != nil {
 		t.Fatalf("histogram-shape: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_FoldShapeDispatch(t *testing.
 			"histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:`)")
 	}
 
-	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.MixedRowShape, rateWindowFn, sub, s, ctx)
+	mixedPlan, _, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, chplan.SampleKindMixed, rateWindowFn, sub, s, ctx)
 	if err != nil {
 		t.Fatalf("mixed-shape: %v", err)
 	}

--- a/internal/promql/gremlins_kill_subquery_test.go
+++ b/internal/promql/gremlins_kill_subquery_test.go
@@ -299,9 +299,9 @@ func TestSubqueryInstantSafe_PiExceptionNotRejected(t *testing.T) {
 }
 
 // TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor kills the
-// CONDITIONALS_NEGATION mutant at histogram_shape_guard.go:rowsMayContainHistograms:`return !hasUnambiguousNamedRole(row, chplan.RoleValue)`.
-// A plain `or` composition has one unambiguous float value role, so the live
-// sample-kind guard must return false and allow lowering without query
+// CONDITIONALS_NEGATION mutant at histogram_shape_guard.go:rowsMayContainHistograms:`return liveSampleKind(inner) != chplan.SampleKindFloat`.
+// A plain `or` composition has a float sample kind, so the live guard must
+// return false and allow lowering without query
 // evaluation context. Negating that result wrongly sends this query through
 // the conservative histogram rejection path.
 func TestLowerSubqueryOverBinary_PlainShapeSucceedsWithNoEvalAnchor(t *testing.T) {

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -241,18 +241,7 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // `append([]string(nil), src...) == nil` for both a nil and an empty-non-nil
 // src.
 //
-// 5. RETIRED COMPOUND INVARIANT GUARDS.
-//
-//	histogram_native_range_fn.go:`if !matched`
-//	histogram_native_range_fn.go:`if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram`
-//	histogram_native_subquery_select.go:`if !matched`
-//	histogram_native_subquery_select.go:`if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram`
-//
-// The old `!matched || wrong shape` expressions were split into independent
-// checks for recognizer failure and a wrong published sample kind. There is no
-// longer a compound boolean whose `||` can mutate to `&&`.
-//
-// 7. A `continue` WHOSE `break` BINDS TO A SWITCH, NOT TO THE LOOP.
+// 5. A `continue` WHOSE `break` BINDS TO A SWITCH, NOT TO THE LOOP.
 //
 //	duplicate_labelset_guard.go:`if mixed && mixedPayload[name] {`
 //	duplicate_labelset_guard.go:`if keyOnStep`

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -241,19 +241,16 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // `append([]string(nil), src...) == nil` for both a nil and an empty-non-nil
 // src.
 //
-// 5. AN INTERNAL-INVARIANT ERROR PATH.
+// 5. RETIRED COMPOUND INVARIANT GUARDS.
 //
-//	histogram_native_range_fn.go:`!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
-//	histogram_native_subquery_select.go:`!matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape`
+//	histogram_native_range_fn.go:`if !matched`
+//	histogram_native_range_fn.go:`if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram`
+//	histogram_native_subquery_select.go:`if !matched`
+//	histogram_native_subquery_select.go:`if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram`
 //
-// `||` -> `&&` narrows a check that reports "internal invariant violated".
-// The two readings differ only when exactly one disjunct holds, and neither
-// half is constructible: `lowerExpHistogramValuedShape` returns a nil node
-// whenever `matched` is false, and `chplan.RowShapeOf(nil)` is the sample row
-// shape, so `!matched` always arrives together with a non-histogram shape and
-// both readings error. The complementary case — matched with a non-histogram
-// shape — is the invariant the line exists to report, and producing it would
-// require lowerExpHistogramValuedShape to break its own contract.
+// The old `!matched || wrong shape` expressions were split into independent
+// checks for recognizer failure and a wrong published sample kind. There is no
+// longer a compound boolean whose `||` can mutate to `&&`.
 //
 // 7. A `continue` WHOSE `break` BINDS TO A SWITCH, NOT TO THE LOOP.
 //

--- a/internal/promql/histogram_native_binop.go
+++ b/internal/promql/histogram_native_binop.go
@@ -186,10 +186,10 @@ func lowerExpHistogramValuedOperand(expr parser.Expr, s schema.Metrics, ctx lowe
 	if !matched {
 		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram binop operand matched no known histogram-valued shape for %v", expr)
 	}
-	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+	if kind := node.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
 		return nil, fmt.Errorf(
-			"promql: internal invariant violated: exp-histogram binop operand lowering published %s row shape (%T), want %s",
-			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+			"promql: internal invariant violated: exp-histogram binop operand lowering published %s sample kind (%T), want histogram",
+			kind, node,
 		)
 	}
 	return node, nil

--- a/internal/promql/histogram_native_count.go
+++ b/internal/promql/histogram_native_count.go
@@ -117,8 +117,8 @@ func countOrGroupOverExpHistogramValue(expr parser.Expr, s schema.Metrics, ctx l
 // or a histogram. Grouping by the published evaluation timestamp keeps range
 // query anchors independent while using the same plan for instant queries.
 func lowerExpHistogramCountOrGroupOverPlan(agg *parser.AggregateExpr, input chplan.Node, s schema.Metrics) (chplan.Node, error) {
-	if chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: nested native-histogram count/group input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: nested native-histogram count/group input is %T with %s sample kind", input, kind)
 	}
 
 	groupBy, groupByAliases, attrsRebuild := histogramAggGroupBy(

--- a/internal/promql/histogram_native_count_values.go
+++ b/internal/promql/histogram_native_count_values.go
@@ -38,8 +38,8 @@ func lowerExpHistogramCountValuesOverPlan(agg *parser.AggregateExpr, input chpla
 	if label == "" {
 		return nil, fmt.Errorf("promql: count_values requires a non-empty label name")
 	}
-	if chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: count_values native-histogram input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: count_values native-histogram input is %T with %s sample kind", input, kind)
 	}
 	return lowerCountValuesOverPlan(agg, label, input, nativeHistogramStringExpr(s), s, ctx), nil
 }

--- a/internal/promql/histogram_native_label_replace.go
+++ b/internal/promql/histogram_native_label_replace.go
@@ -77,12 +77,12 @@ func lowerLabelCallOverExpHistogram(call *parser.Call, s schema.Metrics, ctx low
 	// `and`/`or`/`unless` (cerberus issue #2324), and [isExpHistogramValuedShape]
 	// recognises it too, so [labelCallOverExpHistogram] matches an outer
 	// label_replace/label_join around one. Both shapes publish the exact same
-	// thirteen-column contract under the fixed Histogram*Column aliases (see
-	// [chplan.RowShapeOf]), so any node answering [chplan.HistogramRowShape]
+	// thirteen-column contract under the fixed Histogram*Column aliases, so any
+	// node whose schema classifies [chplan.SampleKindHistogram]
 	// here is a valid input to [rewriteHistogramProjectionAttributes] — a
 	// stricter Go-type assertion is what issue #2468 reports as the bug.
-	if shape := chplan.RowShapeOf(inner); shape != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram label_replace input publishes %s row shape (%T), want %s", shape, inner, chplan.HistogramRowShape)
+	if kind := inner.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram label_replace input publishes %s sample kind (%T), want histogram", kind, inner)
 	}
 	return rewriteHistogramProjectionAttributes(inner, attrs, s), nil
 }

--- a/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_aggregate_range_fn.go
@@ -248,8 +248,8 @@ func lowerSumOrAvgMixedOrSubquerySelectFn(shape sumOrAvgMixedOrSubqueryShape, gr
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(mixedRel) != chplan.MixedRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s row shape", mixedRel, chplan.RowShapeOf(mixedRel))
+	if kind := mixedRel.RowType().SampleKind(); kind != chplan.SampleKindMixed {
+		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s sample kind", mixedRel, kind)
 	}
 	// [lowerSelectFnOverExpHistogramSubqueryInput]'s own doc: this
 	// continuation only ever reads the Attributes/Timestamp/Value columns

--- a/internal/promql/histogram_native_mixed_or_subquery_further_setop_range_fn.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_further_setop_range_fn.go
@@ -1,6 +1,8 @@
 package promql
 
 import (
+	"fmt"
+
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -78,7 +80,13 @@ import (
 // function for the three grid modes, and for why the classic ambient-grid
 // fan-outs buried inside its own wideInner stay untouched (cerberus issue
 // #2728).
-func lowerHistogramOrMixedSubqueryOuterFnInput(inner chplan.Node, shape chplan.RowShape, windowFn string, sub *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (node chplan.Node, matched bool, err error) {
+func lowerHistogramOrMixedSubqueryOuterFnInput(inner chplan.Node, kind chplan.SampleKind, windowFn string, sub *parser.SubqueryExpr, s schema.Metrics, ctx lowerCtx) (node chplan.Node, matched bool, err error) {
+	if !histogramSubqueryOuterFnName(windowFn) {
+		return nil, false, nil
+	}
+	if kind != chplan.SampleKindHistogram && kind != chplan.SampleKindMixed {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: histogram subquery outer function input has %s sample kind", kind)
+	}
 	if nestedCallSubqueryShape(sub.Expr) {
 		// Widening mutates inner in place, so it must not run for a name
 		// the switch below leaves unmatched (deriv, predict_linear, …) —
@@ -96,21 +104,21 @@ func lowerHistogramOrMixedSubqueryOuterFnInput(inner chplan.Node, shape chplan.R
 		node, err = lowerSelectFnOverExpHistogramSubqueryInput(inner, sub, windowFn, s, ctx)
 		return node, true, err
 	case lastOverTimeWindowFn, firstOverTimeWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerSelectFnOverExpHistogramSubqueryInput(inner, sub, windowFn, s, ctx)
 			return node, true, err
 		}
 		node, err = lowerMixedOrSubqueryLastFirstInput(inner, sub, windowFn, s, ctx)
 		return node, true, err
 	case resetsWindowFn, changesWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerSelectFnOverExpHistogramSubqueryInput(inner, sub, windowFn, s, ctx)
 			return node, true, err
 		}
 		node, err = lowerMixedOrSubqueryResetsOrChangesInput(inner, sub, windowFn, s, ctx)
 		return node, true, err
 	case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerExpHistogramRangeFnOverSubqueryInput(inner, sub, windowFn, s, ctx)
 			return node, true, err
 		}

--- a/internal/promql/histogram_native_mixed_or_subquery_further_setop_range_fn.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_further_setop_range_fn.go
@@ -89,12 +89,8 @@ func lowerHistogramOrMixedSubqueryOuterFnInput(inner chplan.Node, kind chplan.Sa
 	}
 	if nestedCallSubqueryShape(sub.Expr) {
 		// Widening mutates inner in place, so it must not run for a name
-		// the switch below leaves unmatched (deriv, predict_linear, …) —
-		// those fall through to the caller's own float-only-drop /
-		// rejection handling over the UNwidened relation.
-		if !histogramSubqueryOuterFnName(windowFn) {
-			return nil, false, nil
-		}
+		// the switch below leaves unmatched (deriv, predict_linear, …).
+		// The function-name gate above therefore runs before this mutation.
 		if err := widenNestedCallSubqueryInner(inner, sub, ctx); err != nil {
 			return nil, false, err
 		}

--- a/internal/promql/histogram_native_mixed_or_subquery_last_first.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_last_first.go
@@ -85,8 +85,8 @@ func lowerMixedOrSubqueryLastFirst(shape sumOrAvgMixedOrSubqueryShape, gridCtx l
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(mixedRel) != chplan.MixedRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s row shape", mixedRel, chplan.RowShapeOf(mixedRel))
+	if kind := mixedRel.RowType().SampleKind(); kind != chplan.SampleKindMixed {
+		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s sample kind", mixedRel, kind)
 	}
 	return lowerMixedOrSubqueryLastFirstInput(mixedRel, shape.sub, shape.windowFn, s, ctx)
 }

--- a/internal/promql/histogram_native_mixed_or_subquery_resets_changes.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_resets_changes.go
@@ -283,8 +283,8 @@ func lowerMixedOrSubqueryResetsOrChanges(shape sumOrAvgMixedOrSubqueryShape, gri
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(mixedRel) != chplan.MixedRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s row shape", mixedRel, chplan.RowShapeOf(mixedRel))
+	if kind := mixedRel.RowType().SampleKind(); kind != chplan.SampleKindMixed {
+		return nil, fmt.Errorf("promql: internal invariant violated: sum/avg-mixed-or subquery input is %T with %s sample kind", mixedRel, kind)
 	}
 	return lowerMixedOrSubqueryResetsOrChangesInput(mixedRel, shape.sub, shape.windowFn, s, ctx)
 }

--- a/internal/promql/histogram_native_range_fn.go
+++ b/internal/promql/histogram_native_range_fn.go
@@ -284,8 +284,11 @@ func lowerExpHistogramRangeFnOverSubquery(shape histogramSubqueryRangeShape, s s
 	if err != nil {
 		return nil, err
 	}
-	if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if !matched {
+		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input matched no histogram-valued shape for %v", sub.Expr)
+	}
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input is %T with %s sample kind", input, kind)
 	}
 	node, err := lowerExpHistogramRangeFnOverSubqueryInput(input, sub, shape.windowFn, s, ctx)
 	if err != nil {

--- a/internal/promql/histogram_native_scalar_binop.go
+++ b/internal/promql/histogram_native_scalar_binop.go
@@ -284,8 +284,8 @@ func isExpHistogramValuedShape(expr parser.Expr, s schema.Metrics, ctx lowerCtx)
 // keep=false incompatible-types result; otherwise the capping
 // histogram-shaped node is rewritten to scale it.
 //
-// The histogram side is asserted by ROW SHAPE
-// ([chplan.RowShapeOf] == [chplan.HistogramRowShape]), not by literal Go
+// The histogram side is asserted by validated schema kind
+// ([chplan.Schema.SampleKind] == [chplan.SampleKindHistogram]), not by literal Go
 // type: [isExpHistogramValuedShape] — the very predicate
 // [expHistogramScalarBinop] / [expHistogramDroppingScalarBinop] gate on to
 // decide the histogram side is even eligible — reports true for a
@@ -314,10 +314,10 @@ func lowerExpHistogramScalarBinop(histSide parser.Expr, op chplan.BinaryOp, scal
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+	if kind := node.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
 		return nil, fmt.Errorf(
-			"promql: internal invariant violated: exp-histogram scalar-binop operand lowering published %s row shape (%T), want %s",
-			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+			"promql: internal invariant violated: exp-histogram scalar-binop operand lowering published %s sample kind (%T), want histogram",
+			kind, node,
 		)
 	}
 	if drop {

--- a/internal/promql/histogram_native_set_op.go
+++ b/internal/promql/histogram_native_set_op.go
@@ -151,10 +151,10 @@ func lowerExpHistogramSetOpOperand(expr parser.Expr, s schema.Metrics, ctx lower
 	if !matched {
 		return nil, fmt.Errorf("promql: internal invariant violated: exp-histogram set-op operand matched no known histogram-valued shape for %v", expr)
 	}
-	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+	if kind := node.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
 		return nil, fmt.Errorf(
-			"promql: internal invariant violated: exp-histogram set-op operand lowering published %s row shape (%T), want %s",
-			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+			"promql: internal invariant violated: exp-histogram set-op operand lowering published %s sample kind (%T), want histogram",
+			kind, node,
 		)
 	}
 	return node, nil
@@ -249,10 +249,10 @@ func lowerExpHistogramValuedOrForwardedOperand(expr parser.Expr, s schema.Metric
 	if err != nil {
 		return nil, err
 	}
-	if chplan.RowShapeOf(node) != chplan.HistogramRowShape {
+	if kind := node.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
 		return nil, fmt.Errorf(
-			"promql: internal invariant violated: exp-histogram-forwarding set-op operand lowering published %s row shape (%T), want %s",
-			chplan.RowShapeOf(node), node, chplan.HistogramRowShape,
+			"promql: internal invariant violated: exp-histogram-forwarding set-op operand lowering published %s sample kind (%T), want histogram",
+			kind, node,
 		)
 	}
 	return node, nil

--- a/internal/promql/histogram_native_subquery_call_subquery.go
+++ b/internal/promql/histogram_native_subquery_call_subquery.go
@@ -1,6 +1,7 @@
 package promql
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
@@ -200,37 +201,43 @@ func guardedCallSubqueryFanout(
 // `<fn>(<inner-sub>)[<outer-range>:<step>]`, mirroring
 // [lowerHistogramOrMixedSubqueryOuterFnInput]'s own switch vocabulary rung
 // for rung. wideInner is already lowered (the widened inner subquery's own
-// relation) and shape is its already-computed row shape.
+// relation) and kind is its already-validated sample schema contract.
 func lowerHistogramOrMixedCallSubqueryInput(
 	wideInner chplan.Node,
-	shape chplan.RowShape,
+	kind chplan.SampleKind,
 	windowFn string,
 	outerSub, innerSub *parser.SubqueryExpr,
 	step time.Duration,
 	s schema.Metrics,
 	ctx lowerCtx,
 ) (node chplan.Node, matched bool, err error) {
+	if !histogramSubqueryOuterFnName(windowFn) {
+		return nil, false, nil
+	}
+	if kind != chplan.SampleKindHistogram && kind != chplan.SampleKindMixed {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: histogram call-subquery input has %s sample kind", kind)
+	}
 	grid := histogramCallSubqueryGrid{outerSub: outerSub, innerRange: innerSub.Range, step: step}
 	switch windowFn {
 	case countOverTimeWindowFn, presentOverTimeWindowFn, tsOfFirstOverTimeExpHistFn, tsOfLastOverTimeExpHistFn:
 		node, err = lowerSelectFnOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 		return node, true, err
 	case lastOverTimeWindowFn, firstOverTimeWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerSelectFnOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 			return node, true, err
 		}
 		node, err = lowerMixedLastFirstOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 		return node, true, err
 	case resetsWindowFn, changesWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerSelectFnOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 			return node, true, err
 		}
 		node, err = lowerMixedResetsOrChangesOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 		return node, true, err
 	case rateWindowFn, increaseWindowFn, deltaWindowFn, irateWindowFn, ideltaWindowFn, sumOverTimeWindowFn, avgOverTimeWindowFn:
-		if shape == chplan.HistogramRowShape {
+		if kind == chplan.SampleKindHistogram {
 			node, err = lowerExpHistogramFoldOverCallSubqueryInput(wideInner, grid, windowFn, s, ctx)
 			return node, true, err
 		}

--- a/internal/promql/histogram_native_subquery_select.go
+++ b/internal/promql/histogram_native_subquery_select.go
@@ -179,8 +179,11 @@ func lowerSelectFnOverExpHistogramSubquery(shape histogramSubquerySelectShape, s
 	if err != nil {
 		return nil, err
 	}
-	if !matched || chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if !matched {
+		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input matched no histogram-valued shape for %v", sub.Expr)
+	}
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: histogram subquery input is %T with %s sample kind", input, kind)
 	}
 	node, err := lowerSelectFnOverExpHistogramSubqueryInput(input, sub, shape.windowFn, s, ctx)
 	if err != nil {

--- a/internal/promql/histogram_native_sum.go
+++ b/internal/promql/histogram_native_sum.go
@@ -293,8 +293,8 @@ func expHistogramGroupMergeFanout(perSeries chplan.Node, anchor *chplan.ColumnRe
 // ceiling (ctx.resourceBounds.HistogramMergeMaxCostUnits, cerberus issue
 // #2667), passed straight through to [expHistogramMergeSortStage].
 func lowerExpHistogramSumOrAvgOverPlan(agg *parser.AggregateExpr, input chplan.Node, s schema.Metrics, maxCostUnits int64) (chplan.Node, error) {
-	if chplan.RowShapeOf(input) != chplan.HistogramRowShape {
-		return nil, fmt.Errorf("promql: internal invariant violated: nested native-histogram aggregation input is %T with %s row shape", input, chplan.RowShapeOf(input))
+	if kind := input.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, fmt.Errorf("promql: internal invariant violated: nested native-histogram aggregation input is %T with %s sample kind", input, kind)
 	}
 
 	histSchema := histogramProjectionSchema(s)

--- a/internal/promql/histogram_quantile.go
+++ b/internal/promql/histogram_quantile.go
@@ -1924,14 +1924,14 @@ func lowerHistogramQuantileHistogramValuedArg(
 	if err != nil {
 		return nil, true, err
 	}
-	// RowShapeOf, not a *chplan.HistogramProjection type assertion: a
+	// SampleKind, not a *chplan.HistogramProjection type assertion: a
 	// set-op operand (histogram_native_set_op.go) answers histogram-valued
 	// as a *chplan.VectorSetOp with Histogram=true, publishing the
 	// identical nine-column contract under a different node type.
-	// RowShapeOf is this package's own shared test for "is this the
-	// thirteen-column histogram row shape" across every such producer.
-	if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
-		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
+	// the schema classifier validates the complete histogram contract across
+	// every such producer.
+	if kind := hist.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering produced %s sample kind (%T), want histogram", kind, hist)
 	}
 	return lowerHistogramQuantileNativeOverProjection(hist, phi, s), true, nil
 }

--- a/internal/promql/histogram_shape_guard.go
+++ b/internal/promql/histogram_shape_guard.go
@@ -33,137 +33,25 @@ func mixedRowsNeedPreparation(inner chplan.Node) bool {
 	return completeHistogram && discriminated && !mixedFloatRowsProven(inner)
 }
 
+// liveSampleKind refines the physical schema contract with the only
+// value-domain proof represented in the plan: a discriminator-zero filter over
+// a mixed payload contains float rows only while retaining all mixed columns.
+func liveSampleKind(inner chplan.Node) chplan.SampleKind {
+	if inner == nil {
+		return chplan.SampleKindOpaque
+	}
+	kind := inner.RowType().SampleKind()
+	if kind == chplan.SampleKindMixed && mixedFloatRowsProven(inner) {
+		return chplan.SampleKindFloat
+	}
+	return kind
+}
+
 // rowsMayContainHistograms answers which payload path a subquery must take.
 // A discriminator-zero proof makes a physically mixed relation safe for the
 // float path without changing its columns. Unknown or malformed schemas stay
 // on the conservative path: callers must never erase a possible histogram by
 // projecting the ordinary float envelope over a relation they cannot prove.
 func rowsMayContainHistograms(inner chplan.Node) bool {
-	row := inner.RowType()
-	if row.Open {
-		return true
-	}
-	completeHistogram, discriminated, valid := inspectLiveSamplePayload(row)
-	if !valid {
-		return true
-	}
-	if !liveSampleRolesAreUnambiguous(row) {
-		return true
-	}
-	if completeHistogram {
-		if !discriminated {
-			return true
-		}
-		return !mixedFloatRowsProven(inner)
-	}
-	return !hasUnambiguousNamedRole(row, chplan.RoleValue)
-}
-
-func liveSampleRolesAreUnambiguous(row chplan.Schema) bool {
-	for _, role := range [...]chplan.ColumnRole{
-		chplan.RoleMetricName,
-		chplan.RoleAttributes,
-		chplan.RoleTimestamp,
-		chplan.RoleAnchor,
-		chplan.RoleValue,
-		chplan.RoleDiscriminator,
-	} {
-		if !roleIsUnambiguousWhenPresent(row, role) {
-			return false
-		}
-	}
-	return true
-}
-
-// inspectLiveSamplePayload validates the public histogram/discriminator
-// envelope without panicking. The lowering pipeline can then conservatively
-// retain an unrecognised payload and let its histogram-aware continuation
-// report the established error, rather than silently selecting the float path.
-func inspectLiveSamplePayload(row chplan.Schema) (completeHistogram, discriminated, valid bool) {
-	valid = true
-	histogramFields := chplan.HistogramPayloadColumns()
-	sawHistogramContract := false
-	completeHistogram = true
-	for _, field := range histogramFields {
-		count := 0
-		for _, column := range row.Columns {
-			if column.Name != field.Name {
-				continue
-			}
-			sawHistogramContract = true
-			if column.Role != chplan.RoleHistogramField {
-				valid = false
-				continue
-			}
-			count++
-			if count != 1 {
-				valid = false
-			}
-		}
-		if count != 1 {
-			completeHistogram = false
-		}
-	}
-	for _, column := range row.Columns {
-		if column.Role != chplan.RoleHistogramField {
-			continue
-		}
-		sawHistogramContract = true
-		canonicalName := false
-		for _, field := range histogramFields {
-			if column.Name == field.Name {
-				canonicalName = true
-				break
-			}
-		}
-		if !canonicalName {
-			valid = false
-		}
-	}
-	if sawHistogramContract && !completeHistogram {
-		valid = false
-	}
-
-	discriminated = row.Has(chplan.RoleDiscriminator)
-	if !roleIsUnambiguousWhenPresent(row, chplan.RoleDiscriminator) {
-		valid = false
-	}
-	if discriminated && !completeHistogram {
-		valid = false
-	}
-	if completeHistogram && discriminated && !hasUnambiguousNamedRole(row, chplan.RoleValue) {
-		valid = false
-	}
-	return completeHistogram, discriminated, valid
-}
-
-func hasUnambiguousNamedRole(row chplan.Schema, role chplan.ColumnRole) bool {
-	found := false
-	name := ""
-	for _, column := range row.Columns {
-		if column.Role != role {
-			continue
-		}
-		if found || column.Name == "" {
-			return false
-		}
-		found = true
-		name = column.Name
-	}
-	if !found {
-		return false
-	}
-	for _, column := range row.Columns {
-		if column.Name == name && column.Role != role {
-			return false
-		}
-	}
-	return true
-}
-
-func roleIsUnambiguousWhenPresent(row chplan.Schema, role chplan.ColumnRole) bool {
-	if !row.Has(role) {
-		return true
-	}
-	return hasUnambiguousNamedRole(row, role)
+	return liveSampleKind(inner) != chplan.SampleKindFloat
 }

--- a/internal/promql/histogram_value_fns.go
+++ b/internal/promql/histogram_value_fns.go
@@ -266,15 +266,15 @@ func lowerHistogramValueFnHistogramValuedArg(
 	if err != nil {
 		return nil, true, err
 	}
-	// RowShapeOf, not a *chplan.HistogramProjection type assertion: a
+	// SampleKind, not a *chplan.HistogramProjection type assertion: a
 	// set-op operand (histogram_native_set_op.go) answers histogram-valued
 	// as a *chplan.VectorSetOp with Histogram=true, publishing the
 	// identical nine-column contract under a different node type, and
-	// RowShapeOf is this package's own shared test for "is this the
-	// thirteen-column histogram row shape" across every such producer
+	// the schema classifier is the shared validation of that histogram
+	// contract across every such producer
 	// (mirrors lowerExpHistogramCountOrGroupOverPlan's identical check).
-	if chplan.RowShapeOf(hist) != chplan.HistogramRowShape {
-		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering did not produce a histogram-shaped plan, got %T", hist)
+	if kind := hist.RowType().SampleKind(); kind != chplan.SampleKindHistogram {
+		return nil, true, fmt.Errorf("promql: internal invariant violated: exp-histogram lowering produced %s sample kind (%T), want histogram", kind, hist)
 	}
 	node, err = lowerHistogramValueFnOverProjection(c, hist, s, ctx)
 	return node, true, err

--- a/internal/promql/mixed_consumer_inventory_test.go
+++ b/internal/promql/mixed_consumer_inventory_test.go
@@ -12,15 +12,11 @@ import (
 )
 
 // Mixed-wrapper consumers decide from mixedRowsNeedPreparation, which keeps
-// physical payload separate from the live-row proof. The three remaining
-// RowShapeOf comparisons are histogram-recognizer postconditions covered by
-// #3349; adding another site means a consumer regressed to legacy inference.
+// physical payload separate from the live-row proof. No production consumer
+// compares RowShapeOf with MixedRowShape; adding a site means a consumer
+// regressed to legacy inference.
 func TestMixedWrapperLegacyShapeInventory(t *testing.T) {
-	want := []string{
-		"histogram_native_mixed_or_subquery_aggregate_range_fn.go:lowerSumOrAvgMixedOrSubquerySelectFn",
-		"histogram_native_mixed_or_subquery_last_first.go:lowerMixedOrSubqueryLastFirstInput",
-		"histogram_native_mixed_or_subquery_resets_changes.go:lowerMixedOrSubqueryResetsOrChanges",
-	}
+	var want []string
 	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/promql/mixed_physical_payload_test.go
+++ b/internal/promql/mixed_physical_payload_test.go
@@ -35,23 +35,25 @@ func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.
 		input                chplan.Node
 		physicalMixed        bool
 		floatProven          bool
+		physicalKind         chplan.SampleKind
+		liveKind             chplan.SampleKind
 		legacyShape          chplan.RowShape
 		needsPreparation     bool
 		mayContainHistograms bool
 	}{
-		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleRowShape, false, false},
-		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.HistogramRowShape, false, true},
-		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleRowShape, true, true},
-		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleRowShape, false, false},
-		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleRowShape, false, false},
-		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleRowShape, false, false},
-		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleRowShape, false, false},
-		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleRowShape, false, false},
-		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.MixedRowShape, true, true},
-		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleRowShape, true, true},
-		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleRowShape, true, true},
-		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleRowShape, true, true},
-		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.MixedRowShape, false, false},
+		{"canonical_float", sampleForwardTestInput(metricRoles(s)...), false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"pure_histogram", &chplan.HistogramProjection{Input: &chplan.OneRow{}}, false, false, chplan.SampleKindHistogram, chplan.SampleKindHistogram, chplan.HistogramRowShape, false, true},
+		{"physical_mixed_legacy_sample", mixed, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
+		{"float_proof_preserves_physical_mixed", floatRows, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"ordered_float_proof", &chplan.OrderBy{Input: floatRows}, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"filter_over_float_proof", &chplan.Filter{Input: floatRows, Predicate: &chplan.LitBool{V: true}}, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"empty_ranked_selector_preserves_proof", emptyRankedSelector, true, true, chplan.SampleKindMixed, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"nonempty_ranked_selector_projects_float", nonemptyRankedSelector, false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.SampleRowShape, false, false},
+		{"preserving_selector_keeps_live_mixed", preservingSelector, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.MixedRowShape, true, true},
+		{"unrelated_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: true}}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
+		{"false_filter", &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
+		{"project_barrier", &chplan.Project{Input: floatRows}, true, false, chplan.SampleKindMixed, chplan.SampleKindMixed, chplan.SampleRowShape, true, true},
+		{"legacy_mixed_without_physical_payload", legacyMixedFloat, false, false, chplan.SampleKindFloat, chplan.SampleKindFloat, chplan.MixedRowShape, false, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			row := tc.input.RowType()
@@ -61,6 +63,12 @@ func TestMixedRowsNeedPreparationSeparatesPayloadProofAndLegacyShape(t *testing.
 			}
 			if got := mixedFloatRowsProven(tc.input); got != tc.floatProven {
 				t.Fatalf("float proof=%v, want %v", got, tc.floatProven)
+			}
+			if got := row.SampleKind(); got != tc.physicalKind {
+				t.Fatalf("physical sample kind=%s, want %s", got, tc.physicalKind)
+			}
+			if got := liveSampleKind(tc.input); got != tc.liveKind {
+				t.Fatalf("live sample kind=%s, want %s", got, tc.liveKind)
 			}
 			if got := chplan.RowShapeOf(tc.input); got != tc.legacyShape {
 				t.Fatalf("legacy shape=%s, want %s", got, tc.legacyShape)

--- a/internal/promql/mixed_physical_payload_test.go
+++ b/internal/promql/mixed_physical_payload_test.go
@@ -243,7 +243,7 @@ func TestRowsMayContainHistogramsUsesRolesAcrossSampleEnvelopes(t *testing.T) {
 		chplan.RoleAnchor,
 	} {
 		for _, input := range []chplan.Node{
-			sampleForwardTestInput(value, chplan.Column{Role: role}),
+			&chplan.Scan{Roles: []chplan.Column{value, {Role: role}}},
 			sampleForwardTestInput(
 				value,
 				chplan.Column{Name: "first", Role: role},

--- a/internal/promql/presence_kernel_test.go
+++ b/internal/promql/presence_kernel_test.go
@@ -62,7 +62,7 @@ func TestPresenceKernelPayloadPolicy(t *testing.T) {
 	if plan, err := preserveMixedPlan(&chplan.VectorSetOp{Mixed: true}, mixedCountGroupFamily); plan != nil || err == nil {
 		t.Fatal("missing plan policy admitted")
 	}
-	for _, input := range []chplan.Node{&chplan.Scan{}, &chplan.HistogramProjection{}} {
+	for _, input := range []chplan.Node{&chplan.Scan{}, &chplan.HistogramProjection{Input: &chplan.OneRow{}}} {
 		got, err := preserveMixedPlan(input, mixedCountGroupFamily)
 		if got != input || err != nil {
 			t.Fatalf("ordinary input %T consulted mixed policy: plan=%T err=%v", input, got, err)

--- a/internal/promql/subquery.go
+++ b/internal/promql/subquery.go
@@ -1048,7 +1048,7 @@ func lowerOuterRangeFnOverSubquery(
 	// still, by [rangeFnOverExpHistogramSubquery] /
 	// [lowerExpHistogramRangeFnOverSubquery] (histogram_native_range_fn.go).
 	if rowsMayContainHistograms(inner) {
-		shape := chplan.RowShapeFromSchema(inner.RowType())
+		kind := liveSampleKind(inner)
 		// Cerberus issue #2724: inner may have reached this Histogram/Mixed
 		// shape via a further and/unless/or wrapping a mixed `or`, a bare
 		// and/unless-forwarded histogram selector, or (since cerberus issue
@@ -1063,7 +1063,7 @@ func lowerOuterRangeFnOverSubquery(
 		if err := requireMixedPlanPolicy(inner, mixedSubqueryFamily); err != nil {
 			return nil, err
 		}
-		if node, matched, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, shape, outer.Func.Name, sub, s, ctx); matched {
+		if node, matched, err := lowerHistogramOrMixedSubqueryOuterFnInput(inner, kind, outer.Func.Name, sub, s, ctx); matched {
 			return node, err
 		}
 		if !histogramSubqueryFloatOnlyDropFunc(outer.Func.Name) {
@@ -3093,7 +3093,7 @@ func lowerSubqueryOverCallSubquery(
 	// this mirrors) already gets for
 	// `<outer-fn>(<bare-histogram-selector>[range:step])`.
 	if rowsMayContainHistograms(wideInner) {
-		shape := chplan.RowShapeFromSchema(wideInner.RowType())
+		kind := liveSampleKind(wideInner)
 		// Cerberus issue #2726: wideInner may be histogram/mixed-shaped
 		// because innerSub's OWN inner expression resolved histogram-native
 		// (or a further and/unless/or wrapping one, cerberus issue #2724).
@@ -3105,7 +3105,7 @@ func lowerSubqueryOverCallSubquery(
 		if err := requireMixedPlanPolicy(wideInner, mixedSubqueryFamily); err != nil {
 			return nil, err
 		}
-		if node, matched, err := lowerHistogramOrMixedCallSubqueryInput(wideInner, shape, call.Func.Name, sub, innerSub, step, s, ctx); matched {
+		if node, matched, err := lowerHistogramOrMixedCallSubqueryInput(wideInner, kind, call.Func.Name, sub, innerSub, step, s, ctx); matched {
 			return node, err
 		}
 		if !histogramSubqueryFloatOnlyDropFunc(call.Func.Name) {


### PR DESCRIPTION
## Summary

- introduce a strict five-state sample-schema classifier: float, histogram, mixed, opaque, and invalid
- validate canonical histogram payload roles and reject missing, duplicate, unnamed, and shadowed public columns
- keep custom sample-column names semantic by classifying from roles rather than positions or familiar names
- migrate all native-histogram operand, aggregate, `count_values`, label, scalar, set-op, quantile, value-function, and range/select-subquery guards
- make mixed and nested-subquery postconditions reject opaque or invalid contracts instead of treating every non-float shape as mixed

## Stack

- stacked on #3348 (`codex/3348-reconcile-mixed-consumers`)
- rebased on the parent branch's exact head before review

## Validation

- `gofmt`
- `git diff --check`
- heavy validation runs on GitHub CI only

Closes #3349
