### PR TITLE
refactor(chplan): resolve native instant value role

### DIFF
--- a/internal/chplan/range_window_grid_native_instant.go
+++ b/internal/chplan/range_window_grid_native_instant.go
@@ -89,12 +89,14 @@ type RangeWindowGridNativeInstant struct {
 	// without moving Anchor itself. Zero means no offset.
 	Offset time.Duration
 
-	// Column names on Input (canonical OTel-CH: Attributes / TimeUnix /
-	// Value, plus MetricName only when GroupBy has been widened by the
-	// name-collision guard). TimestampColumn / ValueColumn are the two
-	// positional arguments of the aggregate's second paren group.
+	// TimestampColumn names the per-sample timestamp on Input (canonical
+	// OTel-CH: TimeUnix), the first positional argument of the aggregate's
+	// second paren group.
 	TimestampColumn string
-	ValueColumn     string
+
+	// ValueColumn is the public reduced-window value output alias. The
+	// aggregate's physical value input is resolved from Input's RoleValue.
+	ValueColumn string
 
 	// GroupBy is the per-series identity key — ordinarily just Attributes,
 	// widened to also carry MetricName when the caller applies the
@@ -110,6 +112,35 @@ type RangeWindowGridNativeInstant struct {
 func (*RangeWindowGridNativeInstant) planNode() {}
 
 func (r *RangeWindowGridNativeInstant) Children() []Node { return []Node{r.Input} }
+
+// InputValueColumn resolves the aggregate's physical value argument from the
+// child schema. It fails closed unless RoleValue is uniquely declared under a
+// non-empty physical name that no other output shares.
+func (r *RangeWindowGridNativeInstant) InputValueColumn() (string, bool) {
+	if r == nil || r.Input == nil {
+		return "", false
+	}
+	row := r.Input.RowType()
+	if row.Open {
+		return "", false
+	}
+	value := ""
+	nameCount := make(map[string]int, len(row.Columns))
+	for _, column := range row.Columns {
+		nameCount[column.Name]++
+		if column.Role != RoleValue {
+			continue
+		}
+		if column.Name == "" || value != "" {
+			return "", false
+		}
+		value = column.Name
+	}
+	if value == "" || nameCount[value] != 1 {
+		return "", false
+	}
+	return value, true
+}
 
 // Equal compares two RangeWindowGridNativeInstant nodes field-by-field,
 // mirroring [RangeWindowStaleResample.Equal]'s compact shape: a scalar-fields

--- a/internal/chplan/range_window_grid_native_instant_test.go
+++ b/internal/chplan/range_window_grid_native_instant_test.go
@@ -1,0 +1,56 @@
+package chplan
+
+import "testing"
+
+type nativeInstantSchemaNode struct {
+	schema Schema
+}
+
+func (*nativeInstantSchemaNode) planNode()               {}
+func (*nativeInstantSchemaNode) Children() []Node        { return nil }
+func (n *nativeInstantSchemaNode) Equal(other Node) bool { return n == other }
+func (n *nativeInstantSchemaNode) RowType() Schema       { return n.schema }
+
+func nativeInstantNode(schema Schema) *RangeWindowGridNativeInstant {
+	return &RangeWindowGridNativeInstant{Input: &nativeInstantSchemaNode{schema: schema}}
+}
+
+func TestRangeWindowGridNativeInstantInputValueColumn(t *testing.T) {
+	t.Parallel()
+	valid := []Column{
+		{Name: "labels", Role: RoleAttributes},
+		{Name: "sample_time", Role: RoleTimestamp},
+		{Name: "physical_value", Role: RoleValue},
+	}
+	missing := Schema{Columns: append(append([]Column{}, valid[:2]...), Column{})}
+	unnamed := Schema{Columns: append(append([]Column{}, valid[:2]...),
+		Column{Role: RoleValue}, Column{Name: "later_value", Role: RoleValue})}
+	duplicate := Schema{Columns: append(append([]Column{}, valid...),
+		Column{Name: "other_value", Role: RoleValue})}
+	sharedName := Schema{Columns: append(append([]Column{}, valid...),
+		Column{Name: "physical_value", Role: RoleOpaque})}
+	tests := []struct {
+		name  string
+		node  *RangeWindowGridNativeInstant
+		want  string
+		valid bool
+	}{
+		{name: "nil_receiver"},
+		{name: "nil_input", node: &RangeWindowGridNativeInstant{}},
+		{name: "open", node: nativeInstantNode(Schema{Columns: valid, Open: true})},
+		{name: "missing", node: nativeInstantNode(missing)},
+		{name: "unnamed", node: nativeInstantNode(unnamed)},
+		{name: "duplicate_role", node: nativeInstantNode(duplicate)},
+		{name: "shared_name", node: nativeInstantNode(sharedName)},
+		{name: "valid", node: nativeInstantNode(Schema{Columns: valid}), want: "physical_value", valid: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := tc.node.InputValueColumn()
+			if ok != tc.valid || got != tc.want {
+				t.Fatalf("InputValueColumn() = (%q, %v), want (%q, %v)", got, ok, tc.want, tc.valid)
+			}
+		})
+	}
+}

--- a/internal/chsql/range_window_grid_native_instant.go
+++ b/internal/chsql/range_window_grid_native_instant.go
@@ -56,6 +56,10 @@ func (e *emitter) emitRangeWindowGridNativeInstant(r *chplan.RangeWindowGridNati
 	if r.TimestampColumn == "" {
 		return fmt.Errorf("%w: RangeWindowGridNativeInstant.TimestampColumn unset", ErrUnsupported)
 	}
+	inputValueColumn, ok := r.InputValueColumn()
+	if !ok {
+		return fmt.Errorf("%w: RangeWindowGridNativeInstant requires a closed child schema with one unique named value role", ErrUnsupported)
+	}
 	if r.ValueColumn == "" {
 		return fmt.Errorf("%w: RangeWindowGridNativeInstant.ValueColumn unset", ErrUnsupported)
 	}
@@ -107,7 +111,7 @@ func (e *emitter) emitRangeWindowGridNativeInstant(r *chplan.RangeWindowGridNati
 
 	inner := NewQuery().From(innerSub)
 	inner.Select(groupFrags...)
-	inner.Select(As(Parametric(agg.Fn, gridParams, tsAxis, Col(r.ValueColumn)), nativeGridArrayAlias))
+	inner.Select(As(Parametric(agg.Fn, gridParams, tsAxis, Col(inputValueColumn)), nativeGridArrayAlias))
 	// Prune the inner scan to the SAME single-window bound the matrix
 	// emitter uses (Anchor for both the start and end of the pruning span),
 	// so ClickHouse skips granules outside the eval window instead of

--- a/internal/chsql/range_window_grid_native_instant_schema_test.go
+++ b/internal/chsql/range_window_grid_native_instant_schema_test.go
@@ -1,0 +1,67 @@
+package chsql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+)
+
+func TestRangeWindowGridNativeInstantResolvesPhysicalValueAndPreservesOutputAlias(t *testing.T) {
+	t.Parallel()
+	input := &chplan.Project{
+		Input: &chplan.OneRow{},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.FuncCall{Fn: chplan.FnMap}, Alias: "labels"},
+			{Expr: chplan.NowNano(), Alias: "sample_time"},
+			{Expr: &chplan.LitFloat{V: 1}, Alias: "physical_value"},
+		},
+		Roles: []chplan.Column{
+			{Name: "labels", Role: chplan.RoleAttributes},
+			{Name: "sample_time", Role: chplan.RoleTimestamp},
+			{Name: "physical_value", Role: chplan.RoleValue},
+		},
+	}
+	plan := &chplan.RangeWindowGridNativeInstant{
+		Input:           input,
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Anchor:          time.Unix(1_700_000_000, 0).UTC(),
+		TimestampColumn: "sample_time",
+		ValueColumn:     "public_value",
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: "labels"}},
+	}
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if !strings.Contains(sql, "(`sample_time`, `physical_value`)") {
+		t.Fatalf("native aggregate does not read physical child value: %s", sql)
+	}
+	if !strings.Contains(sql, "AS `public_value`") {
+		t.Fatalf("native output does not preserve public value alias: %s", sql)
+	}
+}
+
+func TestRangeWindowGridNativeInstantRejectsMissingChildValueRole(t *testing.T) {
+	t.Parallel()
+	plan := &chplan.RangeWindowGridNativeInstant{
+		Input: &chplan.Scan{
+			Table:   "samples",
+			Columns: []string{"sample_time"},
+			Roles:   []chplan.Column{{Name: "sample_time", Role: chplan.RoleTimestamp}},
+		},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		Anchor:          time.Unix(1_700_000_000, 0).UTC(),
+		TimestampColumn: "sample_time",
+		ValueColumn:     "public_value",
+	}
+	if _, _, err := chsql.Emit(context.Background(), plan); err == nil {
+		t.Fatal("Emit accepted child schema without RoleValue")
+	}
+}

--- a/internal/chsql/range_window_grid_native_ts_axis_test.go
+++ b/internal/chsql/range_window_grid_native_ts_axis_test.go
@@ -185,6 +185,18 @@ const (
 // therefore skipped by the loop below rather than left silently uncovered.
 var nativeTsAxisInstantOutOfScope = map[string]bool{"increase": true, "delta": true}
 
+func nativeTsAxisInstantInput() *chplan.Scan {
+	return &chplan.Scan{
+		Table:   "otel_metrics_gauge",
+		Columns: []string{"Attributes", nativeScanBoundTSCol, "Value"},
+		Roles: []chplan.Column{
+			{Name: "Attributes", Role: chplan.RoleAttributes},
+			{Name: nativeScanBoundTSCol, Role: chplan.RoleTimestamp},
+			{Name: "Value", Role: chplan.RoleValue},
+		},
+	}
+}
+
 // TestNativeTSGrid_TsAxis_InstantEmitter covers nativeGridTsAxisFrag's OTHER
 // caller. RangeWindowGridNativeInstant is a distinct node type with its own
 // emitter, so the registry loop above cannot reach it — the same gap
@@ -211,7 +223,7 @@ func TestNativeTSGrid_TsAxis_InstantEmitter(t *testing.T) {
 			t.Parallel()
 
 			node := &chplan.RangeWindowGridNativeInstant{
-				Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+				Input:           nativeTsAxisInstantInput(),
 				Func:            fn,
 				Range:           nativeTsAxisInstantWindow,
 				Anchor:          anchor,
@@ -249,7 +261,7 @@ func TestNativeTSGrid_TsAxis_InstantOutOfScopeStillRejected(t *testing.T) {
 			t.Parallel()
 
 			node := &chplan.RangeWindowGridNativeInstant{
-				Input:           &chplan.Scan{Table: "otel_metrics_gauge"},
+				Input:           nativeTsAxisInstantInput(),
 				Func:            fn,
 				Range:           nativeTsAxisInstantWindow,
 				Anchor:          anchor,

--- a/internal/promql/gremlins_kill_test.go
+++ b/internal/promql/gremlins_kill_test.go
@@ -1005,6 +1005,43 @@ func TestGuardLabelRewriteCollision_MixedPayloadSkipContinuesLoop(t *testing.T) 
 	}
 }
 
+func TestGuardLabelRewriteCollision_PureHistogramIsNotMixed(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	columns := append([]chplan.Column{
+		{Name: s.AttributesColumn, Role: chplan.RoleAttributes},
+		{Name: s.ValueColumn, Role: chplan.RoleValue},
+	}, chplan.HistogramPayloadColumns()...)
+	input := sampleForwardTestInput(columns...)
+	rewritten := &chplan.Project{Input: &chplan.RangeWindow{
+		Input:           input,
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}}
+	for _, column := range columns {
+		rewritten.Projections = append(rewritten.Projections,
+			chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}, Alias: column.Name})
+	}
+
+	plan := guardLabelRewriteCollision(rewritten, s)
+	if project, ok := plan.(*chplan.Project); ok {
+		plan = project.Input
+	}
+	agg, ok := plan.(*chplan.Aggregate)
+	if !ok {
+		t.Fatalf("plan = %T, want *chplan.Aggregate", plan)
+	}
+	for _, aggregate := range agg.AggFuncs {
+		for _, field := range chplan.HistogramPayloadColumns() {
+			if aggregate.Alias == field.Name {
+				t.Fatalf("pure histogram field %q was treated as mixed payload", field.Name)
+			}
+		}
+	}
+}
+
 // TestGuardLabelRewriteCollision_KeyOnStepSkipContinuesLoop pins that two
 // consecutive key-on-step projections BOTH reach the group key, rather
 // than the first one ending the walk. The fixture uses two non-payload,

--- a/internal/promql/lower.go
+++ b/internal/promql/lower.go
@@ -3824,8 +3824,25 @@ func nativeTSGridInstantNode(rw *chplan.RangeWindow, wantFunc string, s schema.M
 	if rw.TemporalityColumn != "" {
 		return nil
 	}
+	input := rw.Input
+	if input.RowType().Open {
+		// A resource-empty custom schema deliberately leaves the selector as
+		// a raw Scan. Close its public sample boundary here, above any matcher
+		// Filter, so the native node can resolve the physical value role
+		// without narrowing columns needed by that predicate.
+		input = &chplan.Project{
+			Roles: metricRoles(s),
+			Input: input,
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: s.MetricNameColumn}, Alias: s.MetricNameColumn},
+				{Expr: &chplan.ColumnRef{Name: s.AttributesColumn}, Alias: s.AttributesColumn},
+				{Expr: &chplan.ColumnRef{Name: s.TimestampColumn}, Alias: s.TimestampColumn},
+				{Expr: &chplan.ColumnRef{Name: s.ValueColumn}, Alias: s.ValueColumn},
+			},
+		}
+	}
 	return &chplan.RangeWindowGridNativeInstant{
-		Input:           rw.Input,
+		Input:           input,
 		Func:            rw.Func,
 		Range:           rw.Range,
 		Anchor:          rw.End,

--- a/internal/promql/native_grid_instant_value_schema_test.go
+++ b/internal/promql/native_grid_instant_value_schema_test.go
@@ -1,12 +1,41 @@
 package promql
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
 )
+
+func TestNativeTSGridInstantProductionLoweringClosesResourceEmptySchema(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	s.ResourceAttributesColumn = ""
+	s.AggregationTemporalityColumn = ""
+	expr, err := parser.NewParser(parser.Options{}).ParseExpr("rate(cerberus_queries_total[5m])")
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	end := time.Unix(1_700_000_000, 0).UTC()
+	plan, err := LowerAtRangeOpts(context.Background(), expr, s, time.Time{}, end, 0, LowerOpts{
+		Lowerers: RangeLowerers{Rate: NativeRateLowerer{Fallback: FanoutRateLowerer{}, Instant: true}},
+	})
+	if err != nil {
+		t.Fatalf("lower query: %v", err)
+	}
+	native, ok := plan.(*chplan.RangeWindowGridNativeInstant)
+	if !ok {
+		t.Fatalf("lowered plan = %T, want *chplan.RangeWindowGridNativeInstant", plan)
+	}
+	value, ok := native.InputValueColumn()
+	if !ok || value != s.ValueColumn {
+		t.Fatalf("InputValueColumn() = (%q, %v), want (%q, true)", value, ok, s.ValueColumn)
+	}
+}
 
 func TestNativeTSGridInstantNodeCarriesClosedValueRole(t *testing.T) {
 	t.Parallel()

--- a/internal/promql/native_grid_instant_value_schema_test.go
+++ b/internal/promql/native_grid_instant_value_schema_test.go
@@ -1,0 +1,41 @@
+package promql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestNativeTSGridInstantNodeCarriesClosedValueRole(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelMetrics()
+	roles := metricRoles(s)
+	names := make([]string, len(roles))
+	for i, role := range roles {
+		names[i] = role.Name
+	}
+	rw := &chplan.RangeWindow{
+		Input: &chplan.Scan{
+			Table:   s.GaugeTable,
+			Columns: names,
+			Roles:   roles,
+		},
+		Func:            "rate",
+		Range:           5 * time.Minute,
+		End:             time.Unix(1_700_000_000, 0).UTC(),
+		TimestampColumn: s.TimestampColumn,
+		ValueColumn:     s.ValueColumn,
+		GroupBy:         []chplan.Expr{&chplan.ColumnRef{Name: s.AttributesColumn}},
+	}
+
+	native := nativeTSGridInstantNode(rw, "rate", s)
+	if native == nil {
+		t.Fatal("eligible instant grid did not lower natively")
+	}
+	value, ok := native.InputValueColumn()
+	if !ok || value != s.ValueColumn {
+		t.Fatalf("InputValueColumn() = (%q, %v), want (%q, true)", value, ok, s.ValueColumn)
+	}
+}

--- a/internal/promql/sample_forward_test.go
+++ b/internal/promql/sample_forward_test.go
@@ -524,6 +524,41 @@ func TestSamplePayloadRequiresCompletePublicHistogramWithoutDiscriminator(t *tes
 		}
 		capturePanic(t, func() { validateSamplePayload(chplan.Schema{Columns: incomplete}) })
 	}
+	capturePanic(t, func() {
+		validateSamplePayload(chplan.Schema{Columns: []chplan.Column{columns[0]}})
+	})
+}
+
+func TestSampleRoleResolversRejectEachAmbiguousBoundary(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	base := []chplan.Column{
+		{Name: s.AttributesColumn, Role: chplan.RoleAttributes},
+		{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+		{Name: s.ValueColumn, Role: chplan.RoleValue},
+	}
+	for _, extra := range []chplan.Column{
+		{Name: "helper", Role: chplan.RoleHistogramField},
+		{Name: "kind", Role: chplan.RoleDiscriminator},
+	} {
+		row := chplan.Schema{Columns: append(append([]chplan.Column(nil), base...), extra)}
+		capturePanic(t, func() {
+			resolveSampleRoleRefs(row, s, sampleProjectionPolicy{name: preserveSampleName}, sampleProjectionLayout{canonical: true})
+		})
+	}
+	open := chplan.Schema{Columns: append([]chplan.Column(nil), base...), Open: true}
+	capturePanic(t, func() {
+		resolveSampleRoleRefs(open, s, sampleProjectionPolicy{name: preserveSampleName}, sampleProjectionLayout{canonical: true})
+	})
+
+	_, ok, err := resolveOptionalSampleRoleName(chplan.Schema{Columns: []chplan.Column{
+		{Name: "first_value", Role: chplan.RoleValue},
+		{Name: "second_value", Role: chplan.RoleValue},
+	}}, chplan.RoleValue)
+	if err == nil || ok {
+		t.Fatalf("duplicate value roles resolved: ok=%v err=%v", ok, err)
+	}
 }
 
 func TestSampleForwardRejectsUnknownPolicy(t *testing.T) {

--- a/internal/promql/sample_forward_test.go
+++ b/internal/promql/sample_forward_test.go
@@ -189,6 +189,33 @@ func TestLegacySampleProjectionLayoutDistinguishesCanonicalAndDerivedProjects(t 
 	}
 }
 
+func TestLegacySampleProjectionLayoutKeepsDeclaredAnchorWithoutGridSpine(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	columns := append(metricRoles(s), chplan.Column{Name: chplan.RangeWindowAnchorColumn, Role: chplan.RoleAnchor})
+	input := sampleForwardTestInput(columns...)
+	project := &chplan.Project{Input: input, Roles: columns}
+	for _, column := range columns {
+		project.Projections = append(project.Projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}})
+	}
+	if got := legacySampleProjectionLayout(project); got != (sampleProjectionLayout{canonical: true, anchored: true}) {
+		t.Fatalf("layout = %#v, want canonical plus anchor", got)
+	}
+}
+
+func TestAnchoredGridLayoutSpineAcceptsEitherCrossJoinInput(t *testing.T) {
+	t.Parallel()
+
+	grid := &chplan.RangeWindow{OuterRange: 1}
+	plain := sampleForwardTestInput(chplan.Column{Name: "value", Role: chplan.RoleValue})
+	for _, join := range []*chplan.CrossJoin{{Left: grid, Right: plain}, {Left: plain, Right: grid}} {
+		if !anchoredGridLayoutSpine(join) {
+			t.Fatalf("grid spine was not found through %T", join)
+		}
+	}
+}
+
 func TestLegacySampleProjectionLayoutAcceptsReducedWindowSpine(t *testing.T) {
 	t.Parallel()
 
@@ -446,6 +473,56 @@ func TestSampleForwardPreserveNameCompatibility(t *testing.T) {
 				t.Fatalf("missing name was not synthesized canonically: %#v", first)
 			}
 		}
+	}
+}
+
+func TestSampleForwardRolePolicyBoundaries(t *testing.T) {
+	t.Parallel()
+
+	s := schema.DefaultOTelMetrics()
+	refs := sampleRoleRefs{Value: &chplan.ColumnRef{Name: "actual_value"}}
+	if got := refs.sourceMetrics(s); got.AttributesColumn != s.AttributesColumn || got.ValueColumn != "actual_value" {
+		t.Fatalf("source metrics = %#v", got)
+	}
+
+	row := chplan.Schema{Columns: []chplan.Column{
+		{Name: s.MetricNameColumn, Role: chplan.RoleOpaque},
+		{Name: s.AttributesColumn, Role: chplan.RoleAttributes},
+		{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
+		{Name: s.ValueColumn, Role: chplan.RoleValue},
+	}}
+	resolveSampleRoleRefs(row, s, sampleProjectionPolicy{name: preserveSampleName}, sampleProjectionLayout{canonical: true})
+
+	conflicting := row
+	conflicting.Columns = append([]chplan.Column(nil), row.Columns...)
+	conflicting.Columns[0].Role = chplan.RoleAnchor
+	resolveSampleRoleRefs(conflicting, s, sampleProjectionPolicy{name: dropSampleName}, sampleProjectionLayout{canonical: true})
+	capturePanic(t, func() {
+		resolveSampleRoleRefs(conflicting, s, sampleProjectionPolicy{name: preserveSampleName}, sampleProjectionLayout{canonical: true})
+	})
+
+	validateConfiguredSampleRole(row, s.MetricNameColumn, chplan.RoleMetricName, true)
+	capturePanic(t, func() {
+		validateConfiguredSampleRole(row, s.MetricNameColumn, chplan.RoleMetricName, false)
+	})
+}
+
+func TestSamplePayloadRequiresCompletePublicHistogramWithoutDiscriminator(t *testing.T) {
+	t.Parallel()
+
+	columns := chplan.HistogramPayloadColumns()
+	complete, discriminated := validateSamplePayload(chplan.Schema{Columns: columns})
+	if !complete || discriminated {
+		t.Fatalf("payload = complete:%v discriminated:%v", complete, discriminated)
+	}
+	for _, missing := range columns {
+		incomplete := make([]chplan.Column, 0, len(columns)-1)
+		for _, column := range columns {
+			if column.Name != missing.Name {
+				incomplete = append(incomplete, column)
+			}
+		}
+		capturePanic(t, func() { validateSamplePayload(chplan.Schema{Columns: incomplete}) })
 	}
 }
 

--- a/internal/promql/scalar_comparison_test.go
+++ b/internal/promql/scalar_comparison_test.go
@@ -117,6 +117,41 @@ func TestScalarComparisonPredicateResolvesValueRole(t *testing.T) {
 	}
 }
 
+func TestScalarComparisonValueRefRejectsNonValueAndAmbiguousProjects(t *testing.T) {
+	t.Parallel()
+
+	input := sampleForwardTestInput(
+		chplan.Column{Name: "labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: "value", Role: chplan.RoleValue},
+		chplan.Column{Name: "other_value", Role: chplan.RoleValue},
+	)
+	project := func(columns ...chplan.Column) *chplan.Project {
+		projections := make([]chplan.Projection, len(columns))
+		for i, column := range columns {
+			projections[i] = chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}, Alias: column.Name}
+		}
+		return &chplan.Project{Input: input, Roles: columns, Projections: projections}
+	}
+
+	valid := project(
+		chplan.Column{Name: "labels", Role: chplan.RoleAttributes},
+		chplan.Column{Name: "value", Role: chplan.RoleValue},
+	)
+	if got := scalarComparisonValueRef(valid); got.Name != "value" {
+		t.Fatalf("value ref = %q, want value", got.Name)
+	}
+
+	for _, invalid := range []*chplan.Project{
+		project(chplan.Column{Name: "labels", Role: chplan.RoleAttributes}),
+		project(
+			chplan.Column{Name: "value", Role: chplan.RoleValue},
+			chplan.Column{Name: "other_value", Role: chplan.RoleValue},
+		),
+	} {
+		capturePanic(t, func() { scalarComparisonValueRef(invalid) })
+	}
+}
+
 func TestScalarComparisonPriorBoundaryEquivalence(t *testing.T) {
 	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	p := parser.NewParser(parser.Options{EnableExperimentalFunctions: true})


### PR DESCRIPTION
## Summary

- resolve `RangeWindowGridNativeInstant`'s physical aggregate value input from the child schema's `RoleValue`
- retain `ValueColumn` solely as the public reduced-window output alias
- reject nil, open, missing, unnamed, duplicated, and physically conflicting value-role schemas
- keep instant-grid timestamp ownership and matrix-grid timestamp/value ownership unchanged for later slices

## Verification

- `go test -race -run '^TestRangeWindowGridNativeInstantInputValueColumn$' ./internal/chplan`
- `go test -race -run '^TestRangeWindowGridNativeInstant(ResolvesPhysicalValueAndPreservesOutputAlias|RejectsMissingChildValueRole)$' ./internal/chsql`
- `go test -race -run '^TestNativeTSGrid_TsAxis_(InstantEmitter|InstantOutOfScopeStillRejected)$' ./internal/chsql`
- `go test -race -run '^TestNativeTSGridInstantNodeCarriesClosedValueRole$|^TestNativeRateLowererSplitsTemporalityInstant$' ./internal/promql`

Generated artifacts are delegated to the CI golden updater.

Closes #3410

Part of #3284
