### PR TITLE
refactor(promql): complete mixed-family policy audit

### DIFF
--- a/internal/promql/float_aggregate_input_test.go
+++ b/internal/promql/float_aggregate_input_test.go
@@ -68,23 +68,52 @@ func TestFloatAggregateMixedInputNarrowing(t *testing.T) {
 	}
 }
 
-func TestFloatAggregateAuthorizationBeforeNarrowing(t *testing.T) {
+func TestFloatAggregatePlanPolicyDrivesNarrowing(t *testing.T) {
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
 	s := schema.DefaultOTelMetrics()
 	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	for _, fn := range []string{"min", "max", "stddev", "stdvar", "quantile"} {
 		t.Run(fn, func(t *testing.T) {
 			key := mixedWrapperKey{family: mixedFloatAggregateFamily, site: mixedPlanAdmission}
-			policy := mixedOperandPolicies[key]
-			delete(mixedOperandPolicies, key)
-			t.Cleanup(func() { mixedOperandPolicies[key] = policy })
 			expr, err := p.ParseExpr(floatAggregateTestQuery(fn, `sort_by_label(latency_exp_hist or num_cpus,"job")`))
 			if err != nil {
 				t.Fatal(err)
 			}
+			policy := mixedOperandPolicies[key]
 			plan, err := LowerAt(context.Background(), expr, s, at, at)
-			if plan != nil || err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for float-aggregate at existing-plan") {
-				t.Fatalf("original Mixed authorization bypassed: %T %v", plan, err)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var narrowed bool
+			chplan.Walk(plan, func(node chplan.Node) bool {
+				if filter, ok := node.(*chplan.Filter); ok && chplan.IsMixedFloatNarrowing(filter) {
+					narrowed = true
+				}
+				return true
+			})
+			if !narrowed {
+				t.Fatal("float-only plan policy did not narrow the mixed relation")
+			}
+			for _, denied := range []struct {
+				name    string
+				policy  mixedOperandPolicy
+				present bool
+			}{
+				{name: "missing"},
+				{name: "bespoke", policy: mixedBespoke, present: true},
+				{name: "preserve", policy: mixedPreserve, present: true},
+			} {
+				t.Run(denied.name, func(t *testing.T) {
+					delete(mixedOperandPolicies, key)
+					if denied.present {
+						mixedOperandPolicies[key] = denied.policy
+					}
+					t.Cleanup(func() { mixedOperandPolicies[key] = policy })
+					plan, err := LowerAt(context.Background(), expr, s, at, at)
+					if plan != nil || err == nil || !strings.Contains(err.Error(), "mixed operand is not admitted for float-aggregate at existing-plan") {
+						t.Fatalf("non-float-only policy reached aggregate: %T %v", plan, err)
+					}
+				})
 			}
 			for _, operand := range []string{"up", "latency_exp_hist"} {
 				expr, err := p.ParseExpr(floatAggregateTestQuery(fn, operand))

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -5328,22 +5328,12 @@ func lowerAggregate(a *parser.AggregateExpr, s schema.Metrics, ctx lowerCtx) (ch
 	}
 
 	family := mixedAggregateFamily(a.Op)
-	if family == mixedCountGroupFamily {
-		input, err = preserveMixedPlan(input, family)
-	} else {
-		err = requireMixedPlanPolicy(input, family)
-	}
+	input, err = prepareMixedAggregatePlan(input, family)
 	if err != nil {
 		return nil, err
 	}
 	if expHistogramAggOpIsMergeable(a.Op) && mixedRowsNeedPreparation(input) {
 		return lowerSumOrAvgOverMixedPlan(a, input, s, ctx)
-	}
-	// Authorize the original Mixed relation before discarding histogram rows.
-	// Float-only reductions must not aggregate their placeholder Value column;
-	// narrowing this already-lowered relation preserves union shadow precedence.
-	if expHistogramAggDropsHistogramSamples(a.Op) {
-		input = mixedRowsFloatOnly(input)
 	}
 	wrapped, err := lowerPlainAggregateOverInput(a, input, s, ctx, ordinaryPlainAggregateLayout)
 	if err != nil {

--- a/internal/promql/mixed_operand_policy.go
+++ b/internal/promql/mixed_operand_policy.go
@@ -97,9 +97,11 @@ type mixedWrapperKey struct {
 //
 // Bespoke entries select a family-specific payload transformation. Sum/avg, for
 // example, partitions and recombines a mixed plan; count/group instead preserve
-// that plan for their payload-neutral reduction. Scalar arithmetic's root and
-// existing-plan entries execute the float-only policy through its shared value
-// kernel, preserving each projection boundary.
+// that plan for their payload-neutral reduction. Float aggregates remain bespoke
+// at the root, where their mixed union needs shadow resolution, while their
+// existing-plan entries execute the shared float-only transform after that
+// resolution. Scalar arithmetic follows the same policy-driven narrowing while
+// preserving each projection boundary.
 var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedLeafFamily, mixedRootAdmission}:              mixedBespoke,
 	{mixedSumAvgFamily, mixedRootAdmission}:            mixedBespoke,
@@ -148,7 +150,7 @@ var mixedOperandPolicies = map[mixedWrapperKey]mixedOperandPolicy{
 	{mixedVectorComparisonFamily, mixedPlanAdmission}:  mixedBespoke,
 	{mixedSumAvgFamily, mixedPlanAdmission}:            mixedBespoke,
 	{mixedCountGroupFamily, mixedPlanAdmission}:        mixedPreserve,
-	{mixedFloatAggregateFamily, mixedPlanAdmission}:    mixedBespoke,
+	{mixedFloatAggregateFamily, mixedPlanAdmission}:    mixedFloatOnly,
 	{mixedTopKFamily, mixedPlanAdmission}:              mixedFloatOnly,
 	{mixedCountValuesFamily, mixedPlanAdmission}:       mixedBespoke,
 }
@@ -194,6 +196,30 @@ func mixedPlanTransformForPolicy(policy mixedOperandPolicy) mixedPlanTransform {
 		return mixedRowsFloatOnly
 	}
 	return preserveMixedPlanTransform
+}
+
+// prepareMixedAggregatePlan applies the registered existing-plan policy for
+// the aggregate families which reach lowerAggregate's generic input path.
+// Keeping this switch closed prevents a new aggregate family from inheriting a
+// plausible payload transform merely because somebody added a table entry.
+func prepareMixedAggregatePlan(inner chplan.Node, family mixedWrapperFamily) (chplan.Node, error) {
+	if !mixedRowsNeedPreparation(inner) {
+		return inner, nil
+	}
+
+	expected := mixedPolicyClosed
+	switch family {
+	case mixedSumAvgFamily:
+		expected = mixedBespoke
+	case mixedCountGroupFamily:
+		expected = mixedPreserve
+	case mixedFloatAggregateFamily:
+		expected = mixedFloatOnly
+	}
+	if err := requireMixedPlanPolicy(inner, family, expected); err != nil {
+		return nil, err
+	}
+	return mixedPlanTransformForPolicy(expected)(inner), nil
 }
 
 func requireMixedBespokePolicy(key mixedWrapperKey, policy mixedOperandPolicy) error {

--- a/internal/promql/mixed_operand_policy_test.go
+++ b/internal/promql/mixed_operand_policy_test.go
@@ -204,6 +204,9 @@ func TestMixedOperandPolicyAdmissionInventory(t *testing.T) {
 			case mixedLabelFamily, mixedSortByLabelFamily, mixedCountGroupFamily, mixedLimitFamily:
 				wantPolicy = mixedPreserve
 			}
+			if key == (mixedWrapperKey{family: mixedFloatAggregateFamily, site: mixedPlanAdmission}) {
+				wantPolicy = mixedFloatOnly
+			}
 			if got := mixedOperandPolicies[key]; got != wantPolicy {
 				t.Errorf("admission %v = %v, want %v", key, got, wantPolicy)
 			}


### PR DESCRIPTION
Closes #3344

## Summary

- reclassify already-lowered float aggregates from bespoke handling to the registered `mixedFloatOnly` policy
- apply aggregate plan policies through a closed dispatcher, while retaining root float aggregates as bespoke because they must resolve mixed-union shadow precedence before narrowing
- pin correct narrowing plus fail-closed behavior for missing and mismatched policies

## Final source audit

- 25 mixed-wrapper families and 50 policy sites
- 27 bespoke, 15 float-only, and 8 preserve policy rows
- 23 production physical-schema `SampleKind()` consumers: 19 in PromQL, 2 in chplan, and 2 in the Prom API
- zero executable `RowShapeOf` consumers outside `internal/chplan/row_shape.go`; it is now only the schema-derived compatibility adapter
- no separate shape-agreement classifier remains; surviving `Histogram` / `Mixed` node fields carry operator or emitter semantics rather than competing with `RowType()`

## Retained bespoke families

| Family | Why bespoke remains | Focused coverage |
| --- | --- | --- |
| leaf | Builds the initial mixed relation and resolves float/histogram shadowing. | mixed-`or` TXTAR and chDB cases |
| sum/avg | Partitions by sample kind, aggregates each arm, then recombines groups. | `sum_avg_mixed_input_test.go`, `sum_avg_mixed_input_chdb_test.go` |
| float aggregate (root only) | Resolves union shadows before the existing-plan float-only policy can safely drop histogram rows. | `float_aggregate_input_test.go`, `float_aggregate_input_chdb_test.go` |
| count_values | Implements histogram-specific value labeling instead of a generic drop/preserve rule. | `count_values_mixed_test.go`, `count_values_mixed_chdb_test.go` |
| scalar scale | Scaling preserves valid histogram arithmetic while other scalar arithmetic discards histograms. | `scalar_arithmetic_test.go`, `scalar_arithmetic_chdb_test.go` |
| vector arithmetic | Applies per-operator histogram legality, matching, and collision rules. | mixed vector-arithmetic unit, TXTAR, and chDB cases |
| vector comparison | Separates filter and `bool` semantics and validates histogram pairings. | mixed vector-comparison unit, TXTAR, and chDB cases |
| subquery | Select/fold behavior depends on range function, step grid, and call-subquery continuation. | mixed subquery TXTAR and chDB families |
| timestamp | Converts both sample kinds to floats after shadow resolution. | `timestamp_nested_mixed_test.go` and collision chDB cases |
| info | Enriches both sample kinds while preserving join semantics. | `info_mixed_or_arg.txtar`, `info_mixed_or_mirror.txtar` |
| histogram value | Selects the histogram arm and extracts function-specific fields. | `histogram_count_mixed_or.txtar`, `histogram_sum_mixed_or.txtar` |
| unary | Preserves or transforms histograms according to unary-sign semantics. | `unary_plus_mixed_or.txtar`, `unary_minus_mixed_or.txtar` |
| vector-set operand | Evaluates membership and duplicate/shadow collisions independently of payload narrowing. | mixed set-operation TXTAR and chDB cases |
| absent | Evaluates series existence across both sample kinds. | `absent_mixed_or.txtar`, `absent_subquery_exp_histogram_chdb_test.go` |

## Validation

- `gofumpt` and `goimports` passed in the commit hook
- `git diff --check` passed
- heavy tests, generated-artifact updates, and golden regeneration are delegated to CI per repository policy
