### PR TITLE
refactor(chplan): fold RowShapeOf over validated schemas

### DIFF
--- a/internal/chplan/row_shape.go
+++ b/internal/chplan/row_shape.go
@@ -1,160 +1,36 @@
 package chplan
 
-// RowShape names the column set a node publishes to whatever sits directly
-// above it, for the one consumer that has to build that "whatever": a
-// projection which forwards its input's columns unchanged and rewrites
-// exactly one of them.
-//
-// Such a forwarder cannot list a fixed set of columns. A projection names
-// its outputs by REFERENCE, and ClickHouse resolves every reference against
-// the scope the subquery below it actually exposes — naming a column that
-// scope does not carry is rejected outright with code 47, `Unknown
-// expression identifier`, and OMITTING one the layer above still reads
-// silently deletes it from the wire. Both failures are 502s or empty
-// panels at the HTTP edge, never a plan-level error, so the forwarder has
-// to DERIVE the set from its input rather than declare it.
-//
-// The three shapes a PromQL forwarder can be handed:
-//
-//   - [SampleRowShape] — the canonical four-column sample row
-//     `(MetricName, Attributes, Timestamp, Value)`. Only the NAMES are
-//     the contract: a Scan reads all four off storage, a Filter or Limit
-//     passes its input's through untouched, and an aggregation
-//     re-publishes them from group keys (`? AS MetricName`, the group map
-//     as `Attributes`, an evaluation-time `TimeUnix`) — which is why an
-//     [Aggregate] is never the node a forwarder sits directly on, its
-//     lowering always caps it with exactly that Project.
-//     [RangeWindowStaleResample] and RangeLWR likewise emit all four by
-//     construction. What each name CONTAINS is a separate question, and
-//     [IsDerivedShape] is what answers it.
-//   - [GridWindowRowShape] — one row per (series, ANCHOR). A window that
-//     materialises a query_range grid publishes that grid axis TWICE: once
-//     under [RangeWindowAnchorColumn], which api/prom's matrix wrapper
-//     reads back to bucket each series' points, and once under the schema
-//     timestamp column, which a step-aligned vector↔vector join reads off
-//     each arm. There is no `MetricName`: a range window computes a
-//     DERIVED sample, and PromQL drops `__name__` from those, so the
-//     window's emitter never selects the column at all. A forwarder that
-//     drops either timestamp column breaks the layer above it; one that
-//     references `MetricName` gets code 47.
-//   - [ReducedWindowRowShape] — one row per series, already reduced to a
-//     single point. There is no per-row timestamp to forward at all and no
-//     `MetricName`; only the group keys and the value survive.
-//
-// The classifier exists because the two windowed shapes were previously
-// recognised by asserting ONE concrete node kind at each consumer. That
-// spelling answers "is this a *RangeWindow", not "what does my input
-// expose", and the two questions came apart the moment a second node grew
-// the same row shape: [RangeWindowGridNative] publishes byte-for-byte the
-// columns a matrix [RangeWindow] does, so every `label_replace` /
-// `label_join` / `abs` over a range-mode `rate()` on the ts_grid path fell
-// through to the canonical branch and emitted a reference to a
-// `MetricName` its own subquery never exposed. Deriving the shape here
-// means a future node inherits the right branch by publishing the right
-// columns, not by being added to a list at each consumer.
-//
-// This answers a DIFFERENT question from [IsDerivedShape], which asks only
-// whether `MetricName` is absent and walks through the transparent nodes
-// to find out. Here the caller sits directly on the node it is projecting
-// over and needs the timestamp columns too, which "derived" does not
-// distinguish.
+// RowShape summarizes a node's physical output schema in the sample
+// vocabulary. It is diagnostic: it does not prove which sample kinds remain
+// live after filtering, or whether a wrapper should preserve metric names.
+// Consumers that need specific columns must resolve and validate their roles.
 type RowShape int
 
 const (
-	// SampleRowShape is the canonical `(MetricName, Attributes, Timestamp,
-	// Value)` row. It is the answer for every node that is not a range
-	// window, which is what makes it the zero value: a forwarder that
-	// cannot recognise its input is safest assuming the shape the vast
-	// majority of plans carry.
+	// SampleRowShape covers canonical samples and is also the documentation
+	// default for opaque, incomplete, open, or invalid outputs. It is not a
+	// float-only proof.
 	SampleRowShape RowShape = iota
 
-	// GridWindowRowShape is the matrix window row: `(group keys…,
-	// RangeWindowAnchorColumn, Timestamp, Value)` and no `MetricName`.
+	// GridWindowRowShape carries attributes, a value, and a per-step anchor.
+	// A metric-name column may also be present.
 	GridWindowRowShape
 
-	// ReducedWindowRowShape is the instant window row: `(group keys…,
-	// Value)` — no timestamp of any kind and no `MetricName`.
+	// ReducedWindowRowShape carries attributes and a value without a timestamp
+	// or anchor. A metric-name column may also survive grouping.
 	ReducedWindowRowShape
 
-	// HistogramRowShape is [HistogramProjection]'s row: `(group keys…,
-	// Histogram*Column…)` — nine named histogram columns instead of a
-	// `Value`, and no `MetricName` of its own (a wrapping Project adds
-	// one, the same way HistogramQuantileNative's wrapping Project
-	// does). It answers TRUE to every `shape != SampleRowShape` check
-	// the PromQL forwarders (projectValueOverInner,
-	// projectAttributesOverInner) make, so it would take their WINDOWED
-	// branch — which is wrong, not merely unhandled: that branch
-	// forwards `Value`, and a HistogramProjection publishes `Value`
-	// only as the placeholder it binds alongside the nine real
-	// Histogram*Column outputs. The projection would therefore succeed
-	// in ClickHouse and answer 0, dropping the histogram. Neither
-	// forwarder builds a column list a histogram-shaped row satisfies,
-	// so a histogram-valued lowering that needs them must teach them
-	// this shape first; until then both assert against it on entry
-	// (internal/promql/histogram_shape_guard.go). See also the doc
-	// comment on HistogramProjection.
-	//
-	// Three lowerings build this node today (internal/promql's
-	// histogram_native_bare.go, histogram_native_sum.go and
-	// histogram_native_range_fn.go). Generic forwarders still cannot
-	// consume it directly, and issue #2296 asked whether every wrapping
-	// shape PromQL can put around a histogram-valued result reaches one of
-	// them anyway. It does not: histogram-aware label transforms
-	// (label_replace / label_join) and scalar/histogram or
-	// histogram/histogram arithmetic recognise their operand directly,
-	// composing `sum`/`avg` over an ALREADY histogram-valued result (for
-	// example `sum(rate(m_exp_hist[5m]))`) is recognised recursively by
-	// internal/promql's mergeableExpHistogramAggregate before it would ever
-	// reach a forwarder, and float-only functions drop every histogram
-	// sample and re-project an empty canonical float shape (#2245 closed
-	// #2296 on that basis). Every remaining wrapping shape stays behind
-	// expHistogramSelectorRouting until it grows its own histogram-aware
-	// lowering or an extension to that recognizer set.
-	//
-	// [VectorSetOp] / [NaryVectorSetOp] also answer this shape when their
-	// own Histogram field is set — internal/promql's
-	// lowerExpHistogramSetOp builds one from two HistogramProjection
-	// operands for `and`/`or`/`unless` (cerberus issue #2324). Unlike the
-	// three lowerings above, neither node IS a HistogramProjection; the
-	// chsql emitter widens their projection to the same nine-column
-	// output because both arms publish it under the fixed
-	// Histogram*Column aliases regardless. [RowShapeOf] reports the
-	// SHAPE a node's own SELECT publishes, not which Go type built it, so
-	// this is still the correct answer here.
-	//
-	// [InfoJoin] answers it too when its own Histogram field is set —
-	// internal/promql's lowerInfo builds one when `info(v[, …])`'s base
-	// vector v is histogram-valued (cerberus issue #2509): reference
-	// Prometheus's info() preserves a histogram sample in the base vector
-	// rather than dropping it, so the join's own SELECT widens to carry
-	// Input's nine Histogram*Column outputs through alongside the
-	// canonical quartet. See [InfoJoin]'s own doc comment.
+	// HistogramRowShape carries the complete canonical histogram payload.
+	// Additional columns do not change the physical payload classification.
 	HistogramRowShape
 
-	// MixedRowShape is [VectorSetOp]'s answer when its Mixed field is
-	// set — internal/promql's lowerMixedExpHistogramSetOp builds one for
-	// `or` between a float-valued operand and a histogram-valued operand
-	// (cerberus issue #2330). The SELECT it publishes is the canonical
-	// quartet, the nine Histogram*Column outputs, AND a trailing
-	// discriminator column (unlike [HistogramRowShape]'s thirteen), so a
-	// generic forwarder that reads `Value` unconditionally — the same
-	// hazard [HistogramRowShape]'s doc comment describes — is just as
-	// wrong here: on a histogram-shaped ROW within this result, Value is
-	// still only the placeholder [HistogramProjection] always carries.
-	// [assertValueShapedInput] (internal/promql/histogram_shape_guard.go)
-	// panics on this shape for exactly that reason. Every consumer that
-	// builds a Mixed-shaped node keeps it at the query ROOT — see that
-	// lowering's own doc comment for why nesting one under another
-	// PromQL wrapper is deliberately left unrecognised (falls through to
-	// the pre-existing exp-histogram-selector rejection) rather than
-	// silently forwarding a column whose meaning depends on a per-row
-	// discriminator no generic consumer reads.
+	// MixedRowShape carries canonical float and histogram payloads plus one
+	// discriminator. A float-narrowing Filter retains this physical shape even
+	// when its live rows are proven float-only.
 	MixedRowShape
 )
 
-// String names the shape for test and error output. The names are the
-// constant names minus the stutter, so a failure message reads as the
-// vocabulary the doc comment uses.
+// String names the shape for diagnostics without exposing enum ordinals.
 func (s RowShape) String() string {
 	switch s {
 	case GridWindowRowShape:
@@ -171,173 +47,11 @@ func (s RowShape) String() string {
 	return "unknown"
 }
 
-// RowShapeOf reports which [RowShape] n publishes.
-//
-// A matrix [RangeWindow] (`OuterRange > 0`) fans its samples across the
-// anchors of a materialised grid and emits one row per (series, anchor);
-// an instant one has already reduced each series to a single row.
-// [RangeWindowGridNative] is ALWAYS the matrix case — the lowering builds it
-// only in range mode, with `Step > 0` and both `Start` and `End` pinned
-// (see its doc comment), so it has no instant form to distinguish. Its
-// instant sibling, [RangeWindowGridNativeInstant], is a SEPARATE node type
-// for exactly that reason — reusing this one for the single-anchor shape
-// would have made this classifier (and the several other consumers that key
-// off RangeWindowGridNative meaning "matrix") silently wrong.
-//
-// Every other node publishes all four canonical names, either by passing
-// its input's through or by re-projecting them, so [SampleRowShape] is
-// both the remaining answer and the safe default for a node this
-// classifier has never seen.
-//
-// The classifier deliberately does NOT walk into children: its callers
-// project directly over n, so the shape that matters is the one n's own
-// SELECT exposes. The one apparent exception, [*Project], is not a
-// walk-into-children case either — it reads only the Project's OWN
-// projection list (never its Input) to see whether n's own SELECT
-// republishes [MixedDiscriminatorColumn] as an output, the same
-// derive-from-what-this-node-actually-selects approach every other case
-// here uses. internal/promql's `label_replace`/`label_join` composition
-// over a mixed `or` (cerberus issue #2449) is the one lowering that ends
-// in a Project forwarding that column: [projectAttributesOverInner]'s
-// MixedRowShape branch and [guardLabelRewriteCollision]'s matching
-// re-projection (both label_fns.go / duplicate_labelset_guard.go) always
-// carry it through by construction, so a Project publishing it really is
-// still Mixed-shaped, not merely built from one. No other lowering in
-// the tree ever names an output [MixedDiscriminatorColumn], so this
-// cannot misclassify a Project nothing here wrote.
+// RowShapeOf folds the node's own compositional schema. There is no independent
+// node-kind classifier or Filter/TopK shape declaration to override it.
 func RowShapeOf(n Node) RowShape {
-	switch v := n.(type) {
-	case *Project:
-		for _, proj := range v.Projections {
-			if ProjectionOutputsColumn(proj, MixedDiscriminatorColumn) {
-				return MixedRowShape
-			}
-		}
-	case *RangeWindow:
-		if v.OuterRange > 0 {
-			return GridWindowRowShape
-		}
-		return ReducedWindowRowShape
-	case *RangeWindowGridNative:
-		return GridWindowRowShape
-	case *RangeWindowGridNativeInstant:
-		// The instant-shaped native lowering publishes one row per series
-		// with no per-row anchor timestamp at all — the query's single eval
-		// instant is reported externally, not as a SQL column — exactly the
-		// [ReducedWindowRowShape] contract the fan-out's own instant emit
-		// (RangeWindow with OuterRange == 0) already publishes.
-		return ReducedWindowRowShape
-	case *HistogramProjection:
-		return HistogramRowShape
-	case *VectorSetOp:
-		if v.Histogram {
-			return HistogramRowShape
-		}
-		if v.Mixed {
-			return MixedRowShape
-		}
-	case *NaryVectorSetOp:
-		if v.Histogram {
-			return HistogramRowShape
-		}
-	case *InfoJoin:
-		if v.Histogram {
-			return HistogramRowShape
-		}
-	case *TopK:
-		// TopK either forwards every Input column or selects Columns by name.
-		// Its RowType composes those two declarations without a second shape
-		// flag, including the canonical float projection ranked topk/bottomk
-		// apply after narrowing a physically mixed input.
-		return RowShapeFromSchema(v.RowType())
-	case *Filter:
-		// WHERE changes row membership, never the physical column schema.
-		// This deliberately remains true for a constant-false predicate;
-		// live-row proofs are separate from RowType.
-		return RowShapeFromSchema(v.RowType())
-	case *HistogramVectorJoin:
-		// Its own SELECT exposes `_hq_L_*`/`_hq_R_*` aliases, not the
-		// canonical four names at all — no generic forwarder is ever
-		// placed directly over it (internal/promql's
-		// histogram_native_binop_card.go always wraps it in an
-		// explicit-column Project first), so SampleRowShape here is a
-		// documentation default rather than a claim about live columns.
-		// A hypothetical future direct consumer referencing `Value` or
-		// `MetricName` against it fails loudly with ClickHouse code 47
-		// rather than silently reading the wrong data — see
-		// [IsDerivedShape]'s HistogramVectorJoin arm for the same
-		// reasoning from the MetricName side.
+	if n == nil {
 		return SampleRowShape
-	case *HistogramFloatVectorJoin:
-		// Its own SELECT genuinely does publish the canonical
-		// MetricName/Attributes/TimeUnix names plus the nine fixed
-		// Histogram*Column fields — unlike HistogramVectorJoin's
-		// `_hq_L_*`/`_hq_R_*`-prefixed shape above — but ALSO an extra
-		// Value column no HistogramRowShape consumer expects, so
-		// neither fixed shape is an exact fit. SampleRowShape here is
-		// likewise a documentation default rather than a claim about
-		// live columns: no generic forwarder is ever placed directly
-		// over it — the calling lowering (internal/promql's
-		// histogram_native_float_vector_scaling_binop.go) always wraps
-		// it in an explicit-column Project first, exactly as
-		// HistogramVectorJoin's callers do.
-		return SampleRowShape
-	case *MixedVectorJoin:
-		// Its own SELECT publishes `_mvj_L_*`/`_mvj_R_*`-prefixed aliases
-		// (internal/chsql/mixed_vector_join.go), not any of the fixed
-		// shapes above — like HistogramVectorJoin/HistogramFloatVectorJoin
-		// above, SampleRowShape here is a documentation default rather
-		// than a claim about live columns: no generic forwarder is ever
-		// placed directly over it. internal/promql's
-		// histogram_native_mixed_or_vector_arithmetic.go always wraps it
-		// in an explicit-column Filter+Project before any consumer sees
-		// it; THAT Project is what RowShapeOf's own *Project case above
-		// classifies as MixedRowShape (MUL/DIV) or leaves as the plain
-		// canonical SampleRowShape (ADD/SUB, whose kept rows are always
-		// float-valued — see that file's header for why).
-		return SampleRowShape
-	case *RangeWindowStaleResample:
-		// Spelled out because it is the third `RangeWindow*` node and the
-		// one most likely to be swept in here by analogy. Its emitter
-		// publishes `[MetricName, Attributes, anchor_ts AS TimeUnix,
-		// Value]` — byte-for-byte what the RangeLWR it substitutes for
-		// publishes — so the canonical row genuinely IS its answer, and
-		// letting it fall through would leave that looking like an
-		// oversight.
-		return SampleRowShape
-	case *OrderBy:
-		// emitOrderBy renders `SELECT * FROM (<input>) ORDER BY ...` — a
-		// genuine passthrough of every column its input publishes, sort
-		// keys included. Its own SELECT therefore exposes exactly the
-		// shape its input does, whichever one that is (a plain sample
-		// selector's OrderBy, PromQL `sort_by_label()`'s ordinary case,
-		// stays SampleRowShape through the default branch below; wrapping
-		// a [HistogramProjection] — PromQL `sort_by_label()` /
-		// `sort_by_label_desc()` over an exp-histogram-valued vector,
-		// cerberus issue #2462 — must report HistogramRowShape or the
-		// wire layer's wrapWithSampleProjection re-projects only the
-		// canonical quartet and silently drops the nine histogram
-		// columns). Forwarding is recursive so a further OrderBy over an
-		// OrderBy (never built today) still resolves correctly.
-		return RowShapeOf(v.Input)
-	case *UnionAll:
-		// A UnionAll positionally combines its arms into ONE result set, so
-		// their row shape has to already agree for the SQL itself to be
-		// valid -- every construction site pairs same-shaped arms (the
-		// PromQL histogram companion-suffix routing's two Sample-shaped
-		// Scans; NativeRateLowerer's instant temporality-union split,
-		// cerberus issue #2843, whose native and fan-out arms both answer
-		// ReducedWindowRowShape). Reporting the first arm's own shape is
-		// therefore both correct and recursive, mirroring *OrderBy's
-		// passthrough above -- rather than silently defaulting to
-		// SampleRowShape (the wrong answer for a windowed union: a
-		// forwarder placed directly over one would then reference a
-		// MetricName / Timestamp column neither arm publishes, a live
-		// ClickHouse code 47).
-		if len(v.Inputs) == 0 {
-			return SampleRowShape
-		}
-		return RowShapeOf(v.Inputs[0])
 	}
-	return SampleRowShape
+	return RowShapeFromSchema(n.RowType())
 }

--- a/internal/chplan/row_shape_test.go
+++ b/internal/chplan/row_shape_test.go
@@ -1,268 +1,28 @@
 package chplan_test
 
 import (
-	"reflect"
 	"testing"
-	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 )
 
-// rowShapeVerdicts is the expected chplan.RowShapeOf answer for one
-// populated instance of every Node kind — the instances in allNodeKinds(),
-// whose RangeWindow carries `OuterRange: time.Hour` and is therefore the
-// MATRIX form.
-//
-// The verdict is a statement about the columns that kind's own SELECT
-// exposes to the projection directly above it, and both PromQL forwarders
-// (projectAttributesOverInner, projectValueOverInner) build their column
-// list from this one answer. A wrong verdict is not a stylistic
-// disagreement: it is either a ClickHouse code 47 for a column the scope
-// does not carry, or a column silently missing from the wire.
-//
-// TestRowShapeOf_CoversEveryNodeKind derives the key set from the package's
-// planNode() implementers, so a new Node kind cannot be added without
-// deciding its row shape here.
-var rowShapeVerdicts = map[string]chplan.RowShape{
-	// The two windows that publish a query_range grid: one row per
-	// (series, anchor), the anchor under both its own name and the
-	// timestamp column, and no MetricName.
-	"RangeWindow":           chplan.GridWindowRowShape,
-	"RangeWindowGridNative": chplan.GridWindowRowShape,
-
-	// The instant-mode native lowering: one row per series already reduced
-	// to a single point, mirroring the fan-out's own instant RangeWindow
-	// (OuterRange == 0) shape rather than its matrix sibling above.
-	"RangeWindowGridNativeInstant": chplan.ReducedWindowRowShape,
-
-	// Everything else republishes the canonical four names, whether by
-	// passing its input's through or by projecting them itself.
-	"AbsentOverTime": chplan.SampleRowShape,
-	"Aggregate":      chplan.SampleRowShape,
-	// Same reasoning as Aggregate above: never a direct forwarder target
-	// (its lowering always caps it with wrapAggregateForSample's Project),
-	// so this is a documentation default, not a claim about live columns.
-	"RangeWindowGridNativeVectorAgg": chplan.SampleRowShape,
-	"CrossJoin":                      chplan.SampleRowShape,
-	"Filter":                         chplan.SampleRowShape,
-	"HistogramQuantile":              chplan.SampleRowShape,
-	"HistogramQuantileNative":        chplan.SampleRowShape,
-	"HistogramProjection":            chplan.HistogramRowShape,
-	"HistogramVectorJoin":            chplan.SampleRowShape,
-	"HistogramFloatVectorJoin":       chplan.SampleRowShape,
-	"InfoJoin":                       chplan.SampleRowShape,
-	"Limit":                          chplan.SampleRowShape,
-	"MetricsAggregate":               chplan.SampleRowShape,
-	"MetricsCompare":                 chplan.SampleRowShape,
-	"MetricsHistogramOverTime":       chplan.SampleRowShape,
-	"MetricsSecondStage":             chplan.SampleRowShape,
-	"MixedVectorJoin":                chplan.SampleRowShape,
-	"NaryVectorSetOp":                chplan.SampleRowShape,
-	"NestedSetAnnotate":              chplan.SampleRowShape,
-	"OneRow":                         chplan.SampleRowShape,
-	"OrderBy":                        chplan.SampleRowShape,
-	"Project":                        chplan.SampleRowShape,
-	"RangeBucketFanout":              chplan.SampleRowShape,
-	"RangeBucketGridNative":          chplan.SampleRowShape,
-	"RangeLWR":                       chplan.SampleRowShape,
-	"RangeWindowStaleResample":       chplan.SampleRowShape,
-	"Scan":                           chplan.SampleRowShape,
-	"SearchTraceLimit":               chplan.SampleRowShape,
-	"SetOperation":                   chplan.SampleRowShape,
-	"StepGrid":                       chplan.SampleRowShape,
-	"StructuralJoin":                 chplan.SampleRowShape,
-	"TopK":                           chplan.SampleRowShape,
-	"UnionAll":                       chplan.SampleRowShape,
-	"VectorJoin":                     chplan.SampleRowShape,
-	"VectorSetOp":                    chplan.SampleRowShape,
-}
-
-// TestRowShapeOf_CoversEveryNodeKind is the ratchet: a Node kind added to
-// the IR without a recorded row shape fails here, because a forwarder
-// placed over it would silently take the canonical branch by default.
-func TestRowShapeOf_CoversEveryNodeKind(t *testing.T) {
-	t.Parallel()
-
-	covered := make(map[string]bool, len(rowShapeVerdicts))
-	for kind := range rowShapeVerdicts {
-		covered[kind] = true
+func TestRowShapeOfNil(t *testing.T) {
+	if got := chplan.RowShapeOf(nil); got != chplan.SampleRowShape {
+		t.Fatalf("nil shape = %s; want sample default", got)
 	}
-	assertCoversEveryNodeKind(t, covered, "rowShapeVerdicts",
-		"record the row shape its emitter publishes and, if it is not the canonical "+
-			"sample row, add an arm to chplan.RowShapeOf")
 }
 
-// TestRowShapeOf_ClassifiesEveryNodeKind runs the classifier over one
-// populated instance of every Node kind and compares against the recorded
-// verdict, naming the kind on a mismatch.
-func TestRowShapeOf_ClassifiesEveryNodeKind(t *testing.T) {
-	t.Parallel()
-
+// allNodeKinds is source-derived from the sealed Node implementations. The
+// fold therefore acquires no second node-kind inventory as the IR grows.
+func TestRowShapeOfFoldsEveryNodeSchema(t *testing.T) {
 	for _, node := range allNodeKinds() {
-		kind := reflect.TypeOf(node).Elem().Name()
-		want, recorded := rowShapeVerdicts[kind]
-		if !recorded {
-			// Reported by TestRowShapeOf_CoversEveryNodeKind; skipping the
-			// comparison keeps this failure from duplicating that one.
-			continue
-		}
+		want := chplan.RowShapeFromSchema(node.RowType())
 		if got := chplan.RowShapeOf(node); got != want {
-			t.Errorf("RowShapeOf(*%s) = %s, want %s — a projection forwarding over %s "+
-				"builds its column list from this answer, so the wrong one is a live "+
-				"code 47 or a column dropped from the wire",
-				kind, got, want, kind)
+			t.Errorf("RowShapeOf(%T) = %s, schema fold = %s", node, got, want)
 		}
 	}
 }
 
-// TestRowShapeOf_RangeWindowSplitsOnOuterRange pins the one discrimination
-// allNodeKinds() cannot express, because it holds a single RangeWindow
-// instance: the SAME node kind answers differently depending on whether it
-// materialises a query_range grid.
-//
-// A matrix window (OuterRange > 0) emits one row per (series, anchor) and
-// has both timestamp names to forward; an instant one has already collapsed
-// each series to a single row and has no timestamp at all. Collapsing the
-// two would make an instant `rate(m[5m])` under a label rewrite forward
-// columns its scope does not expose.
-func TestRowShapeOf_RangeWindowSplitsOnOuterRange(t *testing.T) {
-	t.Parallel()
-
-	base := chplan.RangeWindow{
-		Input: &chplan.Scan{Table: "otel_metrics_sum"},
-		Func:  "rate", Range: 5 * time.Minute, Step: time.Minute,
-		Start: time.Unix(1000, 0).UTC(), End: time.Unix(4600, 0).UTC(),
-	}
-
-	instant := base
-	if got := chplan.RowShapeOf(&instant); got != chplan.ReducedWindowRowShape {
-		t.Errorf("RowShapeOf(instant RangeWindow) = %s, want %s", got, chplan.ReducedWindowRowShape)
-	}
-
-	matrix := base
-	matrix.OuterRange = time.Hour
-	if got := chplan.RowShapeOf(&matrix); got != chplan.GridWindowRowShape {
-		t.Errorf("RowShapeOf(matrix RangeWindow) = %s, want %s", got, chplan.GridWindowRowShape)
-	}
-}
-
-// TestRowShapeOf_UnionAllReportsFirstArmShape pins cerberus issue #2843's
-// fix: a UnionAll answers its first arm's own RowShapeOf, not the
-// SampleRowShape default the generic (Scan, Scan) stub in allNodeKinds()
-// happens to also produce. NativeRateLowerer's instant temporality-union
-// split (cerberus issue #2843) returns a raw two-arm UnionAll of
-// ReducedWindowRowShape nodes with NO wrapping Project — unlike the matrix
-// arm's derivedRateArm — specifically so a forwarder placed directly over it
-// (e.g. `abs(rate(...))`) reads the correct answer here rather than
-// defaulting to SampleRowShape and referencing a Timestamp column neither
-// arm publishes (a live ClickHouse code 47).
-func TestRowShapeOf_UnionAllReportsFirstArmShape(t *testing.T) {
-	t.Parallel()
-
-	reducedArm := &chplan.RangeWindow{
-		Input: &chplan.Scan{Table: "otel_metrics_sum"},
-		Func:  "rate", Range: 5 * time.Minute,
-		Start: time.Unix(1000, 0).UTC(), End: time.Unix(4600, 0).UTC(),
-	}
-	union := &chplan.UnionAll{Inputs: []chplan.Node{
-		&chplan.RangeWindowGridNativeInstant{
-			Input: &chplan.Scan{Table: "otel_metrics_sum"}, Func: "rate",
-			Range: 5 * time.Minute, Anchor: time.Unix(4600, 0).UTC(),
-			TimestampColumn: "TimeUnix", ValueColumn: "Value",
-		},
-		reducedArm,
-	}}
-	if got := chplan.RowShapeOf(union); got != chplan.ReducedWindowRowShape {
-		t.Errorf("RowShapeOf(reduced-shape UnionAll) = %s, want %s", got, chplan.ReducedWindowRowShape)
-	}
-
-	if got := chplan.RowShapeOf(&chplan.UnionAll{}); got != chplan.SampleRowShape {
-		t.Errorf("RowShapeOf(empty UnionAll) = %s, want %s", got, chplan.SampleRowShape)
-	}
-}
-
-// TestRowShapeOf_VectorSetOpFlags pins the two boolean flags
-// chplan.RowShapeOf reads off a *VectorSetOp directly, since
-// allNodeKinds() only exercises the zero-value instance (both flags
-// false, SampleRowShape — already covered by
-// TestRowShapeOf_ClassifiesEveryNodeKind). Histogram is #2324's
-// both-arms-histogram flag; Mixed is #2330's exactly-one-arm-histogram
-// sibling — the two are mutually exclusive in practice (chsql's
-// validateVectorSetOpCols rejects both set), but RowShapeOf itself
-// checks Histogram first, so this also pins that ordering doesn't
-// accidentally mask Mixed.
-func TestRowShapeOf_VectorSetOpFlags(t *testing.T) {
-	t.Parallel()
-
-	base := chplan.VectorSetOp{
-		Left: &chplan.Scan{Table: "otel_metrics_sum"}, Right: &chplan.Scan{Table: "otel_metrics_sum"},
-		Op: chplan.VectorSetOr,
-	}
-
-	histogram := base
-	histogram.Histogram = true
-	if got := chplan.RowShapeOf(&histogram); got != chplan.HistogramRowShape {
-		t.Errorf("RowShapeOf(VectorSetOp{Histogram: true}) = %s, want %s", got, chplan.HistogramRowShape)
-	}
-
-	mixed := base
-	mixed.Mixed = true
-	if got := chplan.RowShapeOf(&mixed); got != chplan.MixedRowShape {
-		t.Errorf("RowShapeOf(VectorSetOp{Mixed: true}) = %s, want %s", got, chplan.MixedRowShape)
-	}
-}
-
-// Filter and TopK derive their physical shape from RowType. A predicate may
-// prove that no rows survive without changing Filter's columns, while an
-// explicit TopK column list may deliberately narrow a mixed input to the
-// canonical float sample schema.
-func TestRowShapeOfFilterAndTopKComposePhysicalSchema(t *testing.T) {
-	t.Parallel()
-
-	roles := []chplan.Column{
-		{Name: "name", Role: chplan.RoleMetricName},
-		{Name: "labels", Role: chplan.RoleAttributes},
-		{Name: "time", Role: chplan.RoleTimestamp},
-		{Name: "value", Role: chplan.RoleValue},
-	}
-	roles = append(roles, chplan.HistogramPayloadColumns()...)
-	roles = append(roles, chplan.Column{Name: chplan.MixedDiscriminatorColumn, Role: chplan.RoleDiscriminator})
-	names := make([]string, len(roles))
-	for i, role := range roles {
-		names[i] = role.Name
-	}
-	mixed := &chplan.Scan{Table: "mixed", Columns: names, Roles: roles}
-
-	filter := &chplan.Filter{Input: mixed, Predicate: &chplan.LitBool{V: false}}
-	if !filter.RowType().Equal(mixed.RowType()) {
-		t.Fatalf("constant-false Filter schema = %#v, want Input schema %#v", filter.RowType(), mixed.RowType())
-	}
-	if got := chplan.RowShapeOf(filter); got != chplan.MixedRowShape {
-		t.Fatalf("RowShapeOf(Filter) = %s, want %s", got, chplan.MixedRowShape)
-	}
-
-	passthrough := &chplan.TopK{Input: mixed, K: 1}
-	if !passthrough.RowType().Equal(mixed.RowType()) {
-		t.Fatalf("passthrough TopK schema = %#v, want Input schema %#v", passthrough.RowType(), mixed.RowType())
-	}
-	if got := chplan.RowShapeOf(passthrough); got != chplan.MixedRowShape {
-		t.Fatalf("RowShapeOf(passthrough TopK) = %s, want %s", got, chplan.MixedRowShape)
-	}
-
-	canonicalNames := names[:4]
-	ranked := &chplan.TopK{Input: mixed, K: 1, Columns: canonicalNames}
-	if kind := ranked.RowType().SampleKind(); kind != chplan.SampleKindFloat {
-		t.Fatalf("explicit-column TopK sample kind = %s, want %s", kind, chplan.SampleKindFloat)
-	}
-	if got := chplan.RowShapeOf(ranked); got != chplan.SampleRowShape {
-		t.Fatalf("RowShapeOf(explicit-column TopK) = %s, want %s", got, chplan.SampleRowShape)
-	}
-}
-
-// TestRowShapeString pins the names the failure messages above are written
-// against, including the answer for a value outside the declared set — a
-// forwarder reading a corrupt shape should say so rather than print an
-// integer.
 func TestRowShapeString(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chplan/schema.go
+++ b/internal/chplan/schema.go
@@ -322,21 +322,24 @@ func samplePublicRole(role ColumnRole) bool {
 	}
 }
 
-// RowShapeFromSchema folds physical columns into the legacy sample vocabulary.
-// Opaque relational outputs have no sample contract and retain its default.
+// RowShapeFromSchema folds a validated physical sample contract into the
+// diagnostic row-shape vocabulary. Opaque, open, incomplete, and invalid
+// schemas retain the sample default; that default is not proof of live floats.
 func RowShapeFromSchema(s Schema) RowShape {
-	switch {
-	case s.Has(RoleDiscriminator):
+	switch s.SampleKind() {
+	case SampleKindMixed:
 		return MixedRowShape
-	case s.Has(RoleHistogramField):
+	case SampleKindHistogram:
 		return HistogramRowShape
-	case s.Has(RoleAnchor) && !s.Has(RoleMetricName):
-		return GridWindowRowShape
-	case s.Has(RoleValue) && !s.Has(RoleMetricName) && !s.Has(RoleTimestamp) && !s.Has(RoleAnchor):
-		return ReducedWindowRowShape
-	default:
-		return SampleRowShape
+	case SampleKindFloat:
+		if s.Has(RoleAttributes) && s.Has(RoleAnchor) {
+			return GridWindowRowShape
+		}
+		if s.Has(RoleAttributes) && !s.Has(RoleTimestamp) && !s.Has(RoleAnchor) {
+			return ReducedWindowRowShape
+		}
 	}
+	return SampleRowShape
 }
 
 // IsMixedFloatNarrowing reports an explicit discriminator filter that retains

--- a/internal/chplan/schema_shape_test.go
+++ b/internal/chplan/schema_shape_test.go
@@ -1,0 +1,141 @@
+package chplan
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestRowShapeFromValidatedSchema(t *testing.T) {
+	name := Column{Name: "metric", Role: RoleMetricName}
+	attributes := Column{Name: "labels", Role: RoleAttributes}
+	timestamp := Column{Name: "sample_time", Role: RoleTimestamp}
+	anchor := Column{Name: "step", Role: RoleAnchor}
+	value := Column{Name: "value", Role: RoleValue}
+	discriminator := Column{Name: "sample_kind", Role: RoleDiscriminator}
+	float := []Column{name, attributes, timestamp, value}
+	histogram := HistogramPayloadColumns()
+	mixed := append(slices.Clone(float), histogram...)
+	mixed = append(mixed, discriminator)
+
+	for _, tc := range []struct {
+		name   string
+		schema Schema
+		want   RowShape
+	}{
+		{name: "empty", schema: Schema{}, want: SampleRowShape},
+		{name: "strict_float", schema: Schema{Columns: float}, want: SampleRowShape},
+		{name: "strict_reduced", schema: Schema{Columns: []Column{attributes, value}}, want: ReducedWindowRowShape},
+		{name: "named_reduced", schema: Schema{Columns: []Column{name, attributes, value}}, want: ReducedWindowRowShape},
+		{name: "strict_grid", schema: Schema{Columns: []Column{attributes, anchor, timestamp, value}}, want: GridWindowRowShape},
+		{name: "named_grid", schema: Schema{Columns: []Column{name, attributes, anchor, timestamp, value}}, want: GridWindowRowShape},
+		{name: "partial_value", schema: Schema{Columns: []Column{value}}, want: SampleRowShape},
+		{name: "partial_anchor", schema: Schema{Columns: []Column{anchor}}, want: SampleRowShape},
+		{name: "histogram", schema: Schema{Columns: histogram}, want: HistogramRowShape},
+		{name: "histogram_with_float_columns", schema: Schema{Columns: append(slices.Clone(float), histogram...)}, want: HistogramRowShape},
+		{name: "mixed", schema: Schema{Columns: mixed}, want: MixedRowShape},
+		{name: "opaque_join", schema: Schema{Columns: []Column{{Name: "_hq_L_HistogramCount"}, {Name: "_mvj_R_Value"}}}, want: SampleRowShape},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RowShapeFromSchema(tc.schema); got != tc.want {
+				t.Fatalf("RowShapeFromSchema = %s, want %s; schema=%#v", got, tc.want, tc.schema)
+			}
+		})
+	}
+}
+
+func TestRowShapeFromSchemaRejectsUnvalidatedContracts(t *testing.T) {
+	attributes := Column{Name: "labels", Role: RoleAttributes}
+	anchor := Column{Name: "step", Role: RoleAnchor}
+	value := Column{Name: "value", Role: RoleValue}
+	discriminator := Column{Name: "sample_kind", Role: RoleDiscriminator}
+	histogram := HistogramPayloadColumns()
+	partialHistogram := slices.Clone(histogram[1:])
+
+	for _, tc := range []struct {
+		name   string
+		schema Schema
+	}{
+		{name: "open_reduced", schema: Schema{Open: true, Columns: []Column{attributes, value}}},
+		{name: "open_grid", schema: Schema{Open: true, Columns: []Column{attributes, anchor, value}}},
+		{name: "open_histogram", schema: Schema{Open: true, Columns: histogram}},
+		{name: "partial_histogram", schema: Schema{Columns: partialHistogram}},
+		{name: "orphan_discriminator", schema: Schema{Columns: []Column{attributes, value, discriminator}}},
+		{name: "duplicate_value_role", schema: Schema{Columns: []Column{attributes, value, {Name: "other_value", Role: RoleValue}}}},
+		{name: "unnamed_value", schema: Schema{Columns: []Column{attributes, {Role: RoleValue}}}},
+		{name: "ambiguous_value_name", schema: Schema{Columns: []Column{attributes, value, {Name: value.Name}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RowShapeFromSchema(tc.schema); got != SampleRowShape {
+				t.Fatalf("RowShapeFromSchema = %s, want sample default; schema=%#v", got, tc.schema)
+			}
+		})
+	}
+}
+
+func TestRowShapeOfUsesPhysicalSchemaNotLiveKind(t *testing.T) {
+	roles := []Column{
+		{Name: "metric", Role: RoleMetricName},
+		{Name: "labels", Role: RoleAttributes},
+		{Name: "sample_time", Role: RoleTimestamp},
+		{Name: "value", Role: RoleValue},
+	}
+	roles = append(roles, HistogramPayloadColumns()...)
+	roles = append(roles, Column{Name: MixedDiscriminatorColumn, Role: RoleDiscriminator})
+	names := make([]string, len(roles))
+	for i, role := range roles {
+		names[i] = role.Name
+	}
+	mixed := &Scan{Table: "mixed", Columns: names, Roles: roles}
+	narrowed := &Filter{
+		Input: mixed,
+		Predicate: &Binary{
+			Op:    OpEq,
+			Left:  &ColumnRef{Name: MixedDiscriminatorColumn},
+			Right: &LitInt{V: 0},
+		},
+	}
+	if got := LiveSampleKind(narrowed); got != SampleKindFloat {
+		t.Fatalf("LiveSampleKind(narrowed) = %s, want float", got)
+	}
+	if got := RowShapeOf(narrowed); got != MixedRowShape {
+		t.Fatalf("RowShapeOf(narrowed) = %s, want physical mixed shape", got)
+	}
+}
+
+func TestRowShapeOfReconcilesOpaqueAndHistogramJoins(t *testing.T) {
+	const (
+		metric     = "metric"
+		attributes = "labels"
+		timestamp  = "sample_time"
+		value      = "value"
+	)
+	for _, tc := range []struct {
+		name string
+		node Node
+		want RowShape
+	}{
+		{
+			name: "histogram_vector_join",
+			node: &HistogramVectorJoin{MetricNameColumn: metric, AttributesColumn: attributes, TimestampColumn: timestamp},
+			want: SampleRowShape,
+		},
+		{
+			name: "mixed_vector_join",
+			node: &MixedVectorJoin{MetricNameColumn: metric, AttributesColumn: attributes, TimestampColumn: timestamp, ValueColumn: value},
+			want: SampleRowShape,
+		},
+		{
+			name: "histogram_float_vector_join",
+			node: &HistogramFloatVectorJoin{MetricNameColumn: metric, AttributesColumn: attributes, TimestampColumn: timestamp, ValueColumn: value},
+			want: HistogramRowShape,
+		},
+		{name: "empty_union", node: &UnionAll{}, want: SampleRowShape},
+		{name: "opaque_default", node: &OneRow{}, want: SampleRowShape},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RowShapeOf(tc.node); got != tc.want {
+				t.Fatalf("RowShapeOf(%T) = %s, want %s; schema=%#v", tc.node, got, tc.want, tc.node.RowType())
+			}
+		})
+	}
+}

--- a/internal/logql/lower_test.go
+++ b/internal/logql/lower_test.go
@@ -98,7 +98,8 @@ func TestLower(t *testing.T) {
 		})
 		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 		spec.AssertRowTypeMatchesDriver(t, optimized, roundTripResult)
-		spec.AssertRowShapeAgreement(t, plan)
+		spec.AssertPlanScanRoles(t, plan)
+		spec.AssertPlanScanRoles(t, optimized)
 
 		// A fixture carrying a `parity:` section is additionally answered
 		// by the REAL upstream Loki engine over the same seeded data, and

--- a/internal/promql/float_aggregate_input_test.go
+++ b/internal/promql/float_aggregate_input_test.go
@@ -68,23 +68,52 @@ func TestFloatAggregateMixedInputNarrowing(t *testing.T) {
 	}
 }
 
-func TestFloatAggregateAuthorizationBeforeNarrowing(t *testing.T) {
+func TestFloatAggregatePlanPolicyDrivesNarrowing(t *testing.T) {
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
 	s := schema.DefaultOTelMetrics()
 	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	for _, fn := range []string{"min", "max", "stddev", "stdvar", "quantile"} {
 		t.Run(fn, func(t *testing.T) {
 			key := mixedWrapperKey{family: mixedFloatAggregateFamily, site: mixedPlanAdmission}
-			policy := mixedOperandPolicies[key]
-			delete(mixedOperandPolicies, key)
-			t.Cleanup(func() { mixedOperandPolicies[key] = policy })
 			expr, err := p.ParseExpr(floatAggregateTestQuery(fn, `sort_by_label(latency_exp_hist or num_cpus,"job")`))
 			if err != nil {
 				t.Fatal(err)
 			}
+			policy := mixedOperandPolicies[key]
 			plan, err := LowerAt(context.Background(), expr, s, at, at)
-			if plan != nil || err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for float-aggregate at existing-plan") {
-				t.Fatalf("original Mixed authorization bypassed: %T %v", plan, err)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var narrowed bool
+			chplan.Walk(plan, func(node chplan.Node) bool {
+				if filter, ok := node.(*chplan.Filter); ok && chplan.IsMixedFloatNarrowing(filter) {
+					narrowed = true
+				}
+				return true
+			})
+			if !narrowed {
+				t.Fatal("float-only plan policy did not narrow the mixed relation")
+			}
+			for _, denied := range []struct {
+				name    string
+				policy  mixedOperandPolicy
+				present bool
+			}{
+				{name: "missing"},
+				{name: "bespoke", policy: mixedBespoke, present: true},
+				{name: "preserve", policy: mixedPreserve, present: true},
+			} {
+				t.Run(denied.name, func(t *testing.T) {
+					delete(mixedOperandPolicies, key)
+					if denied.present {
+						mixedOperandPolicies[key] = denied.policy
+					}
+					t.Cleanup(func() { mixedOperandPolicies[key] = policy })
+					plan, err := LowerAt(context.Background(), expr, s, at, at)
+					if plan != nil || err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for float-aggregate at existing-plan") {
+						t.Fatalf("non-float-only policy reached aggregate: %T %v", plan, err)
+					}
+				})
 			}
 			for _, operand := range []string{"up", "latency_exp_hist"} {
 				expr, err := p.ParseExpr(floatAggregateTestQuery(fn, operand))

--- a/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
+++ b/internal/promql/gremlins_kill_mixed_or_subquery_further_setop_test.go
@@ -109,7 +109,7 @@ func TestLowerHistogramOrMixedSubqueryOuterFnInput_LastFirstKindDispatch(t *test
 // histogram_native_mixed_or_subquery_further_setop_range_fn.go:`case resetsWindowFn, changesWindowFn:` —
 // the label locates the arm, the guard inside it is the mutant. This is
 // the resets/changes sibling of the last_over_time/first_over_time
-// dispatch above. Both shapes ultimately produce the same four-column canonical
+// dispatch above. Both kinds ultimately produce the same four-column canonical
 // Project, so the two paths are told apart by whether the underlying
 // Aggregate collected the Mixed-only groupArrays
 // [mixedPairCountAggs] adds.

--- a/internal/promql/info_fn.go
+++ b/internal/promql/info_fn.go
@@ -259,8 +259,8 @@ func lowerInfoNonStaticBase(
 // lowerInfoJoin builds the enrichment join over an already-lowered base
 // arm. Split out of lowerInfo so the ignore-set carve-out can feed it
 // either the whole base vector or just its enrichable arm. histogramBase
-// marks input as histogram-valued (chplan.RowShapeOf(input) ==
-// chplan.HistogramRowShape) — see chplan.InfoJoin.Histogram's doc comment.
+// records the source-derived histogram-valued proof computed before lowering;
+// see chplan.InfoJoin.Histogram's doc comment.
 func lowerInfoJoin(input chplan.Node, histogramBase bool, nameMatchers, dataMatchers []*labels.Matcher, s schema.Metrics, ctx lowerCtx) (chplan.Node, error) {
 	infoNode, err := lowerInfoMetric(nameMatchers, dataMatchers, s, ctx)
 	if err != nil {

--- a/internal/promql/label_forwarding_contract_test.go
+++ b/internal/promql/label_forwarding_contract_test.go
@@ -48,9 +48,9 @@ func TestAttributeRewriteUnnamedFloatPhysicalColumns(t *testing.T) {
 				{name: "opaque_attributes", columns: []chplan.Column{{Name: s.AttributesColumn}, timestamp, value}, wantPanic: true},
 				{name: "opaque_timestamp", columns: []chplan.Column{attributes, {Name: s.TimestampColumn}, value}, wantPanic: true},
 				{name: "opaque_value", columns: []chplan.Column{attributes, timestamp, {Name: s.ValueColumn}}, wantPanic: true},
-				{name: "histogram_payload_retains_legacy_boundary", columns: append([]chplan.Column{attributes, anchor, timestamp, value}, chplan.HistogramPayloadColumns()...), wantPanic: true},
-				{name: "histogram_helper_retains_legacy_boundary", columns: []chplan.Column{attributes, timestamp, value, {Name: chplan.HistogramCountColumn, Role: chplan.RoleHistogramField}}, wantPanic: true},
-				{name: "discriminator_retains_legacy_boundary", columns: []chplan.Column{attributes, timestamp, value, {Name: "sample_kind", Role: chplan.RoleDiscriminator}}, wantPanic: true},
+				{name: "histogram_payload_is_not_value_forwardable", columns: append([]chplan.Column{attributes, anchor, timestamp, value}, chplan.HistogramPayloadColumns()...), wantPanic: true},
+				{name: "partial_histogram_is_not_value_forwardable", columns: []chplan.Column{attributes, timestamp, value, {Name: chplan.HistogramCountColumn, Role: chplan.RoleHistogramField}}, wantPanic: true},
+				{name: "orphan_discriminator_is_not_value_forwardable", columns: []chplan.Column{attributes, timestamp, value, {Name: "sample_kind", Role: chplan.RoleDiscriminator}}, wantPanic: true},
 			} {
 				t.Run(tc.name, func(t *testing.T) {
 					scan := &chplan.Scan{Roles: slices.Clone(tc.columns)}
@@ -60,9 +60,6 @@ func TestAttributeRewriteUnnamedFloatPhysicalColumns(t *testing.T) {
 							scan.Columns = append(scan.Columns, column.Name)
 							inner.Projections = append(inner.Projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}})
 						}
-					}
-					if got := chplan.RowShapeOf(inner); got != chplan.SampleRowShape {
-						t.Fatalf("fixture legacy shape = %v, want Sample", got)
 					}
 					var newAttrs chplan.Expr
 					var project *chplan.Project

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -5328,22 +5328,12 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 	}
 
 	family := mixedAggregateFamily(a.Op)
-	if family == mixedCountGroupFamily {
-		input, err = preserveMixedPlan(input, family)
-	} else {
-		err = requireMixedPlanPolicy(input, family)
-	}
+	input, err = prepareMixedAggregatePlan(input, family)
 	if err != nil {
 		return nil, err
 	}
 	if expHistogramAggOpIsMergeable(a.Op) && mixedRowsNeedPreparation(input) {
 		return lowerSumOrAvgOverMixedPlan(a, input, s, ctx)
-	}
-	// Authorize the original Mixed relation before discarding histogram rows.
-	// Float-only reductions must not aggregate their placeholder Value column;
-	// narrowing this already-lowered relation preserves union shadow precedence.
-	if expHistogramAggDropsHistogramSamples(a.Op) {
-		input = mixedRowsFloatOnly(input)
 	}
 	wrapped, err := lowerPlainAggregateOverInput(a, input, s, ctx, ordinaryPlainAggregateLayout)
 	if err != nil {

--- a/internal/promql/lower_test.go
+++ b/internal/promql/lower_test.go
@@ -219,7 +219,8 @@ func TestLower(t *testing.T) {
 		})
 		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 		spec.AssertRowTypeMatchesDriver(t, optimized, roundTripResult)
-		spec.AssertRowShapeAgreement(t, plan)
+		spec.AssertPlanScanRoles(t, plan)
+		spec.AssertPlanScanRoles(t, optimized)
 
 		// A fixture carrying a `parity:` section is additionally answered
 		// by the REAL upstream Prometheus engine over the same seeded

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -97,9 +97,11 @@ type mixedWrapperKey struct {
 //
 // Bespoke entries select a family-specific payload transformation. Sum/avg, for
 // example, partitions and recombines a mixed plan; count/group instead preserve
-// that plan for their payload-neutral reduction. Scalar arithmetic's root and
-// existing-plan entries execute the float-only policy through its shared value
-// kernel, preserving each projection boundary.
+// that plan for their payload-neutral reduction. Float aggregates remain bespoke
+// at the root, where their mixed union needs shadow resolution, while their
+// existing-plan entries execute the shared float-only transform after that
+// resolution. Scalar arithmetic follows the same policy-driven narrowing while
+// preserving each projection boundary.
 var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedLeafFamily, mixedRootAdmission}:              mixedBespoke,
 	{mixedSumAvgFamily, mixedRootAdmission}:            mixedBespoke,
@@ -148,7 +150,7 @@ var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedVectorComparisonFamily, mixedPlanAdmission}:  mixedBespoke,
 	{mixedSumAvgFamily, mixedPlanAdmission}:            mixedBespoke,
 	{mixedCountGroupFamily, mixedPlanAdmission}:        mixedPreserve,
-	{mixedFloatAggregateFamily, mixedPlanAdmission}:    mixedBespoke,
+	{mixedFloatAggregateFamily, mixedPlanAdmission}:    mixedFloatOnly,
 	{mixedTopKFamily, mixedPlanAdmission}:              mixedFloatOnly,
 	{mixedCountValuesFamily, mixedPlanAdmission}:       mixedBespoke,
 }
@@ -194,6 +196,30 @@ func mixedPlanTransformForPolicy(policy mixedOperandPolicy) mixedPlanTransform {
 		return mixedRowsFloatOnly
 	}
 	return preserveMixedPlanTransform
+}
+
+// prepareMixedAggregatePlan applies the registered existing-plan policy for
+// the aggregate families which reach lowerAggregate's generic input path.
+// Keeping this switch closed prevents a new aggregate family from inheriting a
+// plausible payload transform merely because somebody added a table entry.
+func prepareMixedAggregatePlan(inner chplan.Node, family mixedWrapperFamily) (chplan.Node, error) {
+	if !mixedRowsNeedPreparation(inner) {
+		return inner, nil
+	}
+
+	expected := mixedPolicyClosed
+	switch family {
+	case mixedSumAvgFamily:
+		expected = mixedBespoke
+	case mixedCountGroupFamily:
+		expected = mixedPreserve
+	case mixedFloatAggregateFamily:
+		expected = mixedFloatOnly
+	}
+	if err := requireMixedPlanPolicy(inner, family, expected); err != nil {
+		return nil, err
+	}
+	return mixedPlanTransformForPolicy(expected)(inner), nil
 }
 
 func requireMixedBespokePolicy(key mixedWrapperKey, policy mixedOperandPolicy) error {

--- a/internal/promql/mixed_operand_policy_test.go
+++ b/internal/promql/mixed_operand_policy_test.go
@@ -204,6 +204,9 @@ func TestMixedOperandPolicyAdmissionInventory(t *testing.T) {
 			case mixedLabelFamily, mixedSortByLabelFamily, mixedCountGroupFamily, mixedLimitFamily:
 				wantPolicy = mixedPreserve
 			}
+			if key == (mixedWrapperKey{family: mixedFloatAggregateFamily, site: mixedPlanAdmission}) {
+				wantPolicy = mixedFloatOnly
+			}
 			if got := mixedOperandPolicies[key]; got != wantPolicy {
 				t.Errorf("admission %v = %v, want %v", key, got, wantPolicy)
 			}

--- a/internal/traceql/lower_test.go
+++ b/internal/traceql/lower_test.go
@@ -115,7 +115,8 @@ func TestLower(t *testing.T) {
 		})
 		roundTripResult := spec.RunRoundTripSQL(t, c, optSQL, optArgs)
 		spec.AssertRowTypeMatchesDriver(t, optimized, roundTripResult)
-		spec.AssertRowShapeAgreement(t, plan)
+		spec.AssertPlanScanRoles(t, plan)
+		spec.AssertPlanScanRoles(t, optimized)
 
 		// A fixture carrying a `parity:` section is additionally checked
 		// against the REAL upstream Tempo engine — including its own

--- a/test/spec/schema.go
+++ b/test/spec/schema.go
@@ -1,16 +1,8 @@
 package spec
 
 import (
-	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
-	"path/filepath"
-	"reflect"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/tsouza/cerberus/internal/chplan"
@@ -89,144 +81,15 @@ func bindFixtureSchemas(plan chplan.Node, tables map[string][]string) chplan.Nod
 	return bound
 }
 
-var contractedRowShapeKinds = sync.OnceValues(func() (map[string]bool, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			break
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return nil, fmt.Errorf("cannot find repository from test working directory")
-		}
-		dir = parent
-	}
-	path := filepath.Join(dir, "internal", "chplan", "row_shape.go")
-	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-	if err != nil {
-		return nil, err
-	}
-	kinds := map[string]bool{}
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != "RowShapeOf" {
-			continue
-		}
-		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			clause, ok := n.(*ast.CaseClause)
-			if !ok {
-				return true
-			}
-			for _, expr := range clause.List {
-				pointer, ok := expr.(*ast.StarExpr)
-				if !ok {
-					continue
-				}
-				if name, ok := pointer.X.(*ast.Ident); ok {
-					kinds[name.Name] = true
-				}
-			}
-			return true
-		})
-	}
-	if len(kinds) == 0 {
-		return nil, fmt.Errorf("RowShapeOf has no contracted type-switch cases")
-	}
-	return kinds, nil
-})
-
-// AssertRowShapeAgreement derives the legacy classifier's contracted kinds
-// from its own switch. Other kinds deliberately retain a documentation default.
-func AssertRowShapeAgreement(t *testing.T, plan chplan.Node) {
+// AssertPlanScanRoles checks every storage leaf, including expression subqueries.
+// Physical schema/shape semantics have independent literal, sealed-kind-complete
+// contracts in chplan; executed fixture outputs are checked against driver metadata.
+func AssertPlanScanRoles(t *testing.T, plan chplan.Node) {
 	t.Helper()
-	kinds, err := contractedRowShapeKinds()
-	if err != nil {
-		t.Fatalf("read legacy shape contract: %v", err)
-	}
 	chplan.WalkDeep(plan, func(n chplan.Node) bool {
 		if scan, ok := n.(*chplan.Scan); ok && scan.Database != "system" && len(scan.Roles) == 0 {
 			t.Errorf("storage Scan %q/%q has no declared roles", scan.Table, scan.UnionTables)
 		}
-		kind := reflect.TypeOf(n).Elem().Name()
-		legacy := chplan.RowShapeOf(n)
-		if !kinds[kind] {
-			if legacy != chplan.SampleRowShape {
-				t.Errorf("uncontracted %s legacy shape = %s", kind, legacy)
-			}
-			return true
-		}
-		physical := chplan.RowShapeFromSchema(n.RowType())
-		reason := rowShapeDivergence(n)
-		if legacy != physical && reason == "" {
-			t.Errorf("%s legacy=%s physical=%s schema=%#v", kind, legacy, physical, n.RowType())
-		}
 		return true
 	})
-}
-
-// rowShapeDivergence describes legacy classifier branches whose contract is
-// deliberately weaker than their physical output. These predicates describe
-// actual SELECT structure; they are not fixture or node-name exemptions.
-func rowShapeDivergence(n chplan.Node) string {
-	s := n.RowType()
-	physical, legacy := chplan.RowShapeFromSchema(s), chplan.RowShapeOf(n)
-	if physical == legacy {
-		return ""
-	}
-	switch v := n.(type) {
-	case *chplan.Project:
-		if legacy != chplan.SampleRowShape || s.Has(chplan.RoleDiscriminator) {
-			return ""
-		}
-		if s.Has(chplan.RoleHistogramField) {
-			return "projection republishes histogram fields without discriminator"
-		}
-		if !s.Has(chplan.RoleMetricName) && s.Has(chplan.RoleAnchor) {
-			return "projection republishes grid outputs"
-		}
-		if !s.Has(chplan.RoleMetricName) && !s.Has(chplan.RoleTimestamp) && !s.Has(chplan.RoleAnchor) && s.Has(chplan.RoleValue) {
-			return "projection publishes scalar or reduced output"
-		}
-
-	case *chplan.HistogramFloatVectorJoin:
-		if legacy == chplan.SampleRowShape && physical == chplan.HistogramRowShape && s.Has(chplan.RoleValue) && s.Has(chplan.RoleMetricName) {
-			return "float-histogram join preserves payload and float value"
-		}
-	case *chplan.RangeWindow:
-		if s.Has(chplan.RoleMetricName) && s.Has(chplan.RoleValue) && !s.Has(chplan.RoleHistogramField) && !s.Has(chplan.RoleDiscriminator) {
-			for _, key := range v.GroupBy {
-				ref, ok := key.(*chplan.ColumnRef)
-				if !ok {
-					continue
-				}
-				column, found := v.Input.RowType().ByName(ref.Name)
-				if found && column.Role == chplan.RoleMetricName && ((v.OuterRange > 0 && legacy == chplan.GridWindowRowShape) || (v.OuterRange == 0 && legacy == chplan.ReducedWindowRowShape)) {
-					return "window group keys preserve metric name"
-				}
-			}
-		}
-	case *chplan.OrderBy:
-		if legacy == chplan.RowShapeOf(v.Input) && s.Equal(v.Input.RowType()) {
-			return delegatedShapeDivergence(v.Input)
-		}
-	case *chplan.UnionAll:
-		if len(v.Inputs) > 0 && legacy == chplan.RowShapeOf(v.Inputs[0]) && s.Equal(v.Inputs[0].RowType()) {
-			return delegatedShapeDivergence(v.Inputs[0])
-		}
-	}
-	return ""
-}
-
-func delegatedShapeDivergence(input chplan.Node) string {
-	if reason := rowShapeDivergence(input); reason != "" {
-		return reason
-	}
-	kinds, err := contractedRowShapeKinds()
-	if err == nil && !kinds[reflect.TypeOf(input).Elem().Name()] && chplan.RowShapeOf(input) == chplan.SampleRowShape {
-		return "delegated documentation default from non-sample input"
-	}
-	return ""
 }

--- a/test/spec/schema_test.go
+++ b/test/spec/schema_test.go
@@ -3,7 +3,6 @@ package spec
 import (
 	"slices"
 	"testing"
-	"time"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 )
@@ -67,46 +66,5 @@ func TestBindFixtureSchemasExpressionSubquery(t *testing.T) {
 	}
 	if len(scan.Columns) != 0 {
 		t.Fatal("binding mutated source expression subquery")
-	}
-}
-
-func TestRowShapeDivergencePredicates(t *testing.T) {
-	float := &chplan.Project{Input: &chplan.OneRow{}, Roles: []chplan.Column{{Name: "value", Role: chplan.RoleValue}}, Projections: []chplan.Projection{{Expr: &chplan.LitInt{V: 1}, Alias: "value"}}}
-	mixed := &chplan.Scan{Columns: []string{chplan.MixedDiscriminatorColumn}, Roles: []chplan.Column{{Name: chplan.MixedDiscriminatorColumn, Role: chplan.RoleDiscriminator}}}
-	cases := []struct {
-		name      string
-		node      chplan.Node
-		divergent bool
-	}{
-		{"scalar projection", float, true},
-		{"unflagged mixed filter", &chplan.Filter{Input: mixed}, false},
-		{"mixed projection agrees", &chplan.Project{Input: mixed, Projections: []chplan.Projection{{Expr: &chplan.ColumnRef{Name: chplan.MixedDiscriminatorColumn}}}}, false},
-		{"topk selects scalar", &chplan.TopK{Input: float, Columns: []string{"value"}}, false},
-		{"orderby delegates scalar projection", &chplan.OrderBy{Input: float}, true},
-		{"union delegates scalar projection", &chplan.UnionAll{Inputs: []chplan.Node{float, float}}, true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if reason := rowShapeDivergence(tc.node); (reason != "") != tc.divergent {
-				t.Fatalf("divergence reason = %q, want divergent=%v", reason, tc.divergent)
-			}
-		})
-	}
-}
-
-func TestRowShapeNamedWindowDivergence(t *testing.T) {
-	input := &chplan.Scan{Columns: []string{"name"}, Roles: []chplan.Column{{Name: "name", Role: chplan.RoleMetricName}}}
-	window := &chplan.RangeWindow{Input: input, GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "name"}}, ValueColumn: "value", Func: "last_over_time"}
-	if rowShapeDivergence(window) == "" {
-		t.Fatal("name-preserving instant window not reconciled")
-	}
-	window.OuterRange = time.Minute
-	window.TimestampColumn = "time"
-	if rowShapeDivergence(window) == "" {
-		t.Fatal("name-preserving matrix window not reconciled")
-	}
-	window.GroupBy = nil
-	if rowShapeDivergence(window) != "" {
-		t.Fatal("ordinary grid window incorrectly treated as divergent")
 	}
 }


### PR DESCRIPTION
Closes #3353

## Summary

- fold `RowShapeOf` from each node's compositional `RowType` instead of a handwritten node-kind switch
- classify only validated closed sample contracts, keeping open, partial, ambiguous, and invalid schemas on the diagnostic default
- pin narrowed mixed filters, histogram/float and opaque joins, empty plans, and schema-boundary cases
- remove the legacy AST agreement/divergence harness while retaining scan-role checks on raw and optimized plans

## Validation

- `git diff --check`
- source audit: no non-test `RowShapeOf` callers remain outside its definition
- heavy validation and generated artefacts run on GitHub CI per repository policy
