### PR TITLE
fix(ci): retain failed golden regeneration patches

### DIFF
--- a/.github/scripts/manual-golden-update.test.mjs
+++ b/.github/scripts/manual-golden-update.test.mjs
@@ -186,6 +186,29 @@ test('workflow keeps write authority out of matrix jobs and publishes once', () 
   assert.doesNotMatch(regenerate, /uses: actions\/cache@/);
 });
 
+test('failed regeneration retains a safe patch without masking the red job', () => {
+  const workflow = readFileSync(new URL('../workflows/update-golden.yml', import.meta.url), 'utf8');
+  const regenerate = workflow.slice(
+    workflow.indexOf('\n  regenerate:'),
+    workflow.indexOf('\n  publish:'),
+  );
+  const publish = workflow.slice(workflow.indexOf('\n  publish:'));
+
+  assert.doesNotMatch(regenerate, /continue-on-error/);
+  assert.match(
+    regenerate,
+    /- name: Package only this shard's generated paths\n\s+id: package\n(?:\s+#.*\n)*\s+if: always\(\)/,
+  );
+  assert.match(
+    regenerate,
+    /- name: Upload shard patch\n\s+if: always\(\) && steps\.package\.outcome == 'success'/,
+  );
+  assert.match(
+    publish,
+    /needs\.regenerate\.result == 'success' \|\| needs\.regenerate\.result == 'skipped'/,
+  );
+});
+
 test('two independently generated shard patches publish as one commit', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'manual-golden-update-'));
   try {

--- a/.github/workflows/update-golden.yml
+++ b/.github/workflows/update-golden.yml
@@ -192,6 +192,11 @@ jobs:
         run: just update-golden ${{ matrix.command_shards }}
 
       - name: Package only this shard's generated paths
+        id: package
+        # A generator can write valid output before a human-curation gate
+        # deliberately fails. Preserve that diagnostic patch without masking
+        # the regeneration failure; publish still requires this job to pass.
+        if: always()
         env:
           MODE: package
           TARGET_ROOT: target
@@ -201,6 +206,7 @@ jobs:
         run: node .github/scripts/manual-golden-update.mjs
 
       - name: Upload shard patch
+        if: always() && steps.package.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: golden-patch-${{ matrix.shard }}


### PR DESCRIPTION
## Summary

- retain shard patches when golden regeneration writes useful output before failing a curation gate
- keep the regeneration job red and prevent failed shards from reaching the publisher
- pin the failure-artifact contract in the workflow test

This unblocks recovery of CI-generated rejection-parity updates for #3363 without allowing failed regeneration to commit changes.

## Verification

- `node --test --test-name-pattern='failed regeneration retains a safe patch without masking the red job' .github/scripts/manual-golden-update.test.mjs`

Closes #3369
