### PR TITLE
fix(promql): match set unions on metric names

### DIFF
--- a/internal/chsql/nary_vector_set_op.go
+++ b/internal/chsql/nary_vector_set_op.go
@@ -70,7 +70,7 @@ func (e *emitter) emitNaryVectorSetOp(s *chplan.NaryVectorSetOp) error {
 		return err
 	}
 
-	sig := setOpMatchKeyFrags(s.Match, s.AttributesColumn, s.TimestampColumn, s.StepAligned)
+	sig := setOpMatchKeyFrags(s.Match, s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.StepAligned)
 	outCols := naryVectorSetOpOutputCols(s)
 
 	sideArms := make([]Frag, len(s.Arms))

--- a/internal/chsql/nary_vector_set_op_test.go
+++ b/internal/chsql/nary_vector_set_op_test.go
@@ -80,6 +80,18 @@ func TestEmitNaryVectorSetOp_OrThreeArms(t *testing.T) {
 	}
 }
 
+func TestEmitNaryVectorSetOp_OnMetricName(t *testing.T) {
+	op := naryOp(chplan.VectorSetOr, "a", "b", "c")
+	op.Match = chplan.VectorMatch{On: true, Labels: []string{"__name__"}}
+	sql, _, err := chsql.Emit(context.Background(), op)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "OVER (PARTITION BY `MetricName`)") {
+		t.Fatalf("n-ary set op does not match on MetricName; sql=%s", sql)
+	}
+}
+
 // TestEmitNaryVectorSetOp_AndThreeArms pins the `and` single-pass shape:
 // ONE UNION ALL, ONE groupBitOr window, and the present-in-every-arm
 // WHERE that keeps arm-0 rows whose mask is all-ones (`(1<<3)-1 = 7`).

--- a/internal/chsql/vector_join.go
+++ b/internal/chsql/vector_join.go
@@ -554,15 +554,36 @@ func matchCheckGuardFrag(attrsCol string) Frag {
 }
 
 // setOpMatchKeyFrags returns the key a vector set operator matches
-// on: the label signature alone in instant mode, extended with the
+// on: the set-op label signature alone in instant mode, extended with the
 // evaluation-timestamp column in range mode, where every arm
 // projects the shared grid anchor under that name.
-func setOpMatchKeyFrags(m chplan.VectorMatch, attrsCol, tsCol string, stepAligned bool) []Frag {
-	keys := []Frag{matchKeyGroupExprFrag(m, attrsCol)}
+func setOpMatchKeyFrags(m chplan.VectorMatch, metricNameCol, attrsCol, tsCol string, stepAligned bool) []Frag {
+	keys := []Frag{setOpMatchKeyFrag(m, metricNameCol, attrsCol)}
 	if stepAligned {
 		keys = append(keys, Col(tsCol))
 	}
 	return keys
+}
+
+func setOpMatchKeyFrag(m chplan.VectorMatch, metricNameCol, attrsCol string) Frag {
+	labels := make([]string, 0, len(m.Labels))
+	matchMetricName := false
+	for _, label := range m.Labels {
+		if label == setOpMetricNameLabel {
+			matchMetricName = m.On
+			continue
+		}
+		labels = append(labels, label)
+	}
+
+	attrsMatch := matchKeyGroupExprFrag(chplan.VectorMatch{Labels: labels, On: m.On}, attrsCol)
+	if !matchMetricName {
+		return attrsMatch
+	}
+	if m.On && len(labels) == 0 {
+		return Col(metricNameCol)
+	}
+	return Call("tuple", Col(metricNameCol), attrsMatch)
 }
 
 // canonicalMatchKeyFrag wraps a Map-valued match key in the canonical

--- a/internal/chsql/vector_set_op.go
+++ b/internal/chsql/vector_set_op.go
@@ -13,8 +13,9 @@ import (
 // `or` (drop those whose signature already has a LHS row). Neither name
 // takes user input; both match CH's bare-identifier grammar.
 const (
-	setOpSideCol    = "_setop_side"
-	setOpHasLeftCol = "_setop_has_left"
+	setOpSideCol         = "_setop_side"
+	setOpHasLeftCol      = "_setop_has_left"
+	setOpMetricNameLabel = "__name__"
 	// setOpHasRightCol is `_setop_has_left`'s mirror —
 	// `max(_setop_side = 1) OVER (PARTITION BY <sig>)` — projected only
 	// by a [chplan.VectorSetOp.MixedDropCollisions] union, whose survival
@@ -79,9 +80,9 @@ const (
 // rewrite (`toJSONString(Attributes)`) into the WHERE comparison,
 // producing a `String IN Set<Map>` type mismatch.
 //
-// The match key is a label signature — the full Attributes column
-// (default), or the projected mapFilter expression for `on(...)` /
-// `ignoring(...)` — extended with the evaluation timestamp in range
+// The match key is a label signature — the full Attributes column by
+// default, or the selected MetricName / mapFilter parts for
+// `on(...)` / `ignoring(...)` — extended with the evaluation timestamp in range
 // mode (StepAligned), where PromQL matches the arms once per evaluation
 // timestamp and every arm carries per-step rows under the shared grid
 // anchor. Instant mode keys on the signature alone: each arm holds one
@@ -238,7 +239,7 @@ func (e *emitter) emitVectorSetOp(s *chplan.VectorSetOp) error {
 				As(
 					Window(
 						Call("max", Eq(Col(setOpSideCol), InlineLit(0))),
-						setOpMatchKeyFrags(s.Match, s.AttributesColumn, s.TimestampColumn, s.StepAligned),
+						setOpMatchKeyFrags(s.Match, s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.StepAligned),
 						nil,
 					),
 					setOpHasLeftCol,
@@ -312,7 +313,7 @@ func (e *emitter) emitMixedVectorSetOp(s *chplan.VectorSetOp) error {
 
 	sideArmL := mixedVectorSetOpSideArmFrag(s, leftArm, 0)
 	sideArmR := mixedVectorSetOpSideArmFrag(s, rightArm, 1)
-	partition := setOpMatchKeyFrags(s.Match, s.AttributesColumn, s.TimestampColumn, s.StepAligned)
+	partition := setOpMatchKeyFrags(s.Match, s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.StepAligned)
 	sideFlag := func(side int, alias string) Frag {
 		return As(Window(Call("max", Eq(Col(setOpSideCol), InlineLit(side))), partition, nil), alias)
 	}
@@ -936,7 +937,7 @@ func validateVectorSetOpSampleKinds(s *chplan.VectorSetOp) error {
 // row-level DISTINCT over the whole SELECT list — exactly the
 // per-(signature, timestamp) key set the range shape needs.
 func setOpInSubqueryFrag(s *chplan.VectorSetOp, sub Frag, in bool) Frag {
-	keys := setOpMatchKeyFrags(s.Match, s.AttributesColumn, s.TimestampColumn, s.StepAligned)
+	keys := setOpMatchKeyFrags(s.Match, s.MetricNameColumn, s.AttributesColumn, s.TimestampColumn, s.StepAligned)
 	var sig Frag
 	if len(keys) == 1 {
 		sig = keys[0]

--- a/internal/chsql/vector_set_op_step_aligned_test.go
+++ b/internal/chsql/vector_set_op_step_aligned_test.go
@@ -97,3 +97,43 @@ func TestEmitVectorSetOp_StepAlignedMatchKey(t *testing.T) {
 		})
 	}
 }
+
+func TestEmitVectorSetOp_MetricNameMatchKey(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		match      chplan.VectorMatch
+		want       string
+		forbidName bool
+	}{
+		{name: "default", want: "PARTITION BY mapSort(`Attributes`)", forbidName: true},
+		{name: "on name", match: chplan.VectorMatch{On: true, Labels: []string{"__name__"}}, want: "PARTITION BY `MetricName`"},
+		{name: "on name and label", match: chplan.VectorMatch{On: true, Labels: []string{"__name__", "series"}}, want: "PARTITION BY tuple(`MetricName`, mapSort(mapFilter("},
+		{name: "on ordinary label", match: chplan.VectorMatch{On: true, Labels: []string{"series"}}, want: "PARTITION BY mapSort(mapFilter(", forbidName: true},
+		{name: "ignoring name", match: chplan.VectorMatch{Labels: []string{"__name__"}}, want: "PARTITION BY mapSort(`Attributes`)", forbidName: true},
+		{name: "ignoring ordinary label", match: chplan.VectorMatch{Labels: []string{"series"}}, want: "PARTITION BY mapSort(mapFilter(", forbidName: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := setOpPair(chplan.VectorSetOr, false)
+			op.Match = tc.match
+			sql := emitSetOp(t, op)
+			if !strings.Contains(sql, tc.want) {
+				t.Fatalf("missing match key %q; sql=%s", tc.want, sql)
+			}
+			if tc.forbidName && strings.Contains(sql, "PARTITION BY tuple(`MetricName`") {
+				t.Fatalf("metric name unexpectedly participates in matching; sql=%s", sql)
+			}
+		})
+	}
+}
+
+func TestEmitVectorSetOp_StepAlignedOnMetricName(t *testing.T) {
+	op := setOpPair(chplan.VectorSetOr, true)
+	op.Match = chplan.VectorMatch{On: true, Labels: []string{"__name__"}}
+	sql := emitSetOp(t, op)
+	want := "OVER (PARTITION BY `MetricName`, `TimeUnix`)"
+	if !strings.Contains(sql, want) {
+		t.Fatalf("missing metric-name plus timestamp key %q; sql=%s", want, sql)
+	}
+}

--- a/internal/promql/histogram_native_mixed_or_sort_by_label_chdb_test.go
+++ b/internal/promql/histogram_native_mixed_or_sort_by_label_chdb_test.go
@@ -166,3 +166,76 @@ func TestSortByLabelOverMixedSetOpOr_ShadowCollision_ChDB(t *testing.T) {
 		})
 	}
 }
+
+func TestSortByLabelOverMixedSetOpOr_MetricNameMatching_ChDB(t *testing.T) {
+	fixture := newChDBFixture(t, tkShadowSeed)
+	s := schema.DefaultOTelMetrics()
+	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+
+	type identity struct{ name, series string }
+	cases := []struct {
+		name  string
+		query string
+		want  map[identity]bool
+	}{
+		{
+			name:  "histogram lhs on name",
+			query: `sort_by_label(` + tkShadowHistMetric + ` or on(__name__) ` + tkShadowFloatMetric + `, "series")`,
+			want: map[identity]bool{
+				{tkShadowHistMetric, "dup"}:   true,
+				{tkShadowFloatMetric, "dup"}:  true,
+				{tkShadowFloatMetric, "solo"}: true,
+			},
+		},
+		{
+			name:  "float lhs on name",
+			query: `sort_by_label(` + tkShadowFloatMetric + ` or on(__name__) ` + tkShadowHistMetric + `, "series")`,
+			want: map[identity]bool{
+				{tkShadowHistMetric, "dup"}:   true,
+				{tkShadowFloatMetric, "dup"}:  true,
+				{tkShadowFloatMetric, "solo"}: true,
+			},
+		},
+		{
+			name:  "ordinary label control",
+			query: `sort_by_label(` + tkShadowHistMetric + ` or on(series) ` + tkShadowFloatMetric + `, "series")`,
+			want: map[identity]bool{
+				{tkShadowHistMetric, "dup"}:   true,
+				{tkShadowFloatMetric, "solo"}: true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr(%q): %v", tc.query, err)
+			}
+			plan, err := promql.LowerAt(context.Background(), expr, s, foEvalTS, foEvalTS)
+			if err != nil {
+				t.Fatalf("LowerAt(%q): %v", tc.query, err)
+			}
+			sqlText, args, err := chsql.Emit(context.Background(), plan)
+			if err != nil {
+				t.Fatalf("Emit(%q): %v", tc.query, err)
+			}
+			rows := fixture.queryOverEmitted(t, "`MetricName`, `Attributes`['series']", sqlText, args)
+			defer func() { _ = rows.Close() }()
+			got := map[identity]bool{}
+			for rows.Next() {
+				var id identity
+				if err := rows.Scan(&id.name, &id.series); err != nil {
+					t.Fatal(err)
+				}
+				got[id] = true
+			}
+			if err := testsql.TolerantRowsErr(rows.Err()); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("query %q: identities = %#v, want %#v", tc.query, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- include the physical metric-name column in PromQL set-operation match keys when semantics require `__name__`
- handle default, `on(__name__)`, combined `on(...)`, and `ignoring(__name__)` matching across binary, mixed, n-ary, and range set operations
- keep vector arithmetic/join matching unchanged and pin both mixed-union orientations plus ordinary-label shadowing controls

## Focused verification

- targeted chsql set-operation match-key tests
- targeted PromQL mixed histogram/float chDB union tests

Closes #3305
