### PR TITLE
fix(migration): retry collector startup failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
     # cerberus dependency below is sufficient; the OTel demo's compose
     # stack uses the same pattern.
     image: otel/opentelemetry-collector-contrib:0.152.1
+    restart: "on-failure:5"
     networks: [cerberus-dev]
     command: ["--config=/etc/otel/config.yaml"]
     # The hostmetricsreceiver inside compose-config.yaml reads /proc + /sys
@@ -507,4 +508,3 @@ services:
       interval: 5s
       timeout: 2s
       retries: 12
-

--- a/test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
+++ b/test/e2e/migration/tiers/tier1-dual/docker-compose.dual.yml
@@ -92,6 +92,7 @@ services:
     # data-side instead — the tier-1 contract test waits for the exporter's
     # tables to appear in ClickHouse.
     image: otel/opentelemetry-collector-contrib:0.152.1
+    restart: "on-failure:5"
     command: ["--config=/etc/otel/config.yaml"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel/config.yaml:ro

--- a/test/regression/migration_tier1_test.go
+++ b/test/regression/migration_tier1_test.go
@@ -40,6 +40,7 @@ const (
 	tier1SeedPkgDir      = "../../test/e2e/migration/seed"
 	tier1ComposeProject  = "cerberus-migration-tier1"
 	tier1CerberusService = "cerberus"
+	rootComposePath      = "../../docker-compose.yml"
 )
 
 // The gateway under test is configured from a file, not from the compose
@@ -240,6 +241,7 @@ type composeService struct {
 	Environment map[string]string `yaml:"environment"`
 	Volumes     []string          `yaml:"volumes"`
 	Ports       []string          `yaml:"ports"`
+	Restart     string            `yaml:"restart"`
 }
 
 type composeFile struct {
@@ -432,6 +434,35 @@ func TestMigrationTier1SchemaAuthority(t *testing.T) {
 	}
 	if scanned == 0 {
 		t.Fatalf("%s holds no Go files; the seeder's write clients are gone", tier1SeedPkgDir)
+	}
+}
+
+func TestSchemaAuthorityCollectorsHaveBoundedStartupRetry(t *testing.T) {
+	t.Parallel()
+	const (
+		collectorService = "otel-collector"
+		boundedRestart   = "on-failure:5"
+		writebackService = "otel-collector-writeback"
+	)
+
+	for _, path := range []string{rootComposePath, tier1ComposePath} {
+		cf := readCompose(t, path)
+		collector, ok := cf.Services[collectorService]
+		if !ok {
+			t.Fatalf("%s has no %q service", path, collectorService)
+		}
+		if collector.Restart != boundedRestart {
+			t.Errorf("%s %s restart = %q, want capped %q", path, collectorService, collector.Restart, boundedRestart)
+		}
+	}
+
+	tier2 := readCompose(t, tier2ComposePath)
+	writeback, ok := tier2.Services[writebackService]
+	if !ok {
+		t.Fatalf("%s has no %q service", tier2ComposePath, writebackService)
+	}
+	if writeback.Restart != "" {
+		t.Errorf("%s %s restart = %q, want empty: it starts only after healthy Cerberus", tier2ComposePath, writebackService, writeback.Restart)
 	}
 }
 


### PR DESCRIPTION
## Summary

- give the root and Tier-1 schema-authority collectors a capped `on-failure:5` restart policy
- bridge the brief ClickHouse Unix-socket-health/TCP-listener startup interval while leaving persistent failures terminal
- keep the Tier-2 writeback collector unchanged and pin all three policies through parsed Compose regression coverage

## Focused verification

- targeted `TestSchemaAuthorityCollectorsHaveBoundedStartupRetry` regression

Closes #3357
