### PR TITLE
fix(traceql): coerce unscoped numeric aggregates

### DIFF
--- a/internal/traceql/absent_attribute_test.go
+++ b/internal/traceql/absent_attribute_test.go
@@ -275,6 +275,7 @@ func TestAggregateSkipsSpansMissingTheAttribute(t *testing.T) {
 		{"max", `{} | max(span.size) > 5`, "max(toFloat64OrNull(`SpanAttributes`[?]))"},
 		{"sum", `{} | sum(span.size) > 5`, "sum(toFloat64OrNull(`SpanAttributes`[?]))"},
 		{"resource_scope", `{} | avg(resource.replicas) > 5`, "avg(toFloat64OrNull(`ResourceAttributes`[?]))"},
+		{"unscoped", `{} | sum(.payload_bytes) > 100`, "sum(toFloat64OrNull(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], `ResourceAttributes`[?])))"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -333,6 +334,7 @@ func TestMetricsOverTimeSkipsSpansMissingTheAttribute(t *testing.T) {
 		{"max_over_time", `{} | max_over_time(span.latency_ms)`, "max(toFloat64OrNull(`SpanAttributes`[?]))"},
 		{"min_over_time", `{} | min_over_time(span.latency_ms)`, "min(toFloat64OrNull(`SpanAttributes`[?]))"},
 		{"sum_over_time", `{} | sum_over_time(span.latency_ms)`, "sum(toFloat64OrNull(`SpanAttributes`[?]))"},
+		{"unscoped_sum_over_time", `{} | sum_over_time(.payload_bytes)`, "sum(toFloat64OrNull(if(mapContains(`SpanAttributes`, ?), `SpanAttributes`[?], `ResourceAttributes`[?])))"},
 		{"avg_over_time", `{} | avg_over_time(span.latency_ms)`, "avg(toFloat64OrNull(`SpanAttributes`[?]))"},
 		{
 			"quantile_over_time",

--- a/internal/traceql/aggregate.go
+++ b/internal/traceql/aggregate.go
@@ -340,7 +340,7 @@ func minAggFunc(col, alias string) chplan.AggFunc {
 // arithmetic Binary that was already coerced) keep their existing
 // shape.
 func coerceMapNumericAggInput(expr chplan.Expr) (chplan.Expr, bool) {
-	if _, ok := expr.(*chplan.FieldAccess); ok {
+	if isAttributeRead(expr) {
 		return &chplan.FuncCall{
 			Fn:   chplan.FnToFloat64OrNull,
 			Args: []chplan.Expr{expr},

--- a/internal/traceql/aggregate_coercion_test.go
+++ b/internal/traceql/aggregate_coercion_test.go
@@ -1,0 +1,22 @@
+package traceql
+
+import (
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+)
+
+func TestCoerceMapNumericAggInputLeavesNonAttributeFuncCallAlone(t *testing.T) {
+	t.Parallel()
+
+	expr := &chplan.FuncCall{Fn: chplan.FnToFloat64OrNull, Args: []chplan.Expr{
+		&chplan.FieldAccess{Source: &chplan.ColumnRef{Name: "SpanAttributes"}, Path: "payload_bytes"},
+	}}
+	got, nullable := coerceMapNumericAggInput(expr)
+	if got != expr {
+		t.Fatalf("coerceMapNumericAggInput(non-attribute FuncCall) = %T %p, want original %T %p", got, got, expr, expr)
+	}
+	if nullable {
+		t.Fatal("coerceMapNumericAggInput(non-attribute FuncCall) reported nullable")
+	}
+}


### PR DESCRIPTION
Closes #3279

## Summary

- recognize TraceQL's unscoped span-then-resource attribute fallback as an attribute read when preparing numeric aggregates
- apply the existing nullable numeric coercion to the two nightly failure shapes: `sum(.payload_bytes)` and `sum_over_time(.payload_bytes)`
- preserve existing behavior for scoped attributes, intrinsics, arithmetic expressions, and unrelated function calls

The change is deliberately limited to aggregate input classification. `isAttributeRead` accepts direct field access and the exact three-argument `if` shape whose two value arms are attribute reads; other function calls remain untouched.

The next clean nightly run remains the authoritative end-to-end acceptance check for the two dashboard queries.

## Focused test

```console
GOCACHE=/tmp/cerberus-3279-go-cache go test -timeout 2m -count=1 -run '^(TestAggregateSkipsSpansMissingTheAttribute|TestMetricsOverTimeSkipsSpansMissingTheAttribute|TestCoerceMapNumericAggInputLeavesNonAttributeFuncCallAlone)$' ./internal/traceql
```
