### PR TITLE
fix(promql): preserve scalar negative zero

### DIFF
--- a/internal/chsql/builder.go
+++ b/internal/chsql/builder.go
@@ -466,11 +466,7 @@ func (b *Builder) Expr(x chplan.Expr) (err error) {
 	}()
 	switch v := x.(type) {
 	case *chplan.ColumnRef:
-		if v.Qualifier != "" {
-			b.QualIdent(v.Qualifier, v.Name)
-			return nil
-		}
-		b.Ident(v.Name)
+		b.exprColumnRef(v)
 		return nil
 	case *chplan.LitString:
 		b.Arg(v.V)
@@ -487,6 +483,14 @@ func (b *Builder) Expr(x chplan.Expr) (err error) {
 		b.Arg(v.V)
 		return nil
 	case *chplan.LitFloat:
+		// A bound -0 crosses both clickhouse-go and chdb-go as an ordinary
+		// numeric zero on some paths, losing the IEEE-754 sign that atan2 and
+		// division observe. Keep this one semantically distinct value in SQL
+		// syntax; the positive zero inside negate is still typed as Float64.
+		if v.V == 0 && math.Signbit(v.V) {
+			Neg(Call("toFloat64", InlineLit(0)))(b)
+			return nil
+		}
 		// LitFloat values ride the positional `?` slot via b.Arg, and
 		// the placeholder is wrapped in `toFloat64(?)` here, centrally,
 		// so every LitFloat emission is wire-safe by construction. That
@@ -570,6 +574,14 @@ func (b *Builder) Expr(x chplan.Expr) (err error) {
 	default:
 		return fmt.Errorf("%w: expr %T", ErrUnsupported, x)
 	}
+}
+
+func (b *Builder) exprColumnRef(v *chplan.ColumnRef) {
+	if v.Qualifier != "" {
+		b.QualIdent(v.Qualifier, v.Name)
+		return
+	}
+	b.Ident(v.Name)
 }
 
 // exprBoundedTraceScope renders `<TraceId> IN (<top-N newest root traces>)` by

--- a/internal/chsql/builder_litfloat_test.go
+++ b/internal/chsql/builder_litfloat_test.go
@@ -92,6 +92,27 @@ func TestBuilder_LitFloat_WrapsInToFloat64(t *testing.T) {
 	}
 }
 
+func TestBuilder_LitFloat_PreservesNegativeZero(t *testing.T) {
+	plan := &chplan.Project{
+		Input: &chplan.OneRow{},
+		Projections: []chplan.Projection{{
+			Expr:  &chplan.LitFloat{V: math.Copysign(0, -1)},
+			Alias: "v",
+		}},
+	}
+
+	sql, args, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "-toFloat64(0) AS `v`") {
+		t.Fatalf("negative zero must retain its sign in SQL; got %s", sql)
+	}
+	if len(args) != 0 {
+		t.Fatalf("negative zero must not cross a lossy binder; args = %#v", args)
+	}
+}
+
 // TestBuilder_LitFloat_NonFiniteInline asserts the inline-division
 // path for ±Inf / NaN is NOT wrapped — those values render as
 // `(1.0/0)` / `(-1.0/0)` / `(0.0/0)` directly inside the SQL. They

--- a/internal/promql/scalar_arithmetic_chdb_test.go
+++ b/internal/promql/scalar_arithmetic_chdb_test.go
@@ -55,6 +55,7 @@ func TestScalarArithmeticShadowAndValuesParity_ChDB(t *testing.T) {
 		// nonzero operands are pinned separately by SQL/IR equivalence.
 		{"atan2", "0", false, true, func(v float64) float64 { return math.Atan2(v, 0) }},
 		{"atan2", "0", true, true, func(v float64) float64 { return math.Atan2(0, v) }},
+		{"atan2", "-0", true, true, func(v float64) float64 { return math.Atan2(math.Copysign(0, -1), v) }},
 		{"/", "3", true, false, func(v float64) float64 { return 3 / v }},
 		{"%", "0", false, false, func(float64) float64 { return math.NaN() }},
 		{"+", "NaN", false, false, func(float64) float64 { return math.NaN() }},


### PR DESCRIPTION
## Summary

- preserve scalar negative zero as typed ClickHouse syntax instead of sending it through a lossy positional binding
- pin the emitted SQL and the quadrant-sensitive mixed histogram/float `atan2` result
- verify both mixed-union orientations and nested/plain operand paths against the Prometheus parity oracle

## Focused verification

- `go test -timeout 2m -count=1 -run '^TestBuilder_LitFloat_PreservesNegativeZero$' ./internal/chsql/`
- `go test -timeout 2m -race -tags=chdb -count=1 -run '^TestScalarArithmeticShadowAndValuesParity_ChDB$/^atan2$/^-0$' ./internal/promql/`

Closes #3306
