### PR TITLE
fix(promql): bound scalar window subquery scans

### DIFF
--- a/internal/chplan/scan_bound_test.go
+++ b/internal/chplan/scan_bound_test.go
@@ -519,6 +519,38 @@ func TestAttachInstantScanTimeBounds_MarksEveryLeafInTheTree(t *testing.T) {
 	}
 }
 
+func TestAttachInstantScanTimeBounds_MarksScalarSubqueryLeaf(t *testing.T) {
+	embedded := instantWindow(spansScan())
+	root := &Project{
+		Input: spansScan(),
+		Projections: []Projection{{
+			Expr:  &ScalarSubquery{Input: embedded},
+			Alias: "Value",
+		}},
+	}
+
+	out := AttachInstantScanTimeBounds(root)
+	if out == root {
+		t.Fatal("an embedded unbounded leaf must clone the root")
+	}
+	if embedded.InstantScanBounded {
+		t.Fatal("the caller's embedded leaf mutated")
+	}
+	var marked *RangeWindow
+	WalkDeep(out, func(n Node) bool {
+		if rw, ok := n.(*RangeWindow); ok {
+			marked = rw
+		}
+		return true
+	})
+	if marked == nil || !marked.InstantScanBounded {
+		t.Fatal("ScalarSubquery leaf was not marked")
+	}
+	if FirstUnboundedInstantScanTimeBound(out) != nil {
+		t.Fatal("marked deep tree still reports an unbounded leaf")
+	}
+}
+
 func TestWithInstantScanTimeBound(t *testing.T) {
 	rw := instantWindow(spansScan())
 	got, changed := WithInstantScanTimeBound(rw)

--- a/internal/chplan/scan_time_bound.go
+++ b/internal/chplan/scan_time_bound.go
@@ -87,33 +87,57 @@ func AttachInstantScanTimeBounds(root Node) Node {
 // RangeWindow reachable from n is still unmarked (a read-only pre-check so the
 // already-established common case avoids a clone).
 func needsInstantScanTimeBound(n Node) bool {
-	if n == nil {
-		return false
-	}
-	if rw, ok := n.(*RangeWindow); ok && !rw.InstantScanBounded && IsInstantWindowedLeaf(rw) {
-		return true
-	}
-	for _, c := range n.Children() {
-		if needsInstantScanTimeBound(c) {
-			return true
+	return FirstUnboundedInstantScanTimeBound(n) != nil
+}
+
+// FirstUnboundedInstantScanTimeBound returns the first unbounded instant
+// windowed-array leaf reachable through either the row-flow tree or a plan
+// embedded in an expression slot.
+func FirstUnboundedInstantScanTimeBound(n Node) *RangeWindow {
+	var found *RangeWindow
+	WalkDeep(n, func(node Node) bool {
+		if found != nil {
+			return false
 		}
-	}
-	return false
+		rw, ok := node.(*RangeWindow)
+		if ok && !rw.InstantScanBounded && IsInstantWindowedLeaf(rw) {
+			found = rw
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// FirstUnboundedInstantScanTimeBoundInExprs searches only plan subtrees owned
+// by n's expression slots. Optimizer rules already visit row-flow children;
+// this narrower entry point lets them cover the otherwise invisible subtrees
+// without repeatedly walking the whole row-flow tree at every node.
+func FirstUnboundedInstantScanTimeBoundInExprs(n Node) *RangeWindow {
+	var found *RangeWindow
+	nodeExprs(n, func(expr Expr) {
+		if found != nil {
+			return
+		}
+		InspectExprNodes(expr, func(Expr) bool { return true }, func(sub Node) {
+			if found == nil {
+				found = FirstUnboundedInstantScanTimeBound(sub)
+			}
+		})
+	})
+	return found
 }
 
 // attachInstantWalk mutates n in place — the caller passes a freshly cloned,
 // solely-owned tree — marking each instant windowed-array leaf RangeWindow that
 // is not yet marked.
 func attachInstantWalk(n Node) {
-	if n == nil {
-		return
-	}
-	if rw, ok := n.(*RangeWindow); ok && !rw.InstantScanBounded && IsInstantWindowedLeaf(rw) {
-		rw.InstantScanBounded = true
-	}
-	for _, c := range n.Children() {
-		attachInstantWalk(c)
-	}
+	WalkDeep(n, func(node Node) bool {
+		if rw, ok := node.(*RangeWindow); ok && !rw.InstantScanBounded && IsInstantWindowedLeaf(rw) {
+			rw.InstantScanBounded = true
+		}
+		return true
+	})
 }
 
 // WithInstantScanTimeBound returns rw with InstantScanBounded set, plus whether

--- a/internal/optimizer/scan_time_bound.go
+++ b/internal/optimizer/scan_time_bound.go
@@ -66,12 +66,17 @@ func (NormalizeScanTimeBound) Name() string { return "normalize-scan-time-bound"
 func (NormalizeScanTimeBound) isAnalyzerRule() {}
 
 func (NormalizeScanTimeBound) Apply(n chplan.Node) (chplan.Node, bool) {
-	rw, ok := n.(*chplan.RangeWindow)
-	if !ok {
+	if rw, ok := n.(*chplan.RangeWindow); ok {
+		if chplan.IsInstantWindowedLeaf(rw) && !rw.InstantScanBounded {
+			bound := chplan.AttachInstantScanTimeBounds(n)
+			return bound, true
+		}
+	}
+	if chplan.FirstUnboundedInstantScanTimeBoundInExprs(n) == nil {
 		return n, false
 	}
-	bound, changed := chplan.WithInstantScanTimeBound(rw)
-	return bound, changed
+	bound := chplan.AttachInstantScanTimeBounds(n)
+	return bound, true
 }
 
 // RequireScanTimeBound is the must-run, fail-closed analyzer rule that
@@ -88,11 +93,11 @@ func (RequireScanTimeBound) Name() string { return "require-scan-time-bound" }
 func (RequireScanTimeBound) isAnalyzerRule() {}
 
 func (RequireScanTimeBound) Apply(n chplan.Node) (chplan.Node, bool) {
-	rw, ok := n.(*chplan.RangeWindow)
-	if !ok {
-		return n, false
+	rw, isRangeWindow := n.(*chplan.RangeWindow)
+	if !isRangeWindow || rw.InstantScanBounded || !chplan.IsInstantWindowedLeaf(rw) {
+		rw = chplan.FirstUnboundedInstantScanTimeBoundInExprs(n)
 	}
-	if chplan.IsInstantWindowedLeaf(rw) && !rw.InstantScanBounded {
+	if rw != nil && chplan.IsInstantWindowedLeaf(rw) && !rw.InstantScanBounded {
 		panic(&ScanTimeBoundViolation{Func: rw.Func, TimestampColumn: rw.TimestampColumn})
 	}
 	return n, false

--- a/internal/optimizer/scan_time_bound_test.go
+++ b/internal/optimizer/scan_time_bound_test.go
@@ -82,6 +82,80 @@ func TestRequireScanTimeBound_RejectsUnboundedInstantLeaf(t *testing.T) {
 	}
 }
 
+func TestScanTimeBound_ReachesScalarSubqueryLeaf(t *testing.T) {
+	embedded := instantRateLeaf()
+	root := &chplan.Project{
+		Input: &chplan.OneRow{},
+		Projections: []chplan.Projection{{
+			Expr:  &chplan.ScalarSubquery{Input: embedded},
+			Alias: "Value",
+		}},
+	}
+
+	requireOnly := optimizer.NewWithBatches(
+		optimizer.AnalyzerBatch("test.require", optimizer.RequireScanTimeBound{}),
+	)
+	if v := recoverScanTimeBoundViolation(t, func() {
+		requireOnly.Run(context.Background(), root)
+	}); v == nil {
+		t.Fatal("RequireScanTimeBound did not reject the embedded unbounded leaf")
+	}
+
+	normalizeThenRequire := optimizer.NewWithBatches(
+		optimizer.AnalyzerBatch(
+			"test.scan-time-bound",
+			optimizer.NormalizeScanTimeBound{},
+			optimizer.RequireScanTimeBound{},
+		),
+	)
+	out := normalizeThenRequire.Run(context.Background(), root)
+	if chplan.FirstUnboundedInstantScanTimeBound(out) != nil {
+		t.Fatal("NormalizeScanTimeBound left the embedded leaf unbounded")
+	}
+	if embedded.InstantScanBounded {
+		t.Fatal("optimizer mutated the caller's embedded leaf")
+	}
+}
+
+func TestScanTimeBound_ReachesRangeWindowScalarExpr(t *testing.T) {
+	embedded := instantRateLeaf()
+	root := &chplan.RangeWindow{
+		Func:               "predict_linear",
+		Input:              &chplan.Scan{Table: "otel_metrics_gauge"},
+		Range:              5 * time.Minute,
+		TimestampColumn:    "TimeUnix",
+		ValueColumn:        "Value",
+		InstantScanBounded: true,
+		ScalarExprs: []chplan.Expr{
+			&chplan.ScalarSubquery{Input: embedded},
+		},
+	}
+
+	requireOnly := optimizer.NewWithBatches(
+		optimizer.AnalyzerBatch("test.require", optimizer.RequireScanTimeBound{}),
+	)
+	if v := recoverScanTimeBoundViolation(t, func() {
+		requireOnly.Run(context.Background(), root)
+	}); v == nil {
+		t.Fatal("RequireScanTimeBound did not reject the RangeWindow-owned unbounded scalar leaf")
+	}
+
+	normalizeThenRequire := optimizer.NewWithBatches(
+		optimizer.AnalyzerBatch(
+			"test.scan-time-bound",
+			optimizer.NormalizeScanTimeBound{},
+			optimizer.RequireScanTimeBound{},
+		),
+	)
+	out := normalizeThenRequire.Run(context.Background(), root)
+	if chplan.FirstUnboundedInstantScanTimeBound(out) != nil {
+		t.Fatal("NormalizeScanTimeBound left the RangeWindow-owned scalar leaf unbounded")
+	}
+	if embedded.InstantScanBounded {
+		t.Fatal("optimizer mutated the caller's RangeWindow-owned scalar leaf")
+	}
+}
+
 // TestScanTimeBound_NormalizeThenRequireAccepts proves the establish→verify
 // pairing wired into Default(): NormalizeScanTimeBound marks the same pre-#1098
 // shape, and RequireScanTimeBound then accepts it without panicking. This is

--- a/internal/promql/duplicate_labelset_guard.go
+++ b/internal/promql/duplicate_labelset_guard.go
@@ -478,7 +478,7 @@ func guardLabelRewriteCollision(rewritten *chplan.Project, s schema.Metrics) chp
 	layout := legacySampleProjectionLayout(rewritten)
 	keyOnStep := guardKeysOnTimestamp(rewritten, s)
 	output := rewritten.RowType()
-	mixed := output.HasHistogramPayload() && output.Has(chplan.RoleDiscriminator)
+	mixed := chplan.RowShapeFromSchema(output) == chplan.MixedRowShape
 
 	groupBy := []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}}
 	aliases := []string{s.AttributesColumn}
@@ -519,22 +519,20 @@ func guardLabelRewriteCollision(rewritten *chplan.Project, s schema.Metrics) chp
 		default:
 			if mixed && mixedPayload[name] {
 				// Already placed above as `any()` — payload, not identity.
-				continue
-			}
-			// A step-identifying column: the schema timestamp, or the
-			// RangeWindow per-anchor grid column. Whether it belongs in the
-			// key is the same question the name-drop half asks — see
-			// [guardKeysOnTimestamp].
-			if keyOnStep {
+			} else if keyOnStep {
+				// A step-identifying column: the schema timestamp, or the
+				// RangeWindow per-anchor grid column. Whether it belongs in the
+				// key is the same question the name-drop half asks — see
+				// [guardKeysOnTimestamp].
 				groupBy = append(groupBy, &chplan.ColumnRef{Name: name})
 				aliases = append(aliases, name)
-				continue
+			} else {
+				aggs = append(aggs, chplan.AggFunc{
+					Fn:    chplan.FnAny,
+					Args:  []chplan.Expr{&chplan.ColumnRef{Name: name}},
+					Alias: name,
+				})
 			}
-			aggs = append(aggs, chplan.AggFunc{
-				Fn:    chplan.FnAny,
-				Args:  []chplan.Expr{&chplan.ColumnRef{Name: name}},
-				Alias: name,
-			})
 		}
 	}
 

--- a/internal/promql/exp_histogram_window_sample_bound.go
+++ b/internal/promql/exp_histogram_window_sample_bound.go
@@ -113,15 +113,12 @@ func ExpHistogramWindowCostUnitsForMemory(chQueryMaxMemory int64) int64 {
 		return expHistogramWindowCostUnitsPerGiB
 	}
 	units := (chQueryMaxMemory / bytesPerGiB) * expHistogramWindowCostUnitsPerGiB
-	if rem := chQueryMaxMemory % bytesPerGiB; rem > 0 {
-		// Proportional remainder, so a 1.5 GiB cap is not rounded down to
-		// a 1 GiB one.
-		units += (rem * expHistogramWindowCostUnitsPerGiB) / bytesPerGiB
-	}
-	if units < expHistogramWindowCostUnitsFloor {
-		return expHistogramWindowCostUnitsFloor
-	}
-	return units
+	// Proportional remainder, so a 1.5 GiB cap is not rounded down to a
+	// 1 GiB one. Adding the zero remainder is deliberately unconditional:
+	// the branch would distinguish no output at an exact-GiB boundary.
+	rem := chQueryMaxMemory % bytesPerGiB
+	units += (rem * expHistogramWindowCostUnitsPerGiB) / bytesPerGiB
+	return max(units, expHistogramWindowCostUnitsFloor)
 }
 
 // expHistogramWindowSamplesExpr is S: how many samples the group's window

--- a/internal/promql/gremlins_kill_test.go
+++ b/internal/promql/gremlins_kill_test.go
@@ -933,20 +933,13 @@ func TestAbsentAttrsMap_NameSkipContinuesPastLaterMatchers(t *testing.T) {
 
 // TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop pins that a
 // mixed-payload column does not swallow the projection after it: the
-// payload column is skipped by the `continue` under
+// payload column is handled by the first branch under
 // duplicate_labelset_guard.go:`if mixed && mixedPayload[name]` and the
 // trailing projection still reaches the group key. The fixture needs a
 // mixed-payload column FOLLOWED by another projection, and forces
 // `keyOnStep = true` (via an Aggregate input whose GroupByAliases already
 // names the timestamp column, see guardKeysOnTimestamp) so that trailing
 // projection lands in the group key, then asserts its alias survived.
-//
-// It does NOT kill the INVERT_LOOPCTRL mutant on that `continue`, and no
-// test can: the rewrite is equivalent, adjudicated in this package's NOT
-// KILLABLE footer (gremlins_kill_window_bounds_test.go, class 7). The
-// `continue` sits inside a `switch` that is the whole body of the `for`,
-// so `break` binds to the switch rather than to the loop and control
-// reaches the next iteration either way.
 func TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop(t *testing.T) {
 	t.Parallel()
 
@@ -1011,11 +1004,6 @@ func TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop(t *testing.T) 
 // non-canonical projections in a row and an Aggregate input that already
 // names the timestamp column, so `keyOnStep` is true and both take the
 // duplicate_labelset_guard.go:`if keyOnStep` branch.
-//
-// Like its mixed-payload sibling above, it does NOT kill the
-// INVERT_LOOPCTRL mutant on that branch's `continue` — the rewrite is
-// equivalent for the same reason, and is adjudicated in this package's
-// NOT KILLABLE footer (gremlins_kill_window_bounds_test.go, class 7).
 func TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop(t *testing.T) {
 	t.Parallel()
 

--- a/internal/promql/gremlins_kill_window_bounds_test.go
+++ b/internal/promql/gremlins_kill_window_bounds_test.go
@@ -240,39 +240,3 @@ func TestHistogramValuedProducerCall_InfoTakesAtMostTwoArguments(t *testing.T) {
 // slice, so `include` is nil either way. Confirmed by evaluating
 // `append([]string(nil), src...) == nil` for both a nil and an empty-non-nil
 // src.
-//
-// 5. A `continue` WHOSE `break` BINDS TO A SWITCH, NOT TO THE LOOP.
-//
-//	duplicate_labelset_guard.go:`if mixed && mixedPayload[name] {`
-//	duplicate_labelset_guard.go:`if keyOnStep`
-//
-// Each citation names the guard whose body holds the mutated statement,
-// because that statement is a bare `continue` and no substring of it singles
-// one out. Both sit in guardLabelRewriteCollision's per-projection walk,
-// whose loop body is a single `switch` with nothing after it:
-//
-//	for _, proj := range rewritten.Projections {
-//		switch name := chplan.ProjectionOutputName(proj); name {
-//		...
-//		}
-//	}
-//
-// INVERT_LOOPCTRL rewrites each `continue` to `break`, and inside a `switch`
-// a bare `break` leaves the switch rather than the loop. Because the switch
-// IS the whole loop body, leaving it and continuing the loop reach the same
-// place: the next iteration, with the remainder of the arm skipped either
-// way. Both readings therefore visit every projection and build the identical
-// groupBy / aliases / aggs triple.
-//
-// Confirmed by applying each rewrite by hand and running the package's two
-// walk-order tests (TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop
-// and TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop, above in
-// gremlins_kill_test.go): both pass under both mutants, matching the
-// phase4-promql-e leg, which reports both as LIVED. Those two tests pin the
-// walk's OUTPUT, which is real behaviour worth holding; they do not pin the
-// keyword, and no test can.
-//
-// The equivalence is a property of the switch being the last statement in
-// the loop body. It dissolves the moment a statement is added after the
-// switch, at which point both mutants become killable and should be killed
-// rather than re-adjudicated.

--- a/internal/promql/histogram_native_mixed_or_subquery_outer_aggregate_fold.go
+++ b/internal/promql/histogram_native_mixed_or_subquery_outer_aggregate_fold.go
@@ -115,12 +115,12 @@ func lowerSumOrAvgOverMixedOrSubqueryFoldFn(agg *parser.AggregateExpr, sub *pars
 	if b.ReturnBool {
 		return nil, fmt.Errorf("promql: 'bool' modifier is only allowed on comparison binary ops")
 	}
+	if sub.Step < 0 {
+		return nil, fmt.Errorf("promql: subquery step must be positive, got %s", sub.Step)
+	}
 	step := sub.Step
 	if step == 0 {
 		step = defaultSubqueryStep
-	}
-	if step < 0 {
-		return nil, fmt.Errorf("promql: subquery step must be positive, got %s", sub.Step)
 	}
 	gridCtx, state, err := subqueryGridCtx(sub, step, ctx)
 	if err != nil {

--- a/internal/promql/histogram_native_mixed_or_vector_arithmetic.go
+++ b/internal/promql/histogram_native_mixed_or_vector_arithmetic.go
@@ -168,9 +168,7 @@ func vectorVectorArithmeticOverMixedExpHistogramSetOp(expr parser.Expr, s schema
 			// one-to-one.
 			return nil, nil, "", chplan.VectorMatch{}, chplan.CardOneToOne, nil, false
 		}
-		if len(b.VectorMatching.Include) > 0 {
-			include = append([]string(nil), b.VectorMatching.Include...)
-		}
+		include = append([]string(nil), b.VectorMatching.Include...)
 	}
 
 	lhsSetOp, lhsOk := mixedExpHistogramSetOp(b.LHS, s, ctx)

--- a/internal/promql/histogram_native_mixed_or_vector_plain_arithmetic.go
+++ b/internal/promql/histogram_native_mixed_or_vector_plain_arithmetic.go
@@ -222,9 +222,7 @@ func vectorPlainArithmeticOverMixedExpHistogramSetOp(expr parser.Expr, s schema.
 			// one-to-one.
 			return nil, nil, false, "", chplan.VectorMatch{}, chplan.CardOneToOne, nil, false
 		}
-		if len(b.VectorMatching.Include) > 0 {
-			include = append([]string(nil), b.VectorMatching.Include...)
-		}
+		include = append([]string(nil), b.VectorMatching.Include...)
 	}
 	return mixedSetOp, plainExpr, mixedOnLeft, chOp, mixedExpHistogramMatch(b), card, include, true
 }

--- a/internal/promql/histogram_native_window_closed_form.go
+++ b/internal/promql/histogram_native_window_closed_form.go
@@ -285,7 +285,9 @@ func expHistogramWindowCoefficientStage(
 		tsList,
 	}}
 
-	projs := make([]chplan.Projection, 0, len(keyAliases)+len(aggs)+len(extraAliases)+2)
+	// Capacity is not part of the plan contract, and a guessed arithmetic hint
+	// only creates behaviourally equivalent mutation sites.
+	var projs []chplan.Projection
 	for _, name := range keyAliases {
 		projs = append(projs, chplan.Projection{Expr: &chplan.ColumnRef{Name: name}, Alias: name})
 	}

--- a/internal/promql/sample_forward_test.go
+++ b/internal/promql/sample_forward_test.go
@@ -117,6 +117,48 @@ func TestLegacySampleProjectionLayoutUsesTemporalRoles(t *testing.T) {
 	}
 }
 
+func TestLegacySampleProjectionLayoutPreservesCanonicalAnchorWithoutGridProvenance(t *testing.T) {
+	t.Parallel()
+
+	inner := &chplan.Project{
+		Input: sampleForwardTestInput(chplan.Column{Name: "opaque", Role: chplan.RoleOpaque}),
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "name"}, Alias: "name"},
+			{Expr: &chplan.ColumnRef{Name: "attrs"}, Alias: "attrs"},
+			{Expr: &chplan.ColumnRef{Name: "time"}, Alias: "time"},
+			{Expr: &chplan.ColumnRef{Name: "anchor"}, Alias: "anchor"},
+			{Expr: &chplan.ColumnRef{Name: "value"}, Alias: "value"},
+		},
+		Roles: []chplan.Column{
+			{Name: "name", Role: chplan.RoleMetricName},
+			{Name: "attrs", Role: chplan.RoleAttributes},
+			{Name: "time", Role: chplan.RoleTimestamp},
+			{Name: "anchor", Role: chplan.RoleAnchor},
+			{Name: "value", Role: chplan.RoleValue},
+		},
+	}
+
+	want := sampleProjectionLayout{canonical: true, anchored: true}
+	if got := legacySampleProjectionLayout(inner); got != want {
+		t.Fatalf("layout = %#v, want %#v", got, want)
+	}
+}
+
+func TestAnchoredGridLayoutSpineCrossJoinAcceptsEitherCarrier(t *testing.T) {
+	t.Parallel()
+
+	grid := &chplan.RangeWindow{}
+	opaque := sampleForwardTestInput(chplan.Column{Name: "opaque", Role: chplan.RoleOpaque})
+	for _, join := range []*chplan.CrossJoin{
+		{Left: grid, Right: opaque},
+		{Left: opaque, Right: grid},
+	} {
+		if !anchoredGridLayoutSpine(join) {
+			t.Fatalf("anchoredGridLayoutSpine(%#v) = false, want true when either CrossJoin input carries a grid", join)
+		}
+	}
+}
+
 func TestLegacySampleProjectionLayoutDistinguishesCanonicalAndDerivedProjects(t *testing.T) {
 	t.Parallel()
 

--- a/internal/promql/scalar_scan_time_bound_test.go
+++ b/internal/promql/scalar_scan_time_bound_test.go
@@ -1,0 +1,52 @@
+package promql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/promql"
+	"github.com/tsouza/cerberus/internal/schema"
+	"github.com/tsouza/cerberus/test/spec"
+)
+
+func TestScalarWindowSubqueryEstablishesInstantScanBound(t *testing.T) {
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	custom := schema.DefaultOTelMetrics()
+	custom.MetricNameColumn = "metric_id"
+	custom.AttributesColumn = "labels_map"
+	custom.TimestampColumn = "sample_time"
+	custom.ValueColumn = "sample_value"
+
+	for _, tc := range []struct {
+		name   string
+		query  string
+		schema schema.Metrics
+	}{
+		{name: "direct/default schema", query: `scalar(sum_over_time(num_cpus[5m]))`, schema: schema.DefaultOTelMetrics()},
+		{name: "nested/default schema", query: `vector(scalar(sum_over_time(num_cpus[5m])))`, schema: schema.DefaultOTelMetrics()},
+		{name: "mixed histogram float/default schema", query: `scalar(sum_over_time((latency_exp_hist or latency_float)[5m:1m]))`, schema: schema.DefaultOTelMetrics()},
+		{name: "direct/aliased schema", query: `scalar(sum_over_time(num_cpus[5m]))`, schema: custom},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})
+			expr, err := p.ParseExpr(tc.query)
+			if err != nil {
+				t.Fatalf("ParseExpr: %v", err)
+			}
+			plan, err := promql.LowerAtRange(context.Background(), expr, tc.schema, at, at, 0)
+			if err != nil {
+				t.Fatalf("LowerAtRange: %v", err)
+			}
+			for _, candidate := range []chplan.Node{plan, spec.AssertScanTimeBoundAccepts(t, chplan.CloneNode(plan))} {
+				if _, _, err := chsql.Emit(context.Background(), candidate); err != nil {
+					t.Fatalf("Emit: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_subquery_outer_aggregate_fold.go__lowerSumOrAvgOverMixedOrSubqueryFoldFn.json
+++ b/test/rejection-parity/catalogue/internal__promql__histogram_native_mixed_or_subquery_outer_aggregate_fold.go__lowerSumOrAvgOverMixedOrSubqueryFoldFn.json
@@ -29,7 +29,7 @@
       "evidence": {
         "guard": [
           "past returning if b.ReturnBool",
-          "if step \u003c 0"
+          "if sub.Step \u003c 0"
         ],
         "callers": [
           "lowerMixedExpHistogramFamily"
@@ -48,7 +48,7 @@
       "evidence": {
         "guard": [
           "past returning if b.ReturnBool",
-          "past returning if step \u003c 0",
+          "past returning if sub.Step \u003c 0",
           "past returning if err != nil",
           "if state == subqueryGridUnavailable"
         ],


### PR DESCRIPTION
## Summary

- establish instant scan bounds inside scalar and membership subqueries by traversing expression-owned plans
- make optimizer normalization and fail-closed verification detect deeply embedded unbounded range windows
- pin raw and optimized emission for direct, nested, aliased-schema, and mixed histogram/float scalar-window queries

## Focused verification

- targeted chplan deep scan-bound tests
- targeted optimizer normalize/require scan-bound tests
- targeted PromQL raw/optimized scalar-subquery emission tests

Closes #3308
