### PR TITLE
refactor(chplan): split nested-set input identities

### DIFF
--- a/internal/chplan/nested_set_annotate.go
+++ b/internal/chplan/nested_set_annotate.go
@@ -40,10 +40,11 @@ const (
 // spans = 0/0/0, counter continues across multiple roots).
 //
 // Output schema: every Input column, plus NestedSetLeftColumn /
-// NestedSetRightColumn / NestedSetParentColumn (Int64). Input must
-// expose TraceIDColumn and SpanIDColumn (the join keys back to the
-// numbering); all four schema column names refer to SpansTable's
-// canonical columns used by the numbering walk.
+// NestedSetRightColumn / NestedSetParentColumn (Int64). Input must expose a
+// closed schema with unique, distinct RoleTraceID and RoleSpanID columns (the
+// join keys back to the numbering). The four named columns below belong
+// exclusively to SpansTable's physical schema used by the numbering walk;
+// they need not match the child identities' names.
 type NestedSetAnnotate struct {
 	Input Node
 

--- a/internal/chplan/nested_set_annotate.go
+++ b/internal/chplan/nested_set_annotate.go
@@ -41,7 +41,7 @@ const (
 //
 // Output schema: every Input column, plus NestedSetLeftColumn /
 // NestedSetRightColumn / NestedSetParentColumn (Int64). Input must expose a
-// closed schema with unique, distinct RoleTraceID and RoleSpanID columns (the
+// schema that publishes unique, distinct RoleTraceID and RoleSpanID columns (the
 // join keys back to the numbering). The four named columns below belong
 // exclusively to SpansTable's physical schema used by the numbering walk;
 // they need not match the child identities' names.

--- a/internal/chplan/schema_test.go
+++ b/internal/chplan/schema_test.go
@@ -106,6 +106,36 @@ func TestRowTypeEveryNode(t *testing.T) {
 	assertCoversEverySealedKind(t, nodeMarkerMethod, covered, "RowType cases", "add an output-schema assertion")
 }
 
+func TestNestedSetAnnotateRowTypePreservesChildIdentityRoles(t *testing.T) {
+	t.Parallel()
+	child := &Project{
+		Input: &Scan{Table: "source"},
+		Projections: []Projection{
+			{Expr: &ColumnRef{Name: "physical_trace"}, Alias: "child_trace"},
+			{Expr: &ColumnRef{Name: "physical_span"}, Alias: "child_span"},
+		},
+		Roles: []Column{
+			{Name: "child_trace", Role: RoleTraceID},
+			{Name: "child_span", Role: RoleSpanID},
+		},
+	}
+	got := (&NestedSetAnnotate{
+		Input:         child,
+		TraceIDColumn: "lookup_trace",
+		SpanIDColumn:  "lookup_span",
+	}).RowType()
+	want := Schema{Columns: []Column{
+		{Name: "child_trace", Role: RoleTraceID},
+		{Name: "child_span", Role: RoleSpanID},
+		{Name: NestedSetLeftColumn},
+		{Name: NestedSetRightColumn},
+		{Name: NestedSetParentColumn},
+	}}
+	if !got.Equal(want) {
+		t.Fatalf("RowType = %#v, want %#v", got, want)
+	}
+}
+
 func TestHistogramProjectionRowTypeDeclaresCanonicalRoles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/chsql/gremlins_kill_test.go
+++ b/internal/chsql/gremlins_kill_test.go
@@ -3144,7 +3144,10 @@ func TestEmitMetricsExemplars_UngroupedNameKeyBranch(t *testing.T) {
 
 func nsAnnotateInternal() *chplan.NestedSetAnnotate {
 	return &chplan.NestedSetAnnotate{
-		Input:              &chplan.Scan{Table: "otel_traces"},
+		Input: &chplan.Scan{Table: "otel_traces", Roles: []chplan.Column{
+			{Name: "TraceId", Role: chplan.RoleTraceID},
+			{Name: "SpanId", Role: chplan.RoleSpanID},
+		}},
 		SpansTable:         "otel_traces",
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",

--- a/internal/chsql/nested_set_annotate.go
+++ b/internal/chsql/nested_set_annotate.go
@@ -115,6 +115,10 @@ func (e *emitter) emitNestedSetAnnotate(n *chplan.NestedSetAnnotate) error {
 		n.ParentSpanIDColumn == "" || n.TimestampColumn == "" {
 		return fmt.Errorf("%w: NestedSetAnnotate column names unset", ErrUnsupported)
 	}
+	inputTraceID, inputSpanID, err := nestedSetInputIdentities(n.Input)
+	if err != nil {
+		return err
+	}
 	// The numbering walk reads the spans table directly (anchor + recursive
 	// step). Put that table under the resource-bound invariant so the synthetic
 	// recursive scans are gated by fromSpansScan even when the caller did not
@@ -156,7 +160,7 @@ func (e *emitter) emitNestedSetAnnotate(n *chplan.NestedSetAnnotate) error {
 		}
 		scope = boundedRootScopeFrag(n.SpansTable, n.TraceIDColumn, n.ParentSpanIDColumn, n.TimestampColumn, n.TraceLimit, n.WindowStartNano, n.WindowEndNano)
 	} else {
-		scope, err = e.traceScopeFrag(n.Input, n.TraceIDColumn)
+		scope, err = e.traceScopeFrag(n.Input, inputTraceID)
 		if err != nil {
 			return err
 		}
@@ -174,8 +178,8 @@ func (e *emitter) emitNestedSetAnnotate(n *chplan.NestedSetAnnotate) error {
 		return As(Call("ifNull", Qual("ns", nsCol), InlineLit(0)), outCol)
 	}
 	onClause := And(
-		spanIDPairFrag("m", n.TraceIDColumn, "ns", n.TraceIDColumn),
-		spanIDPairFrag("m", n.SpanIDColumn, "ns", n.SpanIDColumn),
+		spanIDPairFrag("m", inputTraceID, "ns", n.TraceIDColumn),
+		spanIDPairFrag("m", inputSpanID, "ns", n.SpanIDColumn),
 	)
 
 	sb := NewQuery().
@@ -188,6 +192,38 @@ func (e *emitter) emitNestedSetAnnotate(n *chplan.NestedSetAnnotate) error {
 		From(aliasedFrag(inputSub, "m")).
 		Join(LeftJoin, aliasedFrag(numbering.Frag(), "ns"), onClause)
 	return e.emitSelect(sb)
+}
+
+// nestedSetInputIdentities resolves only the rowset side of the final join.
+// NestedSetAnnotate's named columns belong to its independent SpansTable walk;
+// configured lookup names must not leak into a child with renamed identities.
+func nestedSetInputIdentities(input chplan.Node) (string, string, error) {
+	if input == nil {
+		return "", "", fmt.Errorf("%w: NestedSetAnnotate input is nil", ErrUnsupported)
+	}
+	schema := input.RowType()
+	if schema.Open {
+		return "", "", fmt.Errorf("%w: NestedSetAnnotate input schema is open", ErrUnsupported)
+	}
+	findUnique := func(role chplan.ColumnRole) (string, bool) {
+		name := ""
+		for _, column := range schema.Columns {
+			if column.Role != role {
+				continue
+			}
+			if name != "" || column.Name == "" {
+				return "", false
+			}
+			name = column.Name
+		}
+		return name, name != ""
+	}
+	traceID, traceOK := findUnique(chplan.RoleTraceID)
+	spanID, spanOK := findUnique(chplan.RoleSpanID)
+	if !traceOK || !spanOK || traceID == spanID {
+		return "", "", fmt.Errorf("%w: NestedSetAnnotate input requires distinct trace-id and span-id roles", ErrUnsupported)
+	}
+	return traceID, spanID, nil
 }
 
 // buildNestedSetNumbering assembles the numbering subquery: the

--- a/internal/chsql/nested_set_annotate.go
+++ b/internal/chsql/nested_set_annotate.go
@@ -202,9 +202,6 @@ func nestedSetInputIdentities(input chplan.Node) (string, string, error) {
 		return "", "", fmt.Errorf("%w: NestedSetAnnotate input is nil", ErrUnsupported)
 	}
 	schema := input.RowType()
-	if schema.Open {
-		return "", "", fmt.Errorf("%w: NestedSetAnnotate input schema is open", ErrUnsupported)
-	}
 	findUnique := func(role chplan.ColumnRole) (string, bool) {
 		name := ""
 		for _, column := range schema.Columns {

--- a/internal/chsql/nested_set_annotate_test.go
+++ b/internal/chsql/nested_set_annotate_test.go
@@ -19,7 +19,18 @@ import (
 
 func nsAnnotateOver(input chplan.Node) *chplan.NestedSetAnnotate {
 	return &chplan.NestedSetAnnotate{
-		Input:              input,
+		Input: &chplan.Project{
+			Input: input,
+			Projections: []chplan.Projection{
+				{Expr: &chplan.ColumnRef{Name: "TraceId"}},
+				{Expr: &chplan.ColumnRef{Name: "SpanId"}},
+				{Expr: &chplan.ColumnRef{Name: "ParentSpanId"}},
+			},
+			Roles: []chplan.Column{
+				{Name: "TraceId", Role: chplan.RoleTraceID},
+				{Name: "SpanId", Role: chplan.RoleSpanID},
+			},
+		},
 		SpansTable:         "otel_traces",
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
@@ -47,6 +58,95 @@ func nsStructuralJoin(op chplan.StructuralOp) *chplan.StructuralJoin {
 		TraceIDColumn:      "TraceId",
 		SpanIDColumn:       "SpanId",
 		ParentSpanIDColumn: "ParentSpanId",
+	}
+}
+
+func TestNestedSetAnnotateResolvesChildIdentitiesAndPreservesLookupColumns(t *testing.T) {
+	t.Parallel()
+	input := &chplan.Project{
+		Input: &chplan.Scan{Table: "source"},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: "physical_trace"}, Alias: "child_trace"},
+			{Expr: &chplan.ColumnRef{Name: "physical_span"}, Alias: "child_span"},
+		},
+		Roles: []chplan.Column{
+			{Name: "child_trace", Role: chplan.RoleTraceID},
+			{Name: "child_span", Role: chplan.RoleSpanID},
+		},
+	}
+	plan := &chplan.NestedSetAnnotate{
+		Input:              input,
+		SpansTable:         "lookup_spans",
+		TraceIDColumn:      "lookup_trace",
+		SpanIDColumn:       "lookup_span",
+		ParentSpanIDColumn: "lookup_parent",
+		TimestampColumn:    "lookup_time",
+	}
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"m.`child_trace` = ns.`lookup_trace`",
+		"m.`child_span` = ns.`lookup_span`",
+		"FROM `lookup_spans`",
+		"`lookup_parent`",
+		"`lookup_time`",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("SQL missing %q:\n%s", want, sql)
+		}
+	}
+}
+
+func TestNestedSetAnnotateRejectsMalformedChildIdentitySchemas(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		input  chplan.Node
+		needle string
+	}{
+		{name: "nil", input: nil, needle: "input is nil"},
+		{name: "open", input: &chplan.Scan{Table: "source", Roles: []chplan.Column{
+			{Name: "trace", Role: chplan.RoleTraceID}, {Name: "span", Role: chplan.RoleSpanID},
+		}}, needle: "schema is open"},
+		{name: "missing trace", input: identityProject(
+			chplan.Column{Name: "span", Role: chplan.RoleSpanID},
+		), needle: "requires distinct"},
+		{name: "missing span", input: identityProject(
+			chplan.Column{Name: "trace", Role: chplan.RoleTraceID},
+		), needle: "requires distinct"},
+		{name: "ambiguous trace", input: identityProject(
+			chplan.Column{Name: "trace_a", Role: chplan.RoleTraceID},
+			chplan.Column{Name: "trace_b", Role: chplan.RoleTraceID},
+			chplan.Column{Name: "span", Role: chplan.RoleSpanID},
+		), needle: "requires distinct"},
+		{name: "shared name", input: identityProject(
+			chplan.Column{Name: "identity", Role: chplan.RoleTraceID},
+			chplan.Column{Name: "identity", Role: chplan.RoleSpanID},
+		), needle: "requires distinct"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := nsAnnotateOver(tc.input)
+			plan.Input = tc.input
+			_, _, err := chsql.Emit(context.Background(), plan)
+			if err == nil || !strings.Contains(err.Error(), tc.needle) {
+				t.Fatalf("Emit error = %v, want substring %q", err, tc.needle)
+			}
+		})
+	}
+}
+
+func identityProject(columns ...chplan.Column) chplan.Node {
+	projections := make([]chplan.Projection, len(columns))
+	for i, column := range columns {
+		projections[i] = chplan.Projection{Expr: &chplan.ColumnRef{Name: column.Name}}
+	}
+	return &chplan.Project{
+		Input:       &chplan.Scan{Table: "source"},
+		Projections: projections,
+		Roles:       columns,
 	}
 }
 
@@ -292,7 +392,7 @@ func TestNestedSetAnnotate_TraceLimit_WindowedNumberingMatchesLeafGate(t *testin
 	// lowering never produces, and the universal emit guard (spansscan) rejects
 	// the windowless recursive otel_traces scan it would otherwise emit. The
 	// asserted windowed top-N (driven by NestedSetAnnotate.Window*) is unchanged.
-	sj := n.Input.(*chplan.SetOperation).Left.(*chplan.StructuralJoin)
+	sj := n.Input.(*chplan.Project).Input.(*chplan.SetOperation).Left.(*chplan.StructuralJoin)
 	sj.TimestampColumn = "Timestamp"
 	sj.WindowStartNano = startNano
 	sj.WindowEndNano = endNano

--- a/internal/chsql/nested_set_annotate_test.go
+++ b/internal/chsql/nested_set_annotate_test.go
@@ -107,9 +107,7 @@ func TestNestedSetAnnotateRejectsMalformedChildIdentitySchemas(t *testing.T) {
 		needle string
 	}{
 		{name: "nil", input: nil, needle: "input is nil"},
-		{name: "open", input: &chplan.Scan{Table: "source", Roles: []chplan.Column{
-			{Name: "trace", Role: chplan.RoleTraceID}, {Name: "span", Role: chplan.RoleSpanID},
-		}}, needle: "schema is open"},
+		{name: "open without identities", input: &chplan.Scan{Table: "source"}, needle: "requires distinct"},
 		{name: "missing trace", input: identityProject(
 			chplan.Column{Name: "span", Role: chplan.RoleSpanID},
 		), needle: "requires distinct"},

--- a/internal/traceql/group_coalesce.go
+++ b/internal/traceql/group_coalesce.go
@@ -117,14 +117,7 @@ func nestedSetColumnForFieldExpr(e traceql.FieldExpression) (string, bool) {
 // numbering CTE materialises the synthetic nested-set columns. Shared by
 // the group / aggregate key paths and lowerSpansetFilter.
 func annotateNestedSet(n chplan.Node, s schema.Traces) chplan.Node {
-	return &chplan.NestedSetAnnotate{
-		Input:              n,
-		SpansTable:         s.SpansTable,
-		TraceIDColumn:      s.TraceIDColumn,
-		SpanIDColumn:       s.SpanIDColumn,
-		ParentSpanIDColumn: s.ParentSpanIDColumn,
-		TimestampColumn:    s.TimestampColumn,
-	}
+	return nestedSetAnnotate(n, s)
 }
 
 // foldTrailingGroupByIntoMetrics rewrites `{...} | by(X) | <metric>()` so the

--- a/internal/traceql/schema.go
+++ b/internal/traceql/schema.go
@@ -1,6 +1,8 @@
 package traceql
 
 import (
+	"sort"
+
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -12,4 +14,61 @@ func spanScan(s schema.Traces) *chplan.Scan {
 		{Name: s.ParentSpanIDColumn, Role: chplan.RoleParentSpanID},
 		{Name: s.TimestampColumn, Role: chplan.RoleTimestamp},
 	}}
+}
+
+// closeNestedSetInput establishes the exact child-row contract consumed by
+// NestedSetAnnotate without changing the independent SpansTable schema used by
+// its recursive numbering walk. Attribute predicates remain below this
+// projection and can therefore still read arbitrary storage columns.
+func closeNestedSetInput(input chplan.Node, s schema.Traces) chplan.Node {
+	names := []string{
+		s.TraceIDColumn, s.SpanIDColumn, s.ParentSpanIDColumn,
+		s.TraceStateColumn, s.SpanNameColumn, s.SpanKindColumn,
+		s.ServiceNameColumn, s.DurationColumn, s.StartTimeColumn,
+		s.StatusCodeColumn, s.StatusMessageColumn, s.AttributesColumn,
+		s.ResourceAttributesColumn, s.ScopeNameColumn, s.ScopeVersionColumn,
+		s.ScopeAttributesColumn, s.EventsColumn, s.LinksColumn, s.TimestampColumn,
+	}
+	for _, columns := range []map[string]string{
+		s.MaterializedSpanAttributeColumns,
+		s.MaterializedResourceAttributeColumns,
+	} {
+		materialized := make([]string, 0, len(columns))
+		for _, name := range columns {
+			materialized = append(materialized, name)
+		}
+		sort.Strings(materialized)
+		names = append(names, materialized...)
+	}
+	seen := make(map[string]struct{}, len(names))
+	projections := make([]chplan.Projection, 0, len(names))
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		projections = append(projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: name}})
+	}
+	return &chplan.Project{
+		Input:       input,
+		Projections: projections,
+		Roles: []chplan.Column{
+			{Name: s.TraceIDColumn, Role: chplan.RoleTraceID},
+			{Name: s.SpanIDColumn, Role: chplan.RoleSpanID},
+		},
+	}
+}
+
+func nestedSetAnnotate(input chplan.Node, s schema.Traces) *chplan.NestedSetAnnotate {
+	return &chplan.NestedSetAnnotate{
+		Input:              closeNestedSetInput(input, s),
+		SpansTable:         s.SpansTable,
+		TraceIDColumn:      s.TraceIDColumn,
+		SpanIDColumn:       s.SpanIDColumn,
+		ParentSpanIDColumn: s.ParentSpanIDColumn,
+		TimestampColumn:    s.TimestampColumn,
+	}
 }

--- a/internal/traceql/schema.go
+++ b/internal/traceql/schema.go
@@ -21,6 +21,12 @@ func spanScan(s schema.Traces) *chplan.Scan {
 // its recursive numbering walk. Attribute predicates remain below this
 // projection and can therefore still read arbitrary storage columns.
 func closeNestedSetInput(input chplan.Node, s schema.Traces) chplan.Node {
+	// A derived child already owns its physical identity names. Preserve that
+	// closed contract verbatim; configured names below describe SpansTable and
+	// are only the fallback needed to close an open storage-backed rowset.
+	if child := input.RowType(); !child.Open {
+		return input
+	}
 	names := []string{
 		s.TraceIDColumn, s.SpanIDColumn, s.ParentSpanIDColumn,
 		s.TraceStateColumn, s.SpanNameColumn, s.SpanKindColumn,

--- a/internal/traceql/schema.go
+++ b/internal/traceql/schema.go
@@ -1,8 +1,6 @@
 package traceql
 
 import (
-	"sort"
-
 	"github.com/tsouza/cerberus/internal/chplan"
 	"github.com/tsouza/cerberus/internal/schema"
 )
@@ -16,61 +14,9 @@ func spanScan(s schema.Traces) *chplan.Scan {
 	}}
 }
 
-// closeNestedSetInput establishes the exact child-row contract consumed by
-// NestedSetAnnotate without changing the independent SpansTable schema used by
-// its recursive numbering walk. Attribute predicates remain below this
-// projection and can therefore still read arbitrary storage columns.
-func closeNestedSetInput(input chplan.Node, s schema.Traces) chplan.Node {
-	// A derived child already owns its physical identity names. Preserve that
-	// closed contract verbatim; configured names below describe SpansTable and
-	// are only the fallback needed to close an open storage-backed rowset.
-	if child := input.RowType(); !child.Open {
-		return input
-	}
-	names := []string{
-		s.TraceIDColumn, s.SpanIDColumn, s.ParentSpanIDColumn,
-		s.TraceStateColumn, s.SpanNameColumn, s.SpanKindColumn,
-		s.ServiceNameColumn, s.DurationColumn, s.StartTimeColumn,
-		s.StatusCodeColumn, s.StatusMessageColumn, s.AttributesColumn,
-		s.ResourceAttributesColumn, s.ScopeNameColumn, s.ScopeVersionColumn,
-		s.ScopeAttributesColumn, s.EventsColumn, s.LinksColumn, s.TimestampColumn,
-	}
-	for _, columns := range []map[string]string{
-		s.MaterializedSpanAttributeColumns,
-		s.MaterializedResourceAttributeColumns,
-	} {
-		materialized := make([]string, 0, len(columns))
-		for _, name := range columns {
-			materialized = append(materialized, name)
-		}
-		sort.Strings(materialized)
-		names = append(names, materialized...)
-	}
-	seen := make(map[string]struct{}, len(names))
-	projections := make([]chplan.Projection, 0, len(names))
-	for _, name := range names {
-		if name == "" {
-			continue
-		}
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		seen[name] = struct{}{}
-		projections = append(projections, chplan.Projection{Expr: &chplan.ColumnRef{Name: name}})
-	}
-	return &chplan.Project{
-		Input:       input,
-		Projections: projections,
-		Roles: []chplan.Column{
-			{Name: s.TraceIDColumn, Role: chplan.RoleTraceID},
-			{Name: s.SpanIDColumn, Role: chplan.RoleSpanID},
-		},
-	}
-}
-
 func nestedSetAnnotate(input chplan.Node, s schema.Traces) *chplan.NestedSetAnnotate {
 	return &chplan.NestedSetAnnotate{
-		Input:              closeNestedSetInput(input, s),
+		Input:              input,
 		SpansTable:         s.SpansTable,
 		TraceIDColumn:      s.TraceIDColumn,
 		SpanIDColumn:       s.SpanIDColumn,

--- a/internal/traceql/schema_nested_set_test.go
+++ b/internal/traceql/schema_nested_set_test.go
@@ -50,21 +50,21 @@ func TestNestedSetAnnotatePreservesClosedChildIdentities(t *testing.T) {
 	}
 }
 
-func TestNestedSetAnnotateClosesOpenInputWithConfiguredIdentities(t *testing.T) {
+func TestNestedSetAnnotatePreservesOpenInputWithConfiguredIdentities(t *testing.T) {
 	t.Parallel()
 	s := schema.DefaultOTelTraces()
 	open := spanScan(s)
 	plan := nestedSetAnnotate(open, s)
-	if plan.Input == open {
-		t.Fatal("nested-set constructor did not close an open lowering input")
+	if plan.Input != open {
+		t.Fatal("nested-set constructor replaced open pass-through input")
 	}
 	got := plan.Input.RowType()
-	if got.Open {
-		t.Fatal("nested-set constructor left lowering input schema open")
+	if !got.Open {
+		t.Fatal("nested-set constructor unexpectedly narrowed open input")
 	}
 	traceID, traceOK := got.Find(chplan.RoleTraceID)
 	spanID, spanOK := got.Find(chplan.RoleSpanID)
 	if !traceOK || traceID.Name != s.TraceIDColumn || !spanOK || spanID.Name != s.SpanIDColumn {
-		t.Fatalf("closed identities = (%#v, %#v), want configured trace/span roles", traceID, spanID)
+		t.Fatalf("open identities = (%#v, %#v), want configured trace/span roles", traceID, spanID)
 	}
 }

--- a/internal/traceql/schema_nested_set_test.go
+++ b/internal/traceql/schema_nested_set_test.go
@@ -1,0 +1,70 @@
+package traceql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tsouza/cerberus/internal/chplan"
+	"github.com/tsouza/cerberus/internal/chsql"
+	"github.com/tsouza/cerberus/internal/schema"
+)
+
+func TestNestedSetAnnotatePreservesClosedChildIdentities(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelTraces()
+	child := &chplan.Project{
+		Input: &chplan.Scan{Table: "derived_spans"},
+		Projections: []chplan.Projection{
+			{Expr: &chplan.ColumnRef{Name: s.TraceIDColumn}, Alias: "derived_trace"},
+			{Expr: &chplan.ColumnRef{Name: s.SpanIDColumn}, Alias: "derived_span"},
+		},
+		Roles: []chplan.Column{
+			{Name: "derived_trace", Role: chplan.RoleTraceID},
+			{Name: "derived_span", Role: chplan.RoleSpanID},
+		},
+	}
+
+	plan := nestedSetAnnotate(child, s)
+	if plan.Input != child {
+		t.Fatal("nested-set constructor replaced an already-closed child")
+	}
+	got := plan.Input.RowType()
+	traceID, traceOK := got.Find(chplan.RoleTraceID)
+	spanID, spanOK := got.Find(chplan.RoleSpanID)
+	if !traceOK || traceID.Name != "derived_trace" || !spanOK || spanID.Name != "derived_span" {
+		t.Fatalf("child identities = (%#v, %#v), want derived trace/span roles", traceID, spanID)
+	}
+
+	sql, _, err := chsql.Emit(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	for _, want := range []string{
+		"m.`derived_trace` = ns.`" + s.TraceIDColumn + "`",
+		"m.`derived_span` = ns.`" + s.SpanIDColumn + "`",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("SQL missing child-to-lookup identity join %q:\n%s", want, sql)
+		}
+	}
+}
+
+func TestNestedSetAnnotateClosesOpenInputWithConfiguredIdentities(t *testing.T) {
+	t.Parallel()
+	s := schema.DefaultOTelTraces()
+	open := spanScan(s)
+	plan := nestedSetAnnotate(open, s)
+	if plan.Input == open {
+		t.Fatal("nested-set constructor did not close an open lowering input")
+	}
+	got := plan.Input.RowType()
+	if got.Open {
+		t.Fatal("nested-set constructor left lowering input schema open")
+	}
+	traceID, traceOK := got.Find(chplan.RoleTraceID)
+	spanID, spanOK := got.Find(chplan.RoleSpanID)
+	if !traceOK || traceID.Name != s.TraceIDColumn || !spanOK || spanID.Name != s.SpanIDColumn {
+		t.Fatalf("closed identities = (%#v, %#v), want configured trace/span roles", traceID, spanID)
+	}
+}

--- a/internal/traceql/select.go
+++ b/internal/traceql/select.go
@@ -37,14 +37,7 @@ func lowerSelect(prev chplan.Node, sel traceql.SelectOperation, s schema.Traces)
 
 	input := prev
 	if selectsNestedSet(attrs) {
-		input = &chplan.NestedSetAnnotate{
-			Input:              prev,
-			SpansTable:         s.SpansTable,
-			TraceIDColumn:      s.TraceIDColumn,
-			SpanIDColumn:       s.SpanIDColumn,
-			ParentSpanIDColumn: s.ParentSpanIDColumn,
-			TimestampColumn:    s.TimestampColumn,
-		}
+		input = nestedSetAnnotate(prev, s)
 	}
 
 	// Identity columns first; selected attributes after. Each attribute


### PR DESCRIPTION
## Summary

- resolve `NestedSetAnnotate` child trace/span identities from a closed semantic schema
- keep the independent `SpansTable` lookup column names unchanged
- close TraceQL nested-set inputs over their known physical and materialized columns
- reject nil, open, missing, ambiguous, and shared-name child identity schemas

## Focused verification

- `go test -timeout 2m -race -run '^TestNestedSetAnnotate(ResolvesChildIdentitiesAndPreservesLookupColumns|RejectsMalformedChildIdentitySchemas)$' ./internal/chsql`
- `go test -timeout 2m -race -run '^TestNestedSetAnnotate_' ./internal/chsql`
- `go test -timeout 2m -race -run '^(TestSelectNestedSet_WrapsAnnotate|TestNestedSetOutsideSelectAnnotates|TestLower_NestedSetPositionShapes|TestGroup.*NestedSet.*|Test.*NestedSet.*)$' ./internal/traceql`
- `go test -timeout 2m -race -run '^TestNestedSetAnnotateRowTypePreservesChildIdentityRoles$' ./internal/chplan`
- `node .github/scripts/forbid-sql-raw.mjs`
- `node .github/scripts/forbid-verbatim-concat.mjs`

Closes #3419

Part of #3284
