### PR TITLE
refactor(chplan): model nested metrics timestamp ownership

### DIFF
--- a/internal/api/tempo/scan_resource_bound_emit_test.go
+++ b/internal/api/tempo/scan_resource_bound_emit_test.go
@@ -179,7 +179,13 @@ func TestScanResourceBound_HistogramFailClosed(t *testing.T) {
 	m := &chplan.MetricsHistogramOverTime{
 		Attr:       &chplan.ColumnRef{Name: "Duration"},
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: s.SpansTable},
+		Inner: &chplan.Scan{
+			Table:   s.SpansTable,
+			Columns: []string{"Duration", s.TimestampColumn},
+			Roles: []chplan.Column{
+				{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+			},
+		},
 	}
 	rw := &chplan.RangeWindow{
 		Input: m, Step: time.Minute, Range: time.Minute, TimestampColumn: "Timestamp",
@@ -253,7 +259,13 @@ func TestScanResourceBound_ExemplarsBoundedAndFailClosed(t *testing.T) {
 		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "resource.service.name"}},
 		GroupByAliases: []string{"resource.service.name"},
 		ValueAlias:     "Value",
-		Inner:          &chplan.Scan{Table: s.SpansTable},
+		Inner: &chplan.Scan{
+			Table:   s.SpansTable,
+			Columns: []string{"resource.service.name", s.TimestampColumn},
+			Roles: []chplan.Column{
+				{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+			},
+		},
 	}
 	rw := &chplan.RangeWindow{
 		Input: m, Step: time.Minute, Range: time.Minute,
@@ -305,7 +317,13 @@ func TestScanResourceBound_MetricsMatrixFailClosed(t *testing.T) {
 		Op:             chplan.MetricsOpCountOverTime,
 		GroupByAliases: nil,
 		ValueAlias:     "Value",
-		Inner:          &chplan.Scan{Table: s.SpansTable},
+		Inner: &chplan.Scan{
+			Table:   s.SpansTable,
+			Columns: []string{s.TimestampColumn},
+			Roles: []chplan.Column{
+				{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+			},
+		},
 	}
 	rw := &chplan.RangeWindow{
 		Input: m, Step: time.Minute, Range: time.Minute, TimestampColumn: "Timestamp",

--- a/internal/chplan/metrics_aggregate.go
+++ b/internal/chplan/metrics_aggregate.go
@@ -122,10 +122,10 @@ func (o MetricsOp) String() string {
 //   - Inner: the underlying spanset relation — typically
 //     Scan(<traces-table>) or Filter(<predicate>, Scan(<traces-table>)).
 //
-// For the matrix path (wrapping RangeWindow), the emitter also reads
-// the underlying timestamp column from the wrapping RangeWindow's
-// TimestampColumn slot; the per-span Timestamp column is the matrix
-// shape's bucket key.
+// For the matrix path (wrapping RangeWindow), the emitter resolves the
+// underlying timestamp from RoleTimestamp on Inner. The wrapping window's
+// TimestampColumn remains the public output contract and never selects a
+// physical column from this nested relation.
 type MetricsAggregate struct {
 	Op                  MetricsOp
 	Attr                Expr

--- a/internal/chplan/metrics_nested_timestamp.go
+++ b/internal/chplan/metrics_nested_timestamp.go
@@ -1,0 +1,43 @@
+package chplan
+
+// InputTimestampColumn resolves the physical timestamp owned by the nested
+// relation that MetricsAggregate reads. The wrapping RangeWindow's
+// TimestampColumn is an output name and is deliberately not consulted.
+func (m *MetricsAggregate) InputTimestampColumn() (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	return metricsNestedTimestampColumn(m.Inner)
+}
+
+// InputTimestampColumn resolves the physical timestamp owned by the nested
+// relation that MetricsHistogramOverTime reads.
+func (m *MetricsHistogramOverTime) InputTimestampColumn() (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	return metricsNestedTimestampColumn(m.Inner)
+}
+
+func metricsNestedTimestampColumn(inner Node) (string, bool) {
+	if inner == nil {
+		return "", false
+	}
+	row := inner.RowType()
+	nameCount := make(map[string]int, len(row.Columns))
+	var timestamp string
+	for _, column := range row.Columns {
+		nameCount[column.Name]++
+		if column.Role != RoleTimestamp {
+			continue
+		}
+		if column.Name == "" || timestamp != "" {
+			return "", false
+		}
+		timestamp = column.Name
+	}
+	if timestamp == "" || nameCount[timestamp] != 1 {
+		return "", false
+	}
+	return timestamp, true
+}

--- a/internal/chplan/metrics_nested_timestamp_test.go
+++ b/internal/chplan/metrics_nested_timestamp_test.go
@@ -1,0 +1,70 @@
+package chplan
+
+import "testing"
+
+func TestMetricsNestedTimestampColumn(t *testing.T) {
+	t.Parallel()
+	valid := &Scan{
+		Table:   "spans",
+		Columns: []string{"physical_timestamp", "Duration"},
+		Roles:   []Column{{Name: "physical_timestamp", Role: RoleTimestamp}},
+	}
+	for name, input := range map[string]interface {
+		InputTimestampColumn() (string, bool)
+	}{
+		"aggregate": &MetricsAggregate{Inner: valid},
+		"histogram": &MetricsHistogramOverTime{Inner: valid},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := input.InputTimestampColumn()
+			if !ok || got != "physical_timestamp" {
+				t.Fatalf("InputTimestampColumn() = (%q, %v), want (physical_timestamp, true)", got, ok)
+			}
+		})
+	}
+}
+
+func TestMetricsNestedTimestampColumnRejectsMalformedSchema(t *testing.T) {
+	t.Parallel()
+	tests := map[string]Node{
+		"missing": &Scan{Table: "spans", Columns: []string{"Duration"}},
+		"unnamed": &Project{
+			Input:       &OneRow{},
+			Projections: []Projection{{Expr: &LitFloat{V: 1}}},
+			Roles:       []Column{{Role: RoleTimestamp}},
+		},
+		"duplicate_role": &Scan{
+			Table:   "spans",
+			Columns: []string{"time_a", "time_b"},
+			Roles: []Column{
+				{Name: "time_a", Role: RoleTimestamp},
+				{Name: "time_b", Role: RoleTimestamp},
+			},
+		},
+		"shared_name": &Project{
+			Input: &OneRow{},
+			Projections: []Projection{
+				{Expr: &LitFloat{V: 1}, Alias: "time"},
+				{Expr: &LitFloat{V: 2}, Alias: "time"},
+			},
+			Roles: []Column{{Name: "time", Role: RoleTimestamp}},
+		},
+	}
+	for name, inner := range tests {
+		inner := inner
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			for _, input := range []interface {
+				InputTimestampColumn() (string, bool)
+			}{
+				&MetricsAggregate{Inner: inner},
+				&MetricsHistogramOverTime{Inner: inner},
+			} {
+				if got, ok := input.InputTimestampColumn(); ok {
+					t.Fatalf("InputTimestampColumn() = (%q, true), want rejection", got)
+				}
+			}
+		})
+	}
+}

--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -119,8 +119,9 @@ type RangeWindow struct {
 	// uses the user-supplied start + k*Step grid (not epoch-aligned).
 	StepAlign bool
 
-	// TimestampColumn names the column carrying the per-sample timestamp
-	// on Input (typically "TimeUnix" for OTel-CH).
+	// TimestampColumn names the public timestamp output. Ordinary inputs still
+	// use this legacy selector; special Metrics* inputs resolve their nested
+	// physical timestamp from the nested relation's RoleTimestamp declaration.
 	TimestampColumn string
 
 	// ValueColumn names the column carrying the per-sample float value

--- a/internal/chplan/range_window.go
+++ b/internal/chplan/range_window.go
@@ -119,9 +119,10 @@ type RangeWindow struct {
 	// uses the user-supplied start + k*Step grid (not epoch-aligned).
 	StepAlign bool
 
-	// TimestampColumn names the public timestamp output. Ordinary inputs still
-	// use this legacy selector; special Metrics* inputs resolve their nested
-	// physical timestamp from the nested relation's RoleTimestamp declaration.
+	// TimestampColumn names the public timestamp output. Ordinary inputs and
+	// MetricsCompare still use this legacy selector; MetricsAggregate and
+	// MetricsHistogramOverTime resolve their nested physical timestamp from the
+	// nested relation's RoleTimestamp declaration.
 	TimestampColumn string
 
 	// ValueColumn names the column carrying the per-sample float value

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -138,7 +138,7 @@ var plans = map[string]chplan.Node{
 	// Limit(OrderBy(Scan, Timestamp DESC), N).
 	"order_by_timestamp_desc": &chplan.Limit{
 		Input: &chplan.OrderBy{
-			Input: metricsTimestampTestScan("otel_traces", "Timestamp"),
+			Input: &chplan.Scan{Table: "otel_traces"},
 			Keys: []chplan.OrderKey{
 				{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
 			},
@@ -147,7 +147,7 @@ var plans = map[string]chplan.Node{
 	},
 	// OrderBy — two-key (composite sort).
 	"order_by_composite": &chplan.OrderBy{
-		Input: metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Input: &chplan.Scan{Table: "otel_traces"},
 		Keys: []chplan.OrderKey{
 			{Expr: &chplan.ColumnRef{Name: "ServiceName"}, Desc: false},
 			{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
@@ -225,8 +225,8 @@ var plans = map[string]chplan.Node{
 
 	// StructuralJoin — TraceQL `>` (parent_of).
 	"structural_join_child": &chplan.StructuralJoin{
-		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
-		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
 		Op:                 chplan.StructuralChild,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -234,8 +234,8 @@ var plans = map[string]chplan.Node{
 	},
 	// StructuralJoin — TraceQL `<` (child_of).
 	"structural_join_parent": &chplan.StructuralJoin{
-		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
-		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
 		Op:                 chplan.StructuralParent,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -244,8 +244,8 @@ var plans = map[string]chplan.Node{
 	// StructuralJoin — TraceQL `>>` (recursive descendant; unbounded
 	// depth via CH `WITH RECURSIVE`).
 	"structural_join_descendant": &chplan.StructuralJoin{
-		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
-		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
 		Op:                 chplan.StructuralDescendant,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -253,8 +253,8 @@ var plans = map[string]chplan.Node{
 	},
 	// StructuralJoin — TraceQL `<<` (recursive ancestor; unbounded depth).
 	"structural_join_ancestor": &chplan.StructuralJoin{
-		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
-		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
 		Op:                 chplan.StructuralAncestor,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -263,8 +263,8 @@ var plans = map[string]chplan.Node{
 	// StructuralJoin — recursive descendant with MaxDepth = 3 (the
 	// recursive step's WHERE clause caps the walk).
 	"structural_join_descendant_bounded": &chplan.StructuralJoin{
-		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
-		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
 		Op:                 chplan.StructuralDescendant,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -485,7 +485,7 @@ var plans = map[string]chplan.Node{
 
 	// FieldAccess — TraceQL dotted attribute access.
 	"filter_field_access": &chplan.Filter{
-		Input: metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Input: &chplan.Scan{Table: "otel_traces"},
 		Predicate: &chplan.Binary{
 			Op: chplan.OpEq,
 			Left: &chplan.FieldAccess{
@@ -827,7 +827,7 @@ var plans = map[string]chplan.Node{
 	// parameter (not splice into the SQL), so CH-special chars in the
 	// key are no-op.
 	"filter_map_access_dotted_key": &chplan.Filter{
-		Input: metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Input: &chplan.Scan{Table: "otel_traces"},
 		Predicate: &chplan.Binary{
 			Op: chplan.OpEq,
 			Left: &chplan.MapAccess{

--- a/internal/chsql/emit_test.go
+++ b/internal/chsql/emit_test.go
@@ -138,7 +138,7 @@ var plans = map[string]chplan.Node{
 	// Limit(OrderBy(Scan, Timestamp DESC), N).
 	"order_by_timestamp_desc": &chplan.Limit{
 		Input: &chplan.OrderBy{
-			Input: &chplan.Scan{Table: "otel_traces"},
+			Input: metricsTimestampTestScan("otel_traces", "Timestamp"),
 			Keys: []chplan.OrderKey{
 				{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
 			},
@@ -147,7 +147,7 @@ var plans = map[string]chplan.Node{
 	},
 	// OrderBy — two-key (composite sort).
 	"order_by_composite": &chplan.OrderBy{
-		Input: &chplan.Scan{Table: "otel_traces"},
+		Input: metricsTimestampTestScan("otel_traces", "Timestamp"),
 		Keys: []chplan.OrderKey{
 			{Expr: &chplan.ColumnRef{Name: "ServiceName"}, Desc: false},
 			{Expr: &chplan.ColumnRef{Name: "Timestamp"}, Desc: true},
@@ -225,8 +225,8 @@ var plans = map[string]chplan.Node{
 
 	// StructuralJoin — TraceQL `>` (parent_of).
 	"structural_join_child": &chplan.StructuralJoin{
-		Left:               &chplan.Scan{Table: "otel_traces"},
-		Right:              &chplan.Scan{Table: "otel_traces"},
+		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
 		Op:                 chplan.StructuralChild,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -234,8 +234,8 @@ var plans = map[string]chplan.Node{
 	},
 	// StructuralJoin — TraceQL `<` (child_of).
 	"structural_join_parent": &chplan.StructuralJoin{
-		Left:               &chplan.Scan{Table: "otel_traces"},
-		Right:              &chplan.Scan{Table: "otel_traces"},
+		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
 		Op:                 chplan.StructuralParent,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -244,8 +244,8 @@ var plans = map[string]chplan.Node{
 	// StructuralJoin — TraceQL `>>` (recursive descendant; unbounded
 	// depth via CH `WITH RECURSIVE`).
 	"structural_join_descendant": &chplan.StructuralJoin{
-		Left:               &chplan.Scan{Table: "otel_traces"},
-		Right:              &chplan.Scan{Table: "otel_traces"},
+		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
 		Op:                 chplan.StructuralDescendant,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -253,8 +253,8 @@ var plans = map[string]chplan.Node{
 	},
 	// StructuralJoin — TraceQL `<<` (recursive ancestor; unbounded depth).
 	"structural_join_ancestor": &chplan.StructuralJoin{
-		Left:               &chplan.Scan{Table: "otel_traces"},
-		Right:              &chplan.Scan{Table: "otel_traces"},
+		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
 		Op:                 chplan.StructuralAncestor,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -263,8 +263,8 @@ var plans = map[string]chplan.Node{
 	// StructuralJoin — recursive descendant with MaxDepth = 3 (the
 	// recursive step's WHERE clause caps the walk).
 	"structural_join_descendant_bounded": &chplan.StructuralJoin{
-		Left:               &chplan.Scan{Table: "otel_traces"},
-		Right:              &chplan.Scan{Table: "otel_traces"},
+		Left:               metricsTimestampTestScan("otel_traces", "Timestamp"),
+		Right:              metricsTimestampTestScan("otel_traces", "Timestamp"),
 		Op:                 chplan.StructuralDescendant,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -485,7 +485,7 @@ var plans = map[string]chplan.Node{
 
 	// FieldAccess — TraceQL dotted attribute access.
 	"filter_field_access": &chplan.Filter{
-		Input: &chplan.Scan{Table: "otel_traces"},
+		Input: metricsTimestampTestScan("otel_traces", "Timestamp"),
 		Predicate: &chplan.Binary{
 			Op: chplan.OpEq,
 			Left: &chplan.FieldAccess{
@@ -566,20 +566,20 @@ var plans = map[string]chplan.Node{
 	"metrics_aggregate_rate_bare": &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpRate,
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 	},
 	"metrics_aggregate_sum_over_time_bare": &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpSumOverTime,
 		Attr:       &chplan.ColumnRef{Name: "Duration"},
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 	},
 	"metrics_aggregate_quantile_over_time_bare": &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpQuantileOverTime,
 		Attr:       &chplan.ColumnRef{Name: "Duration"},
 		Quantiles:  []float64{0.95},
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 	},
 	// Multi-phi quantile_over_time pins the instant-shape fanout:
 	// inner SELECT computes `quantiles(p1, p2, ...)(<attr>)` returning
@@ -591,7 +591,7 @@ var plans = map[string]chplan.Node{
 		Attr:       &chplan.ColumnRef{Name: "Duration"},
 		Quantiles:  []float64{0.5, 0.9, 0.99},
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 	},
 
 	// MetricsSecondStage wraps a MetricsAggregate (instant) — TraceQL's
@@ -604,7 +604,7 @@ var plans = map[string]chplan.Node{
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Op:         chplan.SecondStageTopK,
 		K:          5,
@@ -614,7 +614,7 @@ var plans = map[string]chplan.Node{
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Op:         chplan.SecondStageBottomK,
 		K:          3,
@@ -624,7 +624,7 @@ var plans = map[string]chplan.Node{
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Op:             chplan.SecondStageThreshold,
 		ThresholdOp:    chplan.OpGt,
@@ -636,7 +636,7 @@ var plans = map[string]chplan.Node{
 			Op:         chplan.MetricsOpSumOverTime,
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Op:             chplan.SecondStageThreshold,
 		ThresholdOp:    chplan.OpLt,
@@ -654,7 +654,7 @@ var plans = map[string]chplan.Node{
 				GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
 				GroupByAliases: []string{"service"},
 				ValueAlias:     "Value",
-				Inner:          &chplan.Scan{Table: "otel_traces"},
+				Inner:          metricsTimestampTestScan("otel_traces", "Timestamp"),
 			},
 			Step:            time.Minute,
 			OuterRange:      5 * time.Minute,
@@ -672,7 +672,7 @@ var plans = map[string]chplan.Node{
 			Input: &chplan.MetricsAggregate{
 				Op:         chplan.MetricsOpRate,
 				ValueAlias: "Value",
-				Inner:      &chplan.Scan{Table: "otel_traces"},
+				Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 			},
 			Op:         chplan.SecondStageTopK,
 			K:          5,
@@ -693,7 +693,7 @@ var plans = map[string]chplan.Node{
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Range:           5 * time.Minute,
 		Step:            time.Minute,
@@ -706,7 +706,7 @@ var plans = map[string]chplan.Node{
 			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
 			GroupByAliases: []string{"service"},
 			ValueAlias:     "Value",
-			Inner:          &chplan.Scan{Table: "otel_traces"},
+			Inner:          metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		OuterRange:      10 * time.Minute,
@@ -717,7 +717,7 @@ var plans = map[string]chplan.Node{
 			Op:         chplan.MetricsOpSumOverTime,
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		OuterRange:      5 * time.Minute,
@@ -729,7 +729,7 @@ var plans = map[string]chplan.Node{
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			Quantiles:  []float64{0.95},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		OuterRange:      5 * time.Minute,
@@ -745,7 +745,7 @@ var plans = map[string]chplan.Node{
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			Quantiles:  []float64{0.5, 0.9, 0.99},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		OuterRange:      5 * time.Minute,
@@ -763,7 +763,7 @@ var plans = map[string]chplan.Node{
 			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
 			GroupByAliases: []string{"service"},
 			ValueAlias:     "Value",
-			Inner:          &chplan.Scan{Table: "otel_traces"},
+			Inner:          metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		OuterRange:      5 * time.Minute,
@@ -827,7 +827,7 @@ var plans = map[string]chplan.Node{
 	// parameter (not splice into the SQL), so CH-special chars in the
 	// key are no-op.
 	"filter_map_access_dotted_key": &chplan.Filter{
-		Input: &chplan.Scan{Table: "otel_traces"},
+		Input: metricsTimestampTestScan("otel_traces", "Timestamp"),
 		Predicate: &chplan.Binary{
 			Op: chplan.OpEq,
 			Left: &chplan.MapAccess{

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -296,7 +296,7 @@ func TestEmitMetricsExemplars_StepBoundary(t *testing.T) {
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            0,
 		Range:           time.Minute,
@@ -358,7 +358,7 @@ func TestEmitMetricsExemplars_EmptyTimestampColumn(t *testing.T) {
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		},
 		Step:  time.Minute,
 		Range: time.Minute,
@@ -382,7 +382,7 @@ func TestEmitMetricsExemplars_RangeDurationFallback(t *testing.T) {
 	m := &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpRate,
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 
 	cases := []struct {
@@ -446,7 +446,7 @@ func TestEmitMetricsExemplars_NumAnchorsBoundary(t *testing.T) {
 	m := &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpRate,
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 
 	cases := []struct {
@@ -536,7 +536,7 @@ func TestEmitMetricsExemplars_GroupByDisplayNamesFallback(t *testing.T) {
 				GroupByAliases:      []string{"service"},
 				GroupByDisplayNames: c.displayName,
 				ValueAlias:          "Value",
-				Inner:               &chplan.Scan{Table: "otel_traces"},
+				Inner:               metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			rw := &chplan.RangeWindow{
 				Input: m, Step: time.Minute, Range: time.Minute,
@@ -593,7 +593,7 @@ func TestEmitMetricsExemplars_MetricArgEmission_Op154(t *testing.T) {
 				Op:         c.op,
 				Attr:       c.attr,
 				ValueAlias: "Value",
-				Inner:      &chplan.Scan{Table: "otel_traces"},
+				Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			rw := &chplan.RangeWindow{
 				Input: m, Step: time.Minute, Range: time.Minute,
@@ -648,7 +648,7 @@ func TestEmitMetricsExemplars_ValueExprOpEquality(t *testing.T) {
 				Op:         c.op,
 				Attr:       c.attr,
 				ValueAlias: "Value",
-				Inner:      &chplan.Scan{Table: "otel_traces"},
+				Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			rw := &chplan.RangeWindow{
 				Input: m, Step: time.Minute, Range: time.Minute,
@@ -698,7 +698,7 @@ func TestEmitMetricsAggregate_GroupByBoundary(t *testing.T) {
 				Quantiles:  []float64{0.5, 0.9}, // multi-quantile → exercises the GroupBy branch
 				GroupBy:    c.groupBy,
 				ValueAlias: "Value",
-				Inner:      &chplan.Scan{Table: "otel_traces"},
+				Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			sql, _, err := Emit(context.Background(), plan)
 			if err != nil {
@@ -789,7 +789,7 @@ func TestEmitMetricsExemplars_GroupAliasFallback_Iter1039(t *testing.T) {
 		// Two empty aliases → both must fall back to g0 / g1.
 		GroupByAliases: []string{"", ""},
 		ValueAlias:     "Value",
-		Inner:          &chplan.Scan{Table: "otel_traces"},
+		Inner:          metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	rw := &chplan.RangeWindow{
 		Input: m, Step: time.Minute, Range: time.Minute,
@@ -836,7 +836,7 @@ func TestEmitMetricsAggregate_LogicalAndOnMetricArg(t *testing.T) {
 				Op:         c.op,
 				Attr:       c.attr,
 				ValueAlias: "Value",
-				Inner:      &chplan.Scan{Table: "otel_traces"},
+				Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			rw := &chplan.RangeWindow{
 				Input: m, Step: time.Minute, Range: time.Minute,
@@ -867,7 +867,7 @@ func TestEmitMetricsAggregate_BadStartEndPin(t *testing.T) {
 	m := &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpRate,
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 
 	t.Run("Start > End errors", func(t *testing.T) {
@@ -924,8 +924,8 @@ func TestEmitStructuralJoin_RequiredColumnsTriple(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			plan := &chplan.StructuralJoin{
-				Left:               &chplan.Scan{Table: "otel_traces"},
-				Right:              &chplan.Scan{Table: "otel_traces"},
+				Left:               metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+				Right:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 				Op:                 chplan.StructuralChild,
 				TraceIDColumn:      c.trace,
 				SpanIDColumn:       c.span,
@@ -995,7 +995,7 @@ func TestEmitMetricsHistogramOverTimeBucketAliasFallback(t *testing.T) {
 				IsDuration:  true,
 				BucketAlias: c.bucketAlias,
 				ValueAlias:  c.valueAlias,
-				Inner:       &chplan.Scan{Table: "otel_traces"},
+				Inner:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			sql, _, err := Emit(context.Background(), plan)
 			if err != nil {
@@ -1029,7 +1029,7 @@ func TestEmitMetricsHistogramOverTime_GroupAliasFallback(t *testing.T) {
 		GroupByAliases: []string{"service.name"},
 		BucketAlias:    "__bucket",
 		ValueAlias:     "Value",
-		Inner:          &chplan.Scan{Table: "otel_traces"},
+		Inner:          metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	sql, _, err := Emit(context.Background(), plan)
 	if err != nil {
@@ -1057,7 +1057,7 @@ func TestEmitMetricsHistogramOverTime_RangeFallback(t *testing.T) {
 		IsDuration:  true,
 		BucketAlias: "__bucket",
 		ValueAlias:  "Value",
-		Inner:       &chplan.Scan{Table: "otel_traces"},
+		Inner:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	cases := []struct {
 		name        string
@@ -1104,7 +1104,7 @@ func TestEmitMetricsHistogramOverTime_NumAnchorsBoundary(t *testing.T) {
 		IsDuration:  true,
 		BucketAlias: "__bucket",
 		ValueAlias:  "Value",
-		Inner:       &chplan.Scan{Table: "otel_traces"},
+		Inner:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	cases := []struct {
 		name string
@@ -1148,7 +1148,7 @@ func TestEmitMetricsHistogramOverTime_BadStartEndErrors(t *testing.T) {
 		IsDuration:  true,
 		BucketAlias: "__bucket",
 		ValueAlias:  "Value",
-		Inner:       &chplan.Scan{Table: "otel_traces"},
+		Inner:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	plan := &chplan.RangeWindow{
 		Input:           inner,
@@ -1202,7 +1202,7 @@ func TestEmitMetricsSecondStage_PartitionByBoundary(t *testing.T) {
 				K:           5,
 				PartitionBy: c.parts,
 				ValueAlias:  "Value",
-				Input:       &chplan.Scan{Table: "otel_traces"},
+				Input:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			sql, _, err := Emit(context.Background(), plan)
 			if err != nil {
@@ -1274,7 +1274,7 @@ func TestEmitScan_EmptySelectList(t *testing.T) {
 	t.Parallel()
 	t.Run("no columns → SELECT *", func(t *testing.T) {
 		t.Parallel()
-		plan := &chplan.Scan{Table: "otel_traces"}
+		plan := metricsTimestampInternalTestScan("otel_traces", "Timestamp")
 		sql, _, err := Emit(context.Background(), plan)
 		if err != nil {
 			t.Fatalf("Emit: %v", err)
@@ -1306,7 +1306,7 @@ func TestEmitProject_EmptySelectList(t *testing.T) {
 	t.Parallel()
 	plan := &chplan.Project{
 		Projections: nil,
-		Input:       &chplan.Scan{Table: "otel_traces"},
+		Input:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	sql, _, err := Emit(context.Background(), plan)
 	if err != nil {
@@ -1342,7 +1342,7 @@ func TestEmitLimit_NonPositiveBoundary(t *testing.T) {
 			t.Parallel()
 			plan := &chplan.Limit{
 				Count: c.count,
-				Input: &chplan.Scan{Table: "otel_traces"},
+				Input: metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			sql, _, err := Emit(context.Background(), plan)
 			if err != nil {
@@ -1374,7 +1374,7 @@ func TestEmitFilter_EmptySelectList(t *testing.T) {
 		t.Parallel()
 		plan := &chplan.Filter{
 			Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "ServiceName"}, Right: &chplan.LitString{V: "api"}},
-			Input:     &chplan.Scan{Table: "otel_traces"},
+			Input:     metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		}
 		sql, _, err := Emit(context.Background(), plan)
 		if err != nil {
@@ -1739,7 +1739,7 @@ func TestEmitAggregate_LogicalAndOnEmptyGuard(t *testing.T) {
 		plan := &chplan.Aggregate{
 			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
 			GroupByAliases: []string{"service"},
-			Input:          &chplan.Scan{Table: "otel_traces"},
+			Input:          metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		}
 		_, _, err := Emit(context.Background(), plan)
 		if err != nil {
@@ -1752,7 +1752,7 @@ func TestEmitAggregate_LogicalAndOnEmptyGuard(t *testing.T) {
 		t.Parallel()
 		plan := &chplan.Aggregate{
 			AggFuncs: []chplan.AggFunc{{Fn: chplan.FnCount, Args: []chplan.Expr{&chplan.LitInt{V: 1}}, Alias: "Value"}},
-			Input:    &chplan.Scan{Table: "otel_traces"},
+			Input:    metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		}
 		_, _, err := Emit(context.Background(), plan)
 		if err != nil {
@@ -1762,7 +1762,7 @@ func TestEmitAggregate_LogicalAndOnEmptyGuard(t *testing.T) {
 	// Case: both empty → both original and mutant error (sanity guard).
 	t.Run("both empty errors", func(t *testing.T) {
 		t.Parallel()
-		plan := &chplan.Aggregate{Input: &chplan.Scan{Table: "otel_traces"}}
+		plan := &chplan.Aggregate{Input: metricsTimestampInternalTestScan("otel_traces", "Timestamp")}
 		_, _, err := Emit(context.Background(), plan)
 		if err == nil {
 			t.Fatalf("expected ErrUnsupported for both-empty aggregate")
@@ -1796,7 +1796,7 @@ func TestEmitAggregate_DropEmptyGuard(t *testing.T) {
 				GroupBy:            c.groupBy,
 				AggFuncs:           []chplan.AggFunc{{Fn: chplan.FnCount, Args: []chplan.Expr{&chplan.LitInt{V: 1}}, Alias: "Value"}},
 				DropEmptyOnNoGroup: c.drop,
-				Input:              &chplan.Scan{Table: "otel_traces"},
+				Input:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			}
 			if len(c.groupBy) > 0 {
 				plan.GroupByAliases = []string{"service"}
@@ -1827,7 +1827,7 @@ func TestEmitMetricsExemplars_ArithmeticBoundary118(t *testing.T) {
 	m := &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpRate,
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	// 5-min span / 1-min step = 5; +1 = 6. With `/` → `*`,
 	// the count would be (5 min)*(1 min) in nanoseconds → huge.
@@ -1953,7 +1953,7 @@ func TestEmitMetricsHistogramOverTimeMatrix_AliasFallbackDistinct(t *testing.T) 
 					IsDuration:  true,
 					BucketAlias: c.bucketAlias,
 					ValueAlias:  c.valueAlias,
-					Inner:       &chplan.Scan{Table: "otel_traces"},
+					Inner:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 				},
 				Step:            time.Minute,
 				Range:           time.Minute,
@@ -1996,7 +1996,7 @@ func TestEmitAggregateNoGroup_AliasPreservation(t *testing.T) {
 			{Fn: chplan.FnCount, Args: []chplan.Expr{&chplan.LitInt{V: 1}}, Alias: "user_value"},
 		},
 		DropEmptyOnNoGroup: true,
-		Input:              &chplan.Scan{Table: "otel_traces"},
+		Input:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	sql, _, err := Emit(context.Background(), plan)
 	if err != nil {
@@ -2077,7 +2077,7 @@ func TestPartitionPrewhere_LastWhereRetainsExactConjunct(t *testing.T) {
 	b := &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "SpanName"}, Right: &chplan.LitString{V: "GET /"}}
 	plan := &chplan.Filter{
 		Predicate: &chplan.Binary{Op: chplan.OpAnd, Left: a, Right: b},
-		Input:     &chplan.Scan{Table: "otel_traces"},
+		Input:     metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	sql, _, err := Emit(context.Background(), plan)
 	if err != nil {
@@ -2365,7 +2365,7 @@ func TestEmitRangeWindowMetricsQuantileBuckets_SpanBoundary(t *testing.T) {
 				Attr:       &chplan.ColumnRef{Name: "Duration"},
 				Quantiles:  []float64{0.95},
 				ValueAlias: "Value",
-				Inner:      &chplan.Scan{Table: "otel_traces"},
+				Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 			},
 			Step:            time.Minute,
 			Range:           time.Minute,
@@ -2429,7 +2429,7 @@ func TestEmitRangeWindowMetricsQuantileBuckets_SpanAnchorArithmetic(t *testing.T
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			Quantiles:  []float64{0.95},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		Range:           time.Minute,
@@ -2760,7 +2760,7 @@ func compareNodeInternal() *chplan.MetricsCompare {
 				&chplan.ColumnRef{Name: "SpanName"},
 			}},
 		}},
-		Inner: &chplan.Scan{Table: "otel_traces"},
+		Inner: metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 }
 
@@ -2960,7 +2960,7 @@ func TestEmitRangeWindowCompare_RootLookupTraceIDGuard(t *testing.T) {
 	t.Run("RootLookup set, TraceIDColumn empty → error", func(t *testing.T) {
 		t.Parallel()
 		m := compareNodeInternal()
-		m.RootLookup = &chplan.Scan{Table: "otel_traces"}
+		m.RootLookup = metricsTimestampInternalTestScan("otel_traces", "Timestamp")
 		m.TraceIDColumn = ""
 		_, _, err := Emit(context.Background(), m)
 		if err == nil {
@@ -2974,7 +2974,7 @@ func TestEmitRangeWindowCompare_RootLookupTraceIDGuard(t *testing.T) {
 	t.Run("RootLookup set, TraceIDColumn present → LEFT JOIN on it", func(t *testing.T) {
 		t.Parallel()
 		m := compareNodeInternal()
-		m.RootLookup = &chplan.Scan{Table: "otel_traces"}
+		m.RootLookup = metricsTimestampInternalTestScan("otel_traces", "Timestamp")
 		m.TraceIDColumn = "TraceId"
 		sql, _, err := Emit(context.Background(), m)
 		if err != nil {
@@ -3016,7 +3016,7 @@ func TestEmitMetricsExemplars_OuterRangeNumAnchors(t *testing.T) {
 	m := &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpRate,
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 	}
 	rw := &chplan.RangeWindow{
 		Input:           m,
@@ -3051,7 +3051,7 @@ func TestEmitMetricsExemplars_QuantileKeyBranch(t *testing.T) {
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			Quantiles:  []float64{0.95},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		}
 		rw := &chplan.RangeWindow{Input: m, Step: time.Minute, Range: time.Minute, Start: start, End: end, TimestampColumn: "Timestamp"}
 		_, args, _, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1, "")
@@ -3076,7 +3076,7 @@ func TestEmitMetricsExemplars_QuantileKeyBranch(t *testing.T) {
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			Quantiles:  []float64{0.5, 0.9},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		}
 		rw := &chplan.RangeWindow{Input: m, Step: time.Minute, Range: time.Minute, Start: start, End: end, TimestampColumn: "Timestamp"}
 		_, args, _, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1, "")
@@ -3105,7 +3105,7 @@ func TestEmitMetricsExemplars_UngroupedNameKeyBranch(t *testing.T) {
 		m := &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		}
 		rw := &chplan.RangeWindow{Input: m, Step: time.Minute, Range: time.Minute, Start: start, End: end, TimestampColumn: "Timestamp"}
 		_, args, _, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1, "")
@@ -3127,7 +3127,7 @@ func TestEmitMetricsExemplars_UngroupedNameKeyBranch(t *testing.T) {
 			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
 			GroupByAliases: []string{"service"},
 			ValueAlias:     "Value",
-			Inner:          &chplan.Scan{Table: "otel_traces"},
+			Inner:          metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		}
 		rw := &chplan.RangeWindow{Input: m, Step: time.Minute, Range: time.Minute, Start: start, End: end, TimestampColumn: "Timestamp"}
 		_, args, _, err := EmitMetricsExemplars(context.Background(), rw, m, "TraceId", "SpanId", 1, "")
@@ -3144,7 +3144,7 @@ func TestEmitMetricsExemplars_UngroupedNameKeyBranch(t *testing.T) {
 
 func nsAnnotateInternal() *chplan.NestedSetAnnotate {
 	return &chplan.NestedSetAnnotate{
-		Input:              &chplan.Scan{Table: "otel_traces"},
+		Input:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		SpansTable:         "otel_traces",
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -3521,8 +3521,8 @@ func TestVectorSetOpArmTimestampCol_StopsAtCanonicalProject(t *testing.T) {
 
 func structuralRecursiveNode(op chplan.StructuralOp, maxDepth int) *chplan.StructuralJoin {
 	return &chplan.StructuralJoin{
-		Left:               &chplan.Scan{Table: "otel_traces"},
-		Right:              &chplan.Scan{Table: "otel_traces"},
+		Left:               metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Right:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		Op:                 op,
 		MaxDepth:           maxDepth,
 		TraceIDColumn:      "TraceId",
@@ -3636,8 +3636,8 @@ func TestEmitStructuralRecursiveUnion_InverseClosureMaxDepth(t *testing.T) {
 func TestEmitStructuralSiblingJoin_Succeeds(t *testing.T) {
 	t.Parallel()
 	j := &chplan.StructuralJoin{
-		Left:               &chplan.Scan{Table: "otel_traces"},
-		Right:              &chplan.Scan{Table: "otel_traces"},
+		Left:               metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Right:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
 		Op:                 chplan.StructuralSibling,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -924,8 +924,8 @@ func TestEmitStructuralJoin_RequiredColumnsTriple(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 			plan := &chplan.StructuralJoin{
-				Left:               metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
-				Right:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+				Left:               &chplan.Scan{Table: "otel_traces"},
+				Right:              &chplan.Scan{Table: "otel_traces"},
 				Op:                 chplan.StructuralChild,
 				TraceIDColumn:      c.trace,
 				SpanIDColumn:       c.span,
@@ -1202,7 +1202,7 @@ func TestEmitMetricsSecondStage_PartitionByBoundary(t *testing.T) {
 				K:           5,
 				PartitionBy: c.parts,
 				ValueAlias:  "Value",
-				Input:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+				Input:       &chplan.Scan{Table: "otel_traces"},
 			}
 			sql, _, err := Emit(context.Background(), plan)
 			if err != nil {
@@ -1274,7 +1274,7 @@ func TestEmitScan_EmptySelectList(t *testing.T) {
 	t.Parallel()
 	t.Run("no columns → SELECT *", func(t *testing.T) {
 		t.Parallel()
-		plan := metricsTimestampInternalTestScan("otel_traces", "Timestamp")
+		plan := &chplan.Scan{Table: "otel_traces"}
 		sql, _, err := Emit(context.Background(), plan)
 		if err != nil {
 			t.Fatalf("Emit: %v", err)
@@ -1306,7 +1306,7 @@ func TestEmitProject_EmptySelectList(t *testing.T) {
 	t.Parallel()
 	plan := &chplan.Project{
 		Projections: nil,
-		Input:       metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Input:       &chplan.Scan{Table: "otel_traces"},
 	}
 	sql, _, err := Emit(context.Background(), plan)
 	if err != nil {
@@ -1342,7 +1342,7 @@ func TestEmitLimit_NonPositiveBoundary(t *testing.T) {
 			t.Parallel()
 			plan := &chplan.Limit{
 				Count: c.count,
-				Input: metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+				Input: &chplan.Scan{Table: "otel_traces"},
 			}
 			sql, _, err := Emit(context.Background(), plan)
 			if err != nil {
@@ -1374,7 +1374,7 @@ func TestEmitFilter_EmptySelectList(t *testing.T) {
 		t.Parallel()
 		plan := &chplan.Filter{
 			Predicate: &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "ServiceName"}, Right: &chplan.LitString{V: "api"}},
-			Input:     metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+			Input:     &chplan.Scan{Table: "otel_traces"},
 		}
 		sql, _, err := Emit(context.Background(), plan)
 		if err != nil {
@@ -1739,7 +1739,7 @@ func TestEmitAggregate_LogicalAndOnEmptyGuard(t *testing.T) {
 		plan := &chplan.Aggregate{
 			GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "ServiceName"}},
 			GroupByAliases: []string{"service"},
-			Input:          metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+			Input:          &chplan.Scan{Table: "otel_traces"},
 		}
 		_, _, err := Emit(context.Background(), plan)
 		if err != nil {
@@ -1752,7 +1752,7 @@ func TestEmitAggregate_LogicalAndOnEmptyGuard(t *testing.T) {
 		t.Parallel()
 		plan := &chplan.Aggregate{
 			AggFuncs: []chplan.AggFunc{{Fn: chplan.FnCount, Args: []chplan.Expr{&chplan.LitInt{V: 1}}, Alias: "Value"}},
-			Input:    metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+			Input:    &chplan.Scan{Table: "otel_traces"},
 		}
 		_, _, err := Emit(context.Background(), plan)
 		if err != nil {
@@ -1762,7 +1762,7 @@ func TestEmitAggregate_LogicalAndOnEmptyGuard(t *testing.T) {
 	// Case: both empty → both original and mutant error (sanity guard).
 	t.Run("both empty errors", func(t *testing.T) {
 		t.Parallel()
-		plan := &chplan.Aggregate{Input: metricsTimestampInternalTestScan("otel_traces", "Timestamp")}
+		plan := &chplan.Aggregate{Input: &chplan.Scan{Table: "otel_traces"}}
 		_, _, err := Emit(context.Background(), plan)
 		if err == nil {
 			t.Fatalf("expected ErrUnsupported for both-empty aggregate")
@@ -1796,7 +1796,7 @@ func TestEmitAggregate_DropEmptyGuard(t *testing.T) {
 				GroupBy:            c.groupBy,
 				AggFuncs:           []chplan.AggFunc{{Fn: chplan.FnCount, Args: []chplan.Expr{&chplan.LitInt{V: 1}}, Alias: "Value"}},
 				DropEmptyOnNoGroup: c.drop,
-				Input:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+				Input:              &chplan.Scan{Table: "otel_traces"},
 			}
 			if len(c.groupBy) > 0 {
 				plan.GroupByAliases = []string{"service"}
@@ -1996,7 +1996,7 @@ func TestEmitAggregateNoGroup_AliasPreservation(t *testing.T) {
 			{Fn: chplan.FnCount, Args: []chplan.Expr{&chplan.LitInt{V: 1}}, Alias: "user_value"},
 		},
 		DropEmptyOnNoGroup: true,
-		Input:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Input:              &chplan.Scan{Table: "otel_traces"},
 	}
 	sql, _, err := Emit(context.Background(), plan)
 	if err != nil {
@@ -2077,7 +2077,7 @@ func TestPartitionPrewhere_LastWhereRetainsExactConjunct(t *testing.T) {
 	b := &chplan.Binary{Op: chplan.OpEq, Left: &chplan.ColumnRef{Name: "SpanName"}, Right: &chplan.LitString{V: "GET /"}}
 	plan := &chplan.Filter{
 		Predicate: &chplan.Binary{Op: chplan.OpAnd, Left: a, Right: b},
-		Input:     metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Input:     &chplan.Scan{Table: "otel_traces"},
 	}
 	sql, _, err := Emit(context.Background(), plan)
 	if err != nil {
@@ -2760,7 +2760,7 @@ func compareNodeInternal() *chplan.MetricsCompare {
 				&chplan.ColumnRef{Name: "SpanName"},
 			}},
 		}},
-		Inner: metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Inner: &chplan.Scan{Table: "otel_traces"},
 	}
 }
 
@@ -2960,7 +2960,7 @@ func TestEmitRangeWindowCompare_RootLookupTraceIDGuard(t *testing.T) {
 	t.Run("RootLookup set, TraceIDColumn empty → error", func(t *testing.T) {
 		t.Parallel()
 		m := compareNodeInternal()
-		m.RootLookup = metricsTimestampInternalTestScan("otel_traces", "Timestamp")
+		m.RootLookup = &chplan.Scan{Table: "otel_traces"}
 		m.TraceIDColumn = ""
 		_, _, err := Emit(context.Background(), m)
 		if err == nil {
@@ -2974,7 +2974,7 @@ func TestEmitRangeWindowCompare_RootLookupTraceIDGuard(t *testing.T) {
 	t.Run("RootLookup set, TraceIDColumn present → LEFT JOIN on it", func(t *testing.T) {
 		t.Parallel()
 		m := compareNodeInternal()
-		m.RootLookup = metricsTimestampInternalTestScan("otel_traces", "Timestamp")
+		m.RootLookup = &chplan.Scan{Table: "otel_traces"}
 		m.TraceIDColumn = "TraceId"
 		sql, _, err := Emit(context.Background(), m)
 		if err != nil {
@@ -3144,7 +3144,7 @@ func TestEmitMetricsExemplars_UngroupedNameKeyBranch(t *testing.T) {
 
 func nsAnnotateInternal() *chplan.NestedSetAnnotate {
 	return &chplan.NestedSetAnnotate{
-		Input:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Input:              &chplan.Scan{Table: "otel_traces"},
 		SpansTable:         "otel_traces",
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -3521,8 +3521,8 @@ func TestVectorSetOpArmTimestampCol_StopsAtCanonicalProject(t *testing.T) {
 
 func structuralRecursiveNode(op chplan.StructuralOp, maxDepth int) *chplan.StructuralJoin {
 	return &chplan.StructuralJoin{
-		Left:               metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
-		Right:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
 		Op:                 op,
 		MaxDepth:           maxDepth,
 		TraceIDColumn:      "TraceId",
@@ -3636,8 +3636,8 @@ func TestEmitStructuralRecursiveUnion_InverseClosureMaxDepth(t *testing.T) {
 func TestEmitStructuralSiblingJoin_Succeeds(t *testing.T) {
 	t.Parallel()
 	j := &chplan.StructuralJoin{
-		Left:               metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
-		Right:              metricsTimestampInternalTestScan("otel_traces", "Timestamp"),
+		Left:               &chplan.Scan{Table: "otel_traces"},
+		Right:              &chplan.Scan{Table: "otel_traces"},
 		Op:                 chplan.StructuralSibling,
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",

--- a/internal/chsql/histogram_over_time.go
+++ b/internal/chsql/histogram_over_time.go
@@ -179,7 +179,7 @@ func histogramBucketFrag(attr chplan.Expr, isDuration bool) Frag {
 // that case.
 func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.MetricsHistogramOverTime) error {
 	if r.TimestampColumn == "" {
-		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsHistogramOverTime input)", ErrUnsupported)
+		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required output alias)", ErrUnsupported)
 	}
 	if r.Step <= 0 {
 		return fmt.Errorf("%w: RangeWindow wrapping MetricsHistogramOverTime requires Step > 0", ErrUnsupported)
@@ -189,6 +189,10 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 	}
 	if m.Inner == nil {
 		return fmt.Errorf("%w: MetricsHistogramOverTime.Inner is nil", ErrUnsupported)
+	}
+	tsCol, ok := m.InputTimestampColumn()
+	if !ok {
+		return fmt.Errorf("%w: MetricsHistogramOverTime requires a unique named timestamp role on its nested input", ErrUnsupported)
 	}
 	// Fail closed if the inner is a spans scan with no request window: the
 	// shared maybePushInnerScanTimeBounds (here and in the zero-fill arm)
@@ -242,7 +246,6 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 		alias := groupAliases[i]
 		innerSb.SelectAs(func(b *Builder) { _ = b.Expr(expr) }, alias)
 	}
-	tsCol := r.TimestampColumn
 	innerSb.SelectAs(histogramBucketFrag(m.Attr, m.IsDuration), bucketAlias)
 	innerSb.SelectAs(
 		sampleAnchorFanoutFrag(end, func(b *Builder) { b.Ident(tsCol) }, stepNS, rangeNS, numAnchors),
@@ -262,6 +265,7 @@ func (e *emitter) emitRangeWindowHistogram(r *chplan.RangeWindow, m *chplan.Metr
 		inner:        inner,
 		r:            r,
 		m:            m,
+		tsCol:        tsCol,
 		groupAliases: groupAliases,
 		bucketAlias:  bucketAlias,
 		attrGuard:    attrGuard,
@@ -302,6 +306,7 @@ type histogramZeroFillArgs struct {
 	inner        Frag
 	r            *chplan.RangeWindow
 	m            *chplan.MetricsHistogramOverTime
+	tsCol        string
 	groupAliases []string
 	bucketAlias  string
 	attrGuard    Frag
@@ -330,7 +335,7 @@ func histogramZeroFillGridArm(a histogramZeroFillArgs) Frag {
 	}
 	disc.SelectAs(histogramBucketFrag(a.m.Attr, a.m.IsDuration), a.bucketAlias)
 	disc.Where(a.attrGuard)
-	maybePushInnerScanTimeBounds(disc, a.r, a.r.TimestampColumn, a.rangeNS)
+	maybePushInnerScanTimeBounds(disc, a.r, a.tsCol, a.rangeNS)
 	discKeys := make([]Frag, 0, len(a.groupAliases)+1)
 	for _, alias := range a.groupAliases {
 		al := alias

--- a/internal/chsql/histogram_over_time_test.go
+++ b/internal/chsql/histogram_over_time_test.go
@@ -23,7 +23,7 @@ func TestEmitMetricsHistogramOverTimeBare(t *testing.T) {
 		IsDuration:  true,
 		BucketAlias: "__bucket",
 		ValueAlias:  "Value",
-		Inner:       &chplan.Scan{Table: "otel_traces"},
+		Inner:       metricsTimestampTestScan("otel_traces", "Timestamp"),
 	}
 
 	sql, args, err := chsql.Emit(context.Background(), plan)
@@ -73,7 +73,7 @@ func TestEmitMetricsHistogramOverTimeNonDuration(t *testing.T) {
 		IsDuration:  false,
 		BucketAlias: "__bucket",
 		ValueAlias:  "Value",
-		Inner:       &chplan.Scan{Table: "otel_traces"},
+		Inner:       metricsTimestampTestScan("otel_traces", "Timestamp"),
 	}
 
 	sql, _, err := chsql.Emit(context.Background(), plan)
@@ -100,7 +100,7 @@ func TestEmitMetricsHistogramOverTimeByLabel(t *testing.T) {
 		GroupByAliases: []string{"service.name"},
 		BucketAlias:    "__bucket",
 		ValueAlias:     "Value",
-		Inner:          &chplan.Scan{Table: "otel_traces"},
+		Inner:          metricsTimestampTestScan("otel_traces", "Timestamp"),
 	}
 
 	sql, _, err := chsql.Emit(context.Background(), plan)
@@ -137,7 +137,7 @@ func TestEmitRangeWindowHistogramMatrix(t *testing.T) {
 			IsDuration:  true,
 			BucketAlias: "__bucket",
 			ValueAlias:  "Value",
-			Inner:       &chplan.Scan{Table: "otel_traces"},
+			Inner:       metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		Range:           time.Minute,
@@ -204,7 +204,7 @@ func TestEmitRangeWindowHistogramLeftOpenWindow(t *testing.T) {
 			IsDuration:  true,
 			BucketAlias: "__bucket",
 			ValueAlias:  "Value",
-			Inner:       &chplan.Scan{Table: "otel_traces"},
+			Inner:       metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		Range:           time.Minute,
@@ -243,7 +243,7 @@ func TestEmitRangeWindowHistogramRejectsZeroStep(t *testing.T) {
 			IsDuration:  true,
 			BucketAlias: "__bucket",
 			ValueAlias:  "Value",
-			Inner:       &chplan.Scan{Table: "otel_traces"},
+			Inner:       metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		TimestampColumn: "Timestamp",
 	}
@@ -264,7 +264,7 @@ func TestEmitMetricsHistogramOverTimeRejectsNilAttr(t *testing.T) {
 	plan := &chplan.MetricsHistogramOverTime{
 		BucketAlias: "__bucket",
 		ValueAlias:  "Value",
-		Inner:       &chplan.Scan{Table: "otel_traces"},
+		Inner:       metricsTimestampTestScan("otel_traces", "Timestamp"),
 	}
 	_, _, err := chsql.Emit(context.Background(), plan)
 	if err == nil {

--- a/internal/chsql/metrics_timestamp_internal_test.go
+++ b/internal/chsql/metrics_timestamp_internal_test.go
@@ -1,0 +1,7 @@
+package chsql
+
+import "github.com/tsouza/cerberus/internal/chplan"
+
+func metricsTimestampInternalTestScan(table, timestamp string) *chplan.Scan {
+	return &chplan.Scan{Table: table, Roles: []chplan.Column{{Name: timestamp, Role: chplan.RoleTimestamp}}}
+}

--- a/internal/chsql/range_window.go
+++ b/internal/chsql/range_window.go
@@ -1127,7 +1127,11 @@ func formatFloat(v float64) string {
 // metrics semantics: each bucket covers exactly its Step width).
 func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.MetricsAggregate) error {
 	if r.TimestampColumn == "" {
-		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsAggregate input)", ErrUnsupported)
+		return fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required output alias)", ErrUnsupported)
+	}
+	tsCol, ok := m.InputTimestampColumn()
+	if !ok {
+		return fmt.Errorf("%w: MetricsAggregate requires a unique named timestamp role on its nested input", ErrUnsupported)
 	}
 	if r.Step <= 0 {
 		return fmt.Errorf("%w: RangeWindow wrapping MetricsAggregate requires Step > 0", ErrUnsupported)
@@ -1193,7 +1197,7 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 
 	// Sample-fanout SELECT: fan each Inner row across only the anchors
 	// whose `(anchor_ts - range, anchor_ts]` window contains its
-	// timestamp (sample-side fanout — ≤ range/step + 1 anchors per row,
+	// schema-owned timestamp (sample-side fanout — ≤ range/step + 1 anchors per row,
 	// not the full N-anchor grid; see sampleAnchorFanoutFrag), projecting
 	// group-by cols, [the metric operand as metric_arg,] and anchor_ts.
 	// Group-by columns are aliased so the outer SELECT / GROUP BY can
@@ -1202,7 +1206,6 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 	// predicate IS the window predicate, so no per-row `(anchor_ts -
 	// range, anchor_ts]` re-check survives downstream.
 	groupAliases := outerGroupAliases(m.GroupBy, m.GroupByAliases)
-	tsCol := r.TimestampColumn
 	tsIdent := func(b *Builder) { b.Ident(tsCol) }
 	fanout := NewQuery().From(inner)
 	for i, g := range m.GroupBy {
@@ -1255,7 +1258,7 @@ func (e *emitter) emitRangeWindowMetrics(r *chplan.RangeWindow, m *chplan.Metric
 	var source Frag
 	if zeroFill {
 		grid := e.metricsZeroFillGridArm(
-			inner, r, m, groupAliases, end, stepNS, rangeNS, numAnchors, nil,
+			inner, r, m, tsCol, groupAliases, end, stepNS, rangeNS, numAnchors, nil,
 		)
 		source = Paren(UnionAll(fanout.Frag(), grid))
 	} else {
@@ -1335,12 +1338,12 @@ func (e *emitter) metricsZeroFillGridArm(
 	inner Frag,
 	r *chplan.RangeWindow,
 	m *chplan.MetricsAggregate,
+	tsCol string,
 	groupAliases []string,
 	end Frag,
 	stepNS, rangeNS, numAnchors int64,
 	extraCols []zeroFillExtraCol,
 ) Frag {
-	tsCol := r.TimestampColumn
 	var disc *QueryBuilder
 	if len(groupAliases) > 0 {
 		disc = NewQuery().From(inner)
@@ -1499,6 +1502,10 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 	if m.Inner == nil {
 		return fmt.Errorf("%w: quantile_over_time matrix path requires MetricsAggregate.Inner", ErrUnsupported)
 	}
+	tsCol, ok := m.InputTimestampColumn()
+	if !ok {
+		return fmt.Errorf("%w: MetricsAggregate requires a unique named timestamp role on its nested input", ErrUnsupported)
+	}
 	// Fail closed on a zero-window spans inner (see emitRangeWindowMetrics).
 	// Redundant when reached via emitRangeWindowMetrics, but keeps this entry
 	// point safe if ever called directly.
@@ -1534,7 +1541,6 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 	}
 
 	groupAliases := outerGroupAliases(m.GroupBy, m.GroupByAliases)
-	tsCol := r.TimestampColumn
 	tsIdent := func(b *Builder) { b.Ident(tsCol) }
 
 	// Sample arm — sample-side fanout (≤ range/step + 1 anchors per
@@ -1566,7 +1572,7 @@ func (e *emitter) emitRangeWindowMetricsQuantileBuckets(r *chplan.RangeWindow, m
 	// (which can never satisfy the `>= 2` bucketize guard); see
 	// metricsZeroFillGridArm.
 	grid := e.metricsZeroFillGridArm(
-		inner, r, m, groupAliases, end, stepNS, rangeNS, numAnchors,
+		inner, r, m, tsCol, groupAliases, end, stepNS, rangeNS, numAnchors,
 		[]zeroFillExtraCol{{frag: InlineLit(int64(0)), alias: "metric_arg"}},
 	)
 

--- a/internal/chsql/range_window_metrics_reducer_mutation_test.go
+++ b/internal/chsql/range_window_metrics_reducer_mutation_test.go
@@ -59,7 +59,13 @@ func metricsReducerRoutePlan(op chplan.MetricsOp) *chplan.RangeWindow {
 		GroupBy:        []chplan.Expr{&chplan.ColumnRef{Name: "resource.service.name"}},
 		GroupByAliases: []string{"resource.service.name"},
 		ValueAlias:     "Value",
-		Inner:          &chplan.Scan{Table: "otel_traces"},
+		Inner: &chplan.Scan{
+			Table:   "otel_traces",
+			Columns: []string{"resource.service.name", "Duration", "Timestamp"},
+			Roles: []chplan.Column{
+				{Name: "Timestamp", Role: chplan.RoleTimestamp},
+			},
+		},
 	}
 	if op != chplan.MetricsOpRate && op != chplan.MetricsOpCountOverTime {
 		m.Attr = &chplan.ColumnRef{Name: "Duration"}

--- a/internal/chsql/range_window_metrics_test.go
+++ b/internal/chsql/range_window_metrics_test.go
@@ -29,7 +29,7 @@ func TestRangeWindowMetricsExplicitTimeGrid(t *testing.T) {
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		Range:           time.Minute,
@@ -114,7 +114,7 @@ func TestRangeWindowMetricsLeftOpenWindow(t *testing.T) {
 					Attr:       c.attr,
 					Quantiles:  c.q,
 					ValueAlias: "Value",
-					Inner:      &chplan.Scan{Table: "otel_traces"},
+					Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 				},
 				Step:            time.Minute,
 				OuterRange:      5 * time.Minute,
@@ -154,7 +154,7 @@ func TestRangeWindowMetricsRejectsZeroStep(t *testing.T) {
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		TimestampColumn: "Timestamp",
 		// Step zero — should error.
@@ -178,7 +178,7 @@ func TestRangeWindowMetricsRejectsBadStartEnd(t *testing.T) {
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		Start:           time.Date(2026, 5, 13, 12, 5, 0, 0, time.UTC),
@@ -210,7 +210,7 @@ func TestMetricsAggregateRequiresAttr(t *testing.T) {
 			plan := &chplan.MetricsAggregate{
 				Op:         op,
 				ValueAlias: "Value",
-				Inner:      &chplan.Scan{Table: "otel_traces"},
+				Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 			}
 			if op == chplan.MetricsOpQuantileOverTime {
 				plan.Quantiles = []float64{0.95}
@@ -240,7 +240,7 @@ func TestMetricsAggregateMultiQuantileBare(t *testing.T) {
 		Attr:       &chplan.ColumnRef{Name: "Duration"},
 		Quantiles:  []float64{0.5, 0.9, 0.99},
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 	}
 	sql, args, err := chsql.Emit(context.Background(), plan)
 	if err != nil {
@@ -288,7 +288,7 @@ func TestRangeWindowMetricsQuantileBuckets(t *testing.T) {
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			Quantiles:  []float64{0.5, 0.9, 0.99},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		OuterRange:      5 * time.Minute,
@@ -353,7 +353,7 @@ func TestRangeWindowMetricsQuantileBucketsDuration(t *testing.T) {
 			Quantiles:  []float64{0.95},
 			IsDuration: true,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		OuterRange:      5 * time.Minute,
@@ -416,7 +416,7 @@ func TestRangeWindowMetricsReducerIsFloat64(t *testing.T) {
 					Attr:       c.attr,
 					Quantiles:  c.q,
 					ValueAlias: "Value",
-					Inner:      &chplan.Scan{Table: "otel_traces"},
+					Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 				},
 				Step:            time.Minute,
 				OuterRange:      5 * time.Minute,

--- a/internal/chsql/range_window_metrics_timestamp_schema_test.go
+++ b/internal/chsql/range_window_metrics_timestamp_schema_test.go
@@ -1,0 +1,91 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+func metricsNestedTimestampScan(columns []string, roles []chplan.Column) *chplan.Scan {
+	return &chplan.Scan{Table: "otel_traces", Columns: columns, Roles: roles}
+}
+
+func metricsTimestampTestScan(table, timestamp string) *chplan.Scan {
+	return &chplan.Scan{Table: table, Roles: []chplan.Column{{Name: timestamp, Role: chplan.RoleTimestamp}}}
+}
+
+func metricsTimestampWindow(input chplan.Node) *chplan.RangeWindow {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &chplan.RangeWindow{
+		Input: input, Start: start, End: start.Add(time.Minute),
+		Step: time.Minute, Range: time.Minute, TimestampColumn: "public_timestamp",
+	}
+}
+
+func TestRangeWindowMetricsResolveNestedPhysicalTimestamp(t *testing.T) {
+	t.Parallel()
+	inner := metricsNestedTimestampScan(
+		[]string{"physical_timestamp", "Duration"},
+		[]chplan.Column{{Name: "physical_timestamp", Role: chplan.RoleTimestamp}},
+	)
+	tests := map[string]chplan.Node{
+		"aggregate": &chplan.MetricsAggregate{
+			Op: chplan.MetricsOpRate, ValueAlias: "Value", Inner: inner,
+		},
+		"histogram": &chplan.MetricsHistogramOverTime{
+			Attr: &chplan.ColumnRef{Name: "Duration"}, BucketAlias: "__bucket", ValueAlias: "Value", Inner: inner,
+		},
+	}
+	for name, input := range tests {
+		input := input
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			sql, _, err := chsql.Emit(context.Background(), metricsTimestampWindow(input))
+			if err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+			if !strings.Contains(sql, "dateDiff('nanosecond', `physical_timestamp`") {
+				t.Fatalf("SQL does not fan out from nested physical timestamp: %s", sql)
+			}
+			if strings.Contains(sql, "dateDiff('nanosecond', `public_timestamp`") ||
+				strings.Contains(sql, "WHERE `public_timestamp`") {
+				t.Fatalf("SQL used RangeWindow output alias as nested input: %s", sql)
+			}
+		})
+	}
+}
+
+func TestRangeWindowMetricsRejectMalformedNestedTimestampSchema(t *testing.T) {
+	t.Parallel()
+	tests := map[string]*chplan.Scan{
+		"missing": metricsNestedTimestampScan([]string{"Duration"}, nil),
+		"duplicate": metricsNestedTimestampScan(
+			[]string{"time_a", "time_b", "Duration"},
+			[]chplan.Column{
+				{Name: "time_a", Role: chplan.RoleTimestamp},
+				{Name: "time_b", Role: chplan.RoleTimestamp},
+			},
+		),
+	}
+	for name, inner := range tests {
+		inner := inner
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			inputs := []chplan.Node{
+				&chplan.MetricsAggregate{Op: chplan.MetricsOpRate, ValueAlias: "Value", Inner: inner},
+				&chplan.MetricsHistogramOverTime{
+					Attr: &chplan.ColumnRef{Name: "Duration"}, ValueAlias: "Value", Inner: inner,
+				},
+			}
+			for _, input := range inputs {
+				if _, _, err := chsql.Emit(context.Background(), metricsTimestampWindow(input)); err == nil {
+					t.Fatalf("Emit accepted malformed nested timestamp schema for %T", input)
+				}
+			}
+		})
+	}
+}

--- a/internal/chsql/range_window_pushdown_test.go
+++ b/internal/chsql/range_window_pushdown_test.go
@@ -54,7 +54,7 @@ func TestRangeWindowMetricsInnerScanPushdown_BothSet(t *testing.T) {
 		Input: &chplan.MetricsAggregate{
 			Op:         chplan.MetricsOpRate,
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		Range:           time.Minute,
@@ -102,7 +102,7 @@ func TestRangeWindowMetricsInnerScanPushdown_OnlyOneSet(t *testing.T) {
 				Input: &chplan.MetricsAggregate{
 					Op:         chplan.MetricsOpRate,
 					ValueAlias: "Value",
-					Inner:      &chplan.Scan{Table: "otel_traces"},
+					Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 				},
 				Step:            time.Minute,
 				Range:           time.Minute,
@@ -203,7 +203,7 @@ func TestRangeWindowMetricsQuantileBucketsInnerScanPushdown_BothSet(t *testing.T
 			Attr:       &chplan.ColumnRef{Name: "Duration"},
 			Quantiles:  []float64{0.95},
 			ValueAlias: "Value",
-			Inner:      &chplan.Scan{Table: "otel_traces"},
+			Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 		},
 		Step:            time.Minute,
 		Range:           time.Minute,
@@ -250,7 +250,7 @@ func TestRangeWindowMetricsQuantileBucketsInnerScanPushdown_OnlyOneSet(t *testin
 					Attr:       &chplan.ColumnRef{Name: "Duration"},
 					Quantiles:  []float64{0.95},
 					ValueAlias: "Value",
-					Inner:      &chplan.Scan{Table: "otel_traces"},
+					Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 				},
 				Step:            time.Minute,
 				Range:           time.Minute,
@@ -284,7 +284,7 @@ func TestEmitMetricsExemplarsInnerScanPushdown_BothSet(t *testing.T) {
 	m := &chplan.MetricsAggregate{
 		Op:         chplan.MetricsOpRate,
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 	}
 	rw := &chplan.RangeWindow{
 		Input:           m,
@@ -335,7 +335,7 @@ func TestEmitMetricsExemplarsInnerScanPushdown_OnlyOneSet(t *testing.T) {
 			m := &chplan.MetricsAggregate{
 				Op:         chplan.MetricsOpRate,
 				ValueAlias: "Value",
-				Inner:      &chplan.Scan{Table: "otel_traces"},
+				Inner:      metricsTimestampTestScan("otel_traces", "Timestamp"),
 			}
 			rw := &chplan.RangeWindow{
 				Input:           m,

--- a/internal/optimizer/optimizer_test.go
+++ b/internal/optimizer/optimizer_test.go
@@ -616,7 +616,12 @@ var inputs = map[string]chplan.Node{
 			Op:   chplan.MetricsOpAvgOverTime,
 			Attr: &chplan.ColumnRef{Name: "Duration"},
 			Inner: &chplan.Filter{
-				Input: &chplan.Scan{Table: "otel_traces"},
+				Input: &chplan.Scan{
+					Table: "otel_traces",
+					Roles: []chplan.Column{
+						{Name: "Timestamp", Role: chplan.RoleTimestamp},
+					},
+				},
 				Predicate: &chplan.Binary{
 					Op:    chplan.OpEq,
 					Left:  &chplan.ColumnRef{Name: "SpanName"},

--- a/internal/traceql/histogram_over_time_test.go
+++ b/internal/traceql/histogram_over_time_test.go
@@ -90,6 +90,9 @@ func TestLowerHistogramOverTime(t *testing.T) {
 			if h.Inner == nil {
 				t.Errorf("Inner is nil; want the spanset tree")
 			}
+			if timestamp, ok := h.InputTimestampColumn(); !ok || timestamp != s.TimestampColumn {
+				t.Errorf("InputTimestampColumn() = (%q, %v), want (%q, true)", timestamp, ok, s.TimestampColumn)
+			}
 		})
 	}
 }

--- a/internal/traceql/metrics_pipeline_test.go
+++ b/internal/traceql/metrics_pipeline_test.go
@@ -138,6 +138,9 @@ func TestLowerMetricsPipeline(t *testing.T) {
 			if len(ma.GroupBy) > 0 && len(ma.GroupBy) != len(ma.GroupByDisplayNames) {
 				t.Errorf("GroupBy/GroupByDisplayNames length mismatch: %d vs %d", len(ma.GroupBy), len(ma.GroupByDisplayNames))
 			}
+			if timestamp, ok := ma.InputTimestampColumn(); !ok || timestamp != s.TimestampColumn {
+				t.Errorf("InputTimestampColumn() = (%q, %v), want (%q, true)", timestamp, ok, s.TimestampColumn)
+			}
 
 			// Walk the inner subtree: Scan, optionally wrapped by Filter.
 			inner := ma.Inner


### PR DESCRIPTION
Closes #3404

## Summary

- derive the physical timestamp used by special MetricsAggregate and MetricsHistogramOverTime windows from the nested relation's `RoleTimestamp`
- keep `RangeWindow.TimestampColumn` separate as the public output contract
- use the resolved timestamp consistently for sample fanout, zero-fill discovery, and scan bounds
- reject missing, unnamed, duplicated, or name-conflicting nested timestamp declarations

## Verification

- focused race tests for the new chplan resolver, chsql metrics/histogram paths, and TraceQL lowering
- `node .github/scripts/forbid-sql-raw.mjs`
- `node .github/scripts/forbid-verbatim-concat.mjs`
- read-only golden planner: `chsql traceql` required; regeneration delegated to CI
