### PR TITLE
refactor(chplan): identify histogram schema fields

### DIFF
--- a/internal/chplan/schema.go
+++ b/internal/chplan/schema.go
@@ -19,11 +19,36 @@ const (
 	RoleParentSpanID
 )
 
+// HistogramField identifies one physical histogram component independently
+// of its configured storage name and public histogram-payload role.
+type HistogramField uint8
+
+const (
+	// HistogramFieldNone marks a column with no histogram identity.
+	HistogramFieldNone HistogramField = iota
+	HistogramFieldCount
+	HistogramFieldSum
+	HistogramFieldScale
+	HistogramFieldZeroThreshold
+	HistogramFieldZeroCount
+	HistogramFieldPositiveOffset
+	HistogramFieldPositiveBucketCounts
+	HistogramFieldNegativeOffset
+	HistogramFieldNegativeBucketCounts
+	HistogramFieldBucketCounts
+	HistogramFieldExplicitBounds
+)
+
+func (field HistogramField) valid() bool {
+	return field >= HistogramFieldCount && field <= HistogramFieldExplicitBounds
+}
+
 // Column is one output. An empty Name denotes an unaliased expression whose
 // driver-assigned name cannot be derived without rendering SQL.
 type Column struct {
-	Name string
-	Role ColumnRole
+	Name           string
+	Role           ColumnRole
+	HistogramField HistogramField
 }
 
 // Schema describes a node's own output. Closed schemas preserve SELECT order.
@@ -79,6 +104,32 @@ func (s Schema) Find(role ColumnRole) (Column, bool) {
 // Has reports whether any output carries role.
 func (s Schema) Has(role ColumnRole) bool { _, ok := s.Find(role); return ok }
 
+// FindHistogramField returns the uniquely identified histogram column.
+// Invalid, missing, duplicate, unnamed, wrongly-role-tagged, and physically
+// name-aliased identities fail closed.
+func (s Schema) FindHistogramField(field HistogramField) (Column, bool) {
+	if !field.valid() {
+		return Column{}, false
+	}
+	var found Column
+	seen := false
+	for _, column := range s.Columns {
+		if column.HistogramField != field {
+			continue
+		}
+		if seen || column.Name == "" || column.Role != RoleHistogramField {
+			return Column{}, false
+		}
+		for _, candidate := range s.Columns {
+			if candidate.Name == column.Name && candidate.HistogramField != column.HistogramField {
+				return Column{}, false
+			}
+		}
+		found, seen = column, true
+	}
+	return found, seen
+}
+
 // ByName looks up a named output; unnamed expressions never match.
 func (s Schema) ByName(name string) (Column, bool) {
 	if name != "" {
@@ -114,8 +165,34 @@ func roleColumn(name string, input Schema, declared []Column) Column {
 		HistogramPositiveOffsetColumn, HistogramPositiveBucketCountsColumn,
 		HistogramNegativeOffsetColumn, HistogramNegativeBucketCountsColumn:
 		c.Role = RoleHistogramField
+		c.HistogramField = canonicalHistogramField(name)
 	}
 	return c
+}
+
+func canonicalHistogramField(name string) HistogramField {
+	switch name {
+	case HistogramCountColumn:
+		return HistogramFieldCount
+	case HistogramSumColumn:
+		return HistogramFieldSum
+	case HistogramScaleColumn:
+		return HistogramFieldScale
+	case HistogramZeroThresholdColumn:
+		return HistogramFieldZeroThreshold
+	case HistogramZeroCountColumn:
+		return HistogramFieldZeroCount
+	case HistogramPositiveOffsetColumn:
+		return HistogramFieldPositiveOffset
+	case HistogramPositiveBucketCountsColumn:
+		return HistogramFieldPositiveBucketCounts
+	case HistogramNegativeOffsetColumn:
+		return HistogramFieldNegativeOffset
+	case HistogramNegativeBucketCountsColumn:
+		return HistogramFieldNegativeBucketCounts
+	default:
+		return HistogramFieldNone
+	}
 }
 
 func selectNames(input Schema, names []string, roles []Column) Schema {
@@ -157,20 +234,20 @@ func appendReducers(out, input Schema, funcs []AggFunc, roles []Column) Schema {
 }
 
 func sampleSchema(metric, attributes, timestamp, value string) Schema {
-	return Schema{Columns: []Column{{metric, RoleMetricName}, {attributes, RoleAttributes}, {timestamp, RoleTimestamp}, {value, RoleValue}}}
+	return Schema{Columns: []Column{{Name: metric, Role: RoleMetricName}, {Name: attributes, Role: RoleAttributes}, {Name: timestamp, Role: RoleTimestamp}, {Name: value, Role: RoleValue}}}
 }
 
 func histogramColumns() []Column {
 	return []Column{
-		{HistogramCountColumn, RoleHistogramField},
-		{HistogramSumColumn, RoleHistogramField},
-		{HistogramScaleColumn, RoleHistogramField},
-		{HistogramZeroThresholdColumn, RoleHistogramField},
-		{HistogramZeroCountColumn, RoleHistogramField},
-		{HistogramPositiveOffsetColumn, RoleHistogramField},
-		{HistogramPositiveBucketCountsColumn, RoleHistogramField},
-		{HistogramNegativeOffsetColumn, RoleHistogramField},
-		{HistogramNegativeBucketCountsColumn, RoleHistogramField},
+		{Name: HistogramCountColumn, Role: RoleHistogramField, HistogramField: HistogramFieldCount},
+		{Name: HistogramSumColumn, Role: RoleHistogramField, HistogramField: HistogramFieldSum},
+		{Name: HistogramScaleColumn, Role: RoleHistogramField, HistogramField: HistogramFieldScale},
+		{Name: HistogramZeroThresholdColumn, Role: RoleHistogramField, HistogramField: HistogramFieldZeroThreshold},
+		{Name: HistogramZeroCountColumn, Role: RoleHistogramField, HistogramField: HistogramFieldZeroCount},
+		{Name: HistogramPositiveOffsetColumn, Role: RoleHistogramField, HistogramField: HistogramFieldPositiveOffset},
+		{Name: HistogramPositiveBucketCountsColumn, Role: RoleHistogramField, HistogramField: HistogramFieldPositiveBucketCounts},
+		{Name: HistogramNegativeOffsetColumn, Role: RoleHistogramField, HistogramField: HistogramFieldNegativeOffset},
+		{Name: HistogramNegativeBucketCountsColumn, Role: RoleHistogramField, HistogramField: HistogramFieldNegativeBucketCounts},
 	}
 }
 
@@ -205,6 +282,9 @@ func (s Schema) SampleKind() SampleKind {
 	var histogramSeen [histogramPayloadColumnCount]bool
 	canonicalHistogram := histogramColumns()
 	for _, column := range s.Columns {
+		if (column.Role == RoleHistogramField) != column.HistogramField.valid() {
+			return SampleKindInvalid
+		}
 		if !samplePublicRole(column.Role) {
 			continue
 		}
@@ -224,7 +304,7 @@ func (s Schema) SampleKind() SampleKind {
 		if column.Role == RoleHistogramField {
 			matched := false
 			for i, field := range canonicalHistogram {
-				if column.Name == field.Name {
+				if column.Name == field.Name && column.HistogramField == field.HistogramField {
 					histogramSeen[i] = true
 					matched = true
 					break

--- a/internal/chplan/schema_histogram_field_test.go
+++ b/internal/chplan/schema_histogram_field_test.go
@@ -1,0 +1,57 @@
+package chplan
+
+import "testing"
+
+func TestHistogramPayloadFieldIdentity(t *testing.T) {
+	t.Parallel()
+
+	fields := []HistogramField{
+		HistogramFieldCount, HistogramFieldSum, HistogramFieldScale,
+		HistogramFieldZeroThreshold, HistogramFieldZeroCount,
+		HistogramFieldPositiveOffset, HistogramFieldPositiveBucketCounts,
+		HistogramFieldNegativeOffset, HistogramFieldNegativeBucketCounts,
+	}
+	schema := Schema{Columns: HistogramPayloadColumns()}
+	for _, field := range fields {
+		column, ok := schema.FindHistogramField(field)
+		if !ok || column.HistogramField != field {
+			t.Fatalf("FindHistogramField(%d) = %#v, %v", field, column, ok)
+		}
+	}
+	if _, ok := schema.FindHistogramField(HistogramFieldNone); ok {
+		t.Fatal("zero histogram identity unexpectedly resolved")
+	}
+	if _, ok := schema.FindHistogramField(HistogramFieldExplicitBounds + 1); ok {
+		t.Fatal("out-of-range histogram identity unexpectedly resolved")
+	}
+}
+
+func TestFindHistogramFieldFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	valid := Column{Name: "configured_count", Role: RoleHistogramField, HistogramField: HistogramFieldCount}
+	for _, columns := range [][]Column{
+		{valid, valid},
+		{{Role: RoleHistogramField, HistogramField: HistogramFieldCount}},
+		{{Name: "count", Role: RoleOpaque, HistogramField: HistogramFieldCount}},
+		{valid, {Name: "configured_count", Role: RoleHistogramField, HistogramField: HistogramFieldSum}},
+	} {
+		if _, ok := (Schema{Columns: columns}).FindHistogramField(HistogramFieldCount); ok {
+			t.Fatalf("malformed histogram identity resolved from %#v", columns)
+		}
+	}
+}
+
+func TestHistogramFieldCloneAndEquality(t *testing.T) {
+	t.Parallel()
+
+	scan := &Scan{Table: "samples", Roles: []Column{{Name: "configured_count", Role: RoleHistogramField, HistogramField: HistogramFieldCount}}}
+	clone := CloneNode(scan).(*Scan)
+	clone.Roles[0].HistogramField = HistogramFieldSum
+	if scan.Equal(clone) {
+		t.Fatal("scan equality ignored histogram field identity")
+	}
+	if scan.Roles[0].HistogramField != HistogramFieldCount {
+		t.Fatal("clone mutation changed original histogram field identity")
+	}
+}

--- a/internal/chplan/schema_nodes.go
+++ b/internal/chplan/schema_nodes.go
@@ -19,7 +19,7 @@ func (s *Scan) RowType() Schema {
 
 func (*OneRow) RowType() Schema { return Schema{Columns: []Column{{Name: "1"}}} }
 func (*StepGrid) RowType() Schema {
-	return Schema{Columns: []Column{{RangeWindowAnchorColumn, RoleAnchor}}}
+	return Schema{Columns: []Column{{Name: RangeWindowAnchorColumn, Role: RoleAnchor}}}
 }
 func (f *Filter) RowType() Schema             { return f.Input.RowType() }
 func (l *Limit) RowType() Schema              { return l.Input.RowType() }
@@ -117,7 +117,7 @@ func payloadSchema(out Schema, histogram, mixed bool) Schema {
 		out.Columns = append(out.Columns, histogramColumns()...)
 	}
 	if mixed {
-		out.Columns = append(out.Columns, Column{MixedDiscriminatorColumn, RoleDiscriminator})
+		out.Columns = append(out.Columns, Column{Name: MixedDiscriminatorColumn, Role: RoleDiscriminator})
 	}
 	return out
 }
@@ -144,9 +144,9 @@ func (h *HistogramProjection) RowType() Schema {
 func windowSchema(input Schema, keys []Expr, matrix bool, timestamp, value string) Schema {
 	out := groupSchema(input, keys, nil, nil)
 	if matrix {
-		out.Columns = append(out.Columns, Column{RangeWindowAnchorColumn, RoleAnchor}, Column{timestamp, RoleTimestamp})
+		out.Columns = append(out.Columns, Column{Name: RangeWindowAnchorColumn, Role: RoleAnchor}, Column{Name: timestamp, Role: RoleTimestamp})
 	}
-	out.Columns = append(out.Columns, Column{value, RoleValue})
+	out.Columns = append(out.Columns, Column{Name: value, Role: RoleValue})
 	return out
 }
 
@@ -170,7 +170,7 @@ func (r *RangeWindowGridNative) RowType() Schema {
 		keys.Columns = append(keys.Columns, roleColumn(groupNames[i], input, nil))
 	}
 	keys.Columns = append(keys.Columns, projectSchema(input, r.Recollapse, nil).Columns...)
-	keys.Columns = append(keys.Columns, Column{RangeWindowAnchorColumn, RoleAnchor}, Column{r.TimestampColumn, RoleTimestamp}, Column{r.ValueColumn, RoleValue})
+	keys.Columns = append(keys.Columns, Column{Name: RangeWindowAnchorColumn, Role: RoleAnchor}, Column{Name: r.TimestampColumn, Role: RoleTimestamp}, Column{Name: r.ValueColumn, Role: RoleValue})
 	return keys
 }
 
@@ -186,7 +186,7 @@ func (r *RangeWindow) RowType() Schema {
 	case *MetricsCompare:
 		out := m.RowType()
 		value := out.Columns[len(out.Columns)-1]
-		out.Columns = append(out.Columns[:len(out.Columns)-1], Column{RangeWindowAnchorColumn, RoleAnchor}, value)
+		out.Columns = append(out.Columns[:len(out.Columns)-1], Column{Name: RangeWindowAnchorColumn, Role: RoleAnchor}, value)
 		return out
 	}
 	input := r.Input.RowType()
@@ -195,16 +195,16 @@ func (r *RangeWindow) RowType() Schema {
 	}
 	out := groupSchema(input, r.GroupBy, nil, nil)
 	if r.OuterRange > 0 {
-		out.Columns = append(out.Columns, Column{RangeWindowAnchorColumn, RoleAnchor})
+		out.Columns = append(out.Columns, Column{Name: RangeWindowAnchorColumn, Role: RoleAnchor})
 		if r.TimestampColumn != "" {
 			timestamp := r.TimestampColumn
 			if timestamp == RangeWindowAnchorColumn {
 				timestamp = "TimeUnix"
 			}
-			out.Columns = append(out.Columns, Column{timestamp, RoleTimestamp})
+			out.Columns = append(out.Columns, Column{Name: timestamp, Role: RoleTimestamp})
 		}
 	}
-	out.Columns = append(out.Columns, Column{r.ValueColumn, RoleValue})
+	out.Columns = append(out.Columns, Column{Name: r.ValueColumn, Role: RoleValue})
 	if r.Func == "predict_linear" && !r.Identity && r.OuterRange == 0 && r.PredictLinearSlopeColumn != "" {
 		out.Columns = append(out.Columns, Column{Name: r.PredictLinearSlopeColumn})
 	}
@@ -214,12 +214,12 @@ func (r *RangeWindow) RowType() Schema {
 func (r *RangeWindow) variantWindowSchema(input Schema, variants bool) Schema {
 	out := groupSchema(input, r.GroupBy, nil, nil)
 	if r.OuterRange > 0 || r.DownsampleTier {
-		out.Columns = append(out.Columns, Column{RangeWindowAnchorColumn, RoleAnchor})
+		out.Columns = append(out.Columns, Column{Name: RangeWindowAnchorColumn, Role: RoleAnchor})
 		if r.TimestampColumn != RangeWindowAnchorColumn {
-			out.Columns = append(out.Columns, Column{r.TimestampColumn, RoleTimestamp})
+			out.Columns = append(out.Columns, Column{Name: r.TimestampColumn, Role: RoleTimestamp})
 		}
 	}
-	out.Columns = append(out.Columns, Column{r.ValueColumn, RoleValue})
+	out.Columns = append(out.Columns, Column{Name: r.ValueColumn, Role: RoleValue})
 	if variants {
 		out.Columns = append(out.Columns, Column{Name: r.VariantColumn})
 	}

--- a/internal/chplan/schema_special.go
+++ b/internal/chplan/schema_special.go
@@ -4,13 +4,13 @@ import "strconv"
 
 func (h *HistogramQuantile) RowType() Schema {
 	out := groupSchema(h.Input.RowType(), h.GroupBy, h.GroupByAliases, nil)
-	out.Columns = append(out.Columns, Column{"Value", RoleValue})
+	out.Columns = append(out.Columns, Column{Name: "Value", Role: RoleValue})
 	return out
 }
 
 func (h *HistogramQuantileNative) RowType() Schema {
 	out := groupSchema(h.Input.RowType(), h.GroupBy, h.GroupByAliases, nil)
-	out.Columns = append(out.Columns, Column{"Value", RoleValue})
+	out.Columns = append(out.Columns, Column{Name: "Value", Role: RoleValue})
 	return out
 }
 
@@ -20,14 +20,14 @@ func (a *AbsentOverTime) RowType() Schema {
 
 func (r *RangeBucketFanout) RowType() Schema {
 	input := r.Input.RowType()
-	out := Schema{Columns: []Column{{r.AnchorAlias, RoleAnchor}}}
+	out := Schema{Columns: []Column{{Name: r.AnchorAlias, Role: RoleAnchor}}}
 	out.Columns = append(out.Columns, groupSchema(input, r.GroupBy, r.GroupByAliases, nil).Columns...)
 	return appendReducers(out, input, r.AggFuncs, nil)
 }
 
 func (r *RangeBucketGridNative) RowType() Schema {
 	input := r.Input.RowType()
-	out := Schema{Columns: []Column{{r.AnchorAlias, RoleAnchor}}}
+	out := Schema{Columns: []Column{{Name: r.AnchorAlias, Role: RoleAnchor}}}
 	out.Columns = append(out.Columns, groupSchema(input, r.GroupBy, r.GroupByAliases, nil).Columns...)
 	out.Columns = append(out.Columns, roleColumn(r.BucketCountsCol, input, nil), roleColumn(r.ExplicitBoundsCol, input, nil))
 	return out
@@ -36,9 +36,9 @@ func (r *RangeBucketGridNative) RowType() Schema {
 func (r *RangeWindowGridNativeVectorAgg) RowType() Schema {
 	input := r.Input.RowType()
 	out := groupSchema(input, r.GroupBy, r.GroupByAliases, nil)
-	out.Columns = append(out.Columns, Column{RangeWindowAnchorColumn, RoleAnchor})
+	out.Columns = append(out.Columns, Column{Name: RangeWindowAnchorColumn, Role: RoleAnchor})
 	if r.AnchorAlias != RangeWindowAnchorColumn {
-		out.Columns = append(out.Columns, Column{r.AnchorAlias, RoleTimestamp})
+		out.Columns = append(out.Columns, Column{Name: r.AnchorAlias, Role: RoleTimestamp})
 	}
 	if value, ok := input.Find(RoleValue); ok {
 		out.Columns = append(out.Columns, value)
@@ -67,13 +67,13 @@ func (m *MetricsAggregate) RowType() Schema {
 	if multi {
 		out.Columns = append(out.Columns, Column{Name: "__phi__"})
 	}
-	out.Columns = append(out.Columns, Column{m.ValueAlias, RoleValue})
+	out.Columns = append(out.Columns, Column{Name: m.ValueAlias, Role: RoleValue})
 	return out
 }
 
 func (m *MetricsHistogramOverTime) RowType() Schema {
 	out := groupSchema(m.Inner.RowType(), m.GroupBy, m.GroupByAliases, nil)
-	out.Columns = append(out.Columns, Column{Name: outputDefault(m.BucketAlias, "__bucket")}, Column{outputDefault(m.ValueAlias, "Value"), RoleValue})
+	out.Columns = append(out.Columns, Column{Name: outputDefault(m.BucketAlias, "__bucket")}, Column{Name: outputDefault(m.ValueAlias, "Value"), Role: RoleValue})
 	return out
 }
 
@@ -82,7 +82,7 @@ func (m *MetricsCompare) RowType() Schema {
 		{Name: outputDefault(m.SelAlias, "is_selection")},
 		{Name: outputDefault(m.AttrAlias, "attr")},
 		{Name: outputDefault(m.ValAlias, "val")},
-		{outputDefault(m.ValueAlias, "Value"), RoleValue},
+		{Name: outputDefault(m.ValueAlias, "Value"), Role: RoleValue},
 	}}
 }
 
@@ -108,17 +108,17 @@ func outerGroupNames(keys []Expr, aliases []string) []string {
 
 func metricsWindowSchema(m *MetricsAggregate) Schema {
 	out := groupSchema(m.Inner.RowType(), m.GroupBy, outerGroupNames(m.GroupBy, m.GroupByAliases), nil)
-	out.Columns = append(out.Columns, Column{RangeWindowAnchorColumn, RoleAnchor})
+	out.Columns = append(out.Columns, Column{Name: RangeWindowAnchorColumn, Role: RoleAnchor})
 	if m.Op == MetricsOpQuantileOverTime {
 		out.Columns = append(out.Columns, Column{Name: "__bucket"})
 	}
-	out.Columns = append(out.Columns, Column{m.ValueAlias, RoleValue})
+	out.Columns = append(out.Columns, Column{Name: m.ValueAlias, Role: RoleValue})
 	return out
 }
 
 func histogramWindowSchema(m *MetricsHistogramOverTime) Schema {
 	out := groupSchema(m.Inner.RowType(), m.GroupBy, outerGroupNames(m.GroupBy, m.GroupByAliases), nil)
-	out.Columns = append(out.Columns, Column{Name: outputDefault(m.BucketAlias, "__bucket")}, Column{RangeWindowAnchorColumn, RoleAnchor}, Column{outputDefault(m.ValueAlias, "Value"), RoleValue})
+	out.Columns = append(out.Columns, Column{Name: outputDefault(m.BucketAlias, "__bucket")}, Column{Name: RangeWindowAnchorColumn, Role: RoleAnchor}, Column{Name: outputDefault(m.ValueAlias, "Value"), Role: RoleValue})
 	return out
 }
 
@@ -159,13 +159,13 @@ func (m *MixedVectorJoin) RowType() Schema {
 func (h *HistogramFloatVectorJoin) RowType() Schema {
 	roles := sampleSchema(h.MetricNameColumn, h.AttributesColumn, h.TimestampColumn, h.ValueColumn)
 	out := selectNames(roles, histogramJoinColumns(h.MetricNameColumn, h.AttributesColumn, h.TimestampColumn), nil)
-	out.Columns = append(out.Columns, Column{h.ValueColumn, RoleValue})
+	out.Columns = append(out.Columns, Column{Name: h.ValueColumn, Role: RoleValue})
 	return out
 }
 
 func (j *StructuralJoin) RowType() Schema {
 	input := j.Right.RowType()
-	keys := []Column{{j.TraceIDColumn, RoleTraceID}, {j.SpanIDColumn, RoleSpanID}, {j.ParentSpanIDColumn, RoleParentSpanID}}
+	keys := []Column{{Name: j.TraceIDColumn, Role: RoleTraceID}, {Name: j.SpanIDColumn, Role: RoleSpanID}, {Name: j.ParentSpanIDColumn, Role: RoleParentSpanID}}
 	out := Schema{Columns: keys}
 	if len(j.ExtraProjectionColumns) != 0 {
 		out.Columns = append(out.Columns, selectNames(input, j.ExtraProjectionColumns, nil).Columns...)

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -8,23 +8,23 @@ import (
 )
 
 func TestRowTypeEveryNode(t *testing.T) {
-	roles := []Column{{"name", RoleMetricName}, {"labels", RoleAttributes}, {"time", RoleTimestamp}, {"value", RoleValue}}
+	roles := []Column{{Name: "name", Role: RoleMetricName}, {Name: "labels", Role: RoleAttributes}, {Name: "time", Role: RoleTimestamp}, {Name: "value", Role: RoleValue}}
 	scan := &Scan{Table: "samples", Columns: []string{"name", "labels", "time", "value"}, Roles: roles}
 	key := &ColumnRef{Name: "labels"}
 	groups := []Expr{key}
 	grid := &RangeWindowGridNative{Input: scan, GroupBy: groups, TimestampColumn: "time", ValueColumn: "value"}
-	traceRoles := []Column{{"trace", RoleTraceID}, {"span", RoleSpanID}, {"parent", RoleParentSpanID}}
+	traceRoles := []Column{{Name: "trace", Role: RoleTraceID}, {Name: "span", Role: RoleSpanID}, {Name: "parent", Role: RoleParentSpanID}}
 	traces := &Scan{Table: "spans", Columns: []string{"trace", "span", "parent"}, Roles: traceRoles}
 	canonical := Schema{Columns: roles}
-	groupValue := Schema{Columns: []Column{{"labels", RoleAttributes}, {"value", RoleValue}}}
-	hist := []Column{{"HistogramCount", RoleHistogramField}, {"HistogramSum", RoleHistogramField}, {"HistogramScale", RoleHistogramField}, {"HistogramZeroThreshold", RoleHistogramField}, {"HistogramZeroCount", RoleHistogramField}, {"HistogramPositiveOffset", RoleHistogramField}, {"HistogramPositiveBucketCounts", RoleHistogramField}, {"HistogramNegativeOffset", RoleHistogramField}, {"HistogramNegativeBucketCounts", RoleHistogramField}}
+	groupValue := Schema{Columns: []Column{{Name: "labels", Role: RoleAttributes}, {Name: "value", Role: RoleValue}}}
+	hist := histogramColumns()
 	cases := []struct {
 		node Node
 		want Schema
 	}{
 		{scan, canonical},
 		{&OneRow{}, Schema{Columns: []Column{{Name: "1"}}}},
-		{&StepGrid{}, Schema{Columns: []Column{{"anchor_ts", RoleAnchor}}}},
+		{&StepGrid{}, Schema{Columns: []Column{{Name: "anchor_ts", Role: RoleAnchor}}}},
 		{&Filter{Input: scan}, canonical},
 		{&Limit{Input: scan}, canonical},
 		{&OrderBy{Input: scan}, canonical},
@@ -33,7 +33,7 @@ func TestRowTypeEveryNode(t *testing.T) {
 		{&TopK{Input: scan, Columns: []string{"labels", "value"}}, groupValue},
 		{&Project{Input: scan, Projections: []Projection{{Expr: key}, {Expr: &LitInt{V: 1}, Alias: "value"}}}, groupValue},
 		{&Aggregate{Input: scan, GroupBy: groups, AggFuncs: []AggFunc{{Fn: FnSum, Alias: "value"}}}, groupValue},
-		{&CrossJoin{Left: scan, Right: &StepGrid{}}, Schema{Columns: append(slices.Clone(roles), Column{"anchor_ts", RoleAnchor})}},
+		{&CrossJoin{Left: scan, Right: &StepGrid{}}, Schema{Columns: append(slices.Clone(roles), Column{Name: "anchor_ts", Role: RoleAnchor})}},
 		{&UnionAll{Inputs: []Node{scan, scan}}, canonical},
 		{&SetOperation{Left: traces, Right: traces}, Schema{Columns: traceRoles}},
 		{&NestedSetAnnotate{Input: traces}, Schema{Columns: append(slices.Clone(traceRoles), Column{Name: NestedSetLeftColumn}, Column{Name: NestedSetRightColumn}, Column{Name: NestedSetParentColumn})}},
@@ -43,19 +43,19 @@ func TestRowTypeEveryNode(t *testing.T) {
 		{&VectorSetOp{Left: scan, Right: scan, MetricNameColumn: "name", AttributesColumn: "labels", TimestampColumn: "time", ValueColumn: "value"}, canonical},
 		{&NaryVectorSetOp{Arms: []Node{scan, scan}, MetricNameColumn: "name", AttributesColumn: "labels", TimestampColumn: "time", ValueColumn: "value"}, canonical},
 		{&InfoJoin{Input: scan, MetricNameColumn: "name", AttributesColumn: "labels", TimestampColumn: "time", ValueColumn: "value"}, canonical},
-		{&HistogramProjection{Input: scan, GroupBy: groups}, Schema{Columns: append([]Column{{"labels", RoleAttributes}}, hist...)}},
-		{&HistogramQuantile{Input: scan, GroupBy: groups}, Schema{Columns: []Column{{"labels", RoleAttributes}, {"Value", RoleValue}}}},
-		{&HistogramQuantileNative{Input: scan, GroupBy: groups}, Schema{Columns: []Column{{"labels", RoleAttributes}, {"Value", RoleValue}}}},
+		{&HistogramProjection{Input: scan, GroupBy: groups}, Schema{Columns: append([]Column{{Name: "labels", Role: RoleAttributes}}, hist...)}},
+		{&HistogramQuantile{Input: scan, GroupBy: groups}, Schema{Columns: []Column{{Name: "labels", Role: RoleAttributes}, {Name: "Value", Role: RoleValue}}}},
+		{&HistogramQuantileNative{Input: scan, GroupBy: groups}, Schema{Columns: []Column{{Name: "labels", Role: RoleAttributes}, {Name: "Value", Role: RoleValue}}}},
 		{&AbsentOverTime{Input: scan, MetricNameColumn: "name", AttributesColumn: "labels", TimestampColumn: "time", ValueColumn: "value"}, canonical},
-		{grid, Schema{Columns: []Column{{"labels", RoleAttributes}, {"anchor_ts", RoleAnchor}, {"time", RoleTimestamp}, {"value", RoleValue}}}},
+		{grid, Schema{Columns: []Column{{Name: "labels", Role: RoleAttributes}, {Name: "anchor_ts", Role: RoleAnchor}, {Name: "time", Role: RoleTimestamp}, {Name: "value", Role: RoleValue}}}},
 		{&RangeWindowGridNativeInstant{Input: scan, GroupBy: groups, ValueColumn: "value"}, groupValue},
 		{&RangeWindow{Input: scan, GroupBy: groups, ValueColumn: "value"}, groupValue},
-		{&RangeBucketFanout{Input: scan, GroupBy: groups, AnchorAlias: "anchor", AggFuncs: []AggFunc{{Alias: "value"}}}, Schema{Columns: []Column{{"anchor", RoleAnchor}, {"labels", RoleAttributes}, {"value", RoleValue}}}},
-		{&RangeBucketGridNative{Input: scan, GroupBy: groups, AnchorAlias: "anchor", BucketCountsCol: "counts", ExplicitBoundsCol: "bounds"}, Schema{Columns: []Column{{"anchor", RoleAnchor}, {"labels", RoleAttributes}, {Name: "counts"}, {Name: "bounds"}}}},
-		{&RangeWindowGridNativeVectorAgg{Input: grid, GroupBy: groups, GroupByAliases: []string{"labels"}, AnchorAlias: "time"}, Schema{Columns: []Column{{"labels", RoleAttributes}, {"anchor_ts", RoleAnchor}, {"time", RoleTimestamp}, {"value", RoleValue}}}},
+		{&RangeBucketFanout{Input: scan, GroupBy: groups, AnchorAlias: "anchor", AggFuncs: []AggFunc{{Alias: "value"}}}, Schema{Columns: []Column{{Name: "anchor", Role: RoleAnchor}, {Name: "labels", Role: RoleAttributes}, {Name: "value", Role: RoleValue}}}},
+		{&RangeBucketGridNative{Input: scan, GroupBy: groups, AnchorAlias: "anchor", BucketCountsCol: "counts", ExplicitBoundsCol: "bounds"}, Schema{Columns: []Column{{Name: "anchor", Role: RoleAnchor}, {Name: "labels", Role: RoleAttributes}, {Name: "counts"}, {Name: "bounds"}}}},
+		{&RangeWindowGridNativeVectorAgg{Input: grid, GroupBy: groups, GroupByAliases: []string{"labels"}, AnchorAlias: "time"}, Schema{Columns: []Column{{Name: "labels", Role: RoleAttributes}, {Name: "anchor_ts", Role: RoleAnchor}, {Name: "time", Role: RoleTimestamp}, {Name: "value", Role: RoleValue}}}},
 		{&MetricsAggregate{Inner: scan, GroupBy: groups, ValueAlias: "value"}, groupValue},
-		{&MetricsHistogramOverTime{Inner: scan, GroupBy: groups, ValueAlias: "value"}, Schema{Columns: []Column{{"labels", RoleAttributes}, {Name: "__bucket"}, {"value", RoleValue}}}},
-		{&MetricsCompare{Inner: traces}, Schema{Columns: []Column{{Name: "is_selection"}, {Name: "attr"}, {Name: "val"}, {"Value", RoleValue}}}},
+		{&MetricsHistogramOverTime{Inner: scan, GroupBy: groups, ValueAlias: "value"}, Schema{Columns: []Column{{Name: "labels", Role: RoleAttributes}, {Name: "__bucket"}, {Name: "value", Role: RoleValue}}}},
+		{&MetricsCompare{Inner: traces}, Schema{Columns: []Column{{Name: "is_selection"}, {Name: "attr"}, {Name: "val"}, {Name: "Value", Role: RoleValue}}}},
 		{&StructuralJoin{Left: traces, Right: traces, TraceIDColumn: "trace", SpanIDColumn: "span", ParentSpanIDColumn: "parent"}, Schema{Columns: traceRoles}},
 	}
 	// Payload joins use deliberately opaque names: their public outputs are
@@ -86,9 +86,9 @@ func TestRowTypeEveryNode(t *testing.T) {
 	}{&MixedVectorJoin{Left: scan, Right: scan, MetricNameColumn: "name", AttributesColumn: "labels", TimestampColumn: "time", ValueColumn: "value"}, wantJoin("_mvj", mixedNames)})
 	hf := Schema{Columns: append([]Column(nil), roles[:len(roles)-1]...)}
 	for _, name := range hjNames[len(roles)-1:] {
-		hf.Columns = append(hf.Columns, Column{name, RoleHistogramField})
+		hf.Columns = append(hf.Columns, roleColumn(name, Schema{}, nil))
 	}
-	hf.Columns = append(hf.Columns, Column{"value", RoleValue})
+	hf.Columns = append(hf.Columns, Column{Name: "value", Role: RoleValue})
 	cases = append(cases, struct {
 		node Node
 		want Schema
@@ -135,7 +135,7 @@ func TestHistogramProjectionRowTypeDeclaresCanonicalRoles(t *testing.T) {
 }
 
 func TestRowTypeDeclarations(t *testing.T) {
-	roles := []Column{{"renamed_value", RoleValue}, {"renamed_labels", RoleAttributes}}
+	roles := []Column{{Name: "renamed_value", Role: RoleValue}, {Name: "renamed_labels", Role: RoleAttributes}}
 	p := &Project{Input: &OneRow{}, Roles: roles, Projections: []Projection{{Expr: &LitInt{V: 1}, Alias: "renamed_value"}}}
 	if got := p.RowType(); !got.Equal(Schema{Columns: roles[:1]}) {
 		t.Fatalf("synthesized output: %#v", got)
@@ -217,15 +217,15 @@ func TestProjectRowTypeAlignedDeclarations(t *testing.T) {
 }
 
 func TestRowTypeWindowBranches(t *testing.T) {
-	input := &Scan{Columns: []string{"labels", "time", "extra"}, Roles: []Column{{"labels", RoleAttributes}, {"time", RoleTimestamp}}}
+	input := &Scan{Columns: []string{"labels", "time", "extra"}, Roles: []Column{{Name: "labels", Role: RoleAttributes}, {Name: "time", Role: RoleTimestamp}}}
 	r := &RangeWindow{Input: input, GroupBy: []Expr{&ColumnRef{Name: "labels"}}, ValueColumn: "value", TimestampColumn: "anchor_ts", OuterRange: time.Minute, Identity: true}
-	want := Schema{Columns: []Column{{"labels", RoleAttributes}, {"anchor_ts", RoleAnchor}, {"TimeUnix", RoleTimestamp}, {"value", RoleValue}}}
+	want := Schema{Columns: []Column{{Name: "labels", Role: RoleAttributes}, {Name: "anchor_ts", Role: RoleAnchor}, {Name: "TimeUnix", Role: RoleTimestamp}, {Name: "value", Role: RoleValue}}}
 	if got := r.RowType(); !got.Equal(want) {
 		t.Fatalf("identity: %#v", got)
 	}
 	r.Variants = []RangeWindowVariant{{ValueColumn: "value"}}
 	r.VariantColumn = "variant"
-	want.Columns = []Column{{"labels", RoleAttributes}, {"anchor_ts", RoleAnchor}, {"value", RoleValue}, {Name: "variant"}}
+	want.Columns = []Column{{Name: "labels", Role: RoleAttributes}, {Name: "anchor_ts", Role: RoleAnchor}, {Name: "value", Role: RoleValue}, {Name: "variant"}}
 	if got := r.RowType(); !got.Equal(want) {
 		t.Fatalf("variants: %#v", got)
 	}
@@ -234,7 +234,7 @@ func TestRowTypeWindowBranches(t *testing.T) {
 	r.OuterRange = 0
 	r.Func = "predict_linear"
 	r.PredictLinearSlopeColumn = "slope"
-	want.Columns = []Column{{"labels", RoleAttributes}, {"value", RoleValue}, {Name: "slope"}}
+	want.Columns = []Column{{Name: "labels", Role: RoleAttributes}, {Name: "value", Role: RoleValue}, {Name: "slope"}}
 	if got := r.RowType(); !got.Equal(want) {
 		t.Fatalf("slope: %#v", got)
 	}
@@ -306,7 +306,7 @@ func TestRowTypeMatrixAnchorSurvivesSchemaPreservingWrappers(t *testing.T) {
 }
 
 func TestRowTypeMixedFloatNarrowing(t *testing.T) {
-	mixed := &Scan{Columns: []string{MixedDiscriminatorColumn}, Roles: []Column{{MixedDiscriminatorColumn, RoleDiscriminator}}}
+	mixed := &Scan{Columns: []string{MixedDiscriminatorColumn}, Roles: []Column{{Name: MixedDiscriminatorColumn, Role: RoleDiscriminator}}}
 	filter := &Filter{Input: mixed, Predicate: &Binary{Op: OpEq, Left: &ColumnRef{Name: MixedDiscriminatorColumn}, Right: &LitInt{V: 0}}}
 	if !IsMixedFloatNarrowing(filter) {
 		t.Fatal("explicit float partition not recognized")
@@ -333,7 +333,7 @@ func TestRowTypeMixedFloatNarrowing(t *testing.T) {
 		t.Fatal("qualified foreign column accepted as this input's discriminator")
 	}
 	filter.Predicate.(*Binary).Left = &ColumnRef{Name: MixedDiscriminatorColumn}
-	filter.Input = &Scan{Columns: []string{MixedDiscriminatorColumn, "actual_kind"}, Roles: []Column{{MixedDiscriminatorColumn, RoleOpaque}, {"actual_kind", RoleDiscriminator}}}
+	filter.Input = &Scan{Columns: []string{MixedDiscriminatorColumn, "actual_kind"}, Roles: []Column{{Name: MixedDiscriminatorColumn, Role: RoleOpaque}, {Name: "actual_kind", Role: RoleDiscriminator}}}
 	if IsMixedFloatNarrowing(filter) {
 		t.Fatal("same-spelled opaque column accepted as discriminator")
 	}
@@ -410,7 +410,7 @@ func TestRowTypeCanonicalHistogramPayload(t *testing.T) {
 			t.Fatalf("payload missing %s accepted", full.Columns[i].Name)
 		}
 	}
-	raw := Schema{Columns: []Column{{"raw_count", RoleHistogramField}, {"raw_sum", RoleHistogramField}}}
+	raw := Schema{Columns: []Column{{Name: "raw_count", Role: RoleHistogramField}, {Name: "raw_sum", Role: RoleHistogramField}}}
 	if raw.HasHistogramPayload() {
 		t.Fatal("raw storage fields accepted as native payload")
 	}
@@ -425,14 +425,14 @@ func TestRowTypeCanonicalHistogramPayload(t *testing.T) {
 
 func TestSchemaSampleKind(t *testing.T) {
 	floatRoles := []Column{
-		{"source_name", RoleMetricName},
-		{"source_labels", RoleAttributes},
-		{"source_time", RoleTimestamp},
-		{"source_value", RoleValue},
+		{Name: "source_name", Role: RoleMetricName},
+		{Name: "source_labels", Role: RoleAttributes},
+		{Name: "source_time", Role: RoleTimestamp},
+		{Name: "source_value", Role: RoleValue},
 	}
 	histogram := HistogramPayloadColumns()
 	mixed := append(slices.Clone(floatRoles), histogram...)
-	mixed = append(mixed, Column{"source_kind", RoleDiscriminator})
+	mixed = append(mixed, Column{Name: "source_kind", Role: RoleDiscriminator})
 	reorderedMixed := slices.Clone(mixed)
 	slices.Reverse(reorderedMixed)
 
@@ -442,14 +442,14 @@ func TestSchemaSampleKind(t *testing.T) {
 		want SampleKind
 	}{
 		{name: "float_custom_names", row: Schema{Columns: floatRoles}, want: SampleKindFloat},
-		{name: "reduced_float", row: Schema{Columns: []Column{{"source_value", RoleValue}}}, want: SampleKindFloat},
+		{name: "reduced_float", row: Schema{Columns: []Column{{Name: "source_value", Role: RoleValue}}}, want: SampleKindFloat},
 		{name: "pure_histogram", row: Schema{Columns: histogram}, want: SampleKindHistogram},
 		{name: "histogram_with_placeholder", row: Schema{Columns: append(slices.Clone(floatRoles), histogram...)}, want: SampleKindHistogram},
 		{name: "mixed", row: Schema{Columns: mixed}, want: SampleKindMixed},
 		{name: "mixed_reordered", row: Schema{Columns: reorderedMixed}, want: SampleKindMixed},
 		{name: "opaque", row: Schema{Columns: []Column{{Name: "private"}}}, want: SampleKindOpaque},
 		{name: "open_float", row: Schema{Columns: floatRoles, Open: true}, want: SampleKindOpaque},
-		{name: "trace_roles", row: Schema{Columns: []Column{{"trace", RoleTraceID}, {"span", RoleSpanID}}}, want: SampleKindOpaque},
+		{name: "trace_roles", row: Schema{Columns: []Column{{Name: "trace", Role: RoleTraceID}, {Name: "span", Role: RoleSpanID}}}, want: SampleKindOpaque},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.row.SampleKind(); got != tc.want {
@@ -460,9 +460,9 @@ func TestSchemaSampleKind(t *testing.T) {
 }
 
 func TestSchemaSampleKindRejectsMalformedContracts(t *testing.T) {
-	floatRoles := []Column{{"labels", RoleAttributes}, {"value", RoleValue}}
+	floatRoles := []Column{{Name: "labels", Role: RoleAttributes}, {Name: "value", Role: RoleValue}}
 	histogram := HistogramPayloadColumns()
-	kind := Column{"source_kind", RoleDiscriminator}
+	kind := Column{Name: "source_kind", Role: RoleDiscriminator}
 
 	type sampleKindCase struct {
 		name    string
@@ -470,13 +470,13 @@ func TestSchemaSampleKindRejectsMalformedContracts(t *testing.T) {
 	}
 	cases := []sampleKindCase{
 		{name: "orphan_discriminator", columns: append(slices.Clone(floatRoles), kind)},
-		{name: "duplicate_value_role", columns: append(slices.Clone(floatRoles), Column{"other_value", RoleValue})},
+		{name: "duplicate_value_role", columns: append(slices.Clone(floatRoles), Column{Name: "other_value", Role: RoleValue})},
 		{name: "unnamed_value", columns: []Column{{Role: RoleValue}}},
 		{name: "shadowed_value", columns: append(slices.Clone(floatRoles), Column{Name: "value"})},
-		{name: "duplicate_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), kind, Column{"other_kind", RoleDiscriminator})},
+		{name: "duplicate_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), kind, Column{Name: "other_kind", Role: RoleDiscriminator})},
 		{name: "unnamed_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), Column{Role: RoleDiscriminator})},
 		{name: "shadowed_discriminator", columns: append(append(slices.Clone(floatRoles), histogram...), kind, Column{Name: kind.Name})},
-		{name: "noncanonical_histogram_role", columns: append(slices.Clone(floatRoles), Column{"raw_count", RoleHistogramField})},
+		{name: "noncanonical_histogram_role", columns: append(slices.Clone(floatRoles), Column{Name: "raw_count", Role: RoleHistogramField})},
 	}
 	for i, role := range floatRoles {
 		missing := slices.Delete(slices.Clone(floatRoles), i, i+1)
@@ -536,18 +536,18 @@ func TestSampleKindString(t *testing.T) {
 }
 
 func TestRowTypeOpenCrossJoin(t *testing.T) {
-	left := &Scan{Roles: []Column{{"known", RoleAttributes}}}
-	right := &Scan{Columns: []string{"known", "maybe"}, Roles: []Column{{"known", RoleAttributes}, {"maybe", RoleTimestamp}}}
+	left := &Scan{Roles: []Column{{Name: "known", Role: RoleAttributes}}}
+	right := &Scan{Columns: []string{"known", "maybe"}, Roles: []Column{{Name: "known", Role: RoleAttributes}, {Name: "maybe", Role: RoleTimestamp}}}
 	got := (&CrossJoin{Left: left, Right: right}).RowType()
-	want := Schema{Open: true, Columns: []Column{{"known", RoleAttributes}, {"R.known", RoleAttributes}}}
+	want := Schema{Open: true, Columns: []Column{{Name: "known", Role: RoleAttributes}, {Name: "R.known", Role: RoleAttributes}}}
 	if !got.Equal(want) {
 		t.Fatalf("uncertain right names advertised: got %#v want %#v", got, want)
 	}
 }
 
 func TestRowTypeUnionUsesFirstArmNames(t *testing.T) {
-	left := &Scan{Columns: []string{"left_value"}, Roles: []Column{{"left_value", RoleValue}}}
-	right := &Scan{Columns: []string{"right_value"}, Roles: []Column{{"right_value", RoleValue}}}
+	left := &Scan{Columns: []string{"left_value"}, Roles: []Column{{Name: "left_value", Role: RoleValue}}}
+	right := &Scan{Columns: []string{"right_value"}, Roles: []Column{{Name: "right_value", Role: RoleValue}}}
 	union := &UnionAll{Inputs: []Node{left, right}}
 	if got := union.RowType(); !got.Equal(left.RowType()) {
 		t.Fatalf("positional union names: %#v", got)

--- a/internal/promql/schema.go
+++ b/internal/promql/schema.go
@@ -28,16 +28,58 @@ func metricScanRoles(s schema.Metrics, table string) []chplan.Column {
 		// Histogram storage has no float Value; the histogram lowering
 		// explicitly synthesizes any scalar placeholder in a later Project.
 		roles = roles[:len(roles)-1]
-		names := []string{s.CountColumn, s.SumColumn}
+		fields := []struct {
+			name     string
+			identity chplan.HistogramField
+		}{{s.CountColumn, chplan.HistogramFieldCount}, {s.SumColumn, chplan.HistogramFieldSum}}
 		if table == s.ExpHistogramTable {
-			names = append(names, s.ScaleColumn, s.ZeroThresholdColumn, s.ZeroCountColumn, s.PositiveOffsetColumn,
-				s.PositiveBucketCountsColumn, s.NegativeOffsetColumn, s.NegativeBucketCountsColumn)
+			fields = append(
+				fields,
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.ScaleColumn, chplan.HistogramFieldScale},
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.ZeroThresholdColumn, chplan.HistogramFieldZeroThreshold},
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.ZeroCountColumn, chplan.HistogramFieldZeroCount},
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.PositiveOffsetColumn, chplan.HistogramFieldPositiveOffset},
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.PositiveBucketCountsColumn, chplan.HistogramFieldPositiveBucketCounts},
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.NegativeOffsetColumn, chplan.HistogramFieldNegativeOffset},
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.NegativeBucketCountsColumn, chplan.HistogramFieldNegativeBucketCounts},
+			)
 		} else {
-			names = append(names, s.BucketCountsColumn, s.ExplicitBoundsColumn)
+			fields = append(
+				fields,
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.BucketCountsColumn, chplan.HistogramFieldBucketCounts},
+				struct {
+					name     string
+					identity chplan.HistogramField
+				}{s.ExplicitBoundsColumn, chplan.HistogramFieldExplicitBounds},
+			)
 		}
-		for _, name := range names {
-			if name != "" {
-				roles = append(roles, chplan.Column{Name: name, Role: chplan.RoleHistogramField})
+		for _, field := range fields {
+			if field.name != "" {
+				roles = append(roles, chplan.Column{Name: field.name, Role: chplan.RoleHistogramField, HistogramField: field.identity})
 			}
 		}
 	}

--- a/internal/promql/schema_scan_roles_test.go
+++ b/internal/promql/schema_scan_roles_test.go
@@ -23,21 +23,21 @@ func TestMetricScanRolesStorageContracts(t *testing.T) {
 		chplan.Column{Name: s.ValueColumn, Role: chplan.RoleValue})
 	classic := append(append([]chplan.Column{}, identity...),
 		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
-		chplan.Column{Name: s.CountColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.SumColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.BucketCountsColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.ExplicitBoundsColumn, Role: chplan.RoleHistogramField})
+		chplan.Column{Name: s.CountColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldCount},
+		chplan.Column{Name: s.SumColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldSum},
+		chplan.Column{Name: s.BucketCountsColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldBucketCounts},
+		chplan.Column{Name: s.ExplicitBoundsColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldExplicitBounds})
 	native := append(append([]chplan.Column{}, identity...),
 		chplan.Column{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
-		chplan.Column{Name: s.CountColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.SumColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.ScaleColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.ZeroThresholdColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.ZeroCountColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.PositiveOffsetColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.PositiveBucketCountsColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.NegativeOffsetColumn, Role: chplan.RoleHistogramField},
-		chplan.Column{Name: s.NegativeBucketCountsColumn, Role: chplan.RoleHistogramField})
+		chplan.Column{Name: s.CountColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldCount},
+		chplan.Column{Name: s.SumColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldSum},
+		chplan.Column{Name: s.ScaleColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldScale},
+		chplan.Column{Name: s.ZeroThresholdColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldZeroThreshold},
+		chplan.Column{Name: s.ZeroCountColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldZeroCount},
+		chplan.Column{Name: s.PositiveOffsetColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldPositiveOffset},
+		chplan.Column{Name: s.PositiveBucketCountsColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldPositiveBucketCounts},
+		chplan.Column{Name: s.NegativeOffsetColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldNegativeOffset},
+		chplan.Column{Name: s.NegativeBucketCountsColumn, Role: chplan.RoleHistogramField, HistogramField: chplan.HistogramFieldNegativeBucketCounts})
 	const configuredPrefixTable = "custom_delta_prefix"
 	for _, tc := range []struct {
 		name   string

--- a/internal/promql/schema_test.go
+++ b/internal/promql/schema_test.go
@@ -40,20 +40,47 @@ func TestRowTypeSyntheticSampleRoles(t *testing.T) {
 func TestRowTypeHistogramStorageRoles(t *testing.T) {
 	s := schema.DefaultOTelMetrics()
 	s.CountColumn = "custom_count"
-	s.PositiveBucketCountsColumn = "custom_positive"
+	s.SumColumn = "custom_sum"
+	s.ScaleColumn = "custom_scale"
+	s.ZeroThresholdColumn = "custom_zero_threshold"
+	s.ZeroCountColumn = "custom_zero_count"
+	s.PositiveOffsetColumn = "custom_positive_offset"
+	s.PositiveBucketCountsColumn = "custom_positive_buckets"
+	s.NegativeOffsetColumn = "custom_negative_offset"
+	s.NegativeBucketCountsColumn = "custom_negative_buckets"
+	s.BucketCountsColumn = "custom_classic_buckets"
+	s.ExplicitBoundsColumn = "custom_explicit_bounds"
+
+	exponential := map[chplan.HistogramField]string{
+		chplan.HistogramFieldCount:                s.CountColumn,
+		chplan.HistogramFieldSum:                  s.SumColumn,
+		chplan.HistogramFieldScale:                s.ScaleColumn,
+		chplan.HistogramFieldZeroThreshold:        s.ZeroThresholdColumn,
+		chplan.HistogramFieldZeroCount:            s.ZeroCountColumn,
+		chplan.HistogramFieldPositiveOffset:       s.PositiveOffsetColumn,
+		chplan.HistogramFieldPositiveBucketCounts: s.PositiveBucketCountsColumn,
+		chplan.HistogramFieldNegativeOffset:       s.NegativeOffsetColumn,
+		chplan.HistogramFieldNegativeBucketCounts: s.NegativeBucketCountsColumn,
+	}
+	classic := map[chplan.HistogramField]string{
+		chplan.HistogramFieldCount:          s.CountColumn,
+		chplan.HistogramFieldSum:            s.SumColumn,
+		chplan.HistogramFieldBucketCounts:   s.BucketCountsColumn,
+		chplan.HistogramFieldExplicitBounds: s.ExplicitBoundsColumn,
+	}
 	for _, table := range []string{s.HistogramTable, s.ExpHistogramTable} {
 		roles := chplan.Schema{Columns: metricScanRoles(s, table)}
 		if roles.Has(chplan.RoleValue) {
 			t.Errorf("histogram %s falsely declares float Value", table)
 		}
-		count, ok := roles.ByName(s.CountColumn)
-		if !ok || count.Role != chplan.RoleHistogramField {
-			t.Errorf("histogram count role: %#v", count)
-		}
+		want := classic
 		if table == s.ExpHistogramTable {
-			positive, ok := roles.ByName(s.PositiveBucketCountsColumn)
-			if !ok || positive.Role != chplan.RoleHistogramField {
-				t.Errorf("native bucket role: %#v", positive)
+			want = exponential
+		}
+		for identity, name := range want {
+			column, ok := roles.FindHistogramField(identity)
+			if !ok || column.Name != name {
+				t.Errorf("histogram %s identity %d = %#v/%v, want %q", table, identity, column, ok, name)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #3376

Parent epic: #3284

## Summary

- add a closed, granular identity for all eleven classic and exponential histogram storage fields while retaining `RoleHistogramField` as their shared public purpose
- provide fail-closed child-schema lookup that rejects missing, unnamed, wrongly tagged, duplicated, name-ambiguous, and out-of-range identities
- propagate configured histogram column names and identities through PromQL scan schemas, including all custom classic and exponential fields
- make schema equality and cloning preserve the new identity and keep native histogram payload classification tied to the existing canonical output aliases

This is the stage-0 prerequisite only. It does not retire any node input-column fields or change emitted SQL/output aliases; subsequent #3284 migrations can resolve those inputs from the correct child schema incrementally.

## Focused tests

```console
GOCACHE=/tmp/cerberus-3284-stage0-go-cache go test -timeout 2m -count=1 -run '^(TestHistogramPayloadFieldIdentity|TestFindHistogramFieldFailsClosed|TestHistogramFieldCloneAndEquality|TestRowTypeHistogramStorageRoles|TestSchemaSampleKind|TestRowTypeCanonicalHistogramPayload)$' ./internal/chplan ./internal/promql
```
