### PR TITLE
fix(traceql): close chdb session before race exit

### DIFF
--- a/internal/traceql/testmain_test.go
+++ b/internal/traceql/testmain_test.go
@@ -1,0 +1,19 @@
+package traceql_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chdbsession"
+)
+
+// TestMain shuts the process-wide chDB session down before this binary
+// exits. Under `-race`, os.Exit runs runtime.racefini, which runs libchdb's
+// C++ static destructors against a still-live embedded ClickHouse and
+// segfaults AFTER every test has already passed (#1971).
+// chdbsession.CloseForExit is a no-op in the default, non-chdb build.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	chdbsession.CloseForExit()
+	os.Exit(code)
+}


### PR DESCRIPTION
Closes #3285

## Summary

- add the missing `TestMain` teardown to the post-optimizer TraceQL test binary
- preserve `m.Run()`'s exact exit status while closing the process-wide chDB session before `os.Exit` enters `runtime.racefini`
- mirror the established PromQL, LogQL, and TXTAR-package teardown pattern; the hook remains a no-op in non-chDB builds

This does not skip assertions, mask failures, or force a successful exit. A failing test still returns its original nonzero status after teardown.

## Focused verification

```console
GOCACHE=/tmp/cerberus-3285-go-cache go test -timeout 2m -count=1 -run '^$' ./internal/traceql
```

The race/chDB regression is exercised with the issue's exact reproducer:

```console
GODEBUG=asyncpreemptoff=1 go test -timeout 32m -race -count=1 -tags=chdb,agpl_oracle,chdb_agpl_oracle -run '^TestLower$' -json ./internal/traceql
```
