### PR TITLE
refactor(chplan): resolve second-stage value role

### DIFF
--- a/internal/chplan/clone_test.go
+++ b/internal/chplan/clone_test.go
@@ -132,7 +132,7 @@ func allNodeKinds() []chplan.Node {
 		&chplan.MetricsAggregate{Attr: expr, GroupBy: []chplan.Expr{expr}, GroupByAliases: []string{"g0"}, GroupByDisplayNames: []string{"g"}, Quantiles: []float64{0.5}, Inner: leaf},
 		&chplan.MetricsCompare{Selection: expr, Pairs: expr, RootLookup: leaf, Inner: leaf, TraceIDColumn: "TraceId"},
 		&chplan.MetricsHistogramOverTime{Attr: expr, GroupBy: []chplan.Expr{expr}, GroupByAliases: []string{"g0"}, GroupByDisplayNames: []string{"g"}, Inner: leaf},
-		&chplan.MetricsSecondStage{Input: leaf, K: 5, PartitionBy: []string{"p"}, ValueAlias: "v"},
+		&chplan.MetricsSecondStage{Input: leaf, K: 5, PartitionBy: []string{"p"}},
 		&chplan.NestedSetAnnotate{Input: leaf, SpansTable: "spans", TraceIDColumn: "TraceId"},
 		&chplan.InfoJoin{
 			Input: leaf, Info: &chplan.Scan{Table: "info"},

--- a/internal/chplan/metrics_second_stage.go
+++ b/internal/chplan/metrics_second_stage.go
@@ -86,10 +86,9 @@ func (o SecondStageOp) String() string {
 //     timestamp bucket — matching Tempo's per-anchor top-K semantics.
 //     Empty for instant queries (the limit applies globally to the
 //     single row-per-series shape).
-//   - ValueAlias: the column name carrying the per-anchor value (the
-//     `ValueAlias` slot of the inner MetricsAggregate; "Value" in every
-//     current code path but kept configurable so the IR doesn't pin a
-//     magic string).
+//
+// The consumed value column is the unique RoleValue published by
+// Input.RowType; it is not a separate driver field.
 type MetricsSecondStage struct {
 	Input          Node
 	Op             SecondStageOp
@@ -97,7 +96,6 @@ type MetricsSecondStage struct {
 	ThresholdOp    BinaryOp
 	ThresholdValue float64
 	PartitionBy    []string
-	ValueAlias     string
 }
 
 func (*MetricsSecondStage) planNode() {}
@@ -109,7 +107,7 @@ func (m *MetricsSecondStage) Equal(other Node) bool {
 	if !ok {
 		return false
 	}
-	if m.Op != o.Op || m.K != o.K || m.ValueAlias != o.ValueAlias {
+	if m.Op != o.Op || m.K != o.K {
 		return false
 	}
 	if m.ThresholdOp != o.ThresholdOp || m.ThresholdValue != o.ThresholdValue {

--- a/internal/chplan/metrics_second_stage.go
+++ b/internal/chplan/metrics_second_stage.go
@@ -50,7 +50,7 @@ func (o SecondStageOp) String() string {
 // or a `RangeWindow` wrapping a MetricsAggregate (matrix path); the
 // emitter wraps the inner SQL with the variant-specific clause:
 //
-//   - SecondStageTopK / SecondStageBottomK: `ORDER BY <ValueAlias>
+//   - SecondStageTopK / SecondStageBottomK: `ORDER BY <RoleValue>
 //     <DESC|ASC> LIMIT K [BY <PartitionBy>...]`. The PartitionBy slot
 //     is the anchor column for matrix queries (`anchor_ts`); empty for
 //     instant queries. ClickHouse's `LIMIT N BY <col>` keeps N rows
@@ -58,7 +58,7 @@ func (o SecondStageOp) String() string {
 //     per anchor, matching Tempo's `processTopK` per-anchor selection
 //     (see engine_metrics.go: processTopK loops timestamps and picks
 //     the top-K series at each).
-//   - SecondStageThreshold: `WHERE <ValueAlias> <ThresholdOp>
+//   - SecondStageThreshold: `WHERE <RoleValue> <ThresholdOp>
 //     <ThresholdValue>`. Filters individual data points whose Value
 //     does not satisfy the comparison; same SQL shape works for both
 //     instant and matrix inputs because the predicate is per-row.

--- a/internal/chplan/metrics_second_stage_test.go
+++ b/internal/chplan/metrics_second_stage_test.go
@@ -21,7 +21,6 @@ func TestMetricsSecondStageEqual(t *testing.T) {
 		Op:          chplan.SecondStageTopK,
 		K:           5,
 		PartitionBy: []string{"anchor_ts"},
-		ValueAlias:  "Value",
 	}
 	same := &chplan.MetricsSecondStage{
 		Input: &chplan.MetricsAggregate{
@@ -32,7 +31,6 @@ func TestMetricsSecondStageEqual(t *testing.T) {
 		Op:          chplan.SecondStageTopK,
 		K:           5,
 		PartitionBy: []string{"anchor_ts"},
-		ValueAlias:  "Value",
 	}
 	if !base.Equal(same) {
 		t.Fatalf("identical MetricsSecondStage trees should be Equal")
@@ -50,13 +48,6 @@ func TestMetricsSecondStageEqual(t *testing.T) {
 	diffK.K = 10
 	if base.Equal(&diffK) {
 		t.Errorf("different K should not be Equal")
-	}
-
-	// Different ValueAlias.
-	diffAlias := *same
-	diffAlias.ValueAlias = "other"
-	if base.Equal(&diffAlias) {
-		t.Errorf("different ValueAlias should not be Equal")
 	}
 
 	// Different PartitionBy length.
@@ -94,7 +85,6 @@ func TestMetricsSecondStageEqual(t *testing.T) {
 		Op:             chplan.SecondStageThreshold,
 		ThresholdOp:    chplan.OpGt,
 		ThresholdValue: 10,
-		ValueAlias:     "Value",
 	}
 	thresholdSame := *threshold
 	if !threshold.Equal(&thresholdSame) {
@@ -128,10 +118,9 @@ func TestMetricsSecondStageChildren(t *testing.T) {
 		Inner:      &chplan.Scan{Table: "otel_traces"},
 	}
 	ms := &chplan.MetricsSecondStage{
-		Input:      inner,
-		Op:         chplan.SecondStageTopK,
-		K:          5,
-		ValueAlias: "Value",
+		Input: inner,
+		Op:    chplan.SecondStageTopK,
+		K:     5,
 	}
 	kids := ms.Children()
 	if len(kids) != 1 {

--- a/internal/chplan/walk_invariants_test.go
+++ b/internal/chplan/walk_invariants_test.go
@@ -216,9 +216,8 @@ func TestMetricsSecondStage_Walk_VisitsInput(t *testing.T) {
 			Op:    chplan.MetricsOpRate,
 			Inner: &chplan.Scan{Table: "mss_input"},
 		},
-		Op:         chplan.SecondStageTopK,
-		K:          5,
-		ValueAlias: "Value",
+		Op: chplan.SecondStageTopK,
+		K:  5,
 	}
 	assertSentinels(t, visitScans(root), []string{"mss_input"})
 }
@@ -503,10 +502,9 @@ func TestChildren_MetricsSecondStageReturnsExactlyInput(t *testing.T) {
 	t.Parallel()
 	input := &chplan.Scan{Table: "t"}
 	m := &chplan.MetricsSecondStage{
-		Input:      input,
-		Op:         chplan.SecondStageTopK,
-		K:          3,
-		ValueAlias: "Value",
+		Input: input,
+		Op:    chplan.SecondStageTopK,
+		K:     3,
 	}
 	kids := m.Children()
 	if len(kids) != 1 || kids[0] != input {

--- a/internal/chsql/emit_negatives_test.go
+++ b/internal/chsql/emit_negatives_test.go
@@ -114,7 +114,6 @@ func TestEmit_RangeWindowUnknownFunc(t *testing.T) {
 //
 //   - Nil Input → ErrUnsupported (Input is required; no parent to
 //     project from).
-//   - Empty ValueAlias → ErrUnsupported (no column to sort or filter).
 //   - Topk with K=0 → ErrUnsupported (LIMIT 0 disables the second-stage
 //     intent; TraceQL's parser already rejects this, so it's a lowering
 //     bug if it reaches the emitter).
@@ -139,28 +138,17 @@ func TestEmit_MetricsSecondStage_Errors(t *testing.T) {
 		{
 			"nil Input",
 			&chplan.MetricsSecondStage{
-				Input:      nil,
-				Op:         chplan.SecondStageTopK,
-				K:          5,
-				ValueAlias: "Value",
-			},
-		},
-		{
-			"empty ValueAlias",
-			&chplan.MetricsSecondStage{
-				Input:      baseInput(),
-				Op:         chplan.SecondStageTopK,
-				K:          5,
-				ValueAlias: "",
+				Input: nil,
+				Op:    chplan.SecondStageTopK,
+				K:     5,
 			},
 		},
 		{
 			"topk with K=0",
 			&chplan.MetricsSecondStage{
-				Input:      baseInput(),
-				Op:         chplan.SecondStageTopK,
-				K:          0,
-				ValueAlias: "Value",
+				Input: baseInput(),
+				Op:    chplan.SecondStageTopK,
+				K:     0,
 			},
 		},
 		{
@@ -170,15 +158,13 @@ func TestEmit_MetricsSecondStage_Errors(t *testing.T) {
 				Op:             chplan.SecondStageThreshold,
 				ThresholdOp:    chplan.OpAnd,
 				ThresholdValue: 10,
-				ValueAlias:     "Value",
 			},
 		},
 		{
 			"SecondStageInvalid op",
 			&chplan.MetricsSecondStage{
-				Input:      baseInput(),
-				Op:         chplan.SecondStageInvalid,
-				ValueAlias: "Value",
+				Input: baseInput(),
+				Op:    chplan.SecondStageInvalid,
 			},
 		},
 	}

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -606,9 +606,8 @@ var plans = map[string]chplan.Node{
 			ValueAlias: "Value",
 			Inner:      &chplan.Scan{Table: "otel_traces"},
 		},
-		Op:         chplan.SecondStageTopK,
-		K:          5,
-		ValueAlias: "Value",
+		Op: chplan.SecondStageTopK,
+		K:  5,
 	},
 	"metrics_second_stage_bottomk_instant": &chplan.MetricsSecondStage{
 		Input: &chplan.MetricsAggregate{
@@ -616,9 +615,8 @@ var plans = map[string]chplan.Node{
 			ValueAlias: "Value",
 			Inner:      &chplan.Scan{Table: "otel_traces"},
 		},
-		Op:         chplan.SecondStageBottomK,
-		K:          3,
-		ValueAlias: "Value",
+		Op: chplan.SecondStageBottomK,
+		K:  3,
 	},
 	"metrics_second_stage_threshold_gt": &chplan.MetricsSecondStage{
 		Input: &chplan.MetricsAggregate{
@@ -629,7 +627,6 @@ var plans = map[string]chplan.Node{
 		Op:             chplan.SecondStageThreshold,
 		ThresholdOp:    chplan.OpGt,
 		ThresholdValue: 10,
-		ValueAlias:     "Value",
 	},
 	"metrics_second_stage_threshold_lt": &chplan.MetricsSecondStage{
 		Input: &chplan.MetricsAggregate{
@@ -641,7 +638,6 @@ var plans = map[string]chplan.Node{
 		Op:             chplan.SecondStageThreshold,
 		ThresholdOp:    chplan.OpLt,
 		ThresholdValue: 0.5,
-		ValueAlias:     "Value",
 	},
 	// MetricsSecondStage wrapping a RangeWindow over MetricsAggregate —
 	// the matrix shape. PartitionBy=["anchor_ts"] so `LIMIT K BY
@@ -663,7 +659,6 @@ var plans = map[string]chplan.Node{
 		Op:          chplan.SecondStageTopK,
 		K:           5,
 		PartitionBy: []string{"anchor_ts"},
-		ValueAlias:  "Value",
 	},
 	// Chained second-stage: `| topk(5) | > 10` nests as an outer
 	// Threshold wrapping an inner TopK.
@@ -674,14 +669,12 @@ var plans = map[string]chplan.Node{
 				ValueAlias: "Value",
 				Inner:      &chplan.Scan{Table: "otel_traces"},
 			},
-			Op:         chplan.SecondStageTopK,
-			K:          5,
-			ValueAlias: "Value",
+			Op: chplan.SecondStageTopK,
+			K:  5,
 		},
 		Op:             chplan.SecondStageThreshold,
 		ThresholdOp:    chplan.OpGt,
 		ThresholdValue: 10,
-		ValueAlias:     "Value",
 	},
 
 	// RangeWindow wrapping MetricsAggregate — the matrix shape used

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -1201,8 +1201,11 @@ func TestEmitMetricsSecondStage_PartitionByBoundary(t *testing.T) {
 				Op:          chplan.SecondStageTopK,
 				K:           5,
 				PartitionBy: c.parts,
-				ValueAlias:  "Value",
-				Input:       &chplan.Scan{Table: "otel_traces"},
+				Input: &chplan.MetricsAggregate{
+					Op:         chplan.MetricsOpRate,
+					ValueAlias: "Value",
+					Inner:      &chplan.Scan{Table: "otel_traces"},
+				},
 			}
 			sql, _, err := Emit(context.Background(), plan)
 			if err != nil {

--- a/internal/chsql/metrics_second_stage.go
+++ b/internal/chsql/metrics_second_stage.go
@@ -45,7 +45,7 @@ func (e *emitter) emitMetricsSecondStage(m *chplan.MetricsSecondStage) error {
 
 // emitMetricsSecondStageTopK renders the topk/bottomk wrap:
 //
-//	SELECT * FROM (<inner>) ORDER BY <ValueAlias> <DESC|ASC>
+//	SELECT * FROM (<inner>) ORDER BY <RoleValue> <DESC|ASC>
 //	  LIMIT <K> [BY <PartitionBy_1>, <PartitionBy_2>, ...]
 //
 // K <= 0 is rejected — TraceQL's parser validates `limit > 0` so the
@@ -80,10 +80,10 @@ func (e *emitter) emitMetricsSecondStageTopK(m *chplan.MetricsSecondStage, value
 
 // emitMetricsSecondStageThreshold renders the threshold wrap:
 //
-//	SELECT * FROM (<inner>) WHERE <ValueAlias> <Op> <Value>
+//	SELECT * FROM (<inner>) WHERE <RoleValue> <Op> <Value>
 //
 // The threshold predicate flows through Builder.Expr as a
-// chplan.Binary{ValueAlias <Op> LitFloat(<Value>)} so the SQL shape
+// chplan.Binary{RoleValue <Op> LitFloat(<Value>)} so the SQL shape
 // matches the rest of the emitter's comparison rendering (parenthesis
 // rules, parameter binding) without duplicating the operator table.
 func (e *emitter) emitMetricsSecondStageThreshold(m *chplan.MetricsSecondStage, valueColumn string) error {

--- a/internal/chsql/metrics_second_stage.go
+++ b/internal/chsql/metrics_second_stage.go
@@ -10,7 +10,7 @@ import (
 // subquery-wrapping SELECT over the lowered metrics aggregate's row
 // shape. The wrap depends on m.Op:
 //
-//   - SecondStageTopK / SecondStageBottomK: `ORDER BY <ValueAlias>
+//   - SecondStageTopK / SecondStageBottomK: `ORDER BY <RoleValue>
 //     <DESC|ASC> LIMIT K [BY <PartitionBy...>]`. ClickHouse's
 //     `LIMIT N BY <col>` keeps N rows per distinct partition value —
 //     for matrix queries the partition is `anchor_ts` so the limit
@@ -18,7 +18,7 @@ import (
 //     per-anchor selection). For instant queries PartitionBy is empty
 //     and the limit applies globally (top-K series in the
 //     row-per-series shape).
-//   - SecondStageThreshold: `WHERE <ValueAlias> <ThresholdOp>
+//   - SecondStageThreshold: `WHERE <RoleValue> <ThresholdOp>
 //     <ThresholdValue>`. Same SQL for instant + matrix since the
 //     predicate is per-row.
 //
@@ -29,15 +29,16 @@ func (e *emitter) emitMetricsSecondStage(m *chplan.MetricsSecondStage) error {
 	if m.Input == nil {
 		return fmt.Errorf("%w: MetricsSecondStage.Input is nil", ErrUnsupported)
 	}
-	if m.ValueAlias == "" {
-		return fmt.Errorf("%w: MetricsSecondStage.ValueAlias unset", ErrUnsupported)
+	valueColumn, err := metricsSecondStageValueColumn(m.Input.RowType())
+	if err != nil {
+		return err
 	}
 
 	switch m.Op {
 	case chplan.SecondStageTopK, chplan.SecondStageBottomK:
-		return e.emitMetricsSecondStageTopK(m)
+		return e.emitMetricsSecondStageTopK(m, valueColumn)
 	case chplan.SecondStageThreshold:
-		return e.emitMetricsSecondStageThreshold(m)
+		return e.emitMetricsSecondStageThreshold(m, valueColumn)
 	}
 	return fmt.Errorf("%w: MetricsSecondStage op %s", ErrUnsupported, m.Op)
 }
@@ -51,7 +52,7 @@ func (e *emitter) emitMetricsSecondStage(m *chplan.MetricsSecondStage) error {
 // only path to a non-positive K is a programmer error in the lowering
 // layer; surfacing it loud avoids an unbounded LIMIT that silently
 // disables the second-stage filter.
-func (e *emitter) emitMetricsSecondStageTopK(m *chplan.MetricsSecondStage) error {
+func (e *emitter) emitMetricsSecondStageTopK(m *chplan.MetricsSecondStage, valueColumn string) error {
 	if m.K <= 0 {
 		return fmt.Errorf("%w: MetricsSecondStage %s with non-positive K=%d", ErrUnsupported, m.Op, m.K)
 	}
@@ -62,7 +63,7 @@ func (e *emitter) emitMetricsSecondStageTopK(m *chplan.MetricsSecondStage) error
 	}
 
 	desc := m.Op == chplan.SecondStageTopK
-	alias := m.ValueAlias
+	alias := valueColumn
 	sb := NewQuery().From(sub).
 		OrderBy(func(b *Builder) { b.Ident(alias) }, desc).
 		Limit(m.K)
@@ -85,7 +86,7 @@ func (e *emitter) emitMetricsSecondStageTopK(m *chplan.MetricsSecondStage) error
 // chplan.Binary{ValueAlias <Op> LitFloat(<Value>)} so the SQL shape
 // matches the rest of the emitter's comparison rendering (parenthesis
 // rules, parameter binding) without duplicating the operator table.
-func (e *emitter) emitMetricsSecondStageThreshold(m *chplan.MetricsSecondStage) error {
+func (e *emitter) emitMetricsSecondStageThreshold(m *chplan.MetricsSecondStage, valueColumn string) error {
 	if !isThresholdOp(m.ThresholdOp) {
 		return fmt.Errorf("%w: MetricsSecondStage threshold op %s not supported", ErrUnsupported, m.ThresholdOp)
 	}
@@ -97,11 +98,32 @@ func (e *emitter) emitMetricsSecondStageThreshold(m *chplan.MetricsSecondStage) 
 
 	pred := &chplan.Binary{
 		Op:    m.ThresholdOp,
-		Left:  &chplan.ColumnRef{Name: m.ValueAlias},
+		Left:  &chplan.ColumnRef{Name: valueColumn},
 		Right: &chplan.LitFloat{V: m.ThresholdValue},
 	}
 	sb := NewQuery().From(sub).Where(func(b *Builder) { _ = b.Expr(pred) })
 	return e.emitSelect(sb)
+}
+
+func metricsSecondStageValueColumn(row chplan.Schema) (string, error) {
+	if row.Open {
+		return "", fmt.Errorf("%w: MetricsSecondStage.Input has open row schema", ErrUnsupported)
+	}
+
+	value := ""
+	for _, column := range row.Columns {
+		if column.Role != chplan.RoleValue {
+			continue
+		}
+		if value != "" || column.Name == "" {
+			return "", fmt.Errorf("%w: MetricsSecondStage.Input has invalid RoleValue schema", ErrUnsupported)
+		}
+		value = column.Name
+	}
+	if value == "" {
+		return "", fmt.Errorf("%w: MetricsSecondStage.Input has no RoleValue column", ErrUnsupported)
+	}
+	return value, nil
 }
 
 // isThresholdOp reports whether op is one of the six comparison

--- a/internal/chsql/metrics_second_stage_schema_test.go
+++ b/internal/chsql/metrics_second_stage_schema_test.go
@@ -1,0 +1,79 @@
+package chsql_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+func TestEmitMetricsSecondStageResolvesValueRole(t *testing.T) {
+	t.Parallel()
+
+	input := &chplan.MetricsAggregate{
+		Op:         chplan.MetricsOpRate,
+		ValueAlias: "physical_value",
+		Inner:      &chplan.Scan{Table: "otel_traces"},
+	}
+	cases := []struct {
+		name string
+		plan *chplan.MetricsSecondStage
+		want string
+	}{
+		{"topk", &chplan.MetricsSecondStage{Input: input, Op: chplan.SecondStageTopK, K: 3}, "ORDER BY `physical_value` DESC"},
+		{"bottomk", &chplan.MetricsSecondStage{Input: input, Op: chplan.SecondStageBottomK, K: 3}, "ORDER BY `physical_value` LIMIT"},
+		{"threshold", &chplan.MetricsSecondStage{Input: input, Op: chplan.SecondStageThreshold, ThresholdOp: chplan.OpGt, ThresholdValue: 2}, "`physical_value` >"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sql, _, err := chsql.Emit(context.Background(), tc.plan)
+			if err != nil {
+				t.Fatalf("Emit() error = %v", err)
+			}
+			if !strings.Contains(sql, tc.want) {
+				t.Fatalf("Emit() SQL does not use child RoleValue column:\n%s", sql)
+			}
+		})
+	}
+}
+
+func TestEmitMetricsSecondStageRejectsInvalidValueSchema(t *testing.T) {
+	t.Parallel()
+
+	project := func(columns ...chplan.Column) chplan.Node {
+		projections := make([]chplan.Projection, len(columns))
+		for i, column := range columns {
+			projections[i] = chplan.Projection{Expr: &chplan.LitInt{V: int64(i)}, Alias: column.Name}
+		}
+		return &chplan.Project{Input: &chplan.Scan{Table: "otel_traces"}, Projections: projections, Roles: columns}
+	}
+	cases := []struct {
+		name  string
+		input chplan.Node
+	}{
+		{"open", &chplan.Scan{Table: "otel_traces"}},
+		{"missing", project(chplan.Column{Name: "opaque"})},
+		{"duplicate", project(
+			chplan.Column{Name: "value_a", Role: chplan.RoleValue},
+			chplan.Column{Name: "value_b", Role: chplan.RoleValue},
+		)},
+		{"unnamed", &chplan.MetricsAggregate{Op: chplan.MetricsOpRate, Inner: &chplan.Scan{Table: "otel_traces"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := chsql.Emit(context.Background(), &chplan.MetricsSecondStage{
+				Input: tc.input,
+				Op:    chplan.SecondStageTopK,
+				K:     3,
+			})
+			if !errors.Is(err, chsql.ErrUnsupported) {
+				t.Fatalf("Emit() error = %v, want ErrUnsupported", err)
+			}
+		})
+	}
+}

--- a/internal/traceql/lower.go
+++ b/internal/traceql/lower.go
@@ -205,10 +205,9 @@ func lowerTopKBottomK(inner chplan.Node, t *traceql.TopKBottomK) (chplan.Node, e
 		return nil, fmt.Errorf("traceql: %s(%d): limit must be > 0", t.Op(), limit)
 	}
 	return &chplan.MetricsSecondStage{
-		Input:      inner,
-		Op:         op,
-		K:          int64(limit),
-		ValueAlias: metricsValueAlias,
+		Input: inner,
+		Op:    op,
+		K:     int64(limit),
 	}, nil
 }
 
@@ -230,7 +229,6 @@ func lowerMetricsFilter(inner chplan.Node, f *traceql.MetricsFilter) (chplan.Nod
 		Op:             chplan.SecondStageThreshold,
 		ThresholdOp:    op,
 		ThresholdValue: f.Value(),
-		ValueAlias:     metricsValueAlias,
 	}, nil
 }
 

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -392,10 +392,6 @@ func TestLowerMetricsSecondStage(t *testing.T) {
 					t.Errorf("MetricsSecondStage.ThresholdValue = %v, want %v", ss.ThresholdValue, tc.wantThreshV)
 				}
 			}
-			if ss.ValueAlias != "Value" {
-				t.Errorf("MetricsSecondStage.ValueAlias = %q, want %q", ss.ValueAlias, "Value")
-			}
-
 			// Walk the nested chain — count how many
 			// MetricsSecondStage wraps stack on top of the
 			// MetricsAggregate.

--- a/test/spec/chplan_print.go
+++ b/test/spec/chplan_print.go
@@ -605,9 +605,6 @@ func printNodeArm(b *strings.Builder, n chplan.Node, depth int, visited *[]chpla
 		if len(v.PartitionBy) > 0 {
 			fmt.Fprintf(b, " partitionBy=[%s]", strings.Join(v.PartitionBy, ", "))
 		}
-		if v.ValueAlias != "" {
-			fmt.Fprintf(b, " valueAlias=%s", v.ValueAlias)
-		}
 		b.WriteString("\n")
 		if v.Input != nil {
 			printChild(b, visited, v.Input, depth+1)

--- a/test/spec/chsql/metrics_second_stage_bottomk_instant.txtar
+++ b/test/spec/chsql/metrics_second_stage_bottomk_instant.txtar
@@ -3,6 +3,6 @@
 -- sql --
 SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces`)) ORDER BY `Value` LIMIT 3
 -- chplan --
-MetricsSecondStage op=bottomk k=3 valueAlias=Value
+MetricsSecondStage op=bottomk k=3
   MetricsAggregate op=rate valueAlias=Value
     Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_chained_topk_threshold.txtar
+++ b/test/spec/chsql/metrics_second_stage_chained_topk_threshold.txtar
@@ -4,7 +4,7 @@
 -- sql --
 SELECT * FROM (SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces`)) ORDER BY `Value` DESC LIMIT 5) WHERE (`Value` > toFloat64(?))
 -- chplan --
-MetricsSecondStage op=threshold threshold=(> 10) valueAlias=Value
-  MetricsSecondStage op=topk k=5 valueAlias=Value
+MetricsSecondStage op=threshold threshold=(> 10)
+  MetricsSecondStage op=topk k=5
     MetricsAggregate op=rate valueAlias=Value
       Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_threshold_gt.txtar
+++ b/test/spec/chsql/metrics_second_stage_threshold_gt.txtar
@@ -4,6 +4,6 @@
 -- sql --
 SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces`)) WHERE (`Value` > toFloat64(?))
 -- chplan --
-MetricsSecondStage op=threshold threshold=(> 10) valueAlias=Value
+MetricsSecondStage op=threshold threshold=(> 10)
   MetricsAggregate op=rate valueAlias=Value
     Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_threshold_lt.txtar
+++ b/test/spec/chsql/metrics_second_stage_threshold_lt.txtar
@@ -3,6 +3,6 @@
 -- sql --
 SELECT * FROM (SELECT sum(`Duration`) AS `Value` FROM (SELECT * FROM `otel_traces`)) WHERE (`Value` < toFloat64(?))
 -- chplan --
-MetricsSecondStage op=threshold threshold=(< 0.5) valueAlias=Value
+MetricsSecondStage op=threshold threshold=(< 0.5)
   MetricsAggregate op=sum_over_time attr=Duration valueAlias=Value
     Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_topk_instant.txtar
+++ b/test/spec/chsql/metrics_second_stage_topk_instant.txtar
@@ -3,6 +3,6 @@
 -- sql --
 SELECT * FROM (SELECT toFloat64(count(?)) AS `Value` FROM (SELECT * FROM `otel_traces`)) ORDER BY `Value` DESC LIMIT 5
 -- chplan --
-MetricsSecondStage op=topk k=5 valueAlias=Value
+MetricsSecondStage op=topk k=5
   MetricsAggregate op=rate valueAlias=Value
     Scan(otel_traces)

--- a/test/spec/chsql/metrics_second_stage_topk_matrix.txtar
+++ b/test/spec/chsql/metrics_second_stage_topk_matrix.txtar
@@ -3,7 +3,7 @@
 -- sql --
 SELECT * FROM (SELECT `service`, `anchor_ts`, toFloat64(sum(in_window)) / 60 AS `Value` FROM ((SELECT `ServiceName` AS `service`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(greatest(0, intDiv(dateDiff('nanosecond', `Timestamp`, now64(9)) - 60000000000, toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `Timestamp`, now64(9)) - 60000000000, toInt64(60000000000)) < 0) + 1), least(6, intDiv(dateDiff('nanosecond', `Timestamp`, now64(9)), toInt64(60000000000)) - (modulo(dateDiff('nanosecond', `Timestamp`, now64(9)), toInt64(60000000000)) < 0) + 1)))) AS `anchor_ts`, 1 AS `in_window` FROM (SELECT * FROM `otel_traces`)) UNION ALL (SELECT `service`, arrayJoin(arrayMap(i -> now64(9) - toIntervalNanosecond(i * 60000000000), range(0, 6))) AS `anchor_ts`, 0 AS `in_window` FROM (SELECT `ServiceName` AS `service` FROM (SELECT * FROM `otel_traces`) GROUP BY `service`))) GROUP BY `service`, `anchor_ts`) ORDER BY `Value` DESC LIMIT 5 BY `anchor_ts`
 -- chplan --
-MetricsSecondStage op=topk k=5 partitionBy=[anchor_ts] valueAlias=Value
+MetricsSecondStage op=topk k=5 partitionBy=[anchor_ts]
   RangeWindow func= range=0s step=1m0s outerRange=5m0s ts=Timestamp
     MetricsAggregate op=rate groupBy=[ServiceName AS service] valueAlias=Value
       Scan(otel_traces)

--- a/test/spec/traceql/metrics_bottomk.txtar
+++ b/test/spec/traceql/metrics_bottomk.txtar
@@ -19,7 +19,7 @@ INSERT INTO otel_traces (Duration, TraceId, SpanId) VALUES
   [2]
 ]
 -- chplan --
-MetricsSecondStage op=bottomk k=3 valueAlias=Value
+MetricsSecondStage op=bottomk k=3
   MetricsAggregate op=rate valueAlias=Value
     Filter predicate=true
       Scan(otel_traces)

--- a/test/spec/traceql/metrics_chained.txtar
+++ b/test/spec/traceql/metrics_chained.txtar
@@ -21,8 +21,8 @@ INSERT INTO otel_traces (Duration, TraceId, SpanId) VALUES
   [3]
 ]
 -- chplan --
-MetricsSecondStage op=threshold threshold=(> 1) valueAlias=Value
-  MetricsSecondStage op=topk k=5 valueAlias=Value
+MetricsSecondStage op=threshold threshold=(> 1)
+  MetricsSecondStage op=topk k=5
     MetricsAggregate op=rate valueAlias=Value
       Filter predicate=true
         Scan(otel_traces)

--- a/test/spec/traceql/metrics_threshold.txtar
+++ b/test/spec/traceql/metrics_threshold.txtar
@@ -33,7 +33,7 @@ INSERT INTO otel_traces (Duration, TraceId, SpanId) VALUES
   [15]
 ]
 -- chplan --
-MetricsSecondStage op=threshold threshold=(> 10) valueAlias=Value
+MetricsSecondStage op=threshold threshold=(> 10)
   MetricsAggregate op=rate valueAlias=Value
     Filter predicate=true
       Scan(otel_traces)

--- a/test/spec/traceql/metrics_topk.txtar
+++ b/test/spec/traceql/metrics_topk.txtar
@@ -22,7 +22,7 @@ INSERT INTO otel_traces (ResourceAttributes, TraceId, SpanId) VALUES
   [3]
 ]
 -- chplan --
-MetricsSecondStage op=topk k=5 valueAlias=Value
+MetricsSecondStage op=topk k=5
   MetricsAggregate op=rate valueAlias=Value
     Filter predicate=(ResourceAttributes["service.name"] = "checkout")
       Scan(otel_traces)


### PR DESCRIPTION
## Summary

- remove the redundant `MetricsSecondStage.ValueAlias` input driver
- resolve top-k, bottom-k, and threshold value columns from the immediate child's unique `RoleValue`
- reject open, missing, duplicate, and unnamed value schemas
- remove the retired field from TraceQL lowering, equality, cloning fixtures, and plan rendering

## Verification

- `go test -run '^TestEmitMetricsSecondStage|^TestEmit_MetricsSecondStage_Errors$' ./internal/chsql`
- `go test -run '^TestMetricsSecondStage(Equal|Children)$' ./internal/chplan`
- `go test -run '^TestLowerMetricsSecondStage' ./internal/traceql`

Generated snapshots are left to the repository's CI golden updater.

Closes #3390
Part of #3284
