### PR TITLE
refactor(chplan): model compare timestamp ownership

### DIFF
--- a/internal/api/tempo/scan_resource_bound_emit_test.go
+++ b/internal/api/tempo/scan_resource_bound_emit_test.go
@@ -283,7 +283,9 @@ func TestScanResourceBound_CompareFailClosed(t *testing.T) {
 	t.Parallel()
 	s := tracesSchema()
 	cmp := &chplan.MetricsCompare{
-		Inner:     &chplan.Scan{Table: s.SpansTable},
+		Inner: &chplan.Scan{Table: s.SpansTable, Roles: []chplan.Column{
+			{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+		}},
 		Selection: &chplan.LitBool{V: true},
 	}
 	rw := &chplan.RangeWindow{

--- a/internal/chplan/metrics_compare.go
+++ b/internal/chplan/metrics_compare.go
@@ -68,6 +68,11 @@ package chplan
 //     and per-group count ("is_selection" / "attr" / "val" / "Value").
 //   - Inner: the underlying spanset relation (Filter / Scan tree from
 //     the query's `{...}` pipeline).
+//   - InputTimestampColumn / RootLookupTimestampColumn: schema-owned physical
+//     timestamps for the cohort and root-enrichment relations. A wrapping
+//     RangeWindow's TimestampColumn remains the public output name. The
+//     trace_id_ts table keeps its own explicitly configured Start/End column
+//     names because it is a separate physical relation, not a plan child.
 //
 // Wrapping by chplan.RangeWindow produces the `/api/metrics/query_range`
 // matrix shape — one row per (cohort, attr, val, anchor_ts). Bare
@@ -100,6 +105,63 @@ type MetricsCompare struct {
 	// request-window Timestamp losslessly — the seed's roots are then in-window
 	// by construction. Only meaningful when RootLookup != nil.
 	InnerRootScoped bool
+}
+
+// InputTimestampColumn resolves the physical timestamp owned by the compare
+// cohort relation. A wrapping RangeWindow's TimestampColumn is an output name
+// and is deliberately not consulted.
+func (m *MetricsCompare) InputTimestampColumn() (string, bool) {
+	if m == nil || m.Inner == nil {
+		return "", false
+	}
+	return uniqueMetricsCompareTimestamp(m.Inner.RowType())
+}
+
+// RootLookupTimestampColumn resolves the physical timestamp owned by the
+// optional root-enrichment relation. RootLookup does not publish this input
+// through its aggregate output, so resolution happens at its physical scan
+// boundary. Every scan in that relation must agree on one timestamp name.
+func (m *MetricsCompare) RootLookupTimestampColumn() (string, bool) {
+	if m == nil || m.RootLookup == nil {
+		return "", false
+	}
+	var timestamp string
+	valid := true
+	found := false
+	Walk(m.RootLookup, func(node Node) bool {
+		scan, ok := node.(*Scan)
+		if !ok {
+			return true
+		}
+		column, columnOK := uniqueMetricsCompareTimestamp(scan.RowType())
+		if !columnOK || (found && timestamp != column) {
+			valid = false
+			return false
+		}
+		timestamp = column
+		found = true
+		return true
+	})
+	return timestamp, valid && found
+}
+
+func uniqueMetricsCompareTimestamp(row Schema) (string, bool) {
+	nameCount := make(map[string]int, len(row.Columns))
+	var timestamp string
+	for _, column := range row.Columns {
+		nameCount[column.Name]++
+		if column.Role != RoleTimestamp {
+			continue
+		}
+		if column.Name == "" || timestamp != "" {
+			return "", false
+		}
+		timestamp = column.Name
+	}
+	if timestamp == "" || nameCount[timestamp] != 1 {
+		return "", false
+	}
+	return timestamp, true
 }
 
 func (*MetricsCompare) planNode() {}

--- a/internal/chplan/metrics_compare.go
+++ b/internal/chplan/metrics_compare.go
@@ -127,22 +127,22 @@ func (m *MetricsCompare) RootLookupTimestampColumn() (string, bool) {
 	}
 	var timestamp string
 	valid := true
-	found := false
+	scanCount := 0
 	Walk(m.RootLookup, func(node Node) bool {
 		scan, ok := node.(*Scan)
 		if !ok {
 			return true
 		}
+		scanCount++
 		column, columnOK := uniqueMetricsCompareTimestamp(scan.RowType())
-		if !columnOK || (found && timestamp != column) {
+		if !columnOK || scanCount > 1 {
 			valid = false
 			return false
 		}
 		timestamp = column
-		found = true
 		return true
 	})
-	return timestamp, valid && found
+	return timestamp, valid && scanCount == 1
 }
 
 func uniqueMetricsCompareTimestamp(row Schema) (string, bool) {

--- a/internal/chplan/metrics_compare_timestamp_test.go
+++ b/internal/chplan/metrics_compare_timestamp_test.go
@@ -1,0 +1,41 @@
+package chplan
+
+import "testing"
+
+func TestMetricsCompareTimestampOwnership(t *testing.T) {
+	t.Parallel()
+	m := &MetricsCompare{
+		Inner: &Scan{Table: "spans", Roles: []Column{{Name: "cohort_time", Role: RoleTimestamp}}},
+		RootLookup: &Aggregate{Input: &Filter{Input: &Scan{
+			Table: "roots", Roles: []Column{{Name: "root_time", Role: RoleTimestamp}},
+		}}},
+	}
+	if got, ok := m.InputTimestampColumn(); !ok || got != "cohort_time" {
+		t.Fatalf("InputTimestampColumn() = (%q, %v), want (cohort_time, true)", got, ok)
+	}
+	if got, ok := m.RootLookupTimestampColumn(); !ok || got != "root_time" {
+		t.Fatalf("RootLookupTimestampColumn() = (%q, %v), want (root_time, true)", got, ok)
+	}
+}
+
+func TestMetricsCompareTimestampOwnershipRejectsMalformedSchemas(t *testing.T) {
+	t.Parallel()
+	malformed := []Node{
+		&Scan{Table: "spans"},
+		&Scan{Table: "spans", Roles: []Column{{Role: RoleTimestamp}}},
+		&Scan{Table: "spans", Columns: []string{"a", "b"}, Roles: []Column{
+			{Name: "a", Role: RoleTimestamp}, {Name: "b", Role: RoleTimestamp},
+		}},
+		&Project{Input: &OneRow{}, Projections: []Projection{
+			{Expr: &LitInt{V: 1}, Alias: "shared"}, {Expr: &LitInt{V: 2}, Alias: "shared"},
+		}, Roles: []Column{{Name: "shared", Role: RoleTimestamp}}},
+	}
+	for _, node := range malformed {
+		if got, ok := (&MetricsCompare{Inner: node}).InputTimestampColumn(); ok {
+			t.Errorf("InputTimestampColumn() = (%q, true), want rejection for %T", got, node)
+		}
+		if got, ok := (&MetricsCompare{RootLookup: node}).RootLookupTimestampColumn(); ok {
+			t.Errorf("RootLookupTimestampColumn() = (%q, true), want rejection for %T", got, node)
+		}
+	}
+}

--- a/internal/chplan/metrics_compare_timestamp_test.go
+++ b/internal/chplan/metrics_compare_timestamp_test.go
@@ -39,3 +39,29 @@ func TestMetricsCompareTimestampOwnershipRejectsMalformedSchemas(t *testing.T) {
 		}
 	}
 }
+
+func TestMetricsCompareRootTimestampOwnershipRejectsMultipleScans(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		right string
+	}{
+		{name: "same timestamp", right: "root_time"},
+		{name: "conflicting timestamp", right: "other_time"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := &CrossJoin{
+				Left: &Scan{Table: "roots_a", Roles: []Column{
+					{Name: "root_time", Role: RoleTimestamp},
+				}},
+				Right: &Scan{Table: "roots_b", Roles: []Column{
+					{Name: tc.right, Role: RoleTimestamp},
+				}},
+			}
+			if got, ok := (&MetricsCompare{RootLookup: root}).RootLookupTimestampColumn(); ok {
+				t.Errorf("RootLookupTimestampColumn() = (%q, true), want multi-scan rejection", got)
+			}
+		})
+	}
+}

--- a/internal/chsql/emitter_context_inheritance_test.go
+++ b/internal/chsql/emitter_context_inheritance_test.go
@@ -242,15 +242,19 @@ func TestEmitCompareRootLegInheritsAttrStrategies(t *testing.T) {
 				&chplan.ColumnRef{Name: "SpanName"},
 			}},
 		}},
-		SelAlias:      "is_selection",
-		AttrAlias:     "attr",
-		ValAlias:      "val",
-		ValueAlias:    "Value",
-		Inner:         &chplan.Scan{Table: "otel_traces"},
+		SelAlias:   "is_selection",
+		AttrAlias:  "attr",
+		ValAlias:   "val",
+		ValueAlias: "Value",
+		Inner: &chplan.Scan{Table: "otel_traces", Roles: []chplan.Column{
+			{Name: "Timestamp", Role: chplan.RoleTimestamp},
+		}},
 		TraceIDColumn: "TraceId",
 		RootLookup: &chplan.Aggregate{
 			Input: &chplan.Filter{
-				Input: &chplan.Scan{Table: "otel_traces"},
+				Input: &chplan.Scan{Table: "otel_traces", Roles: []chplan.Column{
+					{Name: "Timestamp", Role: chplan.RoleTimestamp},
+				}},
 				Predicate: &chplan.Binary{
 					Op:    chplan.OpEq,
 					Left:  &chplan.ColumnRef{Name: "ParentSpanId"},

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -2760,7 +2760,9 @@ func compareNodeInternal() *chplan.MetricsCompare {
 				&chplan.ColumnRef{Name: "SpanName"},
 			}},
 		}},
-		Inner: &chplan.Scan{Table: "otel_traces"},
+		Inner: &chplan.Scan{Table: "otel_traces", Roles: []chplan.Column{
+			{Name: "Timestamp", Role: chplan.RoleTimestamp},
+		}},
 	}
 }
 

--- a/internal/chsql/metrics_compare.go
+++ b/internal/chsql/metrics_compare.go
@@ -604,6 +604,10 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 	if err != nil {
 		return err
 	}
+	inputTS, rootTS, err := compareTimestampColumns(m)
+	if err != nil {
+		return err
+	}
 
 	end := endExprFrag(r)
 	stepNS := r.Step.Nanoseconds()
@@ -622,12 +626,11 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 		numAnchors = 1
 	}
 
-	tsCol := r.TimestampColumn
-	m, bound, err := e.compareWindowedScanBound(r, m, rangeNS)
+	m, bound, err := e.compareWindowedScanBound(r, m, rangeNS, inputTS, rootTS)
 	if err != nil {
 		return err
 	}
-	base, err := e.compareBaseQuery(m, bound, tsCol)
+	base, err := e.compareBaseQuery(m, bound, inputTS)
 	if err != nil {
 		return err
 	}
@@ -639,7 +642,7 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 	fanout.SelectAs(compareTupleElementFrag(1), attrA)
 	fanout.SelectAs(compareTupleElementFrag(2), valA)
 	fanout.SelectAs(
-		sampleAnchorFanoutFrag(end, func(b *Builder) { b.Ident(tsCol) }, stepNS, rangeNS, numAnchors),
+		sampleAnchorFanoutFrag(end, func(b *Builder) { b.Ident(inputTS) }, stepNS, rangeNS, numAnchors),
 		RangeWindowAnchorAlias,
 	)
 
@@ -658,7 +661,7 @@ func (e *emitter) emitRangeWindowCompare(r *chplan.RangeWindow, m *chplan.Metric
 // fields.
 func compareMatrixRangeNS(r *chplan.RangeWindow) (int64, error) {
 	if r.TimestampColumn == "" {
-		return 0, fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required for MetricsCompare input)", ErrUnsupported)
+		return 0, fmt.Errorf("%w: RangeWindow.TimestampColumn unset (required output alias)", ErrUnsupported)
 	}
 	if r.Step <= 0 {
 		return 0, fmt.Errorf("%w: RangeWindow wrapping MetricsCompare requires Step > 0", ErrUnsupported)
@@ -668,6 +671,21 @@ func compareMatrixRangeNS(r *chplan.RangeWindow) (int64, error) {
 		rangeDur = r.Step
 	}
 	return rangeDur.Nanoseconds(), nil
+}
+
+func compareTimestampColumns(m *chplan.MetricsCompare) (input, root string, err error) {
+	input, ok := m.InputTimestampColumn()
+	if !ok {
+		return "", "", fmt.Errorf("%w: MetricsCompare requires a unique named timestamp role on Inner", ErrUnsupported)
+	}
+	if m.RootLookup == nil {
+		return input, "", nil
+	}
+	root, ok = m.RootLookupTimestampColumn()
+	if !ok {
+		return "", "", fmt.Errorf("%w: MetricsCompare requires a unique named timestamp role on RootLookup scans", ErrUnsupported)
+	}
+	return input, root, nil
 }
 
 // compareWindowedScanBound derives the matrix path's scan-bound pushdown: the
@@ -680,9 +698,8 @@ func compareMatrixRangeNS(r *chplan.RangeWindow) (int64, error) {
 // same bound the matrix statement embeds; a second derivation would be a second
 // source of truth for which window the root leg is read under.
 func (e *emitter) compareWindowedScanBound(
-	r *chplan.RangeWindow, m *chplan.MetricsCompare, rangeNS int64,
+	r *chplan.RangeWindow, m *chplan.MetricsCompare, rangeNS int64, inputTS, rootTS string,
 ) (*chplan.MetricsCompare, *compareScanBound, error) {
-	tsCol := r.TimestampColumn
 	// Push the (Start-range, End] Timestamp window INTO each scan of the
 	// compare join (the 's' span scan + the seeded root leg) rather than
 	// above the join where CH 24.12 cannot prune it. Gated on both Start
@@ -697,7 +714,7 @@ func (e *emitter) compareWindowedScanBound(
 	}
 	var bound *compareScanBound
 	if !r.Start.IsZero() && !r.End.IsZero() {
-		lo, hi := innerScanTsBoundsFrags(tsCol, r.Start, r.End, r.Offset.Nanoseconds(), rangeNS)
+		lo, hi := innerScanTsBoundsFrags(inputTS, r.Start, r.End, r.Offset.Nanoseconds(), rangeNS)
 		bound = &compareScanBound{lo: lo, hi: hi}
 	}
 	// Push a `TraceId IN (<windowed cohort>)` seed directly onto the
@@ -741,7 +758,7 @@ func (e *emitter) compareWindowedScanBound(
 		// root-name/root-service enrichment. offsetNS's sign convention matches
 		// offsetShiftedTimeFrag: shiftedNano = wallNano - offsetNS.
 		offsetNS := r.Offset.Nanoseconds()
-		lo, hi := tsBoundExprs(tsCol, r.Start.UnixNano()-offsetNS-rangeNS, r.End.UnixNano()-offsetNS)
+		lo, hi := tsBoundExprs(inputTS, r.Start.UnixNano()-offsetNS-rangeNS, r.End.UnixNano()-offsetNS)
 		seed := compareSeedNode(m.Inner, m.TraceIDColumn, lo, hi)
 		windowed := *m
 		// A root-scoped selection can use the request window directly. For a
@@ -754,9 +771,9 @@ func (e *emitter) compareWindowedScanBound(
 		var envelope *QueryBuilder
 		switch {
 		case m.InnerRootScoped:
-			rootLo, rootHi = lo, hi
+			rootLo, rootHi = tsBoundExprs(rootTS, r.Start.UnixNano()-offsetNS-rangeNS, r.End.UnixNano()-offsetNS)
 		case seed != nil:
-			rootLo, rootHi, envelope = rootLookupTraceIDTsBounds(m, seed, tsCol)
+			rootLo, rootHi, envelope = rootLookupTraceIDTsBounds(m, seed, rootTS)
 		}
 		rootLookup, seeded := windowRootLookupTraceIDSeed(m.RootLookup, m.TraceIDColumn, seed, rootLo, rootHi)
 		windowed.RootLookup = rootLookup
@@ -851,7 +868,11 @@ func EmitCompareRootLeg(ctx context.Context, r *chplan.RangeWindow) (string, []a
 	// ctxSpansTable are already read off ctx by newEmitter; they are the
 	// same value spansTableFromCtx returned above.
 	e := newEmitter(ctx)
-	windowed, bound, err := e.compareWindowedScanBound(rw, m, rangeNS)
+	inputTS, rootTS, err := compareTimestampColumns(m)
+	if err != nil {
+		return fail(err)
+	}
+	windowed, bound, err := e.compareWindowedScanBound(rw, m, rangeNS, inputTS, rootTS)
 	if err != nil {
 		return fail(err)
 	}

--- a/internal/chsql/metrics_compare_test.go
+++ b/internal/chsql/metrics_compare_test.go
@@ -659,7 +659,9 @@ func TestEmitRangeWindowCompare_TraceIDTsEnvelopeUnreferenced(t *testing.T) {
 	m.RootLookupTraceIDTsEndColumn = "End"
 	// Aggregate straight over Scan: no Filter for the bounds to land in.
 	m.RootLookup = &chplan.Aggregate{
-		Input:   &chplan.Scan{Table: "otel_traces"},
+		Input: &chplan.Scan{Table: "otel_traces", Roles: []chplan.Column{
+			{Name: "Timestamp", Role: chplan.RoleTimestamp},
+		}},
 		GroupBy: []chplan.Expr{&chplan.ColumnRef{Name: "TraceId"}},
 		AggFuncs: []chplan.AggFunc{
 			{Fn: chplan.FnAny, Args: []chplan.Expr{&chplan.ColumnRef{Name: "SpanName"}}, Alias: "__root_name"},

--- a/internal/chsql/metrics_compare_test.go
+++ b/internal/chsql/metrics_compare_test.go
@@ -68,7 +68,9 @@ func compareNode() *chplan.MetricsCompare {
 		AttrAlias:  "attr",
 		ValAlias:   "val",
 		ValueAlias: "Value",
-		Inner:      &chplan.Scan{Table: "otel_traces"},
+		Inner: &chplan.Scan{Table: "otel_traces", Roles: []chplan.Column{
+			{Name: "Timestamp", Role: chplan.RoleTimestamp},
+		}},
 	}
 }
 
@@ -85,7 +87,9 @@ func compareNodeWithRoot() *chplan.MetricsCompare {
 	m.TraceIDColumn = "TraceId"
 	m.RootLookup = &chplan.Aggregate{
 		Input: &chplan.Filter{
-			Input: &chplan.Scan{Table: "otel_traces"},
+			Input: &chplan.Scan{Table: "otel_traces", Roles: []chplan.Column{
+				{Name: "Timestamp", Role: chplan.RoleTimestamp},
+			}},
 			Predicate: &chplan.Binary{
 				Op:    chplan.OpEq,
 				Left:  &chplan.ColumnRef{Name: "ParentSpanId"},
@@ -98,6 +102,59 @@ func compareNodeWithRoot() *chplan.MetricsCompare {
 		},
 	}
 	return m
+}
+
+func TestEmitRangeWindowCompareResolvesPerRelationTimestamps(t *testing.T) {
+	t.Parallel()
+	m := compareNodeWithRoot()
+	m.Inner.(*chplan.Scan).Roles = []chplan.Column{{Name: "cohort_time", Role: chplan.RoleTimestamp}}
+	rootScan := m.RootLookup.(*chplan.Aggregate).Input.(*chplan.Filter).Input.(*chplan.Scan)
+	rootScan.Roles = []chplan.Column{{Name: "root_time", Role: chplan.RoleTimestamp}}
+	m.InnerRootScoped = true
+	rw := &chplan.RangeWindow{
+		Input: m, Range: time.Minute, Step: time.Minute,
+		Start:           time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC),
+		End:             time.Date(2026, 5, 12, 10, 3, 0, 0, time.UTC),
+		TimestampColumn: "public_time",
+	}
+	sql, _, err := chsql.Emit(context.Background(), rw)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"dateDiff('nanosecond', `cohort_time`",
+		"`cohort_time` > toDateTime64",
+		"`root_time` >= fromUnixTimestamp64Nano(?)",
+		"`root_time` <= fromUnixTimestamp64Nano(?)",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("emitted SQL missing relation-owned timestamp %q:\n%s", want, sql)
+		}
+	}
+	if strings.Contains(sql, "`public_time`") {
+		t.Errorf("public RangeWindow timestamp alias selected as a physical compare input:\n%s", sql)
+	}
+}
+
+func TestEmitRangeWindowCompareRejectsMalformedTimestampOwnership(t *testing.T) {
+	t.Parallel()
+	window := func(m *chplan.MetricsCompare) *chplan.RangeWindow {
+		return &chplan.RangeWindow{Input: m, Step: time.Minute, TimestampColumn: "public_time"}
+	}
+	missingInner := compareNode()
+	missingInner.Inner = &chplan.Scan{Table: "otel_traces"}
+	missingRoot := compareNodeWithRoot()
+	missingRoot.RootLookup.(*chplan.Aggregate).Input.(*chplan.Filter).Input = &chplan.Scan{Table: "otel_traces"}
+	for name, plan := range map[string]*chplan.RangeWindow{
+		"inner": window(missingInner),
+		"root":  window(missingRoot),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := chsql.Emit(context.Background(), plan); err == nil {
+				t.Fatal("Emit accepted malformed compare timestamp ownership")
+			}
+		})
+	}
 }
 
 // TestEmitRangeWindowCompare_JoinScanPushdown pins the scan-bounding

--- a/internal/traceql/metrics_compare_test.go
+++ b/internal/traceql/metrics_compare_test.go
@@ -53,6 +53,13 @@ func TestLowerMetricsCompare_Defaults(t *testing.T) {
 	if mc.RootLookup == nil {
 		t.Error("RootLookup = nil, want the per-trace root-span relation on the default schema")
 	}
+	s := schema.DefaultOTelTraces()
+	if got, ok := mc.InputTimestampColumn(); !ok || got != s.TimestampColumn {
+		t.Errorf("InputTimestampColumn() = (%q, %v), want (%q, true)", got, ok, s.TimestampColumn)
+	}
+	if got, ok := mc.RootLookupTimestampColumn(); !ok || got != s.TimestampColumn {
+		t.Errorf("RootLookupTimestampColumn() = (%q, %v), want (%q, true)", got, ok, s.TimestampColumn)
+	}
 	if mc.TraceIDColumn != "TraceId" {
 		t.Errorf("TraceIDColumn = %q, want TraceId", mc.TraceIDColumn)
 	}


### PR DESCRIPTION
## Summary

- resolve the compare cohort timestamp from `MetricsCompare.Inner`'s schema
- resolve root-enrichment bounds from the timestamp role owned by the root lookup's physical scan
- keep the wrapping `RangeWindow.TimestampColumn` output-only and preserve the separate `trace_id_ts` table's configured `Start`/`End` names
- reject malformed timestamp ownership and pin default TraceQL lowering

## Verification

- `go test -timeout 2m -race -count=1 -run '^(TestMetricsCompareTimestampOwnership|TestMetricsCompareTimestampOwnershipRejectsMalformedSchemas|TestEmitRangeWindowCompareResolvesPerRelationTimestamps|TestEmitRangeWindowCompareRejectsMalformedTimestampOwnership|TestEmitRangeWindowCompare_JoinScanPushdown|TestEmitRangeWindowCompare_RootScopedEnrichmentTimestampBound|TestEmitRangeWindowCompare_NonRootTraceIDTsEnrichmentBound|TestEmitCompareRootLeg|TestLowerMetricsCompare_Defaults)$' ./internal/chplan ./internal/chsql ./internal/traceql`

Closes #3408
